### PR TITLE
添加了上海交通大学本科生教务办「国际办学」栏目

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1274,6 +1274,8 @@ GitHub 官方也提供了一些 RSS:
 
 <route name="电子信息与电气工程学院本科教务办 -- 直升研究生" author="SkyZH" example="/sjtu/seiee/bjwb/postgraduate" path="/universities/sjtu/seiee/bjwb/postgraduate"/>
 
+<route name="电子信息与电气工程学院本科教务办 -- 国际办学" author="SkyZH" example="/sjtu/seiee/bjwb/international" path="/universities/sjtu/seiee/bjwb/international"/>
+
 <route name="研究生通知公告" author="mzr1996" example="/sjtu/gs/tzgg/pyxx" path="/universities/sjtu/gs/tzgg/:type?" :paramsDesc="['默认列举所有通知公告']">
 
 | 通知公告 | 工作信息 | 招生信息 | 培养信息 | 学位学科 | 国际交流 | 创新工程 |

--- a/router.js
+++ b/router.js
@@ -549,6 +549,7 @@ router.get('/sjtu/seiee/bjwb/major_select', require('./routes/universities/sjtu/
 router.get('/sjtu/seiee/bjwb/major_transfer', require('./routes/universities/sjtu/seiee/bjwb/major_transfer'));
 router.get('/sjtu/seiee/bjwb/postgraduate', require('./routes/universities/sjtu/seiee/bjwb/postgraduate'));
 router.get('/sjtu/seiee/bjwb/abroad', require('./routes/universities/sjtu/seiee/bjwb/abroad'));
+router.get('/sjtu/seiee/bjwb/international', require('./routes/universities/sjtu/seiee/bjwb/international'));
 
 router.get('/sjtu/gs/tzgg/:type?', require('./routes/universities/sjtu/gs/tzgg'));
 

--- a/routes/universities/sjtu/seiee/bjwb/international.js
+++ b/routes/universities/sjtu/seiee/bjwb/international.js
@@ -1,0 +1,57 @@
+const axios = require('../../../../../utils/axios');
+const cheerio = require('cheerio');
+const url = require('url');
+
+const host = 'http://bjwb.seiee.sjtu.edu.cn';
+
+module.exports = async (ctx) => {
+    const link = url.resolve(host, `bkjwb/list/2281-1-20.htm`);
+    const response = await axios.get(link);
+
+    const $ = cheerio.load(response.data);
+
+    const list = $('.list_box_5 li')
+        .map((i, e) => ({
+            date: $(e)
+                .children('span')
+                .text()
+                .slice(1, -1),
+            title: $(e)
+                .children('a')
+                .text()
+                .slice(2),
+            link: $(e)
+                .children('a')
+                .attr('href'),
+        }))
+        .get();
+
+    const out = await Promise.all(
+        list.map(async (item) => {
+            const itemUrl = url.resolve(host, item.link);
+            const cache = await ctx.cache.get(itemUrl);
+            if (cache) {
+                return Promise.resolve(JSON.parse(cache));
+            }
+
+            const response = await axios.get(itemUrl);
+            const $ = cheerio.load(response.data);
+
+            const single = {
+                title: item.title,
+                link: itemUrl,
+                author: '上海交通大学电子信息与电气工程学院本科教务办',
+                description: $('.article_content').text(),
+                pubDate: new Date(item.date),
+            };
+            ctx.cache.set(itemUrl, JSON.stringify(single), 24 * 60 * 60);
+            return Promise.resolve(single);
+        })
+    );
+
+    ctx.state.data = {
+        title: '上海交通大学电子信息与电气工程学院本科教务办 -- 国际办学通知',
+        link,
+        item: out,
+    };
+};


### PR DESCRIPTION
Example

```xml
<rss version="2.0">
<channel>
<title>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 -- 国际办学通知 ]]>
</title>
<link>
http://bjwb.seiee.sjtu.edu.cn/bkjwb/list/2281-1-20.htm
</link>
<description>
<![CDATA[
上海交通大学电子信息与电气工程学院本科教务办 -- 国际办学通知 - Made with love by RSSHub(https://github.com/DIYgod/RSSHub)
]]>
</description>
<generator>RSSHub</generator>
<webMaster>i@diygod.me</webMaster>
<language>zh-cn</language>
<lastBuildDate>Tue, 04 Dec 2018 06:09:58 GMT</lastBuildDate>
<ttl>300</ttl>
<item>
<title>
<![CDATA[ 美国威斯康星大学学期交流项目招生通知 ]]>
</title>
<description>
<![CDATA[
美国威斯康星大学学期交流项目招生通知各位同学，美国威斯康星大学学期交流项目，现已开放招生。项目详情，请点击http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14501.htm。报名时间：2018年 11月27日--2018年12月15日报名方式：请下载电院本科生海外游学计划申请及审批表，双面打印， 按要求填写并签名交至电院本科教务办徐老师处项目及报名咨询：电话：34204693地址：电信群楼3号楼113室（电院本科教务办）访问数量：
]]>
</description>
<pubDate>"2018-11-27T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14506.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14506.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2019年度华盛顿大学暑期交流项目宣讲会通知 ]]>
</title>
<description>
<![CDATA[
2019年度华盛顿大学暑期交流项目宣讲会通知 各位同学，华盛顿大学暑期交流项目专题宣讲会将于2018年12月3日举行。届时，会有华盛顿大学项目负责老师 Ms. Lim为大家进行宣讲。同时，还会有2018年参与项目的学长和大家一并分享经验。时间：2018年12月3日(周一）中午12：30-13：30地点：交大闵行校区电院3号楼100号报告厅内容：2019年华盛顿大学暑期交流项目宣讲和答疑对象：电院大一 、大二全体同学欢迎广大同学积极参加此次宣讲会！电院本教办2018年11月26日访问数量：
]]>
</description>
<pubDate>"2018-11-26T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14499.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14499.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2019年度电院本科生海外交流项目招生通知 ]]>
</title>
<description>
<![CDATA[
2019年度电院本科生海外交流项目招生通知各位同学：大家好！ 2019年电院院级本科生海外交流项目现在开始招生。报名时间： 2018年 11月12日--2018年12月10日报名方式：请下载电院本科生海外游学计划申请及审批表，双面打印， 按要求填写并签名交至电院本科教务办徐老师处本次开放申请项目列表如下： 一、面向电院在读大一 && 大二学生的项目 1. 华盛顿大学暑期交流项目 二、面向电院在读大三学生的项目1. 美国俄亥俄州立大学本硕连读项目2. 德国柏林工业大学学期交换项目 （“学生学术能力提升计划”项目资助）3. 美国新墨西哥大学学期交流项目4. 法国INSA Lyon 学期交流项目5. 瑞典查尔姆斯大学学期交流项目6. 瑞士拉珀斯维尔应用技术学院学期交流项目 项目及报名咨询：电话：34204693地址：电信群楼3号楼113室（电院本科教务办）访问数量：
]]>
</description>
<pubDate>"2018-11-07T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14445.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14445.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2019年INSA Lyon春季学期交流项目招生通知 ]]>
</title>
<description>
<![CDATA[
2019年INSA Lyon春季学期交流项目招生通知各位同学： 2019年INSA Lyon春季学期交流项目现开放招生，面向电院所有大三在读同学，截止日期为10月15日， 项目详情请参见：http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/8473.htm。 有意参加本项目的同学，请将电院本科生海外游学计划申请及审批表填写完整，递交至电院本科教务办。学校简介： 法国里昂国立应用科学学院（INSA Lyon）位于法国里昂市，是法国著名的高等教育和科研机构，是一所顶尖的法国精英学校（Grande Ecole）。该学院以高质量的工程师培养及科研水平在法国和国际上具有极高的知名度，被誉为“工程师院校的典范”。联系方式：电院本科教务办3-113 徐老师  电话：34204693  （欢迎电话或当面咨询）；访问数量：
]]>
</description>
<pubDate>"2018-10-10T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14344.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14344.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2018华盛顿大学本硕连读项目学院推荐学生名单 ]]>
</title>
<description>
<![CDATA[
2018华盛顿大学本硕连读项目学院推荐学生名单经学生申请，学院审核， 2018华盛顿大学本硕连读项目学院推荐学生名单如下所示：序号姓名性别1周建雄男2徐睿男3王浩宇男4冯宇达男5刘萌欣女6刘宇飞女7邵翔玮男8王思棋女电院本科教务办2018年6月7日访问数量：
]]>
</description>
<pubDate>"2018-06-07T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14021.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/14021.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2018华盛顿大学本硕连读项目招生通知 ]]>
</title>
<description>
<![CDATA[
2018华盛顿大学本硕连读项目招生通知各位同学： 2018华盛顿大学本硕连读项目现开放招生，面向非计算机、软件和信安专业的大三在读同学，截止日期为6月1日， 项目详情：http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/7976.htm。 该项目已运行四年，共十余名同学获得华大录取，颇受同学青睐：）学校简介：（http://www.washington.edu）华盛顿大学（University of Washington），简称UW，始建于1861年，位于美国西雅图，是一所享有顶尖学术地位和声誉的世界著名研究型大学。自1974年以来，华盛顿大学一直是全美竞争激烈的联邦科研经费最有实力的竞争者，科研经费长期高居全球大学第三。联系方式：电院本科教务办3-113 徐老师  电话：34204693  （欢迎电话或当面咨询）；访问数量：
]]>
</description>
<pubDate>"2018-05-21T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13917.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13917.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2018年电院双硕士（双学位）项目学院推荐学生名单公示 ]]>
</title>
<description>
<![CDATA[
2018年电院双硕士（双学位）项目学院推荐学生名单公示 经过学生申请，学院审核、面试，现将2018年电院双硕士（双学位）项目学院推荐学生名单公示如下：序号申请项目姓名性别1INSA Lyon双学位项目陈亭轩女2INSA Lyon双学位项目陈立帆男 1米兰理工双硕士项目朱城昊男2米兰理工双硕士项目沈硕伟男3米兰理工双硕士项目王旭东男4米兰理工双硕士项目黄琬迪女5米兰理工双硕士项目刘佳奇男6米兰理工双硕士项目张侨伦男 1早稻田大学双硕士项目刘子瑜女2早稻田大学双硕士项目戚裕绮女3早稻田大学双硕士项目杨于霄女4早稻田大学双硕士项目曹博恒男5早稻田大学双硕士项目罗瑞康男6早稻田大学双硕士项目沈文涛男 1柏林工大双硕士项目郭越女2柏林工大双硕士项目姚航男3柏林工大双硕士项目郑楚君女4柏林工大双硕士项目冯孝鑫男5柏林工大双硕士项目刘琦怡女6柏林工大双硕士项目赵希宇男7柏林工大双硕士项目魏鹏超男8柏林工大双硕士项目骆继祥男9柏林工大双硕士项目韩雨轩女10柏林工大双硕士项目王丹阳女11柏林工大双硕士项目陈晓彤女获学院推荐学生须在规定时间内完成向对方学校递交申请材料；须获得推荐免试研究生资格和交大研究生录取资格。推荐免试研究生资格可参考往年推荐免试标准，以当年《推荐优秀应届本科毕业生免试攻读研究生工作办法》为准（两年派出的双硕士项目学生只需完成本专业前四个学期培养计划要求课程或学分）。如在当年推荐免试研究生工作中，双硕士项目学生满足推荐免试资格要求，将优先获得推荐免试资格；若届时不能通过推荐免试资格审核，将同时失去该项目资格。已经前往国外的同学必须回国继续完成上海交通大学本科学业。电院本科教务办2018年1月9日访问数量：
]]>
</description>
<pubDate>"2018-01-09T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13433.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13433.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2018年电院双硕士项目面试名单及安排 ]]>
</title>
<description>
<![CDATA[
2018年电院双硕士项目面试名单及安排经学生申请， 学院审核， 2018电院双硕士项目面试名单确认如下。 请各位同学按照以下面试时间准时到达面试地点参加面试。 未准时出席面试则视为自动放弃。面试地点： 电院群楼3号楼308会议室 ;面试日期： 2017年12月27日周三;面试 时间序号申请项目姓名12:301法国INSA Lyon双学位陈亭轩2法国INSA Lyon双学位陈立帆 13:001米兰理工双硕士项目朱城昊2米兰理工双硕士项目沈硕伟3米兰理工双硕士项目王旭东4米兰理工双硕士项目黄琬迪5米兰理工双硕士项目刘佳奇6米兰理工双硕士项目张侨伦 13:301早稻田大学双硕士项目刘子瑜2早稻田大学双硕士项目戚裕绮3早稻田大学双硕士项目杨子宵4早稻田大学双硕士项目曹博恒5早稻田大学双硕士项目罗瑞康6早稻田大学双硕士项目沈文涛 14:001柏林工大双硕士项目郭越2柏林工大双硕士项目姚航3柏林工大双硕士项目郑楚君4柏林工大双硕士项目冯孝鑫5柏林工大双硕士项目刘琦怡6柏林工大双硕士项目赵希宇7柏林工大双硕士项目魏鹏超8柏林工大双硕士项目骆继祥9柏林工大双硕士项目韩雨轩10柏林工大双硕士项目王丹阳11柏林工大双硕士项目陈晓彤电院本科教务办2017年12月25日访问数量：
]]>
</description>
<pubDate>"2017-12-25T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13277.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13277.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 【通知转发】2018国家公派留学项目宣讲会通知 ]]>
</title>
<description>
<![CDATA[
【通知转发】2018国家公派留学项目宣讲会通知 2018年国家公派项目申请前期准备工作已经开始了。为使同学们更好了解国家公派研究生项目选派政策和申请办法，研究生院拟于2017年12月12日举行“2018年国家公派研究生项目”专场宣讲会。时间：2017年12月12日(周二）下午14﹕00-15:30地点：交大闵行校区研究生院陈瑞球楼100室（学术报告厅）内容：2018年国家公派出国留学政策宣讲和答疑对象：中国籍在读全日制研究生、本科应届毕业生欢迎广大同学和项目负责人积极参加此次宣讲会！另，为达到更好的宣讲效 果，针对公派项目负责人举办的专场宣讲会，我们将于次年开学后通知各位老师参加！余旖旎上海交通大学闵行校区研究生院国际化办公室上海市东川路800号陈瑞球楼331室 （200240）Tel：+86-021-34207040Fax：+86-021-34207040访问数量：
]]>
</description>
<pubDate>"2017-12-04T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13171.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13171.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2018德语班招生通知 ]]>
</title>
<description>
<![CDATA[
2018德语班 一、参加德语班的原因 １. 你想参加电院和柏林工大的双硕士项目吗？ 那就来我们的德语班吧～ 电院和柏林工大的双硕士项目历史悠久，口碑卓越，先后派出了近百名电院本科生去柏林工大学习。 学生在顺利完成交大本科的３年学习后，去柏林工大完成２年的硕士学习，再返回交大继续完成１．５年的硕士学习，可获得交大本科学位证书，柏林工大硕士学位证书和交大硕士学位证书。 在６年半的时间内不仅多拿一份海外硕士证书， 还掌握了德语，成为炙手可热的国际型人才。 ２. 不想去国外读学位，只想有机会去海外交流１到２个学期？ 那也来我们的德语班吧～ 柏林工大不仅和学院有双硕士项目，还有学期交流项目。参加项目学生无须缴纳柏林工大学费，还可以申请德国ＤＡＡＤ奖学金。另外，瑞士拉珀斯维尔应用技术学院也和我们有学期交流项目，每年都会提供丰厚的奖学金给项目学生。这些学期交流项目绝对是一个开拓国际眼界，增长国际见闻，了解欧洲文化风情的大好机会。 ３. 只想毕业后去德国或德语国家留学深造？ 那我们的德语班也欢迎你哦～ 在项目学生优先的前提下，我们也希望德语班能为更多的电院同学提供学德语的好机会，尽可能为大家创造一个专业而便利的德语学习氛围。 二、德语班介绍 德语班的初衷主要是为了电院海外交流项目，特别是柏林工大双硕士项目而设立的。 德语班为一年期德语课程强化训练，从德语零基础开始，以培养学生德语听、说、读、写等各方面的德语能力为中心，进行全面、严格的语言训练，目标是让学生能够成功通过德语德福考试，具备申请德语大学的语言能力，为今后的学习计划增添多元的选择性。 该班拟在4月初开班，经过一年强化德语学习后，于次年4月左右参加德福考试。 为保证课程进度，寒暑假也会安排课程，具体安排可由学生直接和任课老师协调。   一般需要德语的海外交流项目在大四派出学生，而德语班的学习周期为一年，这样就要求电院本科生至少在大二的时候参加德语班。 但 为使电院同学们有更多的时间学习德语，我们也欢迎电院大一的同学报名。 三、报名与咨询 该德语班面向电院大一、大二在读学生招生，意向学生请于2017年12月15日之前下载《德语班报名表》，填写签名后提交至电院本科教务办陈老师处： 电话：34204693； Email: miaochen@sjtu.edu.cn; 办公室： 电院群楼3号楼113室。 访问数量：
]]>
</description>
<pubDate>"2017-12-04T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13169.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13169.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2018电院本科生海外交流项目招生通知 【延长报名日期至12月15日】 ]]>
</title>
<description>
<![CDATA[
2018电院本科生海外交流项目招生通知 各位同学： 大家好！ 2018年电院院级本科生海外交流项目正在火热招生中， 报名日期延长至12月15日。此次招生几乎囊括了电院院级所有本科生海外交流项目， 是一年仅开放一次的重要活动。 具体开放项目列表如下,点击项目名称可查阅项目详情。 一、面向大一学生的项目 1. 华盛顿大学暑期项目 2. 墨尔本大学暑期项目 3. 德语班 二、面向大二学生的项目 1. 华盛顿大学暑期项目 2. 墨尔本大学暑期项目 3. 德语班 4. 法国INSA Lyon双学位项目 三、面向大三同学的项目 1. 米兰理工双硕士项目 2. 柏林工大双硕士项目 3. 日本早稻田双硕士项目 4. 美国俄亥俄州立大学本硕连读项目 5. 美国新墨西哥大学学期交流项目 6. 柏林工大学期交流项目 7. 法国INSA Lyon 学期交流项目 8. 瑞典查尔姆斯大学学期交流项目 9. 瑞士拉珀斯维尔应用技术学院学期交流项目 报名与咨询： 请下载电院本科生海外游学计划申请及审批表，双面打印， 按要求填写并签名交至电院本科教务办陈老师处，电话：34204693， 34204865-808； Email: miaochen@sjtu.edu.cn；地址：电信群楼3号楼113室。 访问数量：
]]>
</description>
<pubDate>"2017-11-13T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13067.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/13067.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 【校级项目】2018年中法4+4项目招生通知 ]]>
</title>
<description>
<![CDATA[
2018年本科生中法4+4双学位项目学生选拔通知 一、项目简介： 根据中国四所大学（上海交通大学、西南交通大学，西安交通大学，清华大学）与法国五所大学（巴黎中央理工大学，里昂中央理工大学，南特中央理工大学，里尔中央理工大学，马赛中央理工大学）所签署的“4+4”计划，每年从以上四所中国大学选拔一批优秀大学二年级学生于次年七月赴法国五所中央理工大学留学。从2012年起，新增浙江大学、北京交通大学两所中方成员高校。 该项目采取2+2培养模式，即学生在上海交通大学完成第一、第二年学习，随后赴法国五所中央大学之一完成大三、大四学业要求。四年结束后顺利完成中法双方高校学位与学业要求者，获颁上海交通大学本科学历、学位证书，并经学校相关部门审核认定通过后免试保送本校研究生。学生在我校取得硕士学位后，法方将同时授予法国工程师学位。 二、报名条件 1、身体健康、品行端正，学生在校学习期间未受过校纪校规处分，无违纪违规行为，未受过退学警告： 2、成绩优秀，选拔时专业排名前30%，正式派出时，专业排名仍需保持在前30%，并且符合以下条件：（若在派出时未符合这些条件，学校将有权取消该生的派出资格） a) 学生必须修完前四个学期（不含小学期）执行计划中的必修课、限选课，并完成专业培养计划要求的通识课学分的1/2和任选课学分的1/2；且在学习期间不允许有不及格记录； b) 国家英语六级成绩须不低于425分（或托福成绩不低于90分；或雅思成绩不低于6.0分） 三、申请流程 申请流程为： 1、学生个人向院系申请，由院系择优推荐。请学生在本通知页面下载《本科生海外交流项目申请表》，填写完成后请院系签署意见并盖章，交至院系教务办。由院系教务办老师汇总并填写《院系推荐总表》。请在10月10日之前将签字盖章的学生申请表及院系推荐表交至新行政楼B809室，陆老师处，院系推荐总表也请电子版发给我哦。 2、获得院系推荐的学生请登陆my.sjtu.edu.cn上填写本科生派出申请。 3、学校将推荐名单提交到对方学校并通知被推荐同学准备相关申请材料。 4、对方学校审核我校学生申请材料并对候选学生进行面试。面试定于10月30日上午进行。 四、申请时间节点 2017年9月27日中法4+4项目宣讲会： 19:00-20:00, 上院211； 2017年10月15日学院推荐的学生在my.sjtu.edu.cn上完成校内网申 2017年10月30日法方代表面试推荐学生，具体时间地点另行通知。（面试材料学生自备材料） 五、奖学金机会 学生可申请法国政府埃菲尔奖学金，详情请见（http://www.campusfrance.org/en/eiffel），目前2018年的奖学金申请时间还未公布，请及时关注该网站。中法4+4项目属于国家留学基金委支持的国家公派硕士研究生项目之一，成功获得推荐的学生可申请该奖学金，请于每年三月份前后及时关注国家留学基金委网站的通知并申请，详情请见( http://www.csc.edu.cn )。 六、项目列表 合作学校 面试推荐名额 报名 年级 专业 外语要求 培养模式 法国中央理工 （包括巴黎中央理工大学，里昂中央理工大学，南特中央理工大学，里尔中央理工大学，马赛中央理工大学） 20名左右 2016级 理工科 英语优秀， 被法国中央理工正式录取后须学习法语 2+2+2.5 大三赴法学习两年，成绩合格并获法国工程师文凭后，回国攻读交大专业型硕士研究生 巴黎中央理工大学：http://www.ecp.fr/ 里昂中央理工大学：http://www.ec-lyon.fr/ 南特中央理工大学：http://www.ec-nantes.fr/ 里尔中央理工大学：http://www.ec-lille.fr/fr/ 马赛中央理工大学：https://www.centrale-marseille.fr/ 七、特别说明 1、学生只有在获得学校推荐资格后，才可进行网上申请。2、申请项目前，请务必在合作学校官方网站确认该学校是否有相关专业可选读以及相关专业是否对交流生开放，或是否以本人熟悉的语言进行授课，再行申请。 八、项目咨询：留学生发展中心交流办公室： 沈丽丽老师，34203803， lilishen@sjtu.edu.cn, 新行政楼809室；电院本科教务办： 陈淼老师， 34204693，miaochen@sjtu.edu.cn; 电群3号楼113室； 访问数量：
]]>
</description>
<pubDate>"2017-09-18T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12795.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12795.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2017华盛顿大学本硕连读项目学院推荐学生名单 ]]>
</title>
<description>
<![CDATA[
2017华盛顿大学本硕连读项目学院推荐学生名单经学生申请，学院审核， 2017华盛顿大学本硕连读项目学院推荐学生名单如下所示：序号姓名性别1刘修龙男2杨蕴意女3衣帆男4李子扬男5陈屹东男6赵雅雯女7高兴昀女电院本科教务办2017/6/6访问数量：
]]>
</description>
<pubDate>"2017-06-06T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12629.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12629.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 电院2017柏林工大双硕士项目推荐名单 ]]>
</title>
<description>
<![CDATA[
经学生申请、学院推荐审核，现公示2017派出柏林工业大学双硕士项目推荐学生名单：1柏林工大双硕士项目李一仁女2柏林工大双硕士项目陈学磊男3柏林工大双硕士项目张晟嘉男4柏林工大双硕士项目方一晨女5柏林工大双硕士项目李惠原女6柏林工大双硕士项目赵景茜女7柏林工大双硕士项目程晓童女8柏林工大双硕士项目杭盖男9柏林工大双硕士项目陈更新男10柏林工大双硕士项目张珂新女获学院推荐学生须在规定时间内完成向对方学校递交申请材料；须获得推荐免试研究生资格和交大研究生录取资格。推荐免试研究生资格可参考往年推荐免试标准，以当年《推荐优秀应届本科毕业生免试攻读研究生工作办法》为准。 如在当年推荐免试研究生工作中，双硕士项目学生满足推荐免试资格要求，将优先获得推荐免试资格；若届时不能通过推荐免试资格审核，将同时失去该项目资格。已经前往国外的同学必须回国继续完成上海交通大学本科学业。访问数量：
]]>
</description>
<pubDate>"2017-05-23T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12597.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12597.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2017华盛顿大学本硕连读项目招生通知 ]]>
</title>
<description>
<![CDATA[
2017华盛顿大学本硕连读项目招生通知各位同学： 2017华盛顿大学本硕连读项目现开放招生，面向非计算机、软件和信安专业的大三在读同学，截止日期为6月1日， 项目详情： http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/7976.htm。 该项目已运行三年，共13名同学获得华大录取，颇受同学青睐：） 学校简介：（http://www.washington.edu）华盛顿大学（University of Washington），简称UW，始建于1861年，位于美国西雅图，是一所享有顶尖学术地位和声誉的世界著名研究型大学。自1974年以来，华盛顿大学一直是全美竞争激烈的联邦科研经费最有实力的竞争者，科研经费长期高居全球大学第三。2017年US News世界大学排名第11名，2017泰晤士世界大学排名第25名  ，2016路透社全球最具创新力大学排名第4名，2016上海交大世界大学学术排名第15名，2016清华大学知社学术圈全球大学研究影响力排名第6名  。联系方式：电院本科教务办3-113陈老师  电话：34204865-808  Email:miaochen@sjtu.edu.cn （欢迎电话或当面咨询）；访问数量：
]]>
</description>
<pubDate>"2017-05-23T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12596.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12596.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2017德语班《欢迎到德国》开课和选课通知 ]]>
</title>
<description>
<![CDATA[
《欢迎到德国》选课时间和小学期选课时间一样，到4月5日周三上午8点截止，请切勿错过选课时间。 另外，请在4月5日周三16：00之前将《德语班报名表》http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/8475.htm，下载，签字并交至电院本科教务办给我（电群3号楼113室）。 咨询： 陈淼老师， 办公室电话： 34204693。各位同学：１. 你想参加电院和柏林工大的双硕士项目吗？ 那就来我们的德语班吧～电院和柏林工大的双硕士项目历史悠久，口碑卓越，先后派出了近百名电院本科生去柏林工大学习。 学生在顺利完成交大本科的３年学习后，去柏林工大完成２年的硕士学习，再返回交大继续完成１．５年的硕士学习，可获得交大本科学位证书，柏林工大硕士学位证书和交大硕士学位证书。 在６年半的时间内不仅多拿一份海外硕士证书， 还掌握了德语，成为炙手可热的国际型人才。２. 不想去国外读学位，只想有机会去海外交流１到２个学期？ 那也来我们的德语班吧～柏林工大不仅和我们有双硕士项目，还有学期交流项目。不用学费，还可以申请德国ＤＡＡＤ奖学金。另外，瑞士拉珀斯维尔应用技术学院也和我们有学期交流项目，每年都会提供丰厚的奖学金给项目学生。这些学期交流项目绝对是一个开拓国际眼界，增长国际见闻，了解欧洲文化风情的大好机会。３. 只想毕业后去德国或德语国家留学深造？ 那我们的德语班也欢迎你哦～在项目学生优先的前提下，我们也希望德语班能为更多的电院同学提供学德语的好机会，尽可能为大家创造一个专业而便利的德语学习氛围。下面来重点介绍一下２０１７德语班吧德语班的初衷主要是为了电院海外交流项目，特别是柏林工大双硕士项目而建立的，教学目标是让同学们具备通过德福考试４级的能力，而德福考试４级成绩是去德国大学留学的必要条件之一。该班一般在4月初开班，经过一年强化德语学习后，于次年4月左右参加德福考试。 春秋学期将进入学校系统排课，可取得学分。为保证课程进度，寒暑假也会安排课程，但无法进入课程系统。具体安排可和任课老师协调。 陆海燕老师是一位有着50余年丰富德语教学经验的老教师，对教学极富热情。 此次新开课程名称为《欢迎到德国》（上），128学时， 8学分，可计入个性化学分，拟于4月初开班，起讫周另行通知。 主要针对电院意向参加海外交流项目的学生，以柏林工大项目学生优先。 访问数量：
]]>
</description>
<pubDate>"2017-03-30T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12407.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12407.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2017电院暑期项目宣讲会及招生（3月10日截止）通知 ]]>
</title>
<description>
<![CDATA[
同学们：一日之计在于晨， 一年之计在于春！2017电院暑期项目正式启动新一轮招生，期待在这个夏天为你的大学生活刷下浓墨重彩的一笔！你想体验国际一流大学的教学环境和风格吗？ 你想身临其境地感受西雅图不眠夜的浪漫，看一场精彩的橄榄球或棒球赛事，抚摸澳洲的袋鼠和考拉， 沉醉于法国小镇安纳西的恬静优美和勃朗峰的壮丽吗？和我们一起来吧，你会发现你所收获的远远不止这些！ 青春作伴好同行，在你最美好的岁月里留下一段最美的回忆！2017电院暑期项目宣讲会时间： 3月8日12：45-13:25；地点：电信群楼３号楼２００报告厅；项目：１. 华盛顿大学暑期项目： http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/9994.htm （面向电院大一和大二学生）；2.    墨尔本大学暑期项目： http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/9991.htm （面向电院大一和大二学生）；３. 法国INSA Lyon大学暑期项目：http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/7619.htm （面向电院大一大二和大三学生）； 项目咨询： 陈淼老师， 电院本科教务办， 电群３号楼１１３室本科教务办； 电话：34204865-808或34204693； Email: miaochen@sjtu.edu.cn; 欢迎当面咨询!申请表下载： http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/11013.htm （双面打印； 内容电脑填写，签名手写，须本人签名，家长签名，思政老师或年级组长签名后提交给陈淼老师）；2017年3月3日访问数量：
]]>
</description>
<pubDate>"2017-03-03T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12284.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12284.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 【转发】2017/2018学年校级本科生海外交流项目宣讲会通知 ]]>
</title>
<description>
<![CDATA[
【转发】2017/2018学年校级本科生海外交流项目宣讲会通知校级本科生海外交流项目宣讲会将于本周三12月21日中午12:00在东中院1-400召开，目前共有70所合作院校的近300个交换名额供学生申请。学生可申请2017年秋季、2018年春季以及一学年的项目还有2017年暑期项目。宣讲会上会为大家介绍可申请的项目、申请流程、申请条件等。欢迎参加！联系咨询： 沈丽丽老师 （留学生发展中心） Lili SHENProject ManagerInternational Mobility OfficeShanghai Jiao Tong UniversityB809 New Admin. Bldg.No. 800 Dongchuan Road Shanghai 200240Tel: +86 21 34203803Email: lilishen@sjtu.edu.cn电院本科教务办2016年12月19日访问数量：
]]>
</description>
<pubDate>"2016-12-19T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12185.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12185.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2017美国俄亥俄本硕连读项目和美国新墨西哥大学学期交流项目学院推荐学生名单公示 ]]>
</title>
<description>
<![CDATA[
2017美国俄亥俄本硕连读项目和美国新墨西哥大学学期交流项目学院推荐学生名单公示各位同学：经过学生申请，学院审核面试，学院同意推荐以下同学参加所申请海外交流项目。序号申请项目姓名1美国俄亥俄州立大学本硕连读项目卢冰聪2美国俄亥俄州立大学本硕连读项目董亦涵3美国俄亥俄州立大学本硕连读项目王比其4美国俄亥俄州立大学本硕连读项目孙励天5美国俄亥俄州立大学本硕连读项目贾煜6美国俄亥俄州立大学本硕连读项目孙天昊7美国俄亥俄州立大学本硕连读项目姜伟鑫8美国俄亥俄州立大学本硕连读项目王奥9美国俄亥俄州立大学本硕连读项目刘宸钰10美国俄亥俄州立大学本硕连读项目汤顺堃11美国俄亥俄州立大学本硕连读项目廖雪莹12美国俄亥俄州立大学本硕连读项目康圣博13美国俄亥俄州立大学本硕连读项目祁裕1美国新墨西哥大学学期交流项目张皓翔2美国新墨西哥大学学期交流项目陈立恺获学院推荐学生须在规定时间内向对方学校提交申请材料，由对方学校决定是否最终录取。请大家仔细阅读《海外交流重要注意事项》http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/8929.htm，明确派出期间交大的修业要求必须完成，并在派出前妥善处理好修业相关事宜。 电院本科教务办2016年12月16日访问数量：
]]>
</description>
<pubDate>"2016-12-16T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12177.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12177.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
<item>
<title>
<![CDATA[ 2017年法国INSA Lyon 双学位项目/日本早稻田大学双硕士项目学院推荐学生名单公示 ]]>
</title>
<description>
<![CDATA[
2017年法国INSA Lyon  双学位项目/日本早稻田大学双硕士项目学院推荐学生名单公示 经过学生申请，学院审核、面试，现公示2017年法国INSA Lyon  双学位项目/日本早稻田大学双硕士项目推荐学生名单如下： 序号申请项目姓名1日本早稻田大学双硕士项目管乐2日本早稻田大学双硕士项目周晓3日本早稻田大学双硕士项目王钰阳4日本早稻田大学双硕士项目李雨峰5日本早稻田大学双硕士项目李雨琪6日本早稻田大学双硕士项目张健申7日本早稻田大学双硕士项目马诗慧8日本早稻田大学双硕士项目彭珅晖9日本早稻田大学双硕士项目王天炜10日本早稻田大学双硕士项目常中科11日本早稻田大学双硕士项目李雅欣12日本早稻田大学双硕士项目孙昱13日本早稻田大学双硕士项目丁琦14日本早稻田大学双硕士项目骆瑶莹15日本早稻田大学双硕士项目黄靖杰16日本早稻田大学双硕士项目韩正谦17日本早稻田大学双硕士项目许思颖1法国INSA Lyon 双硕士项目石佳银2法国INSA Lyon 双硕士项目唐其川3法国INSA Lyon 双硕士项目李琪获学院推荐学生须在规定时间内完成向对方学校递交申请材料；须获得推荐免试研究生资格和交大研究生录取资格。 推荐免试研究生资格可参考往年推荐免试标准，以当年《推荐优秀应届本科毕业生免试攻读研究生工作办法》为准（两年派出的双硕士项目学生只需完成本专业前四个学期培养计划要求课程或学分）。如在当年推荐免试研究生工作中，双硕士项目学生满足推荐免试资格要求，将优先获得推荐免试资格；若届时不能通过推荐免试资格审核，将同时失去该项目资格。已经前往国外的同学必须回国继续完成上海交通大学本科学业。 电院本科教务办2016年12月12日访问数量：
]]>
</description>
<pubDate>"2016-12-12T00:00:00.000Z"</pubDate>
<guid>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12157.htm</guid>
<link>http://bjwb.seiee.sjtu.edu.cn/bkjwb/info/12157.htm</link>
<author>
<![CDATA[ 上海交通大学电子信息与电气工程学院本科教务办 ]]>
</author>
</item>
</channel>
</rss>
```