### PR TITLE
fix: strip unexpected white space in rss.art

### DIFF
--- a/views/rss.art
+++ b/views/rss.art
@@ -1,22 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
     <channel>
-        <title>
-            <![CDATA[{{@ title || 'RSSHub' }}]]>
-        </title>
+        <title><![CDATA[{{@ title || 'RSSHub' }}]]></title>
         <link>{{ link || 'https://github.com/DIYgod/RSSHub' }}</link>
-        <description>
-            <![CDATA[{{@ description || title }} - 使用 RSSHub(https://github.com/DIYgod/RSSHub) 构建]]>
-        </description>
+        <description><![CDATA[{{@ description || title }} - 使用 RSSHub(https://github.com/DIYgod/RSSHub) 构建]]></description>
         <generator>RSSHub</generator>
         <webMaster>i@html.love</webMaster>
         <language>zh-cn</language>
         {{ if image }}
         <image>
             <url>{{ image }}</url>
-            <title>
-                <![CDATA[{{@ title || 'RSSHub' }}]]>
-            </title>
+            <title><![CDATA[{{@ title || 'RSSHub' }}]]></title>
             <link>{{ link }}</link>
         </image>
         {{ /if }}
@@ -24,12 +18,8 @@
         <ttl>{{ ttl }}</ttl>
         {{ each item }}
         <item>
-            <title>
-                <![CDATA[{{@ $value.title }}]]>
-            </title>
-            <description>
-                <![CDATA[{{@ $value.description || $value.title }}]]>
-            </description>
+            <title><![CDATA[{{@ $value.title }}]]></title>
+            <description><![CDATA[{{@ $value.description || $value.title }}]]></description>
             {{ if $value.pubDate }}
             <pubDate>{{ $value.pubDate }}</pubDate>{{ /if }}
             <guid>{{ $value.guid || $value.link }}</guid>


### PR DESCRIPTION
如图所示, 部分阅读器会显示额外的空白.
![image](https://user-images.githubusercontent.com/7829098/40621067-e7669ec6-62cd-11e8-9d64-48a8ce6116d8.png)
