### PR TITLE
fix:zhihu return HTTP401 "ZERR_NO_AUTH_TOKEN"

### DIFF
--- a/routes/zhihu/activities.js
+++ b/routes/zhihu/activities.js
@@ -10,6 +10,7 @@ module.exports = async (ctx) => {
         headers: {
             ...utils.header,
             Referer: `https://www.zhihu.com/people/${id}/activities`,
+            Authorization: 'oauth c3cef7c66a1843f8b3a9e6a1e3160e20', //hard-coded in js
         },
     });
 

--- a/routes/zhihu/answers.js
+++ b/routes/zhihu/answers.js
@@ -10,6 +10,7 @@ module.exports = async (ctx) => {
         headers: {
             ...utils.header,
             Referer: `https://www.zhihu.com/people/${id}/answers`,
+            Authorization: 'oauth c3cef7c66a1843f8b3a9e6a1e3160e20', //hard-coded in js
         },
     });
 


### PR DESCRIPTION
修复抓取知乎用户动态、知乎用户回答过程中，出现的401错误。

如：抓取 `/zhihu/people/answers/diygod` 出现 `RSSHub 发生了一些意外: Error: Request failed with status code 401`