### PR TITLE
fix: can not get cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,27 @@ if (config.cacheType === 'memory') {
     app.context.cache = {
         get: () => null,
         set: () => null,
+
+        /**
+         *
+         * try get from cache.
+         * if not exists use `getValue` function to get value, and put into cahche.
+         *
+         * @param key cache key
+         * @param getValueFunc a function to get value. call it when key not exists.
+         * @param maxAge
+         *
+         * @returns {Promise<void>}
+         */
+        tryGet: async function(key, getValueFunc, maxAge) {
+            let v = await this.get(key);
+            if (!v) {
+                v = await getValueFunc();
+                this.set(key, v, maxAge);
+            }
+
+            return v;
+        },
     };
 }
 

--- a/middleware/lru-cache.js
+++ b/middleware/lru-cache.js
@@ -22,7 +22,7 @@ module.exports = function(options = {}) {
     options.app.context.cache = {
         get: (key) => {
             if (key) {
-                memoryCache.get(key);
+                return memoryCache.get(key);
             }
         },
         set: (key, value, maxAge) => {

--- a/middleware/redis-cache.js
+++ b/middleware/redis-cache.js
@@ -43,7 +43,7 @@ module.exports = function(options = {}) {
     options.app.context.cache = {
         get: async (key) => {
             if (key) {
-                await redisClient.get(key);
+                return await redisClient.get(key);
             }
         },
         set: async (key, value, maxAge) => {


### PR DESCRIPTION
本补丁主要解决了以下两个问题：

1. 在 a1f060f3d2205fbe5cfc1672ad2bb0212e350c65 提交时，缓存get方法发生了变化。
**cache的get方法未正确返回值**，这将导致所有使用自定义缓存的地方缓存丢失！

2. 同时修正了未设置缓存时系统报`tryGet`方法未定义的问题。