### PR TITLE
Hotfix: baidu topwords

### DIFF
--- a/routes/baidu/topwords.js
+++ b/routes/baidu/topwords.js
@@ -15,7 +15,7 @@ module.exports = async (ctx) => {
             title: item.keyword,
             description: `
         <a href="${desc.originlink}">${desc.title}</a><br>
-        ${desc.description}
+        ${desc.description || ''}
       `,
             link: desc.originlink,
             pubDate: new Date(desc.pubDate).toUTCString(),


### PR DESCRIPTION
修复某些 `description` 为 `undefined` 的问题