### PR TITLE
添加即刻新版路由 /jike/dev/:id

### DIFF
--- a/router.js
+++ b/router.js
@@ -239,6 +239,7 @@ router.get('/jike/topic/text/:id', require('./routes/jike/topicText'));
 router.get('/jike/topic/square/:id', require('./routes/jike/topicSquare'));
 router.get('/jike/user/:id', require('./routes/jike/user'));
 router.get('/jike/daily', require('./routes/jike/daily'));
+router.get('/jike/dev/:id', require('./routes/jike/topicDev'));
 
 // 极客时间
 router.get('/geektime/column/:cid', require('./routes/geektime/column'));

--- a/routes/jike/topicDev.js
+++ b/routes/jike/topicDev.js
@@ -1,0 +1,60 @@
+const axios = require('../../utils/axios');
+
+module.exports = async (ctx) => {
+    const id = ctx.params.id;
+
+    const response = await axios({
+        method: 'post',
+        url: 'https://app.jike.ruguoapp.com/1.0/messages/history',
+        headers: {
+            Referer: `https://m.okjike.com/topics/${id}`,
+            'App-Version': '4.1.0',
+        },
+        data: {
+            loadMoreKey: null,
+            topic: id,
+            limit: 10,
+        },
+    });
+
+    const data = response.data.data;
+    const topic = data[0].topic;
+    let link = `https://web.okjike.com/topic/${id}/official`;
+
+    ctx.state.data = {
+        title: `${topic.content} - 即刻主题精选`,
+        link,
+        description: topic.content,
+        image: topic.squarePicture.picUrl || topic.squarePicture.middlePicUrl || topic.squarePicture.thumbnailUrl,
+        item: data.map((item) => {
+            let content = '';
+
+            // 处理正文内容
+            content += item.content || item.content.trim() !== '' ? `<div>${item.content}</div><br/> ` : '';
+
+            // 处理缩略图， WEBP + JPEG
+            if (item.pictures) {
+                item.pictures.forEach(
+                    (pic) =>
+                        (content += `<picture><source srcset="${pic.picUrl.split('/thumbnail/')[0]}/strip/format/webp" type="image/webp"><source srcset="${pic.picUrl.split('?imageMogr2/')[0]}" type="image/jpeg"><img src="${
+                            pic.picUrl.split('?imageMogr2/')[0]
+                        }"></picture>`)
+                );
+            }
+
+            // 处理外链，originalLinkUrl 优先级高于 linkUrl
+            if (item.linkInfo && (item.linkInfo.originalLinkUrl || item.linkInfo.linkUrl)) {
+                link = item.linkInfo.originalLinkUrl || item.linkInfo.linkUrl;
+                content += `<br/> <a href="${link}">查看外链</a>`;
+            }
+
+            return {
+                // 处理标题，无标题则使用「主题名称」有新消息
+                title: item.content.trim() === '' ? `「${topic.content}」有新消息` : item.content,
+                description: `${content}`,
+                pubDate: new Date(item.createdAt).toUTCString(),
+                link,
+            };
+        }),
+    };
+};


### PR DESCRIPTION
测试中，完善后替代 `/jike/:id`

采用WebP #555

包含了 #692

目标关闭 #621
