### PR TITLE
添加 API: 返回可用公共路由列表

### DIFF
--- a/api_router.js
+++ b/api_router.js
@@ -1,0 +1,34 @@
+const Router = require('koa-router');
+const router = new Router();
+const routes = require('./router');
+
+router.get('/routes/:name?', (ctx) => {
+    const allRoutes = Array.from(routes.stack);
+    allRoutes.shift();
+    const result = {};
+
+    allRoutes.forEach((i) => {
+        const path = i.path;
+        const top = path.split('/')[1];
+
+        if (ctx.params.name === undefined) {
+            if (result[top]) {
+                result[top].routes.push(path);
+            } else {
+                result[top] = { routes: [path] };
+            }
+        } else {
+            if (top === ctx.params.name) {
+                if (result[top]) {
+                    result[top].routes.push(path);
+                } else {
+                    result[top] = { routes: [path] };
+                }
+            }
+        }
+    });
+
+    ctx.body = result;
+});
+
+module.exports = router;

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,57 @@ RSSHub 同时支持 RSS 2.0、Atom 和 [JSON Feed](https://jsonfeed.org/) 输出
 -   JSON Feed - <https://rsshub.app/jianshu/home.json>
 -   和 filter 或其他 URL query 一起使用 <https://rsshub.app/bilibili/user/coin/2267573.atom?filter=微小微|赤九玖|暴走大事件>
 
+## API 接口
+
+RSSHub 提供下列 API 接口:
+
+### 可用公共路由列表
+
+::: tip 提示
+`protected_router.js`下的路由**不会被**包含在此 API 返回的结果当中.
+:::
+
+举例: <https://rsshub.app/api/routes/bilibili>
+
+路由: `/api/routes/:name?`
+
+参数:
+
+-   name, 路由一级名称, 对应 [https://github.com/DIYgod/RSSHub/tree/master/routes](https://github.com/DIYgod/RSSHub/tree/master/routes) 中的文件夹名称. 可选, **缺省则返回所有可用路由**.
+
+返回的 JSON 结果格式如下:
+
+```js
+{
+   "bilibili":{
+      "routes":[
+         "/bilibili/user/video/:uid",
+         "/bilibili/user/article/:uid",
+         "/bilibili/user/fav/:uid",
+         "/bilibili/user/coin/:uid",
+         "/bilibili/user/dynamic/:uid",
+         "/bilibili/user/followers/:uid",
+         "/bilibili/user/followings/:uid",
+         "/bilibili/partion/:tid",
+         "/bilibili/partion/ranking/:tid/:days?",
+         "/bilibili/bangumi/:seasonid",
+         "/bilibili/video/reply/:aid",
+         "/bilibili/link/news/:product",
+         "/bilibili/live/room/:roomID",
+         "/bilibili/live/search/:key/:order",
+         "/bilibili/live/area/:areaID/:order",
+         "/bilibili/fav/:uid/:fid",
+         "/bilibili/blackboard",
+         "/bilibili/mall/new",
+         "/bilibili/mall/ip/:id",
+         "/bilibili/ranking/:rid?/:day?",
+         "/bilibili/channel/:uid/:cid",
+         "/bilibili/topic/:topic"
+      ]
+   }
+}
+```
+
 ## 社交媒体
 
 ### bilibili

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -89,6 +89,39 @@ For exmaple:
 -   JSON Feed - [https://rsshub.app/dribbble/popular.json](https://rsshub.app/dribbble/popular.json)
 -   Apply filters or URL query [https://rsshub.app/dribbble/popular.atom?filterout=Blue|Yellow|Black](https://rsshub.app/dribbble/popular.atom?filterout=Blue|Yellow|Black)
 
+## API
+
+RSSHub provides the following APIs:
+
+### List of Public Routes
+
+::: tip Tip
+This API **will not** return any routes under `protected_router.js`.
+:::
+
+Eg: <https://rsshub.app/api/routes/github>
+
+Route: `/api/routes/:name?`
+
+Parameters:
+
+-   name, route's top level name as in [https://github.com/DIYgod/RSSHub/tree/master/routes](https://github.com/DIYgod/RSSHub/tree/master/routes). Optional, **returns all public routes if not specified**.
+
+The above example returns the following result in JSON:
+
+```js
+{
+   "github":{
+      "routes":[
+         "/github/trending/:since/:language?",
+         "/github/issue/:user/:repo",
+         "/github/user/followers/:user",
+         "/github/stars/:user/:repo"
+      ]
+   }
+}
+```
+
 ## Application Updates
 
 ### RSSHub
@@ -137,9 +170,9 @@ Route: `/appstore/update/:country/:id`
 
 Parameters：
 
-country, App Store Country, obtain from the app URL `https://itunes.apple.com/us/app/reeder-3/id697846300?mt=8`, in this case, `us`.
+-   country, App Store Country, obtain from the app URL `https://itunes.apple.com/us/app/reeder-3/id697846300?mt=8`, in this case, `us`.
 
-id, App Store app id, obtain from the app URL `https://itunes.apple.com/us/app/reeder-3/id697846300?mt=8`, in this case, `id697846300`.
+-   id, App Store app id, obtain from the app URL `https://itunes.apple.com/us/app/reeder-3/id697846300?mt=8`, in this case, `id697846300`.
 
 ### App Store/Mac App Store Price Drop Alert <Author uid="HenryQW"/>
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const auth = require('./middleware/auth');
 
 const router = require('./router');
 const protected_router = require('./protected_router');
+const api_router = require('./api_router');
 const mount = require('koa-mount');
 
 process.on('uncaughtException', (e) => {
@@ -97,6 +98,9 @@ app.use(mount('/', router.routes())).use(router.allowedMethods());
 
 // routes the require authentication
 app.use(mount('/protected', protected_router.routes())).use(protected_router.allowedMethods());
+
+// API router
+app.use(mount('/api', api_router.routes())).use(api_router.allowedMethods());
 
 // connect
 if (config.connect.port) {


### PR DESCRIPTION
方便其他项目如 https://github.com/idealclover/Easy-to-RSS