### PR TITLE
fix middleware/utf8.js file bug

### DIFF
--- a/middleware/utf8.js
+++ b/middleware/utf8.js
@@ -2,5 +2,5 @@
 // https://stackoverflow.com/questions/1497885/remove-control-characters-from-php-string/1497928#1497928
 module.exports = async (ctx, next) => {
     await next();
-    ctx.body = ctx.body.replace(/[\x00-\x1F\x7F]/g, '');
+    ctx.body = ctx.body?ctx.body.replace(/[\x00-\x1F\x7F]/g, ''):ctx.body;
 };


### PR DESCRIPTION
如果请求的是静态资源，则 `ctx.body` 为 `undefined`.那么该处会报错

比如：启动服务之后，打开首页会请求`/favicon.ico` ,就回报错
`error: Promise error: TypeError: Cannot read property 'replace' of undefined`

所以该处应该加一个容错判断