### PR TITLE
妹子图RSS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -319,6 +319,60 @@ number: 快递单号
 
 参数: kw，吧名
 
+### 妹子图
+
+#### 首页（最新）
+
+举例: https://rss.now.sh/mzitu
+举例2: https://rss.now.sh/mzitu/2
+
+路由: `/mzitu/`
+路由: `/mzitu/:page`
+
+参数: page，页码[可选，默认第一页]
+
+#### 分类
+
+举例: https://rss.now.sh/mzitu/category/hot
+举例2: https://rss.now.sh/mzitu/category/hot/3
+
+路由: `/mzitu/category/:category`
+路由: `/mzitu/category/:category/:page`
+
+参数
+category，分类名
+page，页码[可选，默认第一页]
+
+| 热门     | 推荐 | 性感妹子  | 日本妹子      | 台湾妹子     | 清纯妹子 |
+| -------- | ------- | ---- | ------- | ------ | ------- |
+| hot | best | xinggan  | japan | taiwan | mm  |
+
+
+#### 所有专题
+
+举例: https://rss.now.sh/mzitu/tags
+
+路由: `/mzitu/tags`
+
+#### 专题详情
+
+举例: https://rss.now.sh/mzitu/tag/shishen
+举例2: https://rss.now.sh/mzitu/tag/shishen/2
+
+路由: `/mzitu/tag/:tag`
+路由: `/mzitu/tag/:tag/:page`
+
+参数
+tag，专题名 `通过获取所有专题接口获取`
+page，页码[可选，默认第一页]
+
+#### 详情
+
+举例: https://rss.now.sh/mzitu/129452
+
+路由: `/mzitu/:id`
+
+参数: id，详情id `直接将地址栏最后一串数字复制`
 ## 搭建
 
 环境：需要 Node.js v7.6.0 或更高版本，若启用 Redis 缓存需要先启动 Redis

--- a/docs/README.md
+++ b/docs/README.md
@@ -324,24 +324,16 @@ number: 快递单号
 #### 首页（最新）
 
 举例: https://rss.now.sh/mzitu
-举例2: https://rss.now.sh/mzitu/2
 
 路由: `/mzitu/`
-路由: `/mzitu/:page`
-
-参数: page，页码[可选，默认第一页]
 
 #### 分类
 
 举例: https://rss.now.sh/mzitu/category/hot
-举例2: https://rss.now.sh/mzitu/category/hot/3
 
 路由: `/mzitu/category/:category`
-路由: `/mzitu/category/:category/:page`
 
-参数
-category，分类名
-page，页码[可选，默认第一页]
+参数：category，分类名
 
 | 热门     | 推荐 | 性感妹子  | 日本妹子      | 台湾妹子     | 清纯妹子 |
 | -------- | ------- | ---- | ------- | ------ | ------- |
@@ -357,14 +349,10 @@ page，页码[可选，默认第一页]
 #### 专题详情
 
 举例: https://rss.now.sh/mzitu/tag/shishen
-举例2: https://rss.now.sh/mzitu/tag/shishen/2
 
 路由: `/mzitu/tag/:tag`
-路由: `/mzitu/tag/:tag/:page`
 
-参数
-tag，专题名 `通过获取所有专题接口获取`
-page，页码[可选，默认第一页]
+参数: tag，专题名 `通过获取所有专题接口获取`
 
 #### 详情
 

--- a/router.js
+++ b/router.js
@@ -50,4 +50,15 @@ router.get('/zhihu/zhuanlan/:id', require('./routes/zhihu/zhuanlan'));
 // // 贴吧
 router.get('/tieba/forum/:kw', require('./routes/tieba/forum'));
 
+// // 妹子图
+router.get('/mzitu', require('./routes/mzitu/category'));
+router.get('/mzitu/tags', require('./routes/mzitu/tags'));
+router.get('/mzitu/:page', require('./routes/mzitu/category'));
+router.get('/mzitu/category/:category', require('./routes/mzitu/category'));
+router.get('/mzitu/category/:category/:page', require('./routes/mzitu/category'));
+router.get('/mzitu/post/:id', require('./routes/mzitu/post'));
+router.get('/mzitu/tag/:tag', require('./routes/mzitu/tag'));
+router.get('/mzitu/tag/:tag/:page', require('./routes/mzitu/tag'));
+
+
 module.exports = router;

--- a/router.js
+++ b/router.js
@@ -53,12 +53,8 @@ router.get('/tieba/forum/:kw', require('./routes/tieba/forum'));
 // // 妹子图
 router.get('/mzitu', require('./routes/mzitu/category'));
 router.get('/mzitu/tags', require('./routes/mzitu/tags'));
