### PR TITLE
加载配置时优先自动读取环境变量

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,6 @@
-module.exports = {
+const decamelize = require('decamelize');
+
+const config = {
     connect: {
         port: process.env.PORT || 1200, // 监听端口
         socket: process.env.SOCKET || null, // 监听 Unix Socket, null 为禁用
@@ -51,3 +53,56 @@ module.exports = {
         pass: process.env.HTTP_BASIC_AUTH_PASS || 'passw0rd',
     },
 };
+
+const KEY = Symbol();
+
+function isObject(value) {
+    return value && typeof value === 'object' && value.constructor === Object;
+}
+
+function ProxyFactory(obj) {
+    // eslint-disable-next-line lines-around-comment
+    /**
+     * Handler with getter to return env/value/Proxy<-object when inspecting configs
+     *
+     * @type {{get}}
+     */
+    const configHandler = {
+        get: (target, key, receiver) => {
+            // Concat to the matched name required for env
+            // e.g. config.redis.url -> REDIS_URL
+            const envName = [Reflect.get(target, KEY, receiver), key]
+                // exclude void, undefined and null
+                .filter(Boolean)
+                .map((_) => decamelize(_.toString()).toUpperCase())
+                .join('_');
+            // Return the environment variable if there is one
+            const p = process.env[envName];
+            if (p) {
+                return p;
+            }
+            // Get original value/object
+            const o = Reflect.get(target, key, receiver);
+            // Return the value/undefined
+            if (!isObject(o)) {
+                return o;
+            }
+            // Return ProxyFactory(obj) with new object appended with a Symbol key to store envName
+            return ProxyFactory(
+                {
+                    ...o,
+                    [KEY]: envName,
+                },
+                configHandler
+            );
+        },
+    };
+    return new Proxy(obj, configHandler);
+}
+
+/**
+ * Loader for environmental variable configs named after <SERVICE_FIELD> if set else config
+ *
+ * @type {Proxy}
+ */
+module.exports = ProxyFactory(config);

--- a/config.js
+++ b/config.js
@@ -5,17 +5,17 @@ const config = {
         port: process.env.PORT || 1200, // 监听端口
         socket: process.env.SOCKET || null, // 监听 Unix Socket, null 为禁用
     },
-    cacheType: process.env.CACHE_TYPE || 'memory', // 缓存类型，支持 'memory' 和 'redis'，设为空可以禁止缓存
-    cacheExpire: process.env.CACHE_EXPIRE || 5 * 60, // 缓存时间，单位为秒
-    ua: process.env.UA || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
-    listenInaddrAny: process.env.LISTEN_INADDR_ANY || 1, // 是否允许公网连接，取值 0 1
-    requestRetry: process.env.REQUEST_RETRY || 2, // 请求失败重试次数
+    cacheType: 'memory', // 缓存类型，支持 'memory' 和 'redis'，设为空可以禁止缓存
+    cacheExpire: 5 * 60, // 缓存时间，单位为秒
+    ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
+    listenInaddrAny: 1, // 是否允许公网连接，取值 0 1
+    requestRetry: 2, // 请求失败重试次数
     // 是否显示 Debug 信息，取值 boolean 'false' 'key' ，取值为 'false' false 时永远不显示，取值为 'key' 时带上 ?debug=key 显示
-    debugInfo: process.env.DEBUG_INFO || true,
-    sentry: process.env.SENTRY || '', // 使用 sentry 进行错误追踪，这里是 sentry 提供的 DSN 链接
-    titleLengthLimit: process.env.TITLE_LENGTH_LIMIT || 100,
+    debugInfo: true,
+    sentry: '', // 使用 sentry 进行错误追踪，这里是 sentry 提供的 DSN 链接
+    titleLengthLimit: 100,
     redis: {
-        url: process.env.REDIS_URL || 'redis://localhost:6379/',
+        url: 'redis://localhost:6379/',
         options: {
             // 支持这些参数 https://github.com/NodeRedis/node_redis#options-object-properties
             password: process.env.REDIS_PASSWORD || null,
@@ -24,29 +24,29 @@ const config = {
     pixiv: {
         client_id: 'MOBrBDS8blbauoSck0ZfDbtuzpyT',
         client_secret: 'lsACyCD94FhDUtGTXi3QzcFE2uU1hqtDaKeqrdwj',
-        username: process.env.PIXIV_USERNAME,
-        password: process.env.PIXIV_PASSWORD,
+        username: undefined,
+        password: undefined,
     },
     disqus: {
-        api_key: process.env.DISQUS_API_KEY,
+        api_key: undefined,
     },
     twitter: {
-        consumer_key: process.env.TWITTER_CONSUMER_KEY,
-        consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
-        access_token: process.env.TWITTER_ACCESS_TOKEN,
-        access_token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
+        consumer_key: undefined,
+        consumer_secret: undefined,
+        access_token: undefined,
+        access_token_secret: undefined,
     },
     youtube: {
-        key: process.env.YOUTUBE_KEY,
+        key: undefined,
     },
     telegram: {
-        token: process.env.TELEGRAM_TOKEN,
+        token: undefined,
     },
     github: {
-        access_token: process.env.GITHUB_ACCESS_TOKEN,
+        access_token: undefined,
     },
     imgur: {
-        clientId: process.env.IMGUR_CLIRNT_ID,
+        clientId: undefined,
     },
     authentication: {
         name: process.env.HTTP_BASIC_AUTH_NAME || 'usernam3',

--- a/config/default.js
+++ b/config/default.js
@@ -1,6 +1,4 @@
-const decamelize = require('decamelize');
-
-const config = {
+module.exports = {
     connect: {
         port: process.env.PORT || 1200, // 监听端口
         socket: process.env.SOCKET || null, // 监听 Unix Socket, null 为禁用
@@ -53,56 +51,3 @@ const config = {
         pass: process.env.HTTP_BASIC_AUTH_PASS || 'passw0rd',
     },
 };
-
-const KEY = Symbol();
-
-function isObject(value) {
-    return value && typeof value === 'object' && value.constructor === Object;
-}
-
-function ProxyFactory(obj) {
-    // eslint-disable-next-line lines-around-comment
-    /**
-     * Handler with getter to return env/value/Proxy<-object when inspecting configs
-     *
-     * @type {{get}}
-     */
-    const configHandler = {
-        get: (target, key, receiver) => {
-            // Concat to the matched name required for env
-            // e.g. config.redis.url -> REDIS_URL
-            const envName = [Reflect.get(target, KEY, receiver), key]
-                // exclude void, undefined and null
-                .filter(Boolean)
-                .map((_) => decamelize(_.toString()).toUpperCase())
-                .join('_');
-            // Return the environment variable if there is one
-            const p = process.env[envName];
-            if (p) {
-                return p;
-            }
-            // Get original value/object
-            const o = Reflect.get(target, key, receiver);
-            // Return the value/undefined
-            if (!isObject(o)) {
-                return o;
-            }
-            // Return ProxyFactory(obj) with new object appended with a Symbol key to store envName
-            return ProxyFactory(
-                {
-                    ...o,
-                    [KEY]: envName,
-                },
-                configHandler
-            );
-        },
-    };
-    return new Proxy(obj, configHandler);
-}
-
-/**
- * Loader for environmental variable configs named after <SERVICE_FIELD> if set else config
- *
- * @type {Proxy}
- */
-module.exports = ProxyFactory(config);

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,55 @@
+const decamelize = require('decamelize');
+const config = require('./default');
+
+const KEY = Symbol();
+
+function isObject(value) {
+    return value && typeof value === 'object' && value.constructor === Object;
+}
+
+function ProxyFactory(obj) {
+    // eslint-disable-next-line lines-around-comment
+    /**
+     * Handler with getter to return env/value/Proxy<-object when inspecting configs
+     *
+     * @type {{get}}
+     */
+    const configHandler = {
+        get: (target, key, receiver) => {
+            // Concat to the matched name required for env
+            // e.g. config.redis.url -> REDIS_URL
+            const envName = [Reflect.get(target, KEY, receiver), key]
+                // exclude void, undefined and null
+                .filter(Boolean)
+                .map((_) => decamelize(_.toString()).toUpperCase())
+                .join('_');
+            // Return the environment variable if there is one
+            const p = process.env[envName];
+            if (p) {
+                return p;
+            }
+            // Get original value/object
+            const o = Reflect.get(target, key, receiver);
+            // Return the value/undefined
+            if (!isObject(o)) {
+                return o;
+            }
+            // Return ProxyFactory(obj) with new object appended with a Symbol key to store envName
+            return ProxyFactory(
+                {
+                    ...o,
+                    [KEY]: envName,
+                },
+                configHandler
+            );
+        },
+    };
+    return new Proxy(obj, configHandler);
+}
+
+/**
+ * Loader for environmental variable configs named after <SERVICE_FIELD> if set else config
+ *
+ * @type {Proxy}
+ */
+module.exports = ProxyFactory(config);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "crypto": "1.0.1",
     "currency-symbol-map": "^4.0.4",
     "dayjs": "^1.7.5",
+    "decamelize": "^1.2.0",
     "form-data": "^2.3.2",
     "git-rev-sync": "1.12.0",
     "googleapis": "33.0.0",


### PR DESCRIPTION
如题，加载配置时优先自动读取环境变量，再尝试从配置文件中读取。主要使用了 ES6 的 [Proxy](http://es6.ruanyifeng.com/#docs/proxy) 和 [Reflect](http://es6.ruanyifeng.com/#docs/reflect) 特性。支持嵌套读取和[驼峰命名/帕斯卡命名](https://www.npmjs.com/package/decamelize)，例如：

- `config.pixiv.client_secret` -> `process.env.PIXIV_CLIENT_SECRET`
- `config.listenInaddrAny` -> `process.env.LISTEN_INADDR_ANY`

一个缺点是，相对于 `config.js` 中可以设置字符串、数值、布尔、（回调）函数等任意的 JavaScript 对象，process.env 中取得的只能是字符串类型，需要在应用层自行判断或转换。~还有一点是 `decamelize@^2.0.0` 的引入与原有 `@^1` 的依赖的关系尚不明确。~ 项目中，[`decamelize@1` 被依赖](https://github.com/DIYgod/RSSHub/blob/44da2739f1c78f86aa25e3ebaa530717bf86af06/yarn.lock%23L2259)。

TODO: 
- [ ] 不加载 `/options?/` / `connect` 作为查找环境变量名的键值
- [ ] 手动设定搜索键值
- [ ] 统一占位符 `''` / `undefined` / `null` 并明确含义