### PR TITLE
feat(cluster): cluster and ipc memory cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM keymetrics/pm2:8-alpine
+FROM node:10-alpine
+
 ENV NODE_ENV production
+
 WORKDIR /usr/src/app
+
 COPY ["package.json", "./"]
+
 RUN yarn --ignore-engines --prod -s && mv node_modules ../
-COPY . .
+
+COPY . /usr/src/app
+
 EXPOSE 1200
-CMD pm2-runtime start process.json
+
+CMD ["npm", "start"] 

--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ module.exports = {
     cacheExpire: process.env.CACHE_EXPIRE || 5 * 60, // 缓存时间，单位为秒
     ua: process.env.UA || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
     listenInaddrAny: process.env.LISTEN_INADDR_ANY || 1, // 是否允许公网连接，取值 0 1
+    clusterSizes: process.env.CLUSTER_NUMBERS || require('os').cpus().length, // 线程数，默认为 cpu 核心数量
     redis: {
         url: process.env.REDIS_URL || 'redis://localhost:6379/',
         options: {

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ const logger = require('./utils/logger');
 const memoryCacheMaster = require('./utils/memorycache');
 
 new memoryCacheMaster({
-    expire: config.cacheExpire * 1000
-})
+    expire: config.cacheExpire * 1000,
+});
 
 for (let i = 0; i < config.clusterSizes; i++) {
     cluster.setupMaster({
@@ -15,7 +15,7 @@ for (let i = 0; i < config.clusterSizes; i++) {
     cluster.fork();
 }
 
-cluster.on('exit', (worker, code, signal) => {
+cluster.on('exit', (worker) => {
     logger.warn(`worker ${worker.process.pid} died`);
     cluster.setupMaster({
         exec: 'service.js',

--- a/index.js
+++ b/index.js
@@ -1,81 +1,24 @@
-const Koa = require('koa');
-
-const logger = require('./utils/logger');
+const cluster = require('cluster');
 const config = require('./config');
+const logger = require('./utils/logger');
 
-const onerror = require('./middleware/onerror');
-const header = require('./middleware/header.js');
-const utf8 = require('./middleware/utf8');
-const memoryCache = require('./middleware/lru-cache.js');
-const redisCache = require('./middleware/redis-cache.js');
-const filter = require('./middleware/filter.js');
-const template = require('./middleware/template.js');
-const favicon = require('koa-favicon');
-const debug = require('./middleware/debug.js');
+const memoryCacheMaster = require('./utils/memorycache');
 
-const router = require('./router');
+new memoryCacheMaster({
+    expire: config.cacheExpire * 1000
+})
 
-process.on('uncaughtException', (e) => {
-    logger.error('uncaughtException: ' + e);
-});
-
-logger.info('🍻 RSSHub start! Cheers!');
-
-const app = new Koa();
-app.proxy = true;
-
-// favicon
-app.use(favicon(__dirname + '/favicon.png'));
-
-// global error handing
-app.use(onerror);
-
-// 1 set header
-app.use(header);
-
-// 6 debug
-app.context.debug = {
-    hitCache: 0,
-    request: 0,
-    routes: [],
-    ips: [],
-};
-app.use(debug);
-
-// 5 fix incorrect `utf-8` characters
-app.use(utf8);
-
-// 4 generate body
-app.use(template);
-
-// 3 filter content
-app.use(filter);
-
-// 2 cache
-if (config.cacheType === 'memory') {
-    app.use(
-        memoryCache({
-            expire: config.cacheExpire,
-            ignoreQuery: true,
-        })
-    );
-} else if (config.cacheType === 'redis') {
-    app.use(
-        redisCache({
-            expire: config.cacheExpire,
-            ignoreQuery: true,
-            redis: config.redis,
-            onerror: (e) => {
-                logger.error('Redis error: ', e);
-            },
-            onconnect: () => {
-                logger.info('Redis connect.');
-            },
-        })
-    );
+for (let i = 0; i < config.clusterSizes; i++) {
+    cluster.setupMaster({
+        exec: 'service.js',
+    });
+    cluster.fork();
 }
 
-// router
-app.use(router.routes()).use(router.allowedMethods());
-
-app.listen(config.port, parseInt(config.listenInaddrAny) ? null : '127.0.0.1');
+cluster.on('exit', (worker, code, signal) => {
+    logger.warn(`worker ${worker.process.pid} died`);
+    cluster.setupMaster({
+        exec: 'service.js',
+    });
+    cluster.fork();
+});

--- a/middleware/lru-cache.js
+++ b/middleware/lru-cache.js
@@ -3,7 +3,6 @@
 const pathToRegExp = require('path-to-regexp');
 const readall = require('readall');
 const crypto = require('crypto');
-const lru = require('lru-cache');
 const memoryCacheWorker = require('../utils/memorycache');
 const logger = require('../utils/logger');
 
@@ -55,7 +54,7 @@ module.exports = function(options = {}) {
         try {
             ok = await getCache(ctx, key, tkey);
         } catch (e) {
-            logger.error('Get cache error:' + (e instanceof Error ? e.stack : e))
+            logger.error('Get cache error:' + (e instanceof Error ? e.stack : e));
             ok = false;
         }
 
@@ -68,7 +67,7 @@ module.exports = function(options = {}) {
         try {
             const trueExpire = routeExpire || expire;
             await setCache(ctx, key, tkey, trueExpire);
-        } catch (e) { 
+        } catch (e) {
             logger.error('Set cache error:' + (e instanceof Error ? e.stack : e));
         }
         routeExpire = false;
@@ -84,7 +83,7 @@ module.exports = function(options = {}) {
 
         if (value) {
             ctx.response.status = 200;
-            type = await memoryCacheWorker.get(tkey) || 'text/html';
+            type = (await memoryCacheWorker.get(tkey)) || 'text/html';
             // can happen if user specified return_buffers: true in redis options
             if (Buffer.isBuffer(type)) {
                 type = type.toString();

--- a/middleware/lru-cache.js
+++ b/middleware/lru-cache.js
@@ -106,7 +106,6 @@ module.exports = function(options = {}) {
      * setCache
      */
     async function setCache(ctx, key, tkey) {
-        ctx.state.data.lastBuildDate = new Date().toUTCString();
         const body = JSON.stringify(ctx.state.data);
 
         if (ctx.request.method !== 'GET' || !body) {
@@ -115,6 +114,7 @@ module.exports = function(options = {}) {
         if (Buffer.byteLength(body) > maxLength) {
             return;
         }
+        ctx.state.data.lastBuildDate = new Date().toUTCString();
         memoryCacheWorker.set(key, body);
 
         await cacheType(ctx, tkey);

--- a/middleware/lru-cache.js
+++ b/middleware/lru-cache.js
@@ -4,6 +4,8 @@ const pathToRegExp = require('path-to-regexp');
 const readall = require('readall');
 const crypto = require('crypto');
 const lru = require('lru-cache');
+const memoryCacheWorker = require('../utils/memorycache');
+const logger = require('../utils/logger');
 
 module.exports = function(options = {}) {
     const {
@@ -15,11 +17,6 @@ module.exports = function(options = {}) {
         maxLength = Infinity,
         ignoreQuery = false,
     } = options;
-
-    const memoryCache = lru({
-        maxAge: expire * 1000,
-        max: maxLength,
-    });
 
     return async function cache(ctx, next) {
         const { url, path } = ctx.request;
@@ -58,8 +55,10 @@ module.exports = function(options = {}) {
         try {
             ok = await getCache(ctx, key, tkey);
         } catch (e) {
+            logger.error('Get cache error:' + (e instanceof Error ? e.stack : e))
             ok = false;
         }
+
         if (ok) {
             return;
         }
@@ -69,7 +68,9 @@ module.exports = function(options = {}) {
         try {
             const trueExpire = routeExpire || expire;
             await setCache(ctx, key, tkey, trueExpire);
-        } catch (e) {} // eslint-disable-line no-empty
+        } catch (e) { 
+            logger.error('Set cache error:' + (e instanceof Error ? e.stack : e));
+        }
         routeExpire = false;
     };
 
@@ -77,13 +78,13 @@ module.exports = function(options = {}) {
      * getCache
      */
     async function getCache(ctx, key, tkey) {
-        const value = memoryCache.get(key);
+        const value = await memoryCacheWorker.get(key);
         let type;
         let ok = false;
 
         if (value) {
             ctx.response.status = 200;
-            type = memoryCache.get(tkey) || 'text/html';
+            type = await memoryCacheWorker.get(tkey) || 'text/html';
             // can happen if user specified return_buffers: true in redis options
             if (Buffer.isBuffer(type)) {
                 type = type.toString();
@@ -114,7 +115,7 @@ module.exports = function(options = {}) {
         if (Buffer.byteLength(body) > maxLength) {
             return;
         }
-        memoryCache.set(key, body);
+        memoryCacheWorker.set(key, body);
 
         await cacheType(ctx, tkey);
     }
@@ -125,7 +126,7 @@ module.exports = function(options = {}) {
     async function cacheType(ctx, tkey) {
         const type = ctx.response.type;
         if (type) {
-            memoryCache.set(tkey, type);
+            memoryCacheWorker.set(tkey, type);
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node index.js",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
-    "format": "prettier \"**/*.{js,json,md}\" --write"
+    "format": "prettier \"**/*.{js,json,md}\" --write",
+    "lint": "eslint \"**/*.js\""
   },
   "gitHooks": {
     "pre-commit": "lint-staged"

--- a/routes/cctv/category.js
+++ b/routes/cctv/category.js
@@ -3,20 +3,19 @@ const config = require('../../config');
 
 module.exports = async (ctx) => {
     const category = ctx.params.category;
-    const url = `http://news.cctv.com/${category}/data/index.json`
+    const url = `http://news.cctv.com/${category}/data/index.json`;
 
     const response = await axios({
         method: 'get',
         url: url,
         headers: {
             'User-Agent': config.ua,
-            'Referer': url,
-        }
+            Referer: url,
+        },
     });
 
     const data = response.data;
     const list = data.rollData;
-    const article_item = [];
 
     ctx.state.data = {
         title: `央视新闻 ${category}`,
@@ -26,7 +25,7 @@ module.exports = async (ctx) => {
             title: item.title,
             description: item.description,
             link: item.url,
-            pubDate: new Date(item.dateTime).toUTCString()
+            pubDate: new Date(item.dateTime).toUTCString(),
         })),
     };
 };

--- a/service.js
+++ b/service.js
@@ -1,0 +1,81 @@
+const Koa = require('koa');
+
+const logger = require('./utils/logger');
+const config = require('./config');
+
+const onerror = require('./middleware/onerror');
+const header = require('./middleware/header.js');
+const utf8 = require('./middleware/utf8');
+const memoryCache = require('./middleware/lru-cache.js');
+const redisCache = require('./middleware/redis-cache.js');
+const filter = require('./middleware/filter.js');
+const template = require('./middleware/template.js');
+const favicon = require('koa-favicon');
+const debug = require('./middleware/debug.js');
+
+const router = require('./router');
+
+process.on('uncaughtException', (e) => {
+    logger.error('uncaughtException: ' + e);
+});
+
+logger.info('🍻 RSSHub start! Cheers!');
+
+const app = new Koa();
+app.proxy = true;
+
+// favicon
+app.use(favicon(__dirname + '/favicon.png'));
+
+// global error handing
+app.use(onerror);
+
+// 1 set header
+app.use(header);
+
+// 6 debug
+app.context.debug = {
+    hitCache: 0,
+    request: 0,
+    routes: [],
+    ips: [],
+};
+app.use(debug);
+
+// 5 fix incorrect `utf-8` characters
+app.use(utf8);
+
+// 4 generate body
+app.use(template);
+
+// 3 filter content
+app.use(filter);
+
+// 2 cache
+if (config.cacheType === 'memory') {
+    app.use(
+        memoryCache({
+            expire: config.cacheExpire,
+            ignoreQuery: true,
+        })
+    );
+} else if (config.cacheType === 'redis') {
+    app.use(
+        redisCache({
+            expire: config.cacheExpire,
+            ignoreQuery: true,
+            redis: config.redis,
+            onerror: (e) => {
+                logger.error('Redis error: ', e);
+            },
+            onconnect: () => {
+                logger.info('Redis connect.');
+            },
+        })
+    );
+}
+
+// router
+app.use(router.routes()).use(router.allowedMethods());
+
+app.listen(config.port, parseInt(config.listenInaddrAny) ? null : '127.0.0.1');

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -22,12 +22,14 @@ const logger = winston.createLogger({
 // `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
 //
 
-logger.add(new winston.transports.Console({
-    format: winston.format.combine(
-        winston.format.label({ label: (cluster.isWorker ? `#worker${cluster.worker.id}` : '#master') }),
-        winston.format.colorize(),
-        winston.format.printf(info => `${info.label} ${info.level}: ${info.message}`)
-    )
-}));
+logger.add(
+    new winston.transports.Console({
+        format: winston.format.combine(
+            winston.format.label({ label: cluster.isWorker ? `#worker${cluster.worker.id}` : '#master' }),
+            winston.format.colorize(),
+            winston.format.printf((info) => `${info.label} ${info.level}: ${info.message}`)
+        ),
+    })
+);
 
 module.exports = logger;

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,4 +1,5 @@
 const winston = require('winston');
+const cluster = require('cluster');
 
 const logger = winston.createLogger({
     level: 'info',
@@ -20,10 +21,13 @@ const logger = winston.createLogger({
 // If we're not in production then log to the `console` with the format:
 // `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
 //
-logger.add(
-    new winston.transports.Console({
-        format: winston.format.simple(),
-    })
-);
+
+logger.add(new winston.transports.Console({
+    format: winston.format.combine(
+        winston.format.label({ label: (cluster.isWorker ? `#worker${cluster.worker.id}` : '#master') }),
+        winston.format.colorize(),
+        winston.format.printf(info => `${info.label} ${info.level}: ${info.message}`)
+    )
+}));
 
 module.exports = logger;

--- a/utils/memorycache.js
+++ b/utils/memorycache.js
@@ -1,0 +1,142 @@
+const cluster = require('cluster');
+
+const cmd = {
+    GET: 'rsshub/cache/memory/GET',
+    SET: 'rsshub/cache/memory/SET'
+};
+
+if (cluster.isMaster) {
+    const lru = require('lru-cache');
+
+    // 内存缓存服务端
+    class memoryCacheMaster {
+
+        /**
+         * @param {lru.Options<any, any>} option 
+         */
+        constructor(option) {
+            this.memoryCache = lru({
+                maxAge: 30 * 60 * 1000, // 30 min
+                max: Infinity,
+                ...option
+            });
+
+            cluster.on('message', this.handleMessage.bind(this));
+        }
+
+        handleMessage(worker, message = {}, handle) {
+            try {
+                switch (message.method) {
+                    case cmd.GET:
+                        const date = this.memoryCache.get(message.key);
+                        worker.send({
+                            method: cmd.GET,
+                            key: message.key,
+                            payload: date,
+                            success: true,
+                            identifier: message.identifier
+                        });
+                        break;
+                    case cmd.SET:
+                        const res = this.memoryCache.set(message.key, message.payload);
+                        worker.send({
+                            method: cmd.SET,
+                            key: message.key,
+                            success: res,
+                            identifier: message.identifier
+                        });
+                        break;
+                    default:
+                        worker.send({
+                            method: message.method,
+                            key: message.key,
+                            success: false,
+                            identifier: message.identifier
+                        });
+                        break;
+                }
+            } catch (err) {
+                worker.send({
+                    method: message.method,
+                    key: message.key,
+                    success: false,
+                    identifier: message.identifier
+                });
+            }
+        }
+    }
+
+    memoryCacheMaster.prototype.cmd = cmd;
+
+    module.exports = memoryCacheMaster;
+} else {
+    const TIMEOUT = 500;
+    const randomString = require('./randomString');
+    // 内存缓存客户端
+    module.exports = {
+        get: (key) => (new Promise((resolve, reject) => {
+
+            // 生成请求标识符
+            const identifier = randomString(10);
+
+            // 超时
+            const timeout = setTimeout(() => {
+                reject(new Error('Fetch cache timeout.'));
+                process.removeListener(handleMessage);
+            }, 500);
+
+            const handleMessage = (message) => {
+                if (message.identifier === identifier) {
+                    // 命中
+                    if (message.success !== false) {
+                        resolve(message.payload);
+                    } else {
+                        reject(new Error('Fetch cache failed.'));
+                    }
+                    process.removeListener('message', handleMessage);
+                    clearTimeout(timeout);
+                }
+            }
+            process.addListener('message', handleMessage);
+
+            process.send({
+                method: cmd.GET,
+                key,
+                identifier
+            });
+        })),
+        set: (key, value) => (new Promise((resolve, reject) => {
+
+            // 生成请求标识符
+            const identifier = randomString(10);
+            process.send({
+                method: cmd.SET,
+                key,
+                payload: value,
+                identifier
+            });
+
+            // 超时
+            const timeout = setTimeout(() => {
+                reject(new Error('Set cache timeout.'));
+                process.removeListener('message', handleMessage);
+            }, 500);
+
+            const handleMessage = (message = {}) => {
+                if (message.identifier === identifier) {
+                    // 命中
+                    if (message.success !== false) {
+                        resolve(true);
+                    } else {
+                        reject(new Error('Set cache failed.'));
+                    }
+                    process.removeListener('message', handleMessage);
+                    clearTimeout(timeout);
+                }
+            }
+
+            process.addListener('message', handleMessage);
+        })),
+        cmd
+    }
+}

--- a/utils/randomString.js
+++ b/utils/randomString.js
@@ -1,0 +1,10 @@
+module.exports = function randomString(
+    length = 16,
+    charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789') {
+    const result = [];
+
+    while (length--) {
+        result.push(charSet[Math.floor(Math.random() * charSet.length)]);
+    }
+    return result.join('');
+}

--- a/utils/randomString.js
+++ b/utils/randomString.js
@@ -1,10 +1,8 @@
-module.exports = function randomString(
-    length = 16,
-    charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789') {
+module.exports = function randomString(length = 16, charSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789') {
     const result = [];
 
     while (length--) {
         result.push(charSet[Math.floor(Math.random() * charSet.length)]);
     }
     return result.join('');
-}
+};


### PR DESCRIPTION
- 多线程支持，有几个 cpu 核心就开几个进程。
- 跨线程的内存缓存，多个进程可以共用一个内存缓存。
- 为未来的热更新做准备
- 删除 dockerfile 中的 pm，已经不在需要 pm 了。
- 新的 log 格式，#{线程ID}

性能测试:
```
setInterval(() => {
	fetch('http://localhost:1200/bilibili/user/video/' + Math.floor(Math.random() * 1000000))
}, 100)
```
![image](https://user-images.githubusercontent.com/13579374/40126543-2610d9e2-5960-11e8-9fd7-b00fd37e2bc7.png)


已知问题：
- pixiv 等 api 会出现多重登录问题