### PR TITLE
增加对知乎专栏的支持

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -263,6 +263,14 @@ s
 
 参数: id，用户 id，可在用户主页 URL 中找到
 
+#### 专栏
+
+举例: https://rss.now.sh/zhihu/zhuanlan/googledevelopers
+
+路由: `/zhihu/zhuanlan/:id`
+
+参数: id，专栏 id，可在专栏主页 URL 中找到
+
 ### 自如
 
 #### 房源

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "koa-router": "7.4.0",
     "lru-cache": "4.1.2",
     "path-to-regexp": "2.2.0",
+    "phantom": "^4.0.12",
     "readall": "1.0.0",
     "winston": "3.0.0-rc3"
   }

--- a/router.js
+++ b/router.js
@@ -45,6 +45,7 @@ router.get('/jianshu/user/:id', require('./routes/jianshu/user'));
 // // 知乎
 router.get('/zhihu/collection/:id', require('./routes/zhihu/collection'));
 router.get('/zhihu/people/activities/:id', require('./routes/zhihu/activities'));
+router.get('/zhihu/zhuanlan/:id', require('./routes/zhihu/zhuanlan'));
 
 // // 贴吧
 router.get('/tieba/forum/:kw', require('./routes/tieba/forum'));

--- a/routes/zhihu/zhuanlan.js
+++ b/routes/zhihu/zhuanlan.js
@@ -1,0 +1,33 @@
+const phantom = require('phantom');
+const art = require('art-template');
+const path = require('path');
+const cheerio = require('cheerio');
+
+module.exports = async (ctx) => {
+    const id = ctx.params.id;
+
+    const instance = await phantom.create();
+    const page = await instance.createPage();
+    await page.on('onResourceRequested', function(requestData){});
+    await page.open(`https://zhuanlan.zhihu.com/${id}`);
+    const content = await page.property('content');
+    await instance.exit();
+
+    const $ = cheerio.load(content);
+    const list = $(".PostListItem");
+
+    ctx.body = art(path.resolve(__dirname, '../../views/rss.art'), {
+        title: $('title').text(),
+        link: `https://www.zhihu.com/collection/${id}`,
+        description: `知乎专栏-${$('title').text()}`,
+        lastBuildDate: new Date().toUTCString(),
+        item: list && list.map((index, item) => {
+            item = $(item);
+            return {
+                title: item.find('.PostListItem-title').text(),
+                description: `内容：${item.find('.PostListItem-summary').text()}`,
+                link: `https://zhuanlan.zhihu.com${item.find('.PostListItem-info a').attr('href')}`
+            };
+        }).get(),
+    });
+};


### PR DESCRIPTION
需要提到的是专栏是单页应用，单独请求api设置了身份验证，于是使用了 [phantom](https://github.com/amir20/phantomjs-node)，不知道大家对于单页应用内容的抓取有啥经验与解决方案呢，顺带开了一个issue     [issue](https://github.com/DIYgod/RSSHub/issues/23)

效果：
![_ _20180418165409](https://user-images.githubusercontent.com/15937065/38922410-ac26033c-432a-11e8-9955-fb5111f91dd7.png)
