### PR TITLE
:bug: 修复了腾讯视频部分情况下出错的 bug

### DIFF
--- a/routes/tencent/video/playlist.js
+++ b/routes/tencent/video/playlist.js
@@ -6,12 +6,8 @@ module.exports = async (ctx) => {
     const link = `https://v.qq.com/detail/${id[0]}/${id}.html`;
     const page = await axios.get(link);
     const $ = cheerio.load(page.data);
-    const last = $('._tabsNav > .item')
-        .last()
-        .attr('data-range')
-        .split('-')[1];
-    const episodes = await axios.get(`https://s.video.qq.com/get_playsource?id=${id}&plat=2&type=4&data_type=2&video_type=3&range=1-${last}&plname=qq&otype=json&num_mod_cnt=20&callback=a&_t=${Date.now()}`);
-    const playList = JSON.parse(episodes.data.slice(2, -1)).PlaylistItem.videoPlayList.reverse();
+    const episodes = await axios.get(`https://s.video.qq.com/get_playsource?id=${id}&plat=2&type=4&data_type=2&video_type=3&range=1&plname=qq&otype=json&num_mod_cnt=20&callback=a&_t=${Date.now()}`);
+    const playList = JSON.parse(episodes.data.slice(2, -1)).PlaylistItem.videoPlayList;
     const items = playList.map((video) => ({
         title: video.title,
         link: video.playUrl,


### PR DESCRIPTION
原来的代码为了获取总集数（如[名侦探柯南](http://v.qq.com/detail/5/53q0eh78q97e4d1.html)），会通过 jQuery 解析页面。但是在部分播放列表中（如[SSSS.Gridman](https://v.qq.com/detail/o/o28lfr4elqppz6q.html)），相应的解析方法会出现错误：
```
RSSHub 发生了一些意外:
TypeError: Cannot read property 'split' of undefined
    at module.exports (/app/routes/tencent/video/playlist.js:12:9)
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
```

经实验，相应的 API 中 `range` 参数其实只需要随意填一个数字，就会 fallback 到全部集数。因此这里用这个方法修复了相应的 BUG。