### PR TITLE
update zhihu collection link to answer page instead of question page

### DIFF
--- a/routes/zhihu/collection.js
+++ b/routes/zhihu/collection.js
@@ -25,7 +25,7 @@ module.exports = async (ctx) => {
         description: `${$('#zh-fav-head-description').text()}`,
         item: list && list.map((index, item) => {
             item = $(item);
-            let linkUrl = item.find('.zm-item-title a').attr('href');
+            let linkUrl = item.find('link').attr('href');
             if (linkUrl.startsWith('/')) linkUrl = 'https://www.zhihu.com' + linkUrl;
             return {
                 title: item.find('.zm-item-title a').text(),


### PR DESCRIPTION
update reason:
To make it easier to directly locate the answer page and read its comments.

before:
`https://www.zhihu.com/question/30178891`

after:
`https://www.zhihu.com/question/30178891/answer/384043077`