-router.get('/mzitu/:page', require('./routes/mzitu/category'));
 router.get('/mzitu/category/:category', require('./routes/mzitu/category'));
-router.get('/mzitu/category/:category/:page', require('./routes/mzitu/category'));
 router.get('/mzitu/post/:id', require('./routes/mzitu/post'));
 router.get('/mzitu/tag/:tag', require('./routes/mzitu/tag'));
-router.get('/mzitu/tag/:tag/:page', require('./routes/mzitu/tag'));
-
 
 module.exports = router;

--- a/routes/mzitu/README.md
+++ b/routes/mzitu/README.md
@@ -1,0 +1,59 @@
+### 妹子图
+
+#### 首页（最新）
+
+举例: https://rss.now.sh/mzitu
+举例2: https://rss.now.sh/mzitu/2
+
+路由: `/mzitu/`
+路由: `/mzitu/:page`
+
+参数: page，页码[可选，默认第一页]
+
+#### 分类
+
+举例: https://rss.now.sh/mzitu/category/hot
+举例2: https://rss.now.sh/mzitu/category/hot/3
+
+路由: `/mzitu/category/:category`
+路由: `/mzitu/category/:category/:page`
+
+参数
+category，分类名
+page，页码[可选，默认第一页]
+
+| 热门     | 推荐 | 性感妹子  | 日本妹子      | 台湾妹子     | 清纯妹子 |
+| -------- | ------- | ---- | ------- | ------ | ------- |
+| hot | best | xinggan  | japan | taiwan | mm  |
+
+
+#### 所有专题
+
+举例: https://rss.now.sh/mzitu/tags
+
+路由: `/mzitu/tags`
+
+#### 专题详情
+
+举例: https://rss.now.sh/mzitu/tag/shishen
+举例2: https://rss.now.sh/mzitu/tag/shishen/2
+
+路由: `/mzitu/tag/:tag`
+路由: `/mzitu/tag/:tag/:page`
+
+参数
+tag，专题名 `通过获取所有专题接口获取`
+page，页码[可选，默认第一页]
+
+#### 详情
+
+举例: https://rss.now.sh/mzitu/129452
+
+路由: `/mzitu/:id`
+
+参数: id，详情id `直接将地址栏最后一串数字复制`
+
+# TODO
+
+- 自拍
+- 全部

--- a/routes/mzitu/README.md
+++ b/routes/mzitu/README.md
@@ -3,24 +3,17 @@
 #### 首页（最新）
 
 举例: https://rss.now.sh/mzitu
-举例2: https://rss.now.sh/mzitu/2
 
 路由: `/mzitu/`
-路由: `/mzitu/:page`
-
-参数: page，页码[可选，默认第一页]
 
 #### 分类
 
 举例: https://rss.now.sh/mzitu/category/hot
-举例2: https://rss.now.sh/mzitu/category/hot/3
 
 路由: `/mzitu/category/:category`
-路由: `/mzitu/category/:category/:page`
 
 参数
 category，分类名
-page，页码[可选，默认第一页]
 
 | 热门     | 推荐 | 性感妹子  | 日本妹子      | 台湾妹子     | 清纯妹子 |
 | -------- | ------- | ---- | ------- | ------ | ------- |
@@ -36,14 +29,11 @@ page，页码[可选，默认第一页]
 #### 专题详情
 
 举例: https://rss.now.sh/mzitu/tag/shishen
-举例2: https://rss.now.sh/mzitu/tag/shishen/2
 
 路由: `/mzitu/tag/:tag`
-路由: `/mzitu/tag/:tag/:page`
 
 参数
 tag，专题名 `通过获取所有专题接口获取`
-page，页码[可选，默认第一页]
 
 #### 详情
 

