### PR TITLE
文档改为 Route.vue 组件

### DIFF
--- a/docs/.vuepress/components/Route.vue
+++ b/docs/.vuepress/components/Route.vue
@@ -1,0 +1,66 @@
+<template>
+<div class="routeBlock" :id="path">
+  <h4 :id=path class="name">{{name}} <Author :uid=author /> 
+    <a :href="'#'+path" aria-hidden="true" class="header-anchor">#</a>
+  </h4>
+  <p class="example">
+    举例: <a :href="'https://rsshub.app'+ example " target="_blank">https://rsshub.app{{example}}</a>
+  </p>
+  <p class="path">
+    路由: <code>{{ path }}</code>
+  </p>
+  <div v-if="path.match(/(?<=:).*?(?=\/|$)/g)">
+  <p>
+    参数:
+  <ul><li class="params" v-for="(item, index) in path.match(/(?<=:).*?(?=\/|$)/g)">{{item.replace('?','')}}, {{(item.includes('?'))?'可选':'必选'}} - <span v-html="renderMarkdown(paramsDesc[index])"></span></li></ul> </p>
+  </div>
+  <div v-else><p>参数: 无</p></div>
+  <slot></slot>
+</div>
+</template>
+<script>
+import Author from "./Author.vue"
+export default {
+  components:{
+      'Author': Author
+  },
+  props: {
+    author: {
+      type: String,
+      default: 'DIYgod'
+    },
+    name: {
+      type: String,
+      required: true 
+    },
+    path: {
+      type: String,
+      required: true 
+    },
+    example: {
+      type: String,
+      required: true 
+    },
+    paramsDesc: {
+      type: [Array, String],
+      default: '无'
+    }
+  },
+  methods: {
+    renderMarkdown(item) {
+    const md = require('markdown-it')({
+            html: true,
+    });
+        return md.render(item);
+    },
+  }
+}
+</script>
+<style>
+li.params p { 
+  display: inline;
+  }
+.routeBlock {
+  margin: 1rem 0 2rem;
+}
+</style>

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ filter 选出想要的内容
 
 -   filter_description: 过滤描述
 
-bilibili/user/coin/2267573?filter=微小微|赤九玖|暴走大事件>
+举例: <https://rsshub.app/bilibili/user/coin/2267573?filter=微小微|赤九玖|暴走大事件>
 
 filterout 去掉不要的内容
 
@@ -71,7 +71,7 @@ filterout 去掉不要的内容
 
 -   filterout_description: 过滤描述
 
-bilibili/user/coin/2267573?filterout=微小微|赤九玖|暴走大事件>
+举例: <https://rsshub.app/bilibili/user/coin/2267573?filterout=微小微|赤九玖|暴走大事件>
 
 #### 条数限制
 
@@ -105,9 +105,9 @@ RSSHub 提供下列 API 接口:
 `protected_router.js`下的路由**不会被**包含在此 API 返回的结果当中.
 :::
 
-api/routes/bilibili>
+举例: <https://rsshub.app/api/routes/bilibili>
 
-api/routes/:name?`
+路由: `/api/routes/:name?`
 
 参数:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ filter 选出想要的内容
 
 -   filter_description: 过滤描述
 
-举例: <https://rsshub.app/bilibili/user/coin/2267573?filter=微小微|赤九玖|暴走大事件>
+bilibili/user/coin/2267573?filter=微小微|赤九玖|暴走大事件>
 
 filterout 去掉不要的内容
 
@@ -71,7 +71,7 @@ filterout 去掉不要的内容
 
 -   filterout_description: 过滤描述
 
-举例: <https://rsshub.app/bilibili/user/coin/2267573?filterout=微小微|赤九玖|暴走大事件>
+bilibili/user/coin/2267573?filterout=微小微|赤九玖|暴走大事件>
 
 #### 条数限制
 
@@ -105,9 +105,9 @@ RSSHub 提供下列 API 接口:
 `protected_router.js`下的路由**不会被**包含在此 API 返回的结果当中.
 :::
 
-举例: <https://rsshub.app/api/routes/bilibili>
+api/routes/bilibili>
 
-路由: `/api/routes/:name?`
+api/routes/:name?`
 
 参数:
 
@@ -156,119 +156,27 @@ RSSHub 提供下列 API 接口:
 
 ### bilibili
 
-#### 番剧 <Author uid="DIYgod"/>
+<route name="番剧" author="DIYgod" example="/bilibili/bangumi/21680" path="/bilibili/:seasonid" :paramsDesc="['番剧 id, 番剧主页打开控制台执行 `window.__INITIAL_STATE__.ssId` 或 `window.__INITIAL_STATE__.mediaInfo.param.season_id` 获取']"/>
 
-举例: <https://rsshub.app/bilibili/bangumi/21680>
+<route name="UP 主投稿" author="DIYgod" example="/bilibili/user/video/2267573" path="/bilibili/user/video/:uid" :paramsDesc="['用户 id, 可在 UP 主主页中找到']"/>
 
-路由: `/bilibili/bangumi/:seasonid`
+<route name="UP 主专栏" author="lengthmin" example="/bilibili/user/article/334958638" path="/bilibili/user/article/:uid" :paramsDesc="['用户 id, 可在 UP 主主页中找到']"/>
 
-参数:
+<route name="UP 主动态" author="DIYgod" example="/bilibili/user/dynamic/2267573" path="/bilibili/user/dynamic/:uid" :paramsDesc="['用户 id, 可在 UP 主主页中找到']"/>
 
--   seasonid, 番剧 id, 番剧主页打开控制台执行 `window.__INITIAL_STATE__.ssId` 或 `window.__INITIAL_STATE__.mediaInfo.param.season_id` 获取
+<route name="UP 主频道" author="HenryQW" example="/bilibili/channel/142821407/23390" path="/bilibili/channel/:uid/:cid" :paramsDesc="['用户 id, 可在 UP 主主页中找到', '频道 id, 可在频道的 URL 中找到']"/>
 
-#### UP 主投稿 <Author uid="DIYgod"/>
+<route name="UP 主默认收藏夹" author="DIYgod" example="/bilibili/user/fav/2267573" path="/bilibili/user/fav/:uid" :paramsDesc="['用户 id, 可在 UP 主主页中找到']"/>
 
-举例: <https://rsshub.app/bilibili/user/video/2267573>
+<route name="UP 主非默认收藏夹" author="Qixingchen" example="/bilibili/fav/756508/50948568" path="/bilibili/fav/:uid/:fid" :paramsDesc="['用户 id, 可在 UP 主主页中找到', '收藏夹 ID, 可在收藏夹的 URL 中找到, 默认收藏夹建议使用 UP 主默认收藏夹功能']"/>
 
-路由: `/bilibili/user/video/:uid`
+<route name="UP 主投币视频" author="DIYgod" example="/bilibili/user/coin/2267573" path="/bilibili/user/coin/:uid" :paramsDesc="['用户 id, 可在 UP 主主页中找到']"/>
 
-参数:
+<route name="UP 主粉丝" author="Qixingchen" example="/bilibili/user/followers/2267573" path="/bilibili/user/followers/:uid" :paramsDesc="['用户 id, 可在 UP 主主页中找到']"/>
 
--   uid, 用户 id, 可在 UP 主主页中找到
+<route name="UP 主关注用户" author="Qixingchen" example="/bilibili/user/followings/2267573" path="/bilibili/user/followings/:uid" :paramsDesc="['用户 id, 可在 UP 主主页中找到']"/>
 
-#### UP 主专栏 <Author uid="lengthmin"/>
-
-举例: <https://rsshub.app/bilibili/user/article/334958638>
-
-路由: `/bilibili/user/article/:uid`
-
-参数:
-
--   uid, 用户 id, 可在 UP 主主页中找到
-
-#### UP 主动态 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/bilibili/user/dynamic/2267573>
-
-路由: `/bilibili/user/dynamic/:uid`
-
-参数:
-
--   uid, 用户 id, 可在 UP 主主页中找到
-
-#### UP 主频道 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/bilibili/channel/142821407/23390>
-
-路由: `/bilibili/channel/:uid/:cid`
-
-参数:
-
--   uid, 用户 id, 可在 UP 主主页中找到
-
--   cid, 频道 ID, 可在频道的 URL 中找到
-
-#### UP 主默认收藏夹 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/bilibili/user/fav/2267573>
-
-路由: `/bilibili/user/fav/:uid`
-
-参数:
-
--   uid, 用户 id, 可在 UP 主主页中找到
-
-#### UP 主非默认收藏夹 <Author uid="Qixingchen"/>
-
-举例: <https://rsshub.app/bilibili/fav/756508/50948568>
-
-路由: `/bilibili/fav/:uid/:fid`
-
-参数:
-
--   uid, 用户 id, 可在 UP 主主页中找到
-
--   fid, 收藏夹 ID, 可在收藏夹的 URL 中找到, 默认收藏夹建议使用 UP 主默认收藏夹功能
-
-#### UP 主投币视频 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/bilibili/user/coin/2267573>
-
-路由: `/bilibili/user/coin/:uid`
-
-参数:
-
--   uid, 用户 id, 可在 UP 主主页中找到
-
-#### UP 主粉丝 <Author uid="Qixingchen"/>
-
-举例: <https://rsshub.app/bilibili/user/followers/2267573>
-
-路由: `/bilibili/user/followers/:uid`
-
-参数:
-
--   uid, 用户 id, 可在 UP 主主页中找到
-
-#### UP 主关注用户 <Author uid="Qixingchen"/>
-
-举例: <https://rsshub.app/bilibili/user/followings/2267573>
-
-路由: `/bilibili/user/followings/:uid`
-
-参数:
-
--   uid, 用户 id, 可在 UP 主主页中找到
-
-#### 分区视频 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/bilibili/partion/33>
-
-路由: `/bilibili/partion/:tid`
-
-参数:
-
--   tid, 分区 id
+<route name="分区视频" author="DIYgod" example="/bilibili/partion/33" path="/bilibili/partion/:tid" :paramsDesc="['分区 id']">
 
 动画
 
@@ -366,37 +274,13 @@ RSSHub 提供下列 API 接口:
 | ---- | ------ | ------ |
 | 11   | 185    | 187    |
 
-#### 分区视频排行榜 <Author uid="lengthmin"/>
+</route>
 
-举例: <https://rsshub.app/bilibili/partion/ranking/171/3>
+<route name="分区视频排行榜" author="lengthmin" example="/bilibili/partion/ranking/171/3" path="/bilibili/partion/ranking/:tid/:days?" :paramsDesc="['分区 id, 见上方表格', '缺省为 7, 指最近多少天内的热度排序']"/>
 
-路由: `/bilibili/partion/ranking/:tid/:days?`
+<route name="视频评论" author="Qixingchen" example="/bilibili/video/reply/21669336" path="/bilibili/video/reply/:aid" :paramsDesc="['可在视频页 URL 中找到']"/>
 
-参数:
-
--   tid, 分区 id, 见上方表格
-
--   days, 可选, 缺省为 7, 指最近多少天内的热度排序
-
-#### 视频评论 <Author uid="Qixingchen"/>
-
-举例: <https://rsshub.app/bilibili/video/reply/21669336>
-
-路由: `/bilibili/video/reply/:aid`
-
-参数:
-
--   aid, 可在视频页 URL 中找到
-
-#### link 公告 <Author uid="Qixingchen"/>
-
-举例: <https://rsshub.app/bilibili/link/news/live>
-
-路由: `/bilibili/link/news/:product`
-
-参数:
-
--   product, 公告分类 包括 直播:live 小视频:vc 相簿:wh
+<route name="link 公告" author="Qixingchen" example="/bilibili/link/news/live" path="/bilibili/link/news/:product" :paramsDesc="['公告分类, 包括 直播:live 小视频:vc 相簿:wh']"/>
 
 #### 直播开播 <Author uid="Qixingchen"/>
 
