### PR TITLE
Zhihu hot list support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1646,6 +1646,12 @@ GitHub 官方也提供了一些 RSS:
 
 路由: `/zhihu/daily`
 
+### 知乎热榜 <Author uid="Andiedie"/>
+
+举例: [https://rsshub.app/zhihu/hotlist](https://rsshub.app/zhihu/hotlist)
+
+路由: `/zhihu/hotlist`
+
 ## 自如
 
 ### 房源 <Author uid="DIYgod"/>

--- a/router.js
+++ b/router.js
@@ -156,6 +156,7 @@ router.get('/zhihu/people/activities/:id', require('./routes/zhihu/activities'))
 router.get('/zhihu/people/answers/:id', require('./routes/zhihu/answers'));
 router.get('/zhihu/zhuanlan/:id', require('./routes/zhihu/zhuanlan'));
 router.get('/zhihu/daily', require('./routes/zhihu/daily'));
+router.get('/zhihu/hotlist', require('./routes/zhihu/hotlist'));
 
 // 妹子图
 router.get('/mzitu', require('./routes/mzitu/category'));

--- a/routes/zhihu/hotlist.js
+++ b/routes/zhihu/hotlist.js
@@ -1,0 +1,42 @@
+const axios = require('../../utils/axios');
+
+module.exports = async (ctx) => {
+    console.log('run');
+    const {
+        data: { data },
+    } = await axios({
+        method: 'get',
+        url: 'https://www.zhihu.com/api/v3/explore/guest/feeds?limit=40',
+    });
+
+    ctx.state.data = {
+        title: '知乎热榜',
+        link: 'https://www.zhihu.com/billboard',
+        description: '知乎热榜',
+        item: data.map((item) => {
+            switch (item.target.type) {
+                case 'answer':
+                    return {
+                        title: item.target.question.title,
+                        description: `${item.target.author.name}的回答<br/><br/>${item.target.content}`,
+                        pubDate: new Date(item.created_time).toUTCString(),
+                        link: `https://www.zhihu.com/question/${item.target.question.id}`,
+                    };
+                case 'article':
+                    return {
+                        title: item.target.title,
+                        description: `${item.target.author.name}的文章<br/><br/>${item.target.content}`,
+                        pubDate: new Date(item.created_time).toUTCString(),
+                        link: `https://zhuanlan.zhihu.com/p/${item.target.id}`,
+                    };
+                default:
+                    return {
+                        title: '未知类型',
+                        description: '请点击链接提交issue',
+                        pubDate: new Date(item.created_time).toUTCString(),
+                        link: 'https://github.com/DIYgod/RSSHub/issues',
+                    };
+            }
+        }),
+    };
+};


### PR DESCRIPTION
Mentioned at https://github.com/DIYgod/RSSHub/issues/17#issuecomment-417828181

最后实际采用了上述issue中提到的第一个API
即 https://www.zhihu.com/api/v3/explore/guest/feeds?limit=15

虽然从路径上看，后两个更加语义化，但是只有第一个提供了全文