--- a/routes/mzitu/category.js
+++ b/routes/mzitu/category.js
@@ -6,13 +6,10 @@ const config = require('../../config');
 
 module.exports = async (ctx) => {
     let category = ctx.params.category;
-    let page = ctx.params.page;
 
     category = (category === undefined || category === 'undefined') ? '' : category;
 
-    page = (page === undefined || page === 'undefined') ? '' : `/page/${page}`;
-
-    const url = `http://www.mzitu.com/${category}${page}`;
+    const url = `http://www.mzitu.com/${category}`;
 
     const response = await axios({
         method: 'get',

--- a/routes/mzitu/category.js
+++ b/routes/mzitu/category.js
@@ -1,0 +1,47 @@
+const axios = require('axios');
+const art = require('art-template');
+const path = require('path');
+const cheerio = require('cheerio');
+const config = require('../../config');
+
+module.exports = async (ctx) => {
+    let category = ctx.params.category;
+    let page = ctx.params.page;
+
+    category = (category === undefined || category === 'undefined') ? '' : category;
+
+    page = (page === undefined || page === 'undefined') ? '' : `/page/${page}`;
+
+    const url = `http://www.mzitu.com/${category}${page}`;
+
+    const response = await axios({
+        method: 'get',
+        url: url,
+        headers: {
+            'User-Agent': config.ua,
+            Referer: url
+        }
+    });
+
+    const data = response.data;
+    const $ = cheerio.load(data);
+    const list = $('#pins li');
+
+    ctx.body = art(path.resolve(__dirname, '../../views/rss.art'), {
+        title: $('title').text(),
+        link: url,
+        description: $('meta[name="description"]').attr('content') || $('title').text(),
+        lastBuildDate: new Date().toUTCString(),
+        item: list && list.map((item, index) => {
+            item = $(index);
+            const linkA = item.find('a');
+            const previewImg = linkA.find('img');
+            return {
+                title: previewImg.attr('alt'),
+                description: `描述：${previewImg.attr('alt')}<br><img referrerpolicy="no-referrer" src="${previewImg.data('original')}">`,
+                pubDate: new Date(item.find('.time').text()).toUTCString(),
+                link: linkA.attr('href')
+            };
+        }).get(),
+    });
+};

--- a/routes/mzitu/post.js
+++ b/routes/mzitu/post.js
@@ -48,16 +48,24 @@ module.exports = async (ctx) => {
 
   const title = $('title').text();
 
+  const reg = /[1-9]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])\s+(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d/;
+
   ctx.body = art(path.resolve(__dirname, '../../views/rss.art'), {
     title: title,
     link: url,
     description: $('meta[name="description"]').attr('content') || title,
     lastBuildDate: new Date().toUTCString(),
     item: list && list.map((item) => {
+      let date = new Date();
+      const dateStr = $('.main-meta > span:nth-child(2)').text();
+      if (reg.test(dateStr)) {
+        date = new Date(dateStr.match(reg)[0]);
+      }
+
       return {
         title: `${title}（${item.page}）`,
         description: `分类：${$('.main-meta > span:nth-child(1) > a').text()}<br>描述：${title}（${item.page}）<br><img referrerpolicy="no-referrer" src="${item.imgUrl}">`,
-        pubDate: new Date($('.main-meta > span:nth-child(2)').text().replace('发布于 ', '')).toUTCString(),
+        pubDate: date.toUTCString(),
         link: item.url
       };
     })

--- a/routes/mzitu/post.js
+++ b/routes/mzitu/post.js
@@ -1,0 +1,65 @@
+const axios = require('axios');
+const art = require('art-template');
+const path = require('path');
+const cheerio = require('cheerio');
+const config = require('../../config');
+
+module.exports = async (ctx) => {
+  let id = ctx.params.id;
+
+  const url = `http://www.mzitu.com/${id}`;
+
+  const response = await axios({
+    method: 'get',
+    url: url,
+    headers: {
+      'User-Agent': config.ua,
+      Referer: url
+    }
+  });
+
+  const data = response.data;
+  const $ = cheerio.load(data);
+
+  const img = $('.main-image > p > a > img');
+  const imgUrl = img.attr('src');
+
+  const prefix = imgUrl.substr(0, imgUrl.lastIndexOf('01.'));
+  const suffix = imgUrl.substr(imgUrl.lastIndexOf('.'));
+
+  let totalPage = $('.pagenavi > a:nth-last-child(2)').find('span').text();
+  totalPage = +totalPage;
+
+  const list = [{
+    url,
+    imgUrl,
+    page: 1
+  }];
+  for (let i = 2; i <= totalPage; i++) {
+    const p = i < 10 ? `0${i}` : i;
+    const nextImgUrl = `${prefix}${p}${suffix}`;
+    const nextUrl = `${url}/${i}`;
+    list.push({
+      url: nextUrl,
+      imgUrl: nextImgUrl,
+      page: i
+    });
+  }
+
+  const title = $('title').text();
+
+  ctx.body = art(path.resolve(__dirname, '../../views/rss.art'), {
+    title: title,
+    link: url,
+    description: $('meta[name="description"]').attr('content') || title,
+    lastBuildDate: new Date().toUTCString(),
+    item: list && list.map((item) => {
+      return {
+        title: `${title}（${item.page}）`,
+        description: `分类：${$('.main-meta > span:nth-child(1) > a').text()}<br>描述：${title}（${item.page}）<br><img referrerpolicy="no-referrer" src="${item.imgUrl}">`,
+        pubDate: new Date($('.main-meta > span:nth-child(2)').text().replace('发布于 ', '')).toUTCString(),
+        link: item.url
+      };
+    })
+  });
+};

--- a/routes/mzitu/tag.js
+++ b/routes/mzitu/tag.js
@@ -1,0 +1,47 @@
+const axios = require('axios');
+const art = require('art-template');
+const path = require('path');
+const cheerio = require('cheerio');
+const config = require('../../config');
+
+module.exports = async (ctx) => {
+    let tag = ctx.params.tag;
+    let page = ctx.params.page;
+
+    tag = (tag === undefined || tag === 'undefined') ? '' : tag;
+
+    page = (page === undefined || page === 'undefined') ? '' : `/page/${page}`;
+
+    const url = `http://www.mzitu.com/tag/${tag}${page}`;
+
+    const response = await axios({
+        method: 'get',
+        url: url,
+        headers: {
+            'User-Agent': config.ua,
+            Referer: url
+        }
+    });
+
+    const data = response.data;
+    const $ = cheerio.load(data);
+    const list = $('#pins li');
+
+    ctx.body = art(path.resolve(__dirname, '../../views/rss.art'), {
+        title: $('title').text(),
+        link: url,
+        description: $('meta[name="description"]').attr('content') || $('title').text(),
+        lastBuildDate: new Date().toUTCString(),
+        item: list && list.map((item, index) => {
+            item = $(index);
+            const linkA = item.find('a');
+            const previewImg = linkA.find('img');
+            return {
+                title: previewImg.attr('alt'),
+                description: `描述：${previewImg.attr('alt')}<br><img referrerpolicy="no-referrer" src="${previewImg.data('original')}">`,
+                pubDate: new Date(item.find('.time').text()).toUTCString(),
+                link: linkA.attr('href')
+            };
+        }).get(),
+    });
+};

--- a/routes/mzitu/tag.js
+++ b/routes/mzitu/tag.js
@@ -6,13 +6,9 @@ const config = require('../../config');
 
 module.exports = async (ctx) => {
     let tag = ctx.params.tag;
-    let page = ctx.params.page;
-
     tag = (tag === undefined || tag === 'undefined') ? '' : tag;
 
-    page = (page === undefined || page === 'undefined') ? '' : `/page/${page}`;
-
-    const url = `http://www.mzitu.com/tag/${tag}${page}`;
+    const url = `http://www.mzitu.com/tag/${tag}`;
 
     const response = await axios({
         method: 'get',

--- a/routes/mzitu/tags.js
+++ b/routes/mzitu/tags.js
@@ -1,0 +1,41 @@
+const axios = require('axios');
+const art = require('art-template');
+const path = require('path');
+const cheerio = require('cheerio');
+const config = require('../../config');
+
+module.exports = async (ctx) => {
+
+  const url = 'http://www.mzitu.com/zhuanti';
+
+  const response = await axios({
+    method: 'get',
+    url: url,
+    headers: {
+      'User-Agent': config.ua,
+      Referer: url
+    }
+  });
+
+  const data = response.data;
+  const $ = cheerio.load(data);
+  const list = $('.main-content > div.postlist > dl > dd');
+
+  ctx.body = art(path.resolve(__dirname, '../../views/rss.art'), {
+    title: $('title').text(),
+    link: url,
+    description: $('meta[name="description"]').attr('content') || $('title').text(),
+    lastBuildDate: new Date().toUTCString(),
+    item: list && list.map((item, index) => {
+      item = $(index);
+      const linkA = item.find('a');
+      const previewImg = linkA.find('img');
+      return {
+        title: previewImg.attr('alt'),
+        description: `${item.find('i').text()}<br>描述：${previewImg.attr('alt')}<br><img referrerpolicy="no-referrer" src="${previewImg.data('original')}">`,
+        pubDate: '',
+        link: linkA.attr('href')
+      };
+    }).get(),
+  });
+};


### PR DESCRIPTION
> 添加妹子图的RSS
### 妹子图

#### 首页（最新）

举例: https://rss.now.sh/mzitu

路由: `/mzitu/`

#### 分类

举例: https://rss.now.sh/mzitu/category/hot

路由: `/mzitu/category/:category`

参数
category，分类名

| 热门     | 推荐 | 性感妹子  | 日本妹子      | 台湾妹子     | 清纯妹子 |
| -------- | ------- | ---- | ------- | ------ | ------- |
| hot | best | xinggan  | japan | taiwan | mm  |


#### 所有专题

举例: https://rss.now.sh/mzitu/tags

路由: `/mzitu/tags`

#### 专题详情

举例: https://rss.now.sh/mzitu/tag/shishen

路由: `/mzitu/tag/:tag`

参数
tag，专题名 `通过获取所有专题接口获取`

#### 详情

举例: https://rss.now.sh/mzitu/129452

路由: `/mzitu/:id`

参数: id，详情id `直接将地址栏最后一串数字复制`