### PR TITLE
Hotfix: baidu topwords content

### DIFF
--- a/routes/baidu/topwords.js
+++ b/routes/baidu/topwords.js
@@ -9,10 +9,19 @@ module.exports = async (ctx) => {
 
     const { board, topwords, descs } = response.data.result;
     const items = topwords.map((item, index) => {
-        const desc = descs[index].content.data[0];
+        const title = item.keyword;
+        const content = descs[index].content;
+        const desc = content
+            ? content.data[0]
+            : {
+                  originlink: `https://www.baidu.com/s?ie=utf-8&wd=${encodeURIComponent(title)}`,
+                  title,
+                  description: title,
+                  pubDate: Date.now(),
+              };
 
         return {
-            title: item.keyword,
+            title,
             description: `
         <a href="${desc.originlink}">${desc.title}</a><br>
         ${desc.description}


### PR DESCRIPTION
修复翻车的 `content`