### PR TITLE
Remove deprecated npm package crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "axios-retry": "3.1.1",
     "cheerio": "1.0.0-rc.2",
     "co-redis": "2.1.1",
-    "crypto": "1.0.1",
     "currency-symbol-map": "^4.0.4",
     "dayjs": "^1.7.5",
     "form-data": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,10 +2099,6 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
-crypto@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"


### PR DESCRIPTION
```
npm WARN deprecated crypto@1.0.1: This package is no longer supported.
It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's
built-in.
```