### PR TITLE
修复：知乎动态增加 owner

### DIFF
--- a/routes/zhihu/activities.js
+++ b/routes/zhihu/activities.js
@@ -79,7 +79,7 @@ module.exports = async (ctx) => {
                 }
 
                 return {
-                    title: `${item.action_text}: ${title}`,
+                    title: `${data[0].actor.name}${item.action_text}: ${title}`,
                     description: description,
                     pubDate: new Date(item.created_time * 1000).toUTCString(),
                     link: url,


### PR DESCRIPTION
![screen shot 2018-10-28 at 23 45 31](https://user-images.githubusercontent.com/6964284/47618236-aee27500-db0b-11e8-98a5-20b7156ff9f6.png)

同时订阅多个 id 时不能区分是谁的状态，这个 PR 用来解决这个问题。