### PR TITLE
优化对 github api 的访问

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,5 +8,6 @@ module.exports = {
         client_secret: 'lsACyCD94FhDUtGTXi3QzcFE2uU1hqtDaKeqrdwj',
         username: 'rsshub@tmpmail.org',
         password: 'rsshubpixiv'
-    }
+    },
+    github_token: '', // your github personal access token
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "koa-redis-cache": "3.0.0",
     "koa-router": "7.4.0",
     "lru-cache": "4.1.2",
+    "marked": "^0.3.19",
     "path-to-regexp": "2.2.0",
     "readall": "1.0.0",
     "winston": "3.0.0-rc3"

--- a/routes/github/release.js
+++ b/routes/github/release.js
@@ -1,48 +1,47 @@
 const axios = require('axios');
 const art = require('art-template');
 const path = require('path');
+const marked = require('marked');
 const config = require('../../config');
+
+marked.setOptions({
+    gfm: true,
+    breaks: true,
+    tables: true
+});
+
+const limit = 10;
+
+const headers = {
+    'User-Agent': config.ua,
+};
+if (config.github_token) {
+    headers.Authorization = `token ${config.github_token}`;
+}
+
+const session = axios.create({
+    headers,
+    baseURL: 'https://api.github.com/',
+});
 
 module.exports = async (ctx) => {
     const owner = ctx.params.owner;
     const repo = ctx.params.repo;
 
-    const response = await axios({
-        method: 'get',
-        url: `https://api.github.com/repos/${owner}/${repo}/releases`,
-        headers: {
-            'User-Agent': config.ua,
-        }
-    });
-
-    const data = await Promise.all(response.data.map(async (item) => {
-        let text = item.body;
-        if (text) {
-            // render github flavoured markdown
-            const resp = await axios({
-                method: 'post',
-                url: 'https://api.github.com/markdown',
-                data: {
-                    text,
-                    mode: 'gfm',
-                    context: `${owner}/${repo}`,
-                },
-            });
-            text = resp.data;
-        }
-        return {
-            title: `${item.name || item.tag_name}`,
-            description: text,
-            pubDate: new Date(item.published_at).toUTCString(),
-            link: item.html_url,
-        };
-    }));
+    const response = await session.get(`repos/${owner}/${repo}/releases?per_page=${limit}`);
 
     ctx.body = art(path.resolve(__dirname, '../../views/rss.art'), {
         title: `${owner}/${repo} 的 Releases`,
         link: `https://github.com/${owner}/${repo}/releases`,
         description: `${owner}/${repo} 的 Releases`,
         lastBuildDate: new Date().toUTCString(),
-        item: data,
+        item: response.data.map((item) => ({
+            title: item.name || item.tag_name,
+            description: marked(item.body || ''),
+            pubDate: new Date(item.published_at).toUTCString(),
+            link: item.html_url,
+        })),
     });
 };
+
+// vim:set sta et sw=4 ts=4 sts=4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,6 +961,10 @@ lru-cache@4.1.2, lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+marked@^0.3.19:
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "http://registry.npm.taobao.org/media-typer/download/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"


### PR DESCRIPTION
1. 通过携带 token，增加每小时的访问次数
2. 在本地渲染 markdown，减少对 github api 的访问次数
3. 限制返回的 releases 数目为 10 条