@@ -410,133 +294,49 @@ RSSHub 提供下列 API 接口:
 
 见 [#哔哩哔哩直播](#哔哩哔哩直播)
 
-#### 主站话题列表 <Author uid="Qixingchen"/>
+<route name="主站话题列表" author="Qixingchen" example="/bilibili/blackboard" path="/bilibili/blackboard" />
 
-举例: <https://rsshub.app/bilibili/blackboard>
+<route name="会员购新品上架" author="DIYgod" example="/bilibili/mall/new" path="/bilibili/mall/new" />
 
-路由: `bilibili/blackboard`
+<route name="会员购作品" author="DIYgod" example="/bilibili/mall/ip/:id" path="/bilibili/mall/ip/:id" :paramsDesc="['作品 id, 可在作品列表页 URL 中找到']"/>
 
-#### 会员购新品上架 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/bilibili/mall/new>
-
-路由: `bilibili/mall/new`
-
-#### 会员购作品 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/bilibili/mall/ip/1_4494>
-
-路由: `/bilibili/mall/ip/:id`
-
-参数:
-
--   id, 作品 id, 可在作品列表页 URL 中找到
-
-#### 排行榜 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/bilibili/ranking/0/3>
-
-路由: `/bilibili/ranking/:rid?/:day?`
-
-参数:
-
--   day: 时间跨度, 可为 1 3 7 30
-
--   rid: 排行榜分区 id, 默认 0
+<route name="排行榜" author="DIYgod" example="/bilibili/partion/rranking/0/3" path="/bilibili/partion/ranking/:tid/:days?" :paramsDesc="['排行榜分区 id, 默认 0', '时间跨度, 可为 1 3 7 30']">
 
 | 全站 | 动画 | 国创相关 | 音乐 | 舞蹈 | 游戏 | 科技 | 生活 | 鬼畜 | 时尚 | 娱乐 | 影视 |
 | ---- | ---- | -------- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
 | 0    | 1    | 168      | 3    | 129  | 4    | 36   | 160  | 119  | 155  | 5    | 181  |
 
-#### 话题(频道/标签) <Author uid="Qixingchen"/>
+</route>
 
-举例: <https://rsshub.app/bilibili/topic/2233>
-
-路由: `/bilibili/topic/:topic`
-
-参数:
-
--   topic 话题名(又称频道名或标签) 例如 2233 或 COSPLAY
+<route name="话题(频道/标签)" author="Qixingchen" example="/bilibili/topic/2233" path="/bilibili/topic/2233" :paramsDesc="['话题名(又称频道名或标签) 例如 2233 或 COSPLAY']"/>
 
 ### 微博
 
-#### 博主 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/weibo/user/3306934123>
-
-路由: `/weibo/user/:uid`
-
-参数:
-
--   uid, 用户 id, 博主主页打开控制台执行 `/uid=(\d+)/. exec(document.querySelector('.opt_box .btn_bed').getAttribute('action-data'))[1]` 获取
+<route name="博主（方案1）" author="DIYgod" example="/weibo/user/3306934123" path="/weibo/user/:uid" :paramsDesc="['用户 id, 博主主页打开控制台执行 `/uid=(\d+)/. exec(document.querySelector(\'.opt_box .btn_bed\').getAttribute(\'action-data\'))[1]` 获取']"/>
 
 ::: warning 注意
 
-上述方案获取 V+ 付费博主会有数据缺失, 所以这里提供另外一种方式, 这种方式的缺点是描述不如上面的完善, 建议优先选择第一种方案
+上述方案 1 获取 V+ 付费博主会有数据缺失, 所以这里提供方案 2 , 这种方式的缺点是描述不如上面的完善, 建议优先选择第一种方案
 
 :::
 
-举例: <https://rsshub.app/weibo/user2/3306934123>
+<route name="博主（方案2）" author="DIYgod" example="/weibo/user2/3306934123" path="/weibo/user2/:uid" :paramsDesc="['用户 id, 博主主页打开控制台执行 `/uid=(\d+)/. exec(document.querySelector(\'.opt_box .btn_bed\').getAttribute(\'action-data\'))[1]` 获取']"/>
 
-路由: `/weibo/user2/:uid`
-
-#### 关键词 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/weibo/keyword/DIYgod>
-
-路由: `/weibo/keyword/:keyword`
-
-参数:
-
--   keyword, 你想订阅的微博关键词
+<route name="关键词" author="DIYgod" example="/weibo/keyword/DIYgod" path="/weibo/keyword/:keyword" :paramsDesc="['你想订阅的微博关键词']"/>
 
 ### 贴吧
 
-#### 帖子列表 <Author uid="u3u"/>
+<route name="帖子列表" author="u3u" example="/tieba/forum/女图" path="/tieba/forum/:kw" :paramsDesc="['吧名']"/>
 
-举例: <https://rsshub.app/tieba/forum/女图>
+<route name="精品帖子" author="u3u" example="/tieba/forum/good/女图" path="/tieba/forum/good/:kw/:cid?" :paramsDesc="['吧名', '精品分类, 如果不传 `cid` 则获取全部分类']"/>
 
-路由: `/tieba/forum/:kw`
+<route name="帖子动态" author="u3u" example="/tieba/post/5853240586" path="/tieba/post/:id" :paramsDesc="['帖子 ID']"/>
 
-参数:
-
--   kw, 吧名
-
-#### 精品帖子 <Author uid="u3u"/>
-
-举例: <https://rsshub.app/tieba/forum/good/女图>
-
-路由: `/tieba/forum/good/:kw/:cid?`
-
-参数:
-
--   kw: 吧名
-
--   cid: 精品分类, 如果不传 `cid` 则获取全部分类
-
-#### 帖子动态 <Author uid="u3u"/>
-
-举例: <https://rsshub.app/tieba/post/5853240586>
-
-路由: `/tieba/post/:id`
-
-参数:
-
--   id: 帖子 ID
-
-#### 楼主动态 <Author uid="u3u"/>
-
-举例: <https://rsshub.app/tieba/post/lz/5853240586>
-
-路由: `/tieba/post/lz/:id`
-
-参数:
-
--   id: 帖子 ID
+<route name="楼主动态" author="u3u" example="/tieba/post/lz/5853240586" path="/tieba/post/lz/:id" :paramsDesc="['帖子 ID']"/>
 
 ### 即刻
 
-#### 主题-精选 <Author uid="DIYgod"/>
+<route name="主题-精选" author="DIYgod" example="/jike/topic/54dffb40e4b0f57466e675f0" path="/jike/topic/:id" :paramsDesc="['主题 id, 可在即刻 web 端主题页或 APP 分享出来的主题页 URL 中找到']"/>
 
 ::: tip 提示
 
@@ -544,51 +344,15 @@ RSSHub 提供下列 API 接口:
 
 :::
 
-举例: <https://rsshub.app/jike/topic/54dffb40e4b0f57466e675f0>
+<route name="主题-广场" author="DIYgod" example="/jike/topic/square/54dffb40e4b0f57466e675f0" path="/jike/topic/square/:id" :paramsDesc="['主题 id, 可在即刻 web 端主题页或 APP 分享出来的主题页 URL 中找到']"/>
 
-路由: `/jike/topic/:id`
+<route name="主题-纯文字" author="HenryQW" example="/jike/topic/text/553870e8e4b0cafb0a1bef68" path="/jike/topic/text/:id" :paramsDesc="['主题 id, 可在即刻 web 端主题页或 APP 分享出来的主题页 URL 中找到']"/>
 
-参数:
+<route name="用户动态" author="DIYgod" example="/jike/user/82D23B32-CF36-4C59-AD6F-D05E3552CBF3" path="/jike/user/:id" :paramsDesc="['用户 id, 可在即刻 web 端用户页 URL 中找到']"/>
 
--   id, 主题 id, 可在即刻 web 端主题页或 APP 分享出来的主题页 URL 中找到
+<route name="用户动态" author="DIYgod" example="/jike/user/82D23B32-CF36-4C59-AD6F-D05E3552CBF3" path="/jike/user/:id" :paramsDesc="['用户 id, 可在即刻 web 端用户页 URL 中找到']"/>
 
-#### 主题-广场 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/jike/topic/square/54dffb40e4b0f57466e675f0>
-
-路由: `/jike/topic/square/:id`
-
-参数:
-
--   id, 主题 id, 可在即刻 web 端主题页或 APP 分享出来的主题页 URL 中找到
-
-#### 主题-纯文字 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/jike/topic/text/553870e8e4b0cafb0a1bef68>
-
-路由: `/jike/topic/text/:id`
-
-参数:
-
--   id, 主题 id, 可在即刻 web 端主题页或 APP 分享出来的主题页 URL 中找到
-
-#### 用户动态 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/jike/user/82D23B32-CF36-4C59-AD6F-D05E3552CBF3>
-
-路由: `/jike/user/:id`
-
-参数:
-
--   id, 用户 id, 可在即刻 web 端用户页 URL 中找到
-
-#### 即刻小报 <Author uid="Andiedie"/>
-
-举例: <https://rsshub.app/jike/daily>
-
-路由: `/jike/daily`
-
-参数: 无
+<route name="即刻小报" author="Andiedie" example="/jike/daily" path="/jike/daily"/>
 
 ### 微信
 
@@ -598,71 +362,21 @@ RSSHub 提供下列 API 接口:
 
 :::
 
-#### 公众号（即刻来源） <Author uid="DIYgod"/>
+<route name="公众号（即刻来源）" author="DIYgod" example="/jike/topic/584b8ac671a288001154a115" path="/jike/topic/:id" :paramsDesc="['参考 [即刻-主题-精选](#/jike/topic/:id)']"/>
 
-举例: <https://rsshub.app/jike/topic/584b8ac671a288001154a115>
-
-路由: `/jike/topic/:id`
-
-参数:
-
--   id, 参考 [即刻-主题-精选](#主题-精选)
-
-#### 公众号（瓦斯来源） <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/wechat/wasi/5b5adaf358e5c4583338eace>
-
-路由: `/wechat/wasi/:id`
-
-参数:
-
--   id, 瓦斯公众号 id, 可在[瓦斯](https://w.qnmlgb.tech/wx)搜索公众号, 打开公众号页, 在 URL 中找到 id
+<route name="公众号（瓦斯来源）" author="DIYgod" example="/wechat/wasi/:id" path="/wechat/wasi/:id" :paramsDesc="['瓦斯公众号 id, 可在[瓦斯](https://w.qnmlgb.tech/wx)搜索公众号, 打开公众号页, 在 URL 中找到 id']"/>
 
 ### 简书
 
-#### 首页 <Author uid="DIYgod"/>
+<route name="首页" author="DIYgod" example="/jianshu/home" path="/jianshu/home"/>
 
-举例: <https://rsshub.app/jianshu/home>
+<route name="7 日热门" author="DIYgod" example="/jianshu/trending/weekly" path="/jianshu/trending/weekly"/>
 
-路由: `/jianshu/home`
+<route name="30 日热门" author="DIYgod" example="/jianshu/trending/monthly" path="/jianshu/trending/monthly"/>
 
-参数: 无
+<route name="专题" author="DIYgod" example="/jianshu/collection/xYuZYD" path="/jianshu/collection/:id" :paramsDesc="['专题 id, 可在专题页 URL 中找到']"/>
 
-#### 7 日热门 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/jianshu/trending/weekly>
-
-路由: `/jianshu/trending/weekly`
-
-参数: 无
-
-#### 30 日热门 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/jianshu/trending/monthly>
-
-路由: `/jianshu/trending/monthly`
-
-参数: 无
-
-#### 专题 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/jianshu/collection/xYuZYD>
-
-路由: `/jianshu/collection/:id`
-
-参数:
-
--   id, 专题 id, 可在专题页 URL 中找到
-
-#### 作者 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/jianshu/user/yZq3ZV>
-
-路由: `/jianshu/user/:id`
-
-参数:
-
--   id, 作者 id, 可在作者主页 URL 中找到
+<route name="作者" author="DIYgod" example="/jianshu/user/yZq3ZV" path="/jianshu/user/:id" :paramsDesc="['作者 id, 可在作者主页 URL 中找到']"/>
 
 ### 知乎
 
@@ -672,89 +386,25 @@ RSSHub 提供下列 API 接口:
 
 :::
 
-#### 收藏夹 <Author uid="huruji"/>
+<route name="收藏夹" author="huruji" example="/zhihu/collection/26444956" path="/zhihu/collection/:id" :paramsDesc="['收藏夹 id, 可在收藏夹页面 URL 中找到']"/>
 
-举例: <https://rsshub.app/zhihu/collection/26444956>
+<route name="用户动态" author="DIYgod" example="/zhihu/people/activities/diygod" path="/zhihu/people/activities/:id" :paramsDesc="['作者 id, 可在用户主页 URL 中找到']"/>
 
-路由: `/zhihu/collection/:id`
+<route name="用户回答" author="DIYgod" example="/zhihu/people/answers/diygod" path="/zhihu/people/answers/:id" :paramsDesc="['作者 id, 可在用户主页 URL 中找到']"/>
 
-参数:
+<route name="专栏" author="DIYgod" example="/zhihu/zhuanlan/googledevelopers" path="/zhihu/zhuanlan/:id" :paramsDesc="['专栏 id, 可在专栏主页 URL 中找到']"/>
 
--   id, 收藏夹 id, 可在收藏夹页面 URL 中找到
+<route name="知乎日报" author="DHPO" example="/zhihu/daily" path="/zhihu/daily"/>
 
-#### 用户动态 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/zhihu/people/activities/diygod>
-
-路由: `/zhihu/people/activities/:id`
-
-参数:
-
--   id, 用户 id, 可在用户主页 URL 中找到
-
-#### 用户回答 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/zhihu/people/answers/diygod>
-
-路由: `/zhihu/people/answers/:id`
-
-参数:
-
--   id, 用户 id, 可在用户主页 URL 中找到
-
-#### 专栏 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/zhihu/zhuanlan/googledevelopers>
-
-路由: `/zhihu/zhuanlan/:id`
-
-参数:
-
--   id, 专栏 id, 可在专栏主页 URL 中找到
-
-#### 知乎日报 <Author uid="DHPO"/>
-
-举例: <https://rsshub.app/zhihu/daily>
-
-路由: `/zhihu/daily`
-
-#### 知乎热榜 <Author uid="Andiedie"/>
-
-举例: <https://rsshub.app/zhihu/hotlist>
-
-路由: `/zhihu/hotlist`
+<route name="知乎热榜" author="DIYgod" example="/zhihu/hotlist" path="/zhihu/hotlist"/>
 
 ### pixiv
 
-#### 用户收藏 <Author uid="EYHN"/>
+<route name="用户收藏" author="EYHN" example="/pixiv/user/bookmarks/15288095" path="/pixiv/user/bookmarks/:id" :paramsDesc="['用户 id, 可在用户主页 URL 中找到']"/>
 
-举例: <https://rsshub.app/pixiv/user/bookmarks/15288095>
+<route name="用户动态" author="DIYgod" example="/pixiv/user/11" path="/pixiv/user/:id" :paramsDesc="['用户 id, 可在用户主页 URL 中找到']"/>
 
-路由: `/pixiv/user/bookmarks/:id`
-
-参数:
-
--   id, 用户 id, 可在用户主页 URL 中找到
-
-#### 用户动态 <Author uid="EYHN"/>
-
-举例: <https://rsshub.app/pixiv/user/11>
-
-路由: `/pixiv/user/:id`
-
-参数:
-
--   id, 用户 id, 可在用户主页 URL 中找到
-
-#### 排行榜 <Author uid="EYHN"/>
-
-举例: <https://rsshub.app/pixiv/ranking/week>
-
-路由: `/pixiv/ranking/:mode/:date?`
-
-参数
-
--   mode, 排行榜类型
+<route name="排行榜" author="EYHN" example="/pixiv/ranking/week" path="/pixiv/ranking/:mode/:date?" :paramsDesc="['排行榜类型' ,'日期, 取值形如 `2018-4-25`']">
 
 | pixiv 日排行 | pixiv 周排行 | pixiv 月排行 | pixiv 受男性欢迎排行 | pixiv 受女性欢迎排行 | pixiv 原创作品排行 | pixiv 新人排行 |
 | ------------ | ------------ | ------------ | -------------------- | -------------------- | ------------------ | -------------- |
@@ -764,175 +414,54 @@ RSSHub 提供下列 API 接口:
 | ----------------- | ------------------------- | ------------------------- | ----------------- | ---------------- |
 | day_r18           | day_male_r18              | day_female_r18            | week_r18          | week_r18g        |
 
--   date, 日期, 取值形如 `2018-4-25`
+</route>
 
 ### 豆瓣
 
-#### 正在上映的电影 <Author uid="DIYgod"/>
+<route name="正在上映的电影" author="DIYgod" example="/douban/movie/playing" path="/douban/movie/playing"/>
 
-举例: <https://rsshub.app/douban/movie/playing>
+<route name="正在上映的高分电影" author="DIYgod" example="/douban/movie/playing/7.5/杭州" path="/douban/movie/playing/:score/:city?" :paramsDesc="['返回大于等于这个分数的电影', '城市的中文名, 可选, 默认北京']"/>
 
-路由: `/douban/movie/playing`
+<route name="即将上映的电影" author="DIYgod" example="/douban/movie/later" path="/jdouban/movie/later"/>
 
-参数: 无
+<route name="北美票房榜" author="DIYgod" example="/douban/movie/ustop" path="/douban/movie/ustop"/>
 
-#### 正在上映的高分电影 <Author uid="DIYgod"/>
+<route name="豆瓣小组" author="DIYgod" example="/jdouban/group/camera" path="/douban/group/:groupid" :paramsDesc="['豆瓣小组的 id']"/>
 
-举例: <https://rsshub.app/douban/movie/playing/7.5>
+<route name="浏览发现" author="clarkzsd" example="/douban/explore" path="/douban/explore"/>
 
-路由
+<route name="新书速递" author="fengkx" example="/douban/book/latest" path="douban/book/latest"/>
 
-`/douban/movie/playing/:score`
-
-`/douban/movie/playing/:score/:city`
-
-参数
-
--   score: 返回大于等于这个分数的电影
-
--   city: 城市的中文名, 可选, 默认北京
-
-#### 即将上映的电影 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/douban/movie/later>
-
-路由: `/douban/movie/later`
-
-参数: 无
-
-#### 北美票房榜 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/douban/movie/ustop>
-
-路由: `/douban/movie/ustop`
-
-参数: 无
-
-#### 豆瓣小组 <Author uid="derycktse"/>
-
-举例: <https://rsshub.app/douban/group/camera>
-
-路由: `/douban/group/:groupid`
-
-参数:
-
--   groupid: 豆瓣小组的 id
-
-#### 浏览发现 <Author uid="clarkzsd"/>
-
-举例: <https://rsshub.app/douban/explore>
-
-路由: `/douban/explore`
-
-#### 新书速递 <Author uid="fengkx"/>
-
-举例：<https://rsshub.app/douban/book/latest>
-
-路由：`/douban/book/latest`
-
-#### 最新增加的音乐 <Author uid="fengkx"/>
-
-举例：<https://rsshub.app/douban/music/latest>
-
-路由：`/douban/music/latest`
+<route name="最新增加的音乐" author="fengkx" example="/douban/music/latest" path="/jdouban/music/latest"/>
 
 ### Disqus
 
-#### 评论 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/disqus/posts/diygod-me>
-
-路由: `/disqus/posts/:forum`
-
-参数:
-
--   forum, 网站的 disqus name
-
+<route name="评论" author="DIYgod" example="/disqus/posts/diygod-me" path="/disqus/posts/:forum" :paramsDesc="['网站的 disqus name']"/>
 ### Twitter
 
-#### 用户 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/twitter/user/DIYgod>
-
-路由: `/twitter/user/:id`
-
-参数:
-
--   id, 用户 id
+<route name="用户" author="DIYgod" example="/twitter/user/DIYgod" path="/twitter/user/:id" :paramsDesc="['用户 twitter 名']"/>
 
 ### Instagram
 
-#### 用户 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/instagram/user/diygod>
-
-路由: `/instagram/user/:id`
-
-参数:
-
--   id, 用户 id
+<route name="用户" author="DIYgod" example="/instagram/user/diygod" path="/instagram/user/:id" :paramsDesc="['用户 id']"/>
 
 ### Youtube
 
-#### 用户 <Author uid="DIYgod"/>
+<route name="用户" author="DIYgod" example="/youtube/user/JFlaMusic" path="/youtube/user/:username" :paramsDesc="['用户名']"/>
 
-举例: <https://rsshub.app/youtube/user/JFlaMusic>
-
-路由: `/youtube/user/:username`
-
-参数:
-
--   username, 用户名
-
-#### 频道 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/youtube/channel/UCDwDMPOZfxVV0x_dz0eQ8KQ>
-
-路由: `/youtube/channel/:id`
-
-参数:
-
--   id, 频道 id
+<route name="频道" author="DIYgod" example="/youtube/channel/UCDwDMPOZfxVV0x_dz0eQ8KQ>" path="/youtube/channel/:id" :paramsDesc="['频道 id']"/>
 
 ### Dribbble
 
-#### 流行 <Author uid="DIYgod"/>
+<route name="流行" author="DIYgod" example="/dribbble/popular/week" path="/dribbble/popular/:timeframe?" :paramsDesc="['时间维度, 支持 week month year ever']"/>
 
-举例:
+<route name="用户（团队" author="DIYgod" example="/dribbble/user/google" path="/dribbble/user/:name" :paramsDesc="['用户名, 可在该用户主页 URL 中找到']"/>
 
-<https://rsshub.app/dribbble/popular>
-
-<https://rsshub.app/dribbble/popular/week>
-
-路由: `/dribbble/popular/:timeframe?`
-
-参数:
-
--   timeframe, 可选, 时间维度, 支持 week month year ever
-
-#### 用户（团队） <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/dribbble/user/google>
-
-路由: `/dribbble/user/:name`
-
-参数:
-
--   name, 用户名, 可在该用户主页 URL 中找到
-
-#### 关键词 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/dribbble/keyword/player>
-
-路由: `/dribbble/keyword/:keyword`
-
-参数:
-
--   keyword, 想要订阅的关键词
+<route name="关键词" author="DIYgod" example="/dribbble/keyword/player" path="/dribbble/keyword/:keyword" :paramsDesc="['想要订阅的关键词']"/>
 
 ### Telegram
 
-#### 频道 <Author uid="DIYgod"/>
+<route name="频道" author="DIYgod" example="/telegram/channel/awesomeDIYgod" path="/telegram/channel/:username" :paramsDesc="['频道 username']">
 
 ::: tip 提示
 
@@ -940,101 +469,41 @@ RSSHub 提供下列 API 接口:
 
 :::
 
-举例: <https://rsshub.app/telegram/channel/awesomeDIYgod>
+</route>
 
-路由: `/telegram/channel/:username`
-
-参数:
-
--   username, 频道 username
-
-#### 贴纸包 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/telegram/stickerpack/DIYgod>
-
-路由: `/telegram/stickerpack/:name`
-
-参数:
-
--   name, 贴纸包 id, 可在分享贴纸获得的 URL 中找到
+<route name="贴纸包" author="DIYgod" example="/telegram/stickerpack/DIYgod" path="/telegram/stickerpack/:name" :paramsDesc="['贴纸包 id, 可在分享贴纸获得的 URL 中找到']"/>
 
 ### 抖音
 
-#### 用户动态 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/douyin/user/93610979153>
-
-路由: `/douyin/user/:id`
-
-参数:
-
--   id, 用户 id, 可在 分享出去获得的用户主页 URL 中找到
+<route name="用户动态" author="DIYgod" example="/douyin/user/93610979153" path="/douyin/user/:id" :paramsDesc="['用户 id, 可在 分享出去获得的用户主页 URL 中找到']"/>
 
 ### 雪球
 
-#### 用户动态 <Author uid="imlonghao"/>
-
-举例: <https://rsshub.app/xueqiu/user/8152922548>
-
-路由: `/xueqiu/user/:id/:type?`
-
-参数:
-
--   id, 用户 id, 可在用户主页 URL 中找到
-
--   type, 可选, 动态的类型, 不填则默认全部
+<route name="用户动态" author="imlonghao" example="/xueqiu/user/8152922548" path="/xueqiu/user/:id/:type?" :paramsDesc="['用户 id, 可在用户主页 URL 中找到', '动态的类型, 不填则默认全部']">
 
 | 原发布 | 长文 | 问答 | 热门 | 交易 |
 | ------ | ---- | ---- | ---- | ---- |
 | 0      | 2    | 4    | 9    | 11   |
 
-#### 用户收藏动态 <Author uid="imlonghao"/>
+</route>
 
-举例: <https://rsshub.app/xueqiu/favorite/8152922548>
-
-路由: `/xueqiu/favorite/:id`
-
-参数:
-
--   id, 用户 id, 可在用户主页 URL 中找到
+<route name="用户收藏动态" author="imlonghao" example="/xueqiu/favorite/8152922548" path="/xueqiu/favorite/:id" :paramsDesc="['用户 id, 可在用户主页 URL 中找到']"/>
 
 ## 编程
 
 ### 掘金
 
-#### 分类 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/juejin/category/frontend>
-
-路由: `/juejin/category/:category`
-
-参数:
-
--   category, 分类名
+<route name="分类" author="DIYgod" example="/juejin/category/frontend" path="/juejin/category/:category" :paramsDesc="['分类名']">
 
 | 前端     | Android | iOS | 后端    | 设计   | 产品    | 工具资源 | 阅读    | 人工智能 |
 | -------- | ------- | --- | ------- | ------ | ------- | -------- | ------- | -------- |
 | frontend | android | ios | backend | design | product | freebie  | article | ai       |
 
-#### 标签 <Author uid="isheng5"/>
+</route>
 
-举例: <https://rsshub.app/juejin/tag/架构>
+<route name="标签" author="isheng5" example="/juejin/tag/架构" path="/juejin/tag/:tag" :paramsDesc="['标签名, 可在标签 URL 中找到']"/>
 
-路由: `/juejin/tag/:tag`
-
-参数:
-
--   tag, 标签名, 可在标签 URL 中找到
-
-#### 热门 <Author uid="moaix"/>
-
-举例: <https://rsshub.app/juejin/trending/ios/monthly>
-
-路由: `/juejin/trending/:category/:type`
-
-参数:
-
--   category, 分类名, 必选
+<route name="热门" author="moaix" example="/juejin/trending/ios/monthly" path="/juejin/trending/:category/:type" :paramsDesc="['分类名', '类型']">
 
 | category | 标签     |
 | -------- | -------- |
@@ -1050,69 +519,33 @@ RSSHub 提供下列 API 接口:
 | devops   | 运维     |
 | all      | 全部     |
 
--   type, 类型, 必选
-
 | type       | 类型     |
 | ---------- | -------- |
 | weekly     | 本周最热 |
 | monthly    | 本月最热 |
 | historical | 历史最热 |
 
+</route>
+
 ### Dockone
 
-#### 周报 <Author uid="csi0n"/>
-
-举例: <https://rsshub.app/dockone/weekly>
-
-路由: `/dockone/weekly`
-
-参数: 无
+<route name="周报" author="csi0n" example="/dockone/weekly" path="/dockone/weekly"/>
 
 ### 开发者头条
 
-#### 今天头条 <Author uid="jjeejj"/>
+<route name="今天头条" author="jjeejj" example="/toutiao/today" path="/toutiao/today"/>
 
-举例: <https://rsshub.app/toutiao/today>
-
-路由: `/toutiao/today`
-
-#### 独家号 <Author uid="jjeejj"/>
-
-举例: <https://rsshub.app/toutiao/user/140544>
-
-路由: `/toutiao/user/:id`
-
-参数:
-
--   id, 独家号 id, 可在对应独家号页 URL 中找到
+<route name="独家号" author="jjeejj" example="/toutiao/user/140544" path="/toutiao/user/:id" :paramsDesc="['独家号 id, 可在对应独家号页 URL 中找到']"/>
 
 ### 众成翻译
 
-#### 首页 <Author uid="SirM2z"/>
+<route name="首页" author="SirM2z" example="/zcfy/index" path="/zcfy/index"/>
 
-举例: <https://rsshub.app/zcfy/index>
-
-路由: `/zcfy/index`
-
-#### 热门 <Author uid="SirM2z"/>
-
-举例: <https://rsshub.app/zcfy/hot>
-
-路由: `/zcfy/hot`
+<route name="热门" author="SirM2z" example="/zcfy/hot" path="/zcfy/hot"/>
 
 ### V2EX
 
-#### 最热/最新主题 <Author uid="WhiteWorld"/>
-
-举例: <https://rsshub.app/v2ex/topics/latest>
-
-路由: `/v2ex/topics/:type`
-
-参数:
-
--   type: hot 或 latest
-
--   ](https://rsshub.app/yande.re/post/popular_recent?period=1y)
+<route name="最热/最新主题" author="WhiteWorld" example="/v2ex/topics/latest" path="/v2ex/topics/:type" :paramsDesc="['hot 或 latest']"/>
 
 ### GitHub
 
@@ -1126,143 +559,49 @@ GitHub 官方也提供了一些 RSS:
 
 :::
 
-#### 用户仓库 <Author uid="dragon-yuan"/>
+<route name="用户仓库" author="DIYgod" example="/github/repos/DIYgod" path="/github/repos/:user" :paramsDesc="['用户名']"/>
 
-举例: <https://rsshub.app/github/repos/DIYgod>
+<route name="Trending" author="DIYgod" example="/<https://rsshub.app/github/trending/daily/javascript" path="/github/trending/:since/:language?" :paramsDesc="['时间跨度, 可在 [Trending 页](https://github.com/trending/javascript?since=monthly) URL 中找到, 可选 daily weekly monthly', '语言, 可在 [Trending 页](https://github.com/trending/javascript?since=monthly) URL 中找到']"/>
 
-路由: `/github/repos/:user`
+<route name="仓库 Issue" author="HenryQW" example="/github/issue/DIYgod/RSSHub" path="/github/issue/:user/:repo" :paramsDesc="['用户名', '仓库名']"/>
 
-参数:
+<route name="用户" author="HenryQW" example="/github/user/followers/HenryQW" path="/github/user/followers/:user" :paramsDesc="['用户名']"/>
 
--   user, 用户名
-
-#### Trending <Author uid="DIYgod"/>
-
-举例:
-
-<https://rsshub.app/github/trending/daily>
-
-<https://rsshub.app/github/trending/daily/javascript>
-
-路由: `/github/trending/:since/:language?`
-
-参数:
-
--   since, 时间跨度, 可在 [Trending 页](https://github.com/trending/javascript?since=monthly) URL 中找到, 可选 daily weekly monthly
--   language, 语言, 可在 [Trending 页](https://github.com/trending/javascript?since=monthly) URL 中找到
-
-#### 仓库 Issue <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/github/issue/DIYgod/RSSHub>
-
-路由: `/github/issue/:user/:repo`
-
-参数:
-
--   user, 用户名
--   repo, 仓库名
-
-#### 用户 Followers <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/github/user/followers/HenryQW>
-
-路由: `/github/user/followers/:user`
-
-参数:
-
--   user, 用户名
-
-#### 仓库 Stars <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/github/stars/DIYgod/RSSHub>
-
-路由: `/github/stars/:user/:repo`
-
-参数:
-
--   user, 用户名
--   repo, 仓库名
+<route name="仓库 Stars" author="HenryQW" example="/github/stars/DIYgod/RSSHub" path="/github/stars/:user/:repo" :paramsDesc="['用户名', '仓库名']"/>
 
 ### 开源中国
 
-#### 资讯 <Author uid="tgly307"/>
-
-举例: <https://rsshub.app/oschina/news>
-
-路由: `/oschina/news`
-
-参数: 无
+<route name="资讯" author="tgly307" example="/oschina/news" path="/oschina/news"/>
 
 ### GitLab
 
-#### Explore <Author uid="imlonghao"/>
-
-举例: <https://rsshub.app/gitlab/explore/trending>
-
-路由: `/gitlab/explore/:type`
-
-参数:
-
--   type, 分类
+<route name="Explore" author="imlonghao" example="/gitlab/explore/trending" path="/gitlab/explore/:type" :paramsDesc="['分类']">
 
 | Trending | Most stars | All |
 | -------- | ---------- | --- |
 | trending | starred    | all |
 
+</route>
+
 ### 极客时间
 
-#### 专栏文章 <Author uid="fengchang"/>
+<route name="专栏文章" author="fengchang" example="/geektime/column/48" path="/geektime/column/:cid" :paramsDesc="['专栏 id, 可从[全部专栏](https://time.geekbang.org/paid-content)进入专栏介绍页, 在 URL 中找到']"/>
 
 > 极客时间专栏需要付费订阅, RSS 仅做更新提醒, 不含付费内容.
 
-举例: <https://rsshub.app/geektime/column/48>
-
-路由: `/geektime/column/:cid`
-
-参数:
-
--   cid, 专栏 id, 可从[全部专栏](https://time.geekbang.org/paid-content)进入专栏介绍页, 在 URL 中找到
-
 ### LinkedKeeper
 
-#### 博文 <Author uid="imlonghao"/>
-
-举例: <https://rsshub.app/linkedkeeper/sub/1>
-
-路由: `/linkedkeeper/:type/:id?`
-
-参数:
-
--   type, 博文分类, 为 URL 中 `.action` 的文件名
-
--   id, 可选, 分区或标签的 ID, 对应 URL 中的 `sid` 或 `tid`
+<route name="博文" author="imlonghao" example="/linkedkeeper/sub/1" path="/linkedkeeper/:type/:id?" :paramsDesc="['博文分类, 为 URL 中 `.action` 的文件名', '分区或标签的 ID, 对应 URL 中的 `sid` 或 `tid`']"/>
 
 ## 直播
 
-### 哔哩哔哩直播 <Author uid="Qixingchen"/>
+### 哔哩哔哩直播
 
-#### 直播开播 <Author uid="Qixingchen"/>
+<route name="直播开播" author="Qixingchen" example="/bilibili/live/room/3" path="/bilibili/live/room/:roomID" :paramsDesc="['房间号, 可在直播间 URL 中找到, 长短号均可']"/>
 
-举例: <https://rsshub.app/bilibili/live/room/3>
+<route name="直播搜索" author="Qixingchen" example="/bilibili/live/search/编程/online" path="/bilibili/live/search/:key/:order" :paramsDesc="['搜索关键字', '排序方式, live_time 开播时间, online 人气']"/>
 
-路由: `bilibili/live/room/:roomID`
-
-参数:
-
--   roomID, 房间号 可在直播间 URL 中找到, 长短号均可
-
-#### 直播搜索 <Author uid="Qixingchen"/>
-
-举例: <https://rsshub.app/bilibili/live/search/编程/online>
-
-路由: `bilibili/live/search/:key/:order`
-
-参数
-
--   key: 搜索关键字
--   order: 排序方式, live_time 开播时间, online 人气
-
-#### 直播分区 <Author uid="Qixingchen"/>
+<route name="直播分区" author="Qixingchen" example="/bilibili/live/area/143/online" path="/bilibili/live/area/:areaID/:order" :paramsDesc="['分区 ID 分区增删较多, 可通过 [分区列表](https://api.live.bilibili.com/room/v1/Area/getList) 查询', '排序方式, live_time 开播时间, online 人气']">
 
 ::: warning 注意
 
@@ -1270,38 +609,15 @@ GitHub 官方也提供了一些 RSS:
 
 :::
 
-举例: <https://rsshub.app/bilibili/live/area/143/online>
-
-路由: `bilibili/live/area/:areaID/:order`
-
-参数
-
--   areaID: 分区 ID 分区增删较多, 可通过 [分区列表](https://api.live.bilibili.com/room/v1/Area/getList) 查询
--   order: 排序方式, live_time 开播时间, online 人气
+</route>
 
 ### 斗鱼直播
 
-#### 直播间开播 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/douyu/room/24422>
-
-路由: `/douyu/room/:id`
-
-参数:
-
--   id, 直播间 id, 可在主播直播间页 URL 中找到
+<route name="直播间开播" author="DIYgod" example="/douyu/room/24422" path="/douyu/room/:id" :paramsDesc="['直播间 id, 可在主播直播间页 URL 中找到']"/>
 
 ### 熊猫直播
 
-#### 直播间开播下播 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/panda/room/10300>
-
-路由: `/panda/room/:id`
-
-参数:
-
--   id, 直播间 id, 可在主播直播间页 URL 中找到
+<route name="直播间开播下播" author="DIYgod" example="/panda/room/10300" path="/panda/room/:id" :paramsDesc="['直播间 id, 可在主播直播间页 URL 中找到']"/>
 
 ## 音视频
 
@@ -1319,79 +635,31 @@ GitHub 官方也提供了一些 RSS:
 
 ### 网易云音乐
 
-#### 歌单歌曲 <Author uid="DIYgod"/>
+<route name="歌单歌曲" author="DIYgod" example="/ncm/playlist/35798529" path="/ncm/playlist/:id" :paramsDesc="['歌单 id, 可在歌单页 URL 中找到']"/>
 
-举例: <https://rsshub.app/ncm/playlist/35798529>
+<route name="用户歌单" author="DIYgod" example="/ncm/user/playlist/45441555" path="/ncm/user/playlist/:uid" :paramsDesc="['用户 uid, 可在用户主页 URL 中找到']"/>
 
-路由: `/ncm/playlist/:id`
+<route name="歌手专辑" author="metowolf" example="/ncm/artist/2116" path="/ncm/artist/:id" :paramsDesc="[' 歌手 id, 可在歌手详情页 URL 中找到']"/>
 
-参数:
-
--   id, 歌单 id, 可在歌单页 URL 中找到
-
-#### 用户歌单 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/ncm/user/playlist/45441555>
-
-路由: `/ncm/user/playlist/:uid`
-
-参数:
-
--   uid, 用户 uid, 可在用户主页 URL 中找到
-
-#### 歌手专辑 <Author uid="metowolf"/>
-
-举例: <https://rsshub.app/ncm/artist/2116>
-
-路由: `/ncm/artist/:id`
-
-参数:
-
--   id, 歌手 id, 可在歌手详情页 URL 中找到
-
-#### 电台节目 <Author uid="hufan-akari"/>
-
-举例: <https://rsshub.app/ncm/djradio/347317067>
-
-路由: `/ncm/djradio/:id`
-
-参数:
-
--   id, 节目 id, 可在电台节目页 URL 中找到
+<route name="电台节目" author="hufan-akari" example="/ncm/djradio/347317067" path="/ncm/djradio/:id" :paramsDesc="['节目 id, 可在电台节目页 URL 中找到']"/>
 
 ### 爱奇艺
 
-#### 动漫 <Author uid="ranpox"/>
-
-举例: <https://rsshub.app/iqiyi/dongman/a_19rrh1sifx>
-
-路由: `/iqiyi/dongman/:id`
-
-参数:
-
--   id, 动漫 id, 可在该动漫主页 URL 中找到(不包括`.html`)
+<route name="动漫" author="ranpox" example="/iqiyi/dongman/a_19rrh1sifx" path="/iqiyi/dongman/:id" :paramsDesc="['动漫 id, 可在该动漫主页 URL 中找到(不包括`.html`)']"/>
 
 ### 喜马拉雅
 
-#### 专辑(支持泛用型播客订阅) <Author uid="lengthmin jjeejj"/>
+<route name="专辑(支持泛用型播客订阅)" author="lengthmin jjeejj" example="/jximalaya/album/299146" path="/ximalaya/album/:id" :paramsDesc="['专辑 id, 可在对应专辑页面的 URL 中找到']">
 
 ::: warning 注意
 **付费内容可获取更新但无法收听**
 
 目前支持泛用型播客订阅的[输出格式](https://docs.rsshub.app/#输出格式)中标明的格式只有 rss 支持, 也就是说你**只能使用**以下链接来订阅播客:
 
--   https://rsshub.app/ximalaya/album/299146/
+-   https://rsshub.app/ximalaya/album/299146
 -   https://rsshub.app/ximalaya/album/299146.rss
 
 :::
-
-举例: <https://rsshub.app/ximalaya/album/299146/>
-
-路由: `/ximalaya/album/:id`
-
-参数:
-
--   id, 专辑 id, 可在对应**专辑**页面的 URL 中找到
 
 ::: tip 提示
 
@@ -1407,27 +675,11 @@ GitHub 官方也提供了一些 RSS:
 
 :::
 
-#### Lookup Torrents by IMDB ID <Author uid="Songkeys"/>
-
-举例: <https://rsshub.app/eztv/torrents/6048596>
-
-路由: `/eztv/torrents/:imdb_id`
-
-参数:
-
--   imdb_id, 想搜寻的 show 的种子所对应的 IMDB ID, 可在 [IMDB](https://www.imdb.com) 官网找到
+<route name="Lookup Torrents by IMDB ID" author="Songkeys" example="/eztv/torrents/6048596" path="/eztv/torrents/:imdb_id" :paramsDesc="['想搜寻的 show 的种子所对应的 IMDB ID, 可在 [IMDB](https://www.imdb.com) 官网找到']"/>
 
 ### 草榴社区
 
-#### 分区帖子 <Author uid="zhboner"/>
-
-举例: <https://rsshub.app/t66y/7>
-
-路由: `/t66y/:id`
-
-参数:
-
--   id, 分区 id, 可在分区页 URL 中找到
+<route name="分区帖子" author="zhboner" example="/t66y/7" path="/t66y/:id" :paramsDesc="['分区 id, 可在分区页 URL 中找到']">
 
 | 亚洲无码原创区 | 亚洲有码原创区 | 欧美原创区 | 动漫原创区 | 国产原创区 |
 | -------------- | -------------- | ---------- | ---------- | ---------- |
@@ -1441,87 +693,43 @@ GitHub 官方也提供了一些 RSS:
 | ---------- | ------------ | ------------ |
 | 7          | 8            | 16           |
 
+</route>
+
 ## 图片
 
 ### 妹子图
 
 ::: warning 注意
 
-该网站在国外无法访问, 故以下演示无效
+该网站在国外无法访问, 由于 RSSHub 演示部署于国外, 故以下演示无效.
 
 :::
 
-#### 首页（最新） <Author uid="gee1k"/>
+<route name="首页（最新）" author="gee1k" example="/mzitu" path="/mzitu"/>
 
-举例: <https://rsshub.app/mzitu>
-
-路由: `/mzitu/`
-
-#### 分类 <Author uid="gee1k"/>
-
-举例: <https://rsshub.app/mzitu/category/hot>
-
-路由: `/mzitu/category/:category`
-
-参数:
-
--   category, 分类名
+<route name="分类" author="gee1k" example="/mzitu/category/hot" path="/mzitu/category/:category" :paramsDesc="['分类名']">
 
 | 热门 | 推荐 | 性感妹子 | 日本妹子 | 台湾妹子 | 清纯妹子 |
 | ---- | ---- | -------- | -------- | -------- | -------- |
 | hot  | best | xinggan  | japan    | taiwan   | mm       |
 
-#### 所有专题 <Author uid="gee1k"/>
+</route>
 
-举例: <https://rsshub.app/mzitu/tags>
+<route name="所有专题" author="gee1k" example="/mzitu/tags" path="/mzitu/tags"/>
 
-路由: `/mzitu/tags`
+<route name="专题详情" author="gee1k" example="/mzitu/tag/shishen" path="/mzitu/tag/:tag" :paramsDesc="['专题名, 可在专题页 URL 中找到']"/>
 
-#### 专题详情 <Author uid="gee1k"/>
-
-举例: <https://rsshub.app/mzitu/tag/shishen>
-
-路由: `/mzitu/tag/:tag`
-
-参数:
-
--   tag, 专题名, 可在专题页 URL 中找到
-
-#### 详情 <Author uid="gee1k"/>
-
-举例: <https://rsshub.app/mzitu/post/129452>
-
-路由: `/mzitu/post/:id`
-
-参数:
-
--   id, 详情 id, 可在详情页 URL 中找到
+<route name="详情" author="gee1k" example="/mzitu/post/129452" path="/mzitu/post/:id" :paramsDesc="['详情 id, 可在详情页 URL 中找到']"/>
 
 ### 煎蛋
 
-#### 无聊图 <Author uid="Xuanwo"/>
+<route name="无聊图" author="Xuanwo" example="/jandan/pic" path="/jandan/:sub_model" :paramsDesc="['煎蛋板块名称']"/>
 
-举例: <https://rsshub.app/jandan/pic>
-
-路由: `/jandan/:sub_model`
-
-#### 妹子图 <Author uid="kobemtl"/>
-
-举例: <https://rsshub.app/jandan/ooxx>
-
-路由: `/jandan/:sub_model`
-
-参数: 无
+<route name="妹子图" author="kobemtl" example="/jandan/ooxx" path="/jandan/:sub_model" :paramsDesc="['煎蛋板块名称']"/>
 
 ### 喷嚏
 
-#### 图卦 <Author uid="tgly307"/>
-
-举例: <https://rsshub.app/dapenti/tugua>
-
-路由: `/dapenti/tugua`
-
-参数: 无
+<route name="图卦" author="tgly307" example="/dapenti/tugua" path="/dapenti/tugua"/>
 
 ### Konachan Anime Wallpapers
 
@@ -1533,12 +741,7 @@ GitHub 官方也提供了一些 RSS:
 
 :::
 
-#### Popular Recent Posts <Author uid="hufan-akari"/>
-
-路由:
-
--   `/konachan/post/popular_recent` 默认过去 24 小时
--   `/konachan/post/popular_recent/:period`
+<route name="Popular Recent Posts" author="hufan-akari" example="/konachan/post/popular_recent" path="/konachan/post/popular_recent/:period?" :paramsDesc="['默认过去 24 小时']">
 
 举例:
 
@@ -1546,6 +749,8 @@ GitHub 官方也提供了一些 RSS:
 -   过去一周:<https://rsshub.app/konachan/post/popular_recent/1w>
 -   过去一月:<https://rsshub.app/konachan/post/popular_recent/1m>
 -   过去一年:<https://rsshub.app/konachan/post/popular_recent/1y>
+
+</route>
 
 ### yande.re
 
@@ -1555,29 +760,20 @@ GitHub 官方也提供了一些 RSS:
 
 :::
 
-#### Popular Recent Posts <Author uid="hufan-akari"/>
-
-路由:
-
--   `/yande.re/post/popular_recent` 默认过去 24 小时
--   `/yande.re/post/popular_recent/:period`
+<route name="Popular Recent Posts" author="hufan-akari" example="/yande.re/post/popular_recent" path="/yande.re/post/popular_recent/:period?" :paramsDesc="['默认过去 24 小时']">
 
 举例:
 
 -   过去 24 小时:<https://rsshub.app/yande.re/post/popular_recent/1d>
 -   过去一周:<https://rsshub.app/yande.re/post/popular_recent/1w>
 -   过去一月:<https://rsshub.app/yande.re/post/popular_recent/1m>
--   过去一年:[https://rsshub.app/yande.re/post/popular_recent/1y
+-   过去一年:<https://rsshub.app/yande.re/post/popular_recent/1y>
+
+</route>
 
 ### Awesome Pigtails
 
-#### 最新图片 <author uid="Chingyat" />
-
-举例: <https://rsshub.app/pigtails>
-
-路由: `/pigtails`
-
-参数: 无
+<route name="最新图片" author="Chingyat" example="/pigtails" path="/pigtails"/>
 
 ## 动漫
 
@@ -1587,371 +783,138 @@ GitHub 官方也提供了一些 RSS:
 
 ### Bangumi
 
-#### 放送列表 <Author uid="hufan-akari"/>
+<route name="放送列表" author="hufan-akari" example="/bangumi/calendar/today" path="/bangumi/calendar/today"/>
 
-举例: <https://rsshub.app/bangumi/calendar/today>
-
-路由: `/bangumi/calendar/today`
-
-参数: 无
-
+<route name="条目的吐槽箱" author="ylc395" example="/bangumi/subject/214265/comments?minLength=100" path="/bangumi/subject/:id/comments" :paramsDesc="['条目 id, 在条目页面的地址栏查看. minLength: 以查询字符串（query string）的形式指定. 用于过滤掉内容长度小于指定值的吐槽']"/>
 #### 条目的吐槽箱 <Author uid="ylc395"/>
 
-举例: <https://rsshub.app/bangumi/subject/214265/comments>
+<route name="条目的评论" author="ylc395" example="/bangumi/subject/214265/blogs" path="/bangumi/subject/:id/blogs" :paramsDesc="['条目 id, 在条目页面的地址栏查看']"/>
 
-路由: `/bangumi/subject/:id/comments`
+<route name="条目的讨论" author="ylc395" example="/bangumi/subject/214265/topics" path="/bangumi/subject/:id/topics" :paramsDesc="['条目 id, 在条目页面的地址栏查看']"/>
 
-参数:
+<route name="现实人物的新作品" author="ylc395" example="/bangumi/person/32943" path="/bangumi/person/:id" :paramsDesc="['人物 id, 在人物页面的地址栏查看']"/>
 
--   id: 条目 ID. 在条目页面的地址栏查看
-
--   minLength: 以查询字符串（query string）的形式指定. 用于过滤掉内容长度小于指定值的吐槽
-
-#### 条目的评论 <Author uid="ylc395"/>
-
-举例: <https://rsshub.app/bangumi/subject/214265/blogs>
-
-路由: `/bangumi/subject/:id/blogs`
-
-参数:
-
--   id - 条目 ID. 在条目页面的地址栏查看
-
-#### 条目的讨论 <Author uid="ylc395"/>
-
-举例: <https://rsshub.app/bangumi/subject/214265/topics>
-
-路由: `/bangumi/subject/:id/topics`
-
-参数:
-
--   id - 条目 ID. 在条目页面的地址栏查看
-
-#### 现实人物的新作品 <Author uid="ylc395"/>
-
-举例: <https://rsshub.app/bangumi/person/32943>
-
-路由: `/bangumi/person/:id`
-
-参数:
-
--   id - 人物 ID. 在人物页面的地址栏查看
-
-#### 小组话题的新回复 <Author uid="ylc395"/>
-
-举例: <https://rsshub.app/bangumi/topic/24657>
-
-路由: `/bangumi/topic/:id`
-
-参数:
-
--   id - 话题 ID. 在话题页面地址栏查看
+<route name="小组话题的新回复" author="ylc395" example="/bangumi/topic/24657" path="/bangumi/topic/:id" :paramsDesc="['话题 id, 在话题页面地址栏查看']"/>
 
 ### 米哈游
 
-#### 崩坏 2-游戏公告 <Author uid="deepred5"/>
-
-举例: <https://rsshub.app/mihoyo/bh2/gach>
-
-路由: `/mihoyo/bh2/:type`
-
-参数:
-
--   type, 公告种类
+<route name="崩坏 2-游戏公告" author="deepred5" example="/mihoyo/bh2/gach" path="/mihoyo/bh2/:type" :paramsDesc="['公告种类']">
 
 | 最新公告 | 版本信息 | 祈愿信息 | 活动介绍 |
 | -------- | -------- | -------- | -------- |
 | new      | version  | gach     | event    |
 
-#### 崩坏 3-游戏公告 <Author uid="deepred5"/>
+</route>
 
-举例: <https://rsshub.app/mihoyo/bh3/strategy>
-
-路由: `/mihoyo/bh3/:type`
-
-参数:
-
--   type, 公告种类
+<route name="崩坏 3-游戏公告" author="deepred5" example="/mihoyo/bh3/strategy" path="/mihoyo/bh3/:type" :paramsDesc="['公告种类']">
 
 | 最新   | 公告   | 新闻 | 活动     | 攻略     |
 | ------ | ------ | ---- | -------- | -------- |
 | latest | notice | news | activity | strategy |
 
+</route>
+
 ### 忧郁的弟弟
 
-#### 文章
-
-举例: <https://rsshub.app/mygalgame>
-
-路由: `/mygalgame`
-
-参数: 无
+<route name="文章" author="DIYgod" example="/mygalgame" path="mygalgame"/>
 
 ## 程序更新
 
-### RSSHub <Author uid="DIYgod"/>
+<route level="3" name="RSSHub" author="DIYgod" example="/rsshub/rss" path="/rsshub/rss"/>
 
-举例: <https://rsshub.app/rsshub/rss>
-
-路由: `/rsshub/rss`
-
-参数: 无
-
-### MIUI <Author uid="Indexyz"/>
-
-举例: <https://rsshub.app/miui/aries/>
-
-路由: `/miui/:device/:type?`
-
-参数:
-
--   device: 设备的 `codename` 例如 小米 2s 为 `aries`
-
--   type: 类型, 可选参数
+<route level="3" name="MIUI" author="Indexyz" example="/miui/aries" path="/miui/:device/:type?" :paramsDesc="['设备的 `codename` 例如 小米 2s 为 `aries`', '类型, 可选参数']">
 
 | 稳定版  | 开发版 |
 | ------- | ------ |
 | release | dev    |
 
-### Firefox <Author uid="fengkx"/>
+</route>
 
-举例: <https://rsshub.app/firefox/release/desktop>
-
-路由: `/firefox/release/:platform`
-
-参数:
-
--   platform
+<route level="3" name="Firefox" author="fengkx" example="/firefox/release/desktop" path="/firefox/release/:platform" :paramsDesc="['操作平台']">
 
 | 桌面    | Android | Beta | Nightly | Android Beta | ESR           |
 | ------- | ------- | ---- | ------- | ------------ | ------------- |
 | desktop | android | beta | nightly | android-beta | organizations |
 
-### Thunderbird <Author uid="garywill"/>
+</route>
 
-举例: <https://rsshub.app/thunderbird/release>
+### Thunderbird
 
-路由: `/thunderbird/release/`
+<route name="更新日志" author="garywill" example="/thunderbird/release" path="/thunderbird/release"/>
 
-参数: 无
+### 腾讯云移动直播 SDK
 
-### 腾讯云移动直播 SDK <Author uid="cielpy"/>
+<route name="更新日志" author="cielpy" example="/qcloud/mlvb/changelog" path="/qcloud/mlvb/changelog"/>
 
-举例: <https://rsshub.app/qcloud/mlvb/changelog>
+### Bugly SDK
 
-路由: `/qcloud/mlvb/changelog`
+<route level="3" name="更新日志" author="cielpy" example="/bugly/changelog/1" path="/bugly/changelog/:platform" :paramsDesc="['平台类型, 必选, 1 为 Android, 2 为 iOS']"/>
 
-参数: 无
+### fir.im 应用
 
-### Bugly SDK <Author uid="cielpy"/>
+<route level="3" name="更新" author="cielpy" example="/fir/update/xcz" path="/fir/update/:id" :paramsDesc="['fir app id, 必选, 如 fir 生成的链接地址为 https://fir.im/xcz, 则 id 为 `xcz`']"/>
 
-举例: <https://rsshub.app/bugly/changelog/1>
+### Nvidia Web Driver
 
-路由: `/bugly/changelog/:platform`
-
-参数:
-
--   platform, 平台类型, 必选, 1 为 Android, 2 为 iOS
-
-### fir.im 应用 <Author uid="cielpy"/>
-
-举例: <https://rsshub.app/fir/update/xcz>
-
-路由: `/fir/update/:id`
-
-参数:
-
--   id, fir app id, 必选, 如 fir 生成的链接地址为 https://fir.im/xcz, 则 id 为 `xcz`
-
-### Nvidia Web Driver 更新 <Author uid="cielpy"/>
-
-举例: <https://rsshub.app/nvidia/webdriverupdate>
-
-路由: `/nvidia/webdriverupdate`
-
-参数: 无
+<route level="3" name="更新日志" author="cielpy" example="/nvidia/webdriverupdate" path="/nvidia/webdriverupdate"/>
 
 ### App Store/Mac App Store
 
-#### 应用更新 <Author uid="cielpy"/>
+<route name="应用更新" author="HenryQW" example="/appstore/update/cn/id444934666" path="/appstore/update/:country/:id" :paramsDesc="['App Store 国家, 如 QQ 的链接为 https://itunes.apple.com/cn/app/qq/id444934666?mt=8, 则 country 为 `cn`', 'App Store app id, 如 QQ 的链接为 https://itunes.apple.com/cn/app/qq/id444934666?mt=8, 则 id 为 `id444934666`']"/>
 
-举例: <https://rsshub.app/appstore/update/cn/id444934666>
+<route name="价格更新（限免）" author="HenryQW" example="/appstore/price/cn/mac/id1152443474" path="/appstore/price/:country/:type/:id" :paramsDesc="['App Store 国家, 如 Squash 的链接为 https://itunes.apple.com/cn/app/id1152443474, 则 country 为 `cn`', 'App 类型, `iOS` 或 `mac`', 'App Store app id, 必选, 如 Squash 的链接为 https://itunes.apple.com/cn/app/id1152443474, 则 id 为 `id115244347`']"/>
 
-路由: `/appstore/update/:country/:id`
-
-参数:
-
--   country, App Store 国家, 必选, 如 QQ 的链接为 https://itunes.apple.com/cn/app/qq/id444934666?mt=8, 则 country 为 `cn`
-
--   id, App Store app id, 必选, 如 QQ 的链接为 https://itunes.apple.com/cn/app/qq/id444934666?mt=8, 则 id 为 `id444934666`
-
-#### 价格更新（限免） <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/appstore/price/cn/mac/id1152443474>
-
-路由: `/appstore/price/:country/:type/:id`
-
-参数:
-
--   country, App Store 国家, 必选, 如 Squash 的链接为 https://itunes.apple.com/cn/app/id1152443474, 则 country 为 `cn`
-
--   type, App 类型, 必选, `iOS` 或 `mac`
-
--   id, App Store app id, 必选, 如 Squash 的链接为 https://itunes.apple.com/cn/app/id1152443474, 则 id 为 `id115244347`
-
-#### 内购价格更新（限免） <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/appstore/iap/cn/id953286746>
-
-路由: `/appstore/iap/:country/:id`
-
-参数:
-
--   country, App Store 国家, 必选, 如 Darkroom – Photo Editor 的链接为 https://itunes.apple.com/cn/app/id953286746, 则 country 为 `cn`
--   id, App Store app id, 必选, 如 Darkroom – Photo Editor 的链接为 https://itunes.apple.com/cn/app/id953286746, 则 id 为 `id953286746`
+<route name="内购价格更新（限免）" author="HenryQW" example="/appstore/iap/cn/id953286746" path="/appstore/iap/:country/:id" :paramsDesc="['App Store 国家, 必选, 如 Darkroom – Photo Editor 的链接为 https://itunes.apple.com/cn/app/id953286746, 则 country 为 `cn`', 'App Store app id, 必选, 如 Darkroom – Photo Editor 的链接为 https://itunes.apple.com/cn/app/id953286746, 则 id 为 `id953286746`']"/>
 
 ### Greasy Fork
 
-#### 脚本更新 <Author uid="imlonghao"/>
-
-举例: <https://rsshub.app/greasyfork/zh-CN/bilibili.com>
-
-路由: `/greasyfork/:language/:domain?`
-
-参数:
-
--   language, 语言, 可在网站右上角找到, `all` 为所有语言
--   domain, 按脚本生效域名过滤, 可选
+<route name="脚本更新" author="imlonghao" example="/greasyfork/zh-CN/bilibili.com" path="/greasyfork/:language/:domain?" :paramsDesc="['语言, 可在网站右上角找到, `all` 为所有语言', '按脚本生效域名过滤, 可选']"/>
 
 ### Minecraft CurseForge
 
-#### Mod 更新 <Author uid="Indexyz"/>
-
-举例: <https://rsshub.app/curseforge/files/jei>
-
-路由: `/curseforge/files/:project`
-
-参数:
-
--   project: 项目的短名或者 `Project ID`. 项目的短名可以在地址栏获取到, 例如地址为 `https://minecraft.curseforge.com/projects/non-update`, 短名就为 `non-update`. `Project ID` 可在 `Overview` 中的 `About This Project` 中找到
+<route name="Mod 更新" author="Indexyz" example="/curseforge/files/jei" path="/curseforge/files/:project" :paramsDesc="['项目的短名或者 `Project ID`. 项目的短名可以在地址栏获取到, 例如地址为 `https://minecraft.curseforge.com/projects/non-update`, 短名就为 `non-update`. `Project ID` 可在 `Overview` 中的 `About This Project` 中找到']"/>
 
 ### xclient.info
 
-#### 应用更新
-
-举例: <https://rsshub.app/xclient/app/sketch>
-
-路由: `/xclient/app/:name`
-
-参数:
-
--   name: 应用名, 可在应用页 URL 中找到
+<route name="应用更新" author="DIYgod" example="/xclient/app/sketch" path="/xclient/app/:name" :paramsDesc="['应用名, 可在应用页 URL 中找到']"/>
 
 ## 大学通知
 
 ### 上海海事大学
 
-#### 学术讲座 <Author uid="simonsmh"/>
+<route name="学术讲座" author="simonsmh" example="/shmtu/events" path="/universities/shmtu/events"/>
 
-举例: <https://rsshub.app/shmtu/events>
+<route name="通知公告" author="simonsmh" example="/shmtu/notes" path="/universities/shmtu/notes"/>
 
-路由: `/shmtu/events`
-
-参数: 无
-
-#### 通知公告 <Author uid="simonsmh"/>
-
-举例: <https://rsshub.app/shmtu/notes>
-
-路由: `/shmtu/notes`
-
-参数: 无
-
-#### 教务信息 <Author uid="simonsmh"/>
-
-举例: <https://rsshub.app/shmtu/jwc/1>
-
-路由: `/shmtu/jwc/:type`
-
-参数:
-
--   type, 1 为教务新闻, 2 为教务公告
+<route name="教务信息" author="simonsmh" example="/shmtu/jwc/1" path="/universities/shmtu/jwc/:type" :paramsDesc="['1 为教务新闻, 2 为教务公告']"/>
 
 ### 西南科技大学
 
-#### 教务处通知 <Author uid="lengthmin"/>
+<route name="教务处通知" author="lengthmin" example="/swust/jwc/1" path="/universities/swust/jwc/:type" :paramsDesc="['1 为通知公告, 2 为站点新闻']"/>
 
-举例: <https://rsshub.app/swust/jwc/1>
-
-路由: `/swust/jwc/:type`
-
-参数:
-
--   type, 1 为通知公告, 2 为站点新闻
-
-#### 计科学院通知 <Author uid="lengthmin"/>
-
-举例: <https://rsshub.app/swust/cs/1>
-
-路由: `swust/cs/:type`
-
-参数:
-
--   type, 1 为新闻动态, 2 为学术动态, 3 为通知公告, 4 为教研动态
+<route name="计科学院通知" author="lengthmin" example="/swust/cs/1" path="/universities/swust/cs/:type" :paramsDesc="['1 为新闻动态, 2 为学术动态, 3 为通知公告, 4 为教研动态']"/>
 
 ### 北京大学
 
-#### 信科公告通知 <Author uid="Ir1d"/>
-
-举例: <https://rsshub.app/pku/eecs/0>
-
-路由: `/eecs/:type`
-
-参数:
-
--   type, 可选分区 type, 可在网页 URL 中找到
+<route name="信科公告通知" author="Ir1d" example="/pku/eecs/0" path="/universities/pku/eecs/:type" :paramsDesc="['分区 type, 可在网页 URL 中找到']">
 
 | 全部 | 学院通知 | 人事通知 | 教务通知 | 学工通知 | 科研通知 | 财务通知 | 工会通知 | 院友通知 |
 | ---- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
 | 0    | 1        | 2        | 6        | 8        | 7        | 5        | 3        | 4        |
 
+</route>
+
 ### 华南师范大学
 
-#### 教务处通知 <Author uid="fengkx"/>
+<route name="教务处通知" author="fengkx" example="/scnu/jw" path="/universities/scnu/jw"/>
 
-举例: <https://rsshub.app/scnu/jw>
+<route name="图书馆通知" author="fengkx" example="/scnu/library" path="/universities/scnu/library"/>
 
-路由: `/scnu/jw`
-
-参数: 无
-
-#### 图书馆通知 <Author uid="fengkx"/>
-
-举例: <https://rsshub.app/scnu/library>
-
-路由: `/scnu/library`
-
-参数: 无
-
-#### 计算机学院竞赛通知 <Author uid="fengkx"/>
-
-举例: <https://rsshub.app/scnu/cs/match>
-
-路由: `/scnu/cs/match`
-
-参数: 无
+<route name="计算机学院竞赛通知" author="fengkx" example="/scnu/cs/match" path="/universities/scnu/cs/match"/>
 
 ### 江南大学
 
-#### 教务处通知 <Author uid="Chingyat"/>
-
-举例: <https://rsshub.app/ju/jwc/all>
-
-路由: `/ju/jwc/:type?`
-
-参数:
-
--   type, 可选, 默认为 `all`
+<route name="教务处通知" author="Chingyat" example="/ju/jwc/all" path="/universities/ju/jwc/:type?" :paramsDesc="['默认为 `all`']">
 
 | all  | tzgg     | ksap     | wjgg     | tmgz     | djks     | xjgl     | bysj     | syjs     |
 | ---- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
@@ -1961,128 +924,69 @@ GitHub 官方也提供了一些 RSS:
 | -------- | -------- | ---------- | -------- | -------- | -------- | -------- | -------- | -------- |
 | 实践创新 | 学科竞赛 | 研究生助教 | 教学改革 | 专业建设 | 课程建设 | 教材建设 | 教学成果 | 学术报告 |
 
+</route>
+
 ### 大连工业大学
 
-#### 教务处新闻 <Author uid="xu42"/>
-
-举例: <https://rsshub.app/dpu/jiaowu/news/2>
-
-路由: `/dpu/jiaowu/news/:type?`
-
-参数:
-
--   type, 可选, 默认为 `2`
+<route name="教务处新闻" author="xu42" example="/dpu/jiaowu/news/2" path="/universities/dpu/jiaowu/news/:type?" :paramsDesc="['默认为 `2`']">
 
 | 新闻动态 | 通知公告 | 教务文件 |
 | -------- | -------- | -------- |
 | 2        | 3        | 4        |
 
-#### 网络服务新闻 <Author uid="xu42"/>
+</route>
 
-举例: <https://rsshub.app/dpu/wlfw/news/2>
-
-路由: `/dpu/wlfw/news/:type?`
-
-参数: type, 可选, 默认为 `1`
+<route name="网络服务新闻" author="xu42" example="/dpu/wlfw/news/2" path="/universities/dpu/wlfw/news/:type?" :paramsDesc="['默认为 `1`']">
 
 | 新闻动态 | 通知公告 |
 | -------- | -------- |
 | 1        | 2        |
 
+</route>
+
 ### 东南大学
 
-#### 信息科学与工程学院学术活动 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/seu/radio/academic>
-
-路由: `/seu/radio/academic`
-
-参数: 无
+<route name="信息科学与工程学院学术活动" author="HenryQW" example="/seu/radio/academic" path="/universities/seu/radio/academic"/>
 
 ### 哈尔滨工业大学
 
-#### 哈尔滨工业大学教务处通知公告 <Author uid="lty96117"/>
-
-举例: <https://rsshub.app/hit/jwc>
-
-路由: `/hit/jwc`
-
-参数: 无
+<route name="哈尔滨工业大学教务处通知公告" author="lty96117" example="/hit/jwc" path="/universities/hit/jwc"/>
 
 ### 上海科技大学
 
-#### 信息科技与技术学院活动 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/shanghaitech/sist/activity>
-
-路由: `/shanghaitech/sist/activity`
-
-参数: 无
+<route name="信息科技与技术学院活动" author="HenryQW" example="/universities/shanghaitech/sist/activity" path="/shanghaitech/sist/activity"/>
 
 ### 上海交通大学
 
-#### 电子信息与电气工程学院学术动态 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/sjtu/seiee/academic>
-
-路由: `/sjtu/seiee/academic`
-
-参数: 无
+<route name="电子信息与电气工程学院学术动态" author="HenryQW" example="/universities/sjtu/seiee/academic" path="/sjtu/seiee/academic"/>
 
 ### 中国科学院
 
-#### 上海微系统与信息技术研究所学术活动 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/cas/sim/academic>
-
-路由: `/cas/sim/academic`
-
-参数: 无
+<route name="上海微系统与信息技术研究所学术活动" author="HenryQW" example="/universities/cas/sim/academic" path="/cas/sim/academic"/>
 
 ### 南京邮电大学
 
-#### 教务处通知与新闻 <Author uid="shaoye"/>
-
-举例: <https://rsshub.app/njupt/jwc/notice>
-
-路由: `/njupt/jwc/:type?`
-
-参数:
-
--   type, 可选, 默认为 `notice`
+<route name="教务处通知与新闻" author="shaoye" example="/njupt/jwc/notice" path="/universities/njupt/jwc/:type?" :paramsDesc="['默认为 `notice`']">
 
 | 通知公告 | 教务快讯 |
 | -------- | -------- |
 | notice   | news     |
 
+</route>
+
 ### 南昌航空大学
 
-#### 教务处公告与新闻 <Author uid="Sg4Dylan"/>
-
-举例: <https://rsshub.app/nchu/jwc/notice>
-
-路由: `/nchu/jwc/:type?`
-
-参数:
-
--   type, 可选, 默认为 `notice`
+<route name="教务处公告与新闻" author="Sg4Dylan" example="/nchu/jwc/notice" path="/universities/nchu/jwc/:type?" :paramsDesc="['默认为 `notice`']">
 
 | 教务公告 | 教务新闻 |
 | -------- | -------- |
 | notice   | news     |
 
+</route>
+
 ### 哈尔滨工程大学
 
-#### 本科生院工作通知 <Author uid="XYenon"/>
-
-举例: <https://rsshub.app/heu/ugs/news/jwc/jxap>
-
-路由: `/heu/ugs/news/:author?/:category?`
-
-参数:
-
--   author, 可选, 发布部门, 默认为 `gztz`
--   category, 可选, 分类, 默认为 `all`
+<route name="本科生院工作通知" author="XYenon" example="/heu/ugs/news/jwc/jxap" path="/universities/heu/ugs/news/:author?/:category?" :paramsDesc="['发布部门, 默认为 `gztz`', '分类, 默认为 `all`']">
 
 author 列表：
 
@@ -2134,95 +1038,59 @@ category 列表：
 
 工作通知：无
 
+</route>
+
 ### 重庆大学
 
-#### 教务网通知公告 <Author uid="El-Chiang"/>
-
-举例: <https://rsshub.app/cqu/jwc/announcement>
-
-路由: `/cqu/jwc/announcement`
-
-参数: 无
+<route name="教务网通知公告" author="El-Chiang" example="/cqu/jwc/announcement" path="/universities/cqu/jwc/announcement"/>
 
 ### 成都信息工程大学
 
-#### 成信新闻网 <Author uid="kimika"/>
-
-举例: <https://rsshub.app/cuit/cxxww/1>
-
-路由: `/cuit/cxxww/:type?`
-
-参数:
-
--   type, 可选, 默认为 `1`
+<route name="成信新闻网" author="kimika" example="/cuit/cxxww/1" path="/universities/cuit/cxxww/:type?" :paramsDesc="['默认为 `1`']"/>
 
 | 综合新闻 | 信息公告 | 焦点新闻 | 学术动态 | 工作交流 | 媒体成信 | 更名专题 | 文化活动 |
 | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
 | 1        | 2        | 3        | 4        | 5        | 7        | 9        | 10       |
 
+</route>
+
 ### 重庆科技学院
 
-#### 教务处公告 <Author uid="binarization"/>
-
-举例: <https://rsshub.app/cqust/jw/notify>
-
-路由: `/cqust/jw/:type?`
-
-参数:
-
--   type, 可选, 默认为 `notify`
+<route name="教务处公告" author="binarization" example="/universities/cqust/jw/notify" path="/cqust/jw/:type?" :paramsDesc="['可选, 默认为 `notify`']">
 
 | 通知公告 | 教务快讯 |
 | -------- | -------- |
 | notify   | news     |
 
-#### 图书馆公告 <Author uid="binarization"/>
+</route>
 
-路由: `/cqust/lib/:type?`
-
-参数:
-
--   type, 可选, 默认为 `news`
+<route name="图书馆公告" author="binarization" example="/cqust/lib/news" path="/universities/cqust/lib/:type?" :paramsDesc="['可选, 默认为 `news`']">
 
 |  本馆公告 |
 | --------- |
 | news      |
 
+</route>
+
 ## 传统媒体
 
 ### 央视新闻
 
-#### 专题 <Author uid="idealclover"/>
-
-举例: <https://rsshub.app/cctv/world>
-
-路由: `/cctv/:category`
-
-参数:
-
--   category, 分类名
+<route name="专题" author="idealclover" example="/cctv/world" path="/cctv/:category" :paramsDesc="['分类名']">
 
 | 国内  | 国际  | 视频  | 科技 | 社会    | 法律 | 娱乐 |
 | ----- | ----- | ----- | ---- | ------- | ---- | ---- |
 | china | world | video | tech | society | law  | ent  |
 
+</route>
+
 ### 财新网
 
 > 网站部分内容需要付费订阅, RSS 仅做更新提醒, 不含付费内容.
 
-#### 新闻分类 <Author uid="idealclover"/>
+<route name="新闻分类" author="idealclover" example="/caixin/finance/regulation" path="/caixin/:column/:category" :paramsDesc="['栏目名', '栏目下的子分类名']">
 
-举例: <https://rsshub.app/caixin/finance/regulation>
-
-路由: `/caixin/:column/:category`
-
-参数:
-
--   column, 栏目名
-
--   category, 栏目下的子分类名
-
--   column 列表:
+Column 列表:
 
 | 经济    | 金融    | 政经  | 环科    | 世界          | 观点网  | 文化    | 周刊   |
 | ------- | ------- | ----- | ------- | ------------- | ------- | ------- | ------ |
@@ -2234,27 +1102,25 @@ category 列表：
 | ---------- | ---- | -------- | --------------- | ---------- | ---------- | ------ |
 | regulation | bank | stock    | insurance_trust | investment | innovation | market |
 
-财新周刊 category 列表:
+Category 列表:
 
 | 封面报道   | 开卷  | 社论      | 时事            | 编辑寄语    | 经济    | 金融    | 商业     | 环境与科技             | 民生    | 副刊   |
 | ---------- | ----- | --------- | --------------- | ----------- | ------- | ------- | -------- | ---------------------- | ------- | ------ |
 | coverstory | first | editorial | current_affairs | editor_desk | economy | finance | business | environment_technology | cwcivil | column |
 
+</route>
+
 ### 南方周末
 
-#### 新闻分类 <Author uid="ranpox"/>
+<route name="新闻分类" author="ranpox" example="/infzm/5" path="/infzm/:id" :paramsDesc="['南方周末内容分区 id, 可在该内容分区的 URL 中找到(即http://www.infzm.com/contents/:id), 注意 contents 为内容分区, content 为文章页, 添加前请留意.']">
 
-举例: <https://rsshub.app/infzm/5>
-
-路由: `/infzm/:id`
-
-参数:
-
--   id, 南方周末内容分区 id, 可在该内容分区的 URL 中找到(即http://www.infzm.com/contents/:id), 注意 contents 为内容分区, content 为文章页, 添加前请留意. 下面给出部分参考:
+下面给出部分参考:
 
 | 全站 | 新闻 | 经济 | 文化 | 评论 | 图片 | 生活 | 时政 | 社会 | 科技 | 绿色 | 头条 |
 | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
 | 0    | 5    | 6    | 7    | 8    | 9    | 10   | 11   | 12   | 13   | 1374 | 2553 |
+
+</route>
 
 ### 纽约时报
 
@@ -2264,240 +1130,118 @@ category 列表：
 
 :::
 
-#### 新闻早报 <Author uid="yangkghjh"/>
-
-举例: <https://rsshub.app/nytimes/morning_post>
-
-路由: `/nytimes/morning_post`
-
-参数: 无
+<route name="新闻早报" author="yangkghjh" example="/nytimes/morning_post" path="/nytimes/morning_post"/>
 
 ### 新京报
 
-#### 栏目 <Author uid="zhboner"/>
-
-举例: <https://rsshub.app/bjnews/realtime>
-
-路由: `/bjnews/:category`
-
-参数:
-
--   category, 新京报的栏目名, 点击对应栏目后在地址栏找到
+<route name="栏目" author="DIYgod" example="/bjnews/realtime" path="/bjnews/:category" :paramsDesc="['新京报的栏目名, 点击对应栏目后在地址栏找到']"/>
 
 ### 澎湃新闻
 
-#### 首页头条 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/thepaper/featured>
-
-路由: `/thepaper/featured`
-
-参数: 无
+<route name="首页头条" author="HenryQW" example="/thepaper/featured" path="/thepaper/featured"/>
 
 ### 联合早报
 
-#### 即时新闻 <Author uid="lengthmin"/>
-
-举例: <https://rsshub.app/zaobao/realtime/china>
-
-路由: `/zaobao/realtime/:type?`
-
-参数:
-
-type, 分类, 缺省为中港台
+<route name="即时新闻" author="lengthmin" example="/zaobao/realtime/china" path="/zaobao/realtime/:type?" :paramsDesc="['分类, 缺省为中港台']">
 
 | 中港台 | 新加坡    | 国际  | 财经     |
 | ------ | --------- | ----- | -------- |
 | china  | singapore | world | zfinance |
 
-#### 新闻 <Author uid="lengthmin"/>
+</route>
 
-举例: <https://rsshub.app/zaobao/znews/greater-china>
-
-路由: `/zaobao/znews/:type?`
-
-参数:
-
-type, 分类, 缺省为中港台
+<route name="新闻" author="lengthmin" example="/zaobao/znews/greater-china" path="/zaobao/znews/:type?" :paramsDesc="['分类, 缺省为中港台']">
 
 | 中港台        | 新加坡    | 东南亚 | 国际          | 体育   |
 | ------------- | --------- | ------ | ------------- | ------ |
 | greater-china | singapore | sea    | international | sports |
 
+</route>
+
 ## 预报预警
 
 ### 停水通知
 
-配合 [IFTTT](https://ifttt.com/) Applets [邮件通知](https://ifttt.com/applets/SEvmDVKY-) 使用实现自动通知效果
+配合 [IFTTT](https://ifttt.com/) Applets [邮件通知](https://ifttt.com/applets/SEvmDVKY-) 使用实现自动通知效果.
 
-#### 杭州市 <Author uid="znhocn"/>
+<route name="杭州市" author="znhocn" example="/tingshuitz/hangzhou" path="/tingshuitz/hangzhou"/>
 
-举例: <https://rsshub.app/tingshuitz/hangzhou>
+<route name="萧山区" author="znhocn" example="/tingshuitz/xiaoshan" path="/tingshuitz/xiaoshan"/>
 
-路由: `/tingshuitz/hangzhou`
+<route name="大连市" author="DIYgod" example="/tingshuitz/dalian" path="/tingshuitz/dalian"/>
 
-参数: 无
+### 中国气象网
 
-#### 萧山区 <Author uid="znhocn"/>
+<route name="全国气象预警" author="ylc395" example="/weatherAlarm" path="/weatherAlarm">
 
-举例: <https://rsshub.app/tingshuitz/xiaoshan>
+可通过全局过滤参数订阅您感兴趣的地区.
 
-路由: `/tingshuitz/xiaoshan`
+</route>
 
-参数: 无
+### 中国地震局
 
-#### 大连市 <Author uid="znhocn"/>
+<route name="地震速报" author="ylc395" example="/earthquake" path="/earthquake">
 
-举例: <https://rsshub.app/tingshuitz/dalian>
+可通过全局过滤参数订阅您感兴趣的地区.
 
-路由: `/tingshuitz/dalian`
-
-参数: 无
-
-### 中国气象网 全国气象预警 <Author uid="ylc395"/>
-
-举例: <https://rsshub.app/weatherAlarm>
-
-路由: `/weatherAlarm`
-
-参数: 无（提示: 可以使用全局过滤参数订阅您感兴趣的地区的信息）
-
-### 中国地震局 地震速报 <Author uid="ylc395"/>
-
-举例: <https://rsshub.app/earthquake>
-
-路由: `/earthquake`
-
-参数: 无（提示:可通过全局过滤参数订阅您感兴趣的地区）
+</route>
 
 ## 出行旅游
 
 ### All the Flight Deals
 
-#### 特价机票 <Author uid="HenryQW"/>
+<route name="特价机票" author="HenryQW" example="/atfd/us+new%20york,gb+london/1" path="/atfd/:locations/:nearby?" :paramsDesc="['始发地, 由「国家, 参见 ISO 3166-1 国家代码」和「城市」两部分组成', '可选 0 或 1, 默认 0 为不包括, 是否包括临近机场']">
 
 举例: [https://rsshub.app/atfd/us+new york, gb+london/1](https://rsshub.app/atfd/us+new%20york,gb+london/1)
-
-路由: `/atfd/:locations/:nearby?`
-
-参数:
-
--   locations: 始发地, 由「国家, 参见 ISO 3166-1 国家代码」和「城市」两部分组成:
 
 1. 单个始发地, 例如 「us+new york」, [https://rsshub.app/atfd/us+new york](https://rsshub.app/atfd/us+new%20york)
 2. 逗号分隔多个始发地, 例如 「us+new york, gb+london」, [https://rsshub.app/atfd/us+new york, gb+london/](https://rsshub.app/atfd/us+new%20york,gb+london/)
 
 ISO 3166-1 国家代码列表请参见 [维基百科 ISO_3166-1](https://zh.wikipedia.org/wiki/ISO_3166-1)
 
--   nearby: 可选 0 或 1, 默认 0 为不包括, 是否包括临近机场
+</route>
 
 ### iMuseum
 
-#### 展览信息 <Author uid="sinchang"/>
-
-举例: <https://rsshub.app/imuseum/shanghai/all>
-
-路由: `/imuseum/:city/:type`
-
-参数:
-
--   city, 必选, 如 shanghai、beijing
--   type, 可选, 不填则默认为 `all`
+<route name="展览信息" author="sinchang" example="/imuseum/shanghai/all" path="/imuseum/:city/:type" :paramsDesc="['如 shanghai, beijing', '不填则默认为 `all`']"/>
 
 | 全部 | 最新   | 热门 | 即将结束 | 即将开始 | 已结束   |
 | ---- | ------ | ---- | -------- | -------- | -------- |
 | all  | latest | hot  | end_soon | coming   | outdated |
 
+</route>
+
 ### Hopper Flight Deals
 
-#### Hopper 特价机票 <Author uid="HenryQW"/>
+<route name="Hopper 特价机票" author="HenryQW" example="/hopper/1/LHR/PEK" path="/hopper/:lowestOnly/:from/:to?" :paramsDesc="['是否只返回最低价机票, `1`: 是, 其他任意值: 否', '始发地, IATA 国际航空运输协会机场代码', '目的地, IATA 国际航空运输协会机场代码, 可选, 缺省则目的地为`任意城市`']">
 
 本路由返回由 Hopper 算法给出的现在可购入最便宜的折扣机票, 通常包含 6 个结果. 出行日期将由 Hopper 算法定义, 可能是明天也可能是 10 个月后.
 
-举例: 伦敦希思罗 &#9992; 北京首都国际 <https://rsshub.app/hopper/1/LHR/PEK>
+伦敦希思罗 &#9992; 北京首都国际 <https://rsshub.app/hopper/1/LHR/PEK>
 
-路由: `/hopper/:lowestOnly/:from/:to?`
+IATA 国际航空运输协会机场代码, 参见[维基百科 国际航空运输协会机场代码](<https://zh.wikipedia.org/wiki/%E5%9B%BD%E9%99%85%E8%88%AA%E7%A9%BA%E8%BF%90%E8%BE%93%E5%8D%8F%E4%BC%9A%E6%9C%BA%E5%9C%BA%E4%BB%A3%E7%A0%81_(A)>)
 
-参数:
-
--   lowestOnly: 是否只返回最低价机票, `1`: 是, 其他任意值: 否
--   from: 始发地, IATA 国际航空运输协会机场代码
--   to: 目的地, IATA 国际航空运输协会机场代码, 可选, 缺省则目的地为`任意城市`
--   IATA 国际航空运输协会机场代码, 参见[维基百科 国际航空运输协会机场代码](<https://zh.wikipedia.org/wiki/%E5%9B%BD%E9%99%85%E8%88%AA%E7%A9%BA%E8%BF%90%E8%BE%93%E5%8D%8F%E4%BC%9A%E6%9C%BA%E5%9C%BA%E4%BB%A3%E7%A0%81_(A)>)
+</route>
 
 ### 马蜂窝
 
-#### 游记 <Author uid="sinchang"/>
-
-举例: <https://rsshub.app/mafengwo/note/hot>
-
-路由: `/mafengwo/note/:type`
-
-参数:
-
--   type, 必选, 目前支持两种, `hot` 代表热门游记, `latest` 代表最新游记
+<route name="游记" author="sinchang" example="/mafengwo/note/hot" path="/mafengwo/note/:type" :paramsDesc="['目前支持两种, `hot` 代表热门游记, `latest` 代表最新游记']"/>
 
 ### 中国美术馆
 
-#### 通知公告 <Author uid="HenryQW"/>
+<route name="通知公告" author="HenryQW" example="/namoc/announcement" path="/namoc/announcement"/>
 
-举例: <https://rsshub.app/namoc/announcement>
+<route name="新闻" author="HenryQW" example="/namoc/news" path="/namoc/news"/>
 
-路由: `/namoc/announcement`
+<route name="媒体联报" author="HenryQW" example="/namoc/media" path="/namoc/media"/>
 
-参数: 无
+<route name="展览预告" author="HenryQW" example="/namoc/exhibition" path="/namoc/exhibition"/>
 
-#### 新闻 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/namoc/news>
-
-路由: `/namoc/news`
-
-参数: 无
-
-#### 媒体联报 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/namoc/media>
-
-路由: `/namoc/media`
-
-参数: 无
-
-#### 展览预告 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/namoc/exhibition>
-
-路由: `/namoc/exhibition`
-
-参数: 无
-
-#### 焦点专题 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/namoc/specials>
-
-路由: `/namoc/specials`
-
-参数: 无
+<route name="焦点专题" author="HenryQW" example="/namoc/specials" path="/namoc/specials"/>
 
 ### 国家地理
 
-#### 分类 <Author uid="fengkx"/>
-
-举例:
-
-<https://rsshub.app/natgeo/travel>
-
-<https://rsshub.app/natgeo/news/ngnews>
-
-路由: `/natgeo/:cat/:type?`
-
-参数:
-
--   cat, 分类
-
--   type, 类型
-
-可在 url 中获取, 例如`https://www.natgeomedia.com/category/news/ngnews`对应 cat, type 分别为 news, ngnews
+<route name="分类" author="fengkx" example="/natgeo/news/ngnews" path="/natgeo/:cat/:type?" :paramsDesc="['分类', '类型, 例如`https://www.natgeomedia.com/category/news/ngnews`对应 cat, type 分别为 news, ngnews']"/>
 
 ## 购物
 
@@ -2509,31 +1253,19 @@ ISO 3166-1 国家代码列表请参见 [维基百科 ISO_3166-1](https://zh.wiki
 
 :::
 
-#### 关键词 <Author uid="DIYgod"/>
+</route>
 
-举例: <https://rsshub.app/smzdm/keyword/女装>
+<route name="关键词" author="DIYgod" example="/smzdm/keyword/女装" path="/smzdm/keyword/:keyword" :paramsDesc="['你想订阅的关键词']"/>
 
-路由: `/smzdm/keyword/:keyword`
+<route name="排行榜" author="DIYgod" example="/jianshu/user/yZq3ZV" path="/smzdm/ranking/:rank_type/:rank_id/:hour" :paramsDesc="['榜单类型','榜单ID','时间跨度']">
 
-参数:
-
--   keyword, 你想订阅的关键词
-
-#### 排行榜 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/smzdm/ranking/pinlei/11/3>
-
-路由: `/smzdm/ranking/:rank_type/:rank_id/:hour`
-
-参数
-
--   rank_type
+-   榜单类型
 
 | 好价品类榜 | 好价电商榜 | 海淘 TOP 榜 | 好文排行榜 | 好物排行榜 |
 | ---------- | ---------- | ----------- | ---------- | ---------- |
 | pinlei     | dianshang  | haitao      | haowen     | haowu      |
 
--   rank_id
+-   榜单 ID
 
 好价品类榜
 
@@ -2565,123 +1297,44 @@ ISO 3166-1 国家代码列表请参见 [维基百科 ISO_3166-1](https://zh.wiki
 | ------ | -------- | -------- | -------- |
 | hwall  | zc       | nb       | hw       |
 
--   hour, 时间跨度
+</route>
 
 ### 小米
 
-#### 众筹 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/mi/crowdfunding>
-
-路由: `/mi/crowdfunding`
-
-参数: 无
+<route name="众筹" author="DIYgod" example="/mi/crowdfunding" path="/mi/crowdfunding"/>
 
 ## 网络小说
 
-### 笔趣阁 <Author uid="jjeejj"/>
+### 笔趣阁
 
-举例: <https://rsshub.app/novel/biquge/52_52542>
+<route name="小说更新" author="jjeejj" example="/novel/biquge/52_52542" path="/novel/biquge/:id" :paramsDesc="['小说 id, 可在对应小说页 URL 中找到']">
 
-路由: `/novel/biquge/:id`
-
-参数:
-
--   id, 小说 id, 可在对应小说页 URL 中找到
-
-举例网址: https://www.biquge5200.cc/52_52542/
 ::: tip 提示
 
 由于笔趣阁网站有多个, 各站点小说对应的小说 id 不同. 此 feed 只对应在[`www.biquge5200.com`](https://www.biquge5200.com/)中的小说 id.
 
 :::
+</route>
 
-### UU 看书 <Author uid="jacky2001114"/>
+### UU 看书
 
-举例: <https://rsshub.app/novel/uukanshu/49621>
+<route name="小说更新" author="jacky2001114" example="/novel/uukanshu/49621>" path="/novel/uukanshu/:id" :paramsDesc="['小说 id, 可在对应小说页 URL 中找到']"/>
 
-路由: `/novel/uukanshu/:id`
-
-参数:
-
--   id, 小说 id, 可在对应小说页 URL 中找到
-
-举例网址: https://www.uukanshu.com/b/49621
-
-### 文学迷 <Author uid="lengthmin"/>
-
-举例: <https://rsshub.app/novel/wenxuemi/6/6144>
-
-路由: `/novel/wenxuemi/:id1/:id2`
-
-参数:
-
--   id1/id2, 小说网站链接最后的数字, 可在对应小说页 URL 中找到
-
-举例网址: https://www.wenxuemi.com/files/article/html/6/6144/
+<route level="3" name="文学迷" author="lengthmin" example="/novel/wenxuemi/6/6144" path="/novel/wenxuemi/:id1/:id2" :paramsDesc="['小说网站链接倒数第二部分的数字, 可在对应小说页 URL 中找到, 例如 `6` https://www.wenxuemi.com/files/article/html/6/6144/', '小说网站链接最后的数字, 可在对应小说页 URL 中找到, 例如 `6144` https://www.wenxuemi.com/files/article/html/6/6144/']"/>
 
 ### 起点
 
-#### 章节 <Author uid="Chingyat"/>
+<route name="章节" author="Chingyat" example="/qidian/chapter/1010400217" path="/qidian/chapter/:id`" :paramsDesc="['小说 id, 可在对应小说页 URL 中找到']"/>
 
-举例: <https://rsshub.app/qidian/chapter/1010400217>
+<route name="讨论区" author="Chingyat" example="/qidian/forum/1010400217" path="/qidian/forum/:id" :paramsDesc="['小说 id, 可在对应小说页 URL 中找到']"/>
 
-路由: `/qidian/chapter/:id`
-
-参数:
-
--   id, 小说 id, 可在对应小说页 URL 中找到
-
-#### 讨论区 <Author uid="Chingyat"/>
-
-举例: <https://rsshub.app/qidian/forum/1010400217>
-
-路由: `/qidian/forum/:id`
-
-参数:
-
--   id, 小说 id, 可在对应小说页 URL 中找到
-
-### 快眼看书 <Author uid="squkw"/>
-
-举例: <https://rsshub.app/novel/booksky/98619>
-
-路由: `/novel/booksky/:id`
-
-参数:
-
--   id, 小说 id, 可在对应小说页 URL 中找到
-
-举例网址: http://booksky.so/BookDetail.aspx?Level=1&bid=98619
+<route level="3" name="快眼看书" author="squkw" example="/novel/booksky/98619" path="/novel/booksky/:id" :paramsDesc="['小说 id, 可在对应小说页 URL 中找到, 例如 `98619` http://booksky.so/BookDetail.aspx?Level=1&bid=98619']"/>
 
 ## 中国驻外使领馆通知
 
-::: tip 提示
+<route level="3" name="大使馆" author="HenryQW" example="/embassy/us" path="/embassy/:country" :paramsDesc="['国家短代码, 见[支持国家列表](#支持国家列表)', '城市, 对应国家列表下的`领事馆城市列表`']" />
 
-便于分类, 使馆领馆统一归于 `embassy` 路由下, 以所在国家与城市区分.
-
-:::
-
-### 大使馆
-
-举例: <https://rsshub.app/embassy/us>
-
-路由: `/embassy/:country`
-
-参数:
-
--   country, 国家短代码, 见[支持国家列表](#支持国家列表)
-
-### 领事馆
-
-举例: <https://rsshub.app/embassy/us/chicago>
-
-路由: `/embassy/:country/:city`
-
-参数:
-
--   country, 国家短代码, 见[支持国家列表](#支持国家列表)
--   city, 城市, 对应国家列表下的`领事馆城市列表`
+<route level="3" name="领事馆" author="HenryQW" example="/embassy/us/chicago" path="/embassy/:country/:city" :paramsDesc="['国家短代码, 见[支持国家列表](#支持国家列表)', '城市, 对应国家列表下的`领事馆城市列表`']" />
 
 ### 支持国家列表
 
@@ -2778,23 +1431,11 @@ ISO 3166-1 国家代码列表请参见 [维基百科 ISO_3166-1](https://zh.wiki
 
 ### 自如
 
-#### 房源 <Author uid="DIYgod"/>
-
-举例: <https://rsshub.app/ziroom/room/sh/1/2/五角场>
-
-路由: `/ziroom/room/:city/:iswhole/:room/:keyword`
-
-参数
-
--   city: 城市, 北京 bj; 上海 sh; 深圳 sz; 杭州 hz; 南京 nj; 广州 gz; 成都 cd; 武汉 wh; 天津 tj
-
--   iswhole: 是否整租
-
--   room: 房间数
-
--   keyword: 关键词
+<route name="房源" author="DIYgod" example="/ziroom/room/sh/1/2/五角场" path="/ziroom/room/:city/:iswhole/:room/:keyword" :paramsDesc="['城市, 北京 bj; 上海 sh; 深圳 sz; 杭州 hz; 南京 nj; 广州 gz; 成都 cd; 武汉 wh; 天津 tj', '是否整租', '房间数', '关键词']"/>
 
 ### 快递
+
+<route name="快递" author="DIYgod" example="/express/youzhengguoji/CV054432809US" path="/express/:company/:number" :paramsDesc="['快递单号', '快递公司代码, 参考 [API URL 所支持的快递公司及参数说明](https://www.kuaidi100.com/download/api_kuaidi100_com%2820140729%29.doc)']">
 
 ::: warning 注意
 
@@ -2802,181 +1443,74 @@ ISO 3166-1 国家代码列表请参见 [维基百科 ISO_3166-1](https://zh.wiki
 
 :::
 
-举例: <https://rsshub.app/express/youzhengguoji/CV054432809US>
-
-路由: `/express/:company/:number`
-
-参数
-
--   company: 快递公司代码, 参考 [API URL 所支持的快递公司及参数说明](https://www.kuaidi100.com/download/api_kuaidi100_com%2820140729%29.doc)
-
--   number: 快递单号
+</route>
 
 ### 腾讯吐个槽
 
-#### 吐槽新帖 <Author uid="Qixingchen"/>
-
-举例: <https://rsshub.app/tucaoqq/post/28564/CdRI0728>
-
-路由: `/tucaoqq/post/:project/:key`
-
-参数
-
--   project: 产品 ID
-
--   key: 产品密钥
+<route name="吐槽新帖" author="Qixingchen" example="/tucaoqq/post/28564/CdRI0728" path="/tucaoqq/post/:project/:key" :paramsDesc="['产品 ID', '产品密钥']"/>
 
 ### 今日头条
 
-#### 关键词 <Author uid="uni-zheng"/>
-
-举例: <https://rsshub.app/jinritoutiao/keyword/ai>
-
-路由: `/jinritoutiao/keyword/:keyword`
-
-参数:
-
--   keyword, 关键词
+<route name="关键词" author="uni-zheng" example="/jinritoutiao/keyword/AI" path="/jinritoutiao/keyword/:keyword" :paramsDesc="['关键词']"/>
 
 ### Readhub
 
-#### 分类 <Author uid="WhiteWorld"/>
-
-举例: <https://rsshub.app/readhub/category/topic>
-
-路由: `/readhub/category/:category`
-
-参数:
-
--   category, 分类名
+<route name="分类" author="WhiteWorld" example="/readhub/category/topic" path="/readhub/category/:category" :paramsDesc="['分类名']">
 
 | 热门话题 | 科技动态 | 开发者资讯 | 区块链快讯 |
 | -------- | -------- | ---------- | ---------- |
 | topic    | news     | technews   | blockchain |
 
+</route>
+
 ### 3DMGame
 
-#### 新闻中心 <Author uid="zhboner"/>
+<route name="新闻中心" author="zhboner" example="/3dm/news" path="/3dm/news"/>
 
-举例: <https://rsshub.app/3dm/news>
+<route name="新闻" author="sinchang jacky2001114" example="/3dm/detroitbecomehuman/news" path="/3dm/:name/news" :paramsDesc="['游戏的编号可以在专题页的 url 中找到']"/>
 
-路由: `/3dm/news`
+<route name="攻略" author="sinchang jacky2001114" example="/j3dm/detroitbecomehuman/gl" path="/3dm/:name/gl" :paramsDesc="['游戏的编号可以在专题页的 url 中找到']"/>
 
-参数: 无
-
-#### 新闻 <Author uid="sinchang jacky2001114"/>
-
-举例: <https://rsshub.app/3dm/detroitbecomehuman/news>
-
-路由: `/3dm/:name/news`
-
-参数:
-
--   name, 游戏的编号可以在专题页的 url 中找到
-
-#### 攻略 <Author uid="sinchang jacky2001114"/>
-
-举例: <https://rsshub.app/3dm/detroitbecomehuman/gl>
-
-路由: `/3dm/:name/gl`
-
-参数:
-
--   name, 游戏的编号可以在专题页的 url 中找到
-
-#### 下载 <Author uid="sinchang"/>
-
-举例: <https://rsshub.app/3dm/detroitbecomehuman/download>
-
-路由: `/3dm/:name/download`
-
-参数:
-
--   name, 游戏的编号可以在专题页的 url 中找到
+<route name="下载" author="sinchang" example="/3dm/detroitbecomehuman/download" path="/3dm/:name/download" :paramsDesc="['游戏的编号可以在专题页的 url 中找到']"/>
 
 ### 机核网
 
-#### 分类 <Author uid="MoguCloud"/>
-
-举例: <https://rsshub.app/gcores/category/1>
-
-路由: `/gcores/category/:category`
-
-参数:
-
--   category, 分类名
+<route name="分类" author="MoguCloud" example="/gcores/category/1" path="/gcores/category/:category" :paramsDesc="['分类名']">
 
 | 文章 | 新闻 | 电台 |
 | ---- | ---- | ---- |
 | 1    | 2    | 9    |
 
+</route>
+
 ### ONE · 一个
 
-#### 图片文字问答 <Author uid="fengkx"/>
-
-举例: <https://rsshub.app/one>
-
-路由: `/one`
-
-参数: 无
+<route name="图片文字问答" author="fengkx" example="/one" path="/one"/>
 
 ### Hexo
 
-#### Next 主题 <Author uid="fengkx"/>
-
-举例: <http://rsshub.app/hexo/next/fengkx.top>
-
-路由: `/hexo/next/:url`
-
-参数:
-
--   url, 博客 Url 不带协议头
+<route name="Next 主题博客" author="fengkx" example="/hexo/next/fengkx.top" path="/hexo/next/:url" :paramsDesc="['博客 Url 不带协议头']"/>
 
 ### Keep
 
-#### 运动日记 <Author uid="Dectinc"/>
-
-举例: <https://rsshub.app/keep/user/556b02c1ab59390afea671ea>
-
-路由: `/keep/user/:id`
-
-参数:
-
--   id, Keep 用户 id
+<route name="运动日记" author="Dectinc" example="/keep/user/556b02c1ab59390afea671ea" path="/keep/user/:id" :paramsDesc="['Keep 用户 id']"/>
 
 ### 懂球帝
 
-#### 早报 <Author uid="HenryQW"/>
+<route name="早报" author="HenryQW" example="/dongqiudi/daily" path="/dongqiudi/daily"/>
 
-举例: <https://rsshub.app/dongqiudi/daily>
-
-路由: `/dongqiudi/daily`
-
-参数: 无
-
-#### 足球赛果 <Author uid="HenryQW"/>
-
-举例: 皇家马德里: <https://rsshub.app/dongqiudi/result/50001755>
-
-路由: `/dongqiudi/result/:team`
-
-参数:
-
--   team, 球队 id, 可在[懂球帝数据](https://www.dongqiudi.com/data)中找到
+<route name="足球赛果" author="HenryQW" example="/dongqiudi/result/50001755" path="/jdongqiudi/result/:team" :paramsDesc="['球队 id, 可在[懂球帝数据](https://www.dongqiudi.com/data)中找到']"/>
 
 ### 维基百科
 
-#### 中国大陆新闻动态 <Author uid="HenryQW"/>
-
-举例: <https://rsshub.app/wikipedia/mainland>
-
-路由: `/wikipedia/mainland`
-
-参数: 无
+<route name="中国大陆新闻动态" author="HenryQW" example="/wikipedia/mainland" path="/wikipedia/mainland"/>
 
 ### Google
 
-#### 谷歌学术关键词更新 <Author uid="HenryQW"/>
+<route name="谷歌学术关键词更新" author="HenryQW" example="/google/scholar/data+visualization" path="/google/scholar/:query" :paramsDesc="['查询语句, 支持「简单」和「高级」两种模式:']">
+
+1. 简单模式, 例如「data visualization」, <https://rsshub.app/google/scholar/data+visualization>.
+2. 高级模式, 前往 [Google Scholar](https://scholar.google.com/schhp?hl=zh-cn&as_sdt=0, 5), 点击左上角, 选择高级搜索并提交查询. 此时 URL 应为: <https://scholar.google.com/scholar?as_q=data+visualization&as_epq=&as_oq=&as_eq=&as_occt=any&as_sauthors=&as_publication=&as_ylo=2018&as_yhi=&hl=zh-CN&as_sdt=0%2C5>, 复制`https://scholar.google.com/scholar?`后的所有语句作为本路由的查询参数. 例子所对应的完整路由为<https://rsshub.app/google/scholar/as_q=data+visualization&as_epq=&as_oq=&as_eq=&as_occt=any&as_sauthors=&as_publication=&as_ylo=2018&as_yhi=&hl=zh-CN&as_sdt=0%2C5>.
 
 ::: warning 注意
 
@@ -2984,71 +1518,38 @@ ISO 3166-1 国家代码列表请参见 [维基百科 ISO_3166-1](https://zh.wiki
 
 :::
 
-举例: <https://rsshub.app/google/scholar/data+visualization>
+</route>
 
-路由: `/google/scholar/:query`
+### 果壳网
 
-参数:
-
--   query: 查询语句, 支持「简单」和「高级」两种模式:
-
-1. 简单模式, 例如「data visualization」, <https://rsshub.app/google/scholar/data+visualization>.
-2. 高级模式, 前往 [Google Scholar](https://scholar.google.com/schhp?hl=zh-cn&as_sdt=0, 5), 点击左上角, 选择高级搜索并提交查询. 此时 URL 应为: <https://scholar.google.com/scholar?as_q=data+visualization&as_epq=&as_oq=&as_eq=&as_occt=any&as_sauthors=&as_publication=&as_ylo=2018&as_yhi=&hl=zh-CN&as_sdt=0%2C5>, 复制`https://scholar.google.com/scholar?`后的所有语句作为本路由的查询参数. 例子所对应的完整路由为<https://rsshub.app/google/scholar/as_q=data+visualization&as_epq=&as_oq=&as_eq=&as_occt=any&as_sauthors=&as_publication=&as_ylo=2018&as_yhi=&hl=zh-CN&as_sdt=0%2C5>.
-
-### 果壳网 guokr <Author uid="alphardex"/>
-
-#### 科学人
-
-举例: <https://rsshub.app/guokr/scientific>
-
-路由: `/guokr/scientific`
-
-参数: 无
+<route name="科学人" author="alphardex" example="/jguokr/scientific" path="/guokr/scientific"/>
 
 ### 推酷
 
-#### 周刊 <Author uid="zpcc"/>
-
-举例: <https://rsshub.app/tuicool/mags/tech>
-
-路由: `/tuicool/mags/:type`
-
-参数:
-
--   type
+<route name="周刊" author="zpcc" example="/tuicool/mags/tech" path="/tuicool/mags/:type" :paramsDesc="['类型如下']">
 
 | 编程狂人 | 设计匠艺 | 创业周刊 | 科技周刊 |
 | -------- | -------- | -------- | -------- |
 | prog     | design   | startup  | tech     |
 
-### 爱范儿 ifanr <Author uid="HenryQW"/>
+</route>
 
-#### AppSolution
+### 爱范儿 ifanr
 
-举例: <https://rsshub.app/ifanr/appso>
+<route name="AppSolution" author="HenryQW" example="/ifanr/appso" path="/ifanr/appso"/>
 
-路由: `/ifanr/appso`
+### Apple
 
-参数: 无
-
-### Apple <Author uid="metowolf"/>
-
-#### 更换和维修扩展计划
-
-举例: <https://rsshub.app/apple/exchange_repair>
-
-路由: `/apple/exchange_repair`
-
-参数: 无
+<route name="更换和维修扩展计划" author="metowolf" example="/apple/exchange_repair" path="/apple/exchange_repair"/>
 
 #### App Store/Mac App Store
 
 见 [#app-store-mac-app-store](#app-store-mac-app-store)
 
-### 少数派 sspai <Author uid="HenryQW"/>
+### 少数派 sspai
 
-#### 最新上架付费专栏
+<route name="最新上架付费专栏" author="HenryQW" example="/sspai/series" path="/sspai/series">
 
-举例: <https://rsshub.app/sspai/series>
+> 少数派专栏需要付费订阅, RSS 仅做更新提醒, 不含付费内容.
 
-路由: `/sspai/series`
+</route>


### PR DESCRIPTION
1. 统一文档格式。
2. 简化文档，解放开发者。
3. 通过修改后的文档格式，为 API 作准备。

新文档格式如下：

- name:  路由名称
- author: 路由作者
- example: 路由举例
- path: 路由路径
- :paramsDesc: 路由参数说明，数组，组件自动检测路由路径中的可选与必选参数，如缺少说明将会导致报错。说明支持 markdown，但是需要注意说明中的 `'` `"` 必须为 `\'` `\"`


多参数：
```vue
<route name="仓库 Issue" author="HenryQW" example="/github/issue/DIYgod/RSSHub" path="/github/issue/:user/:repo" :paramsDesc="['用户名', '仓库名']"/>
```

支持 markdown:
```vue
<route name="应用更新" author="HenryQW" example="/appstore/update/cn/id444934666" path="/appstore/update/:country/:id" :paramsDesc="['App Store 国家, 如 QQ 的链接为 https://itunes.apple.com/cn/app/qq/id444934666?mt=8, 则 country 为 `cn`', 'App Store app id, 如 QQ 的链接为 https://itunes.apple.com/cn/app/qq/id444934666?mt=8, 则 id 为 `id444934666`']"/>
```

复杂说明支持 slot: 
```vue
<route name="即时新闻" author="lengthmin" example="/zaobao/realtime/china" path="/zaobao/realtime/:type?" :paramsDesc="['分类, 缺省为中港台']">

| 中港台 | 新加坡    | 国际  | 财经     |
| ------ | --------- | ----- | -------- |
| china  | singapore | world | zfinance |

</route>
```