### PR TITLE
Fix deploy to Heroku button

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -33,5 +33,5 @@
 `youtube`: [申请地址](https://console.developers.google.com/)
 
 ## 部署到 Heroku
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https%3A%2F%2Fgithub.com%2FDIYgod%2FRSSHub)
 


### PR DESCRIPTION
只有 GitHub Readme 才可以省略 `template` 参数...

[see also](https://devcenter.heroku.com/articles/heroku-button)