### PR TITLE
t66y: 删除连接中的 viidii 跳转

### DIFF
--- a/routes/t66y/index.js
+++ b/routes/t66y/index.js
@@ -14,6 +14,20 @@ const axios_ins = axios.create({
     responseType: 'arraybuffer',
 });
 
+function killViidii(orginUrl) {
+    var decodeStr = /.*\?http/g;
+    var decodeSig = /______/g;
+    var jsSuffix = '&amp;z';
+    var htmlSuffix = '&z';
+    var returnSuffix = 'return false';
+    if (orginUrl.indexOf('viidii') != -1) {
+      var pureUrl = orginUrl.replace(decodeStr, 'http').replace(decodeSig, '.').replace(jsSuffix, '').replace(htmlSuffix, '').replace(returnSuffix, '');
+      return pureUrl
+    } else {
+      return orginUrl;
+    }
+}
+
 const sourceTimezoneOffset = -8;
 const filterReg = /read\.php/;
 module.exports = async (ctx) => {
@@ -121,6 +135,13 @@ module.exports = async (ctx) => {
         for (let k = 0; k < images.length; k++) {
             $(images[k]).replaceWith(`<img src="${$(images[k]).attr('data-src')}">`);
         }
+
+        // Handle links
+        const links = $('a[href*=\'viidii\']');
+        for (let k = 0; k < links.length; k++) {
+            $(links[k]).attr('href', killViidii($(links[k]).attr('href')));
+        }
+
         out[indexList[i]].description = $.html();
         out[indexList[i]].pubDate = time.toUTCString();
         ctx.cache.set(out[indexList[i]].link, JSON.stringify(out[indexList[i]]), 3 * 60 * 60);


### PR DESCRIPTION
把形如 `http://www.viidii.info/?http://88files______net/download______html&z` 的 anchor href 转换成 `http://88files.net/download.html` 这样无需跳转的形式。
--
Automated submit by PRB0t