### PR TITLE
Hotfix: jike img

### DIFF
--- a/routes/jike/common.js
+++ b/routes/jike/common.js
@@ -109,9 +109,8 @@ module.exports = {
                             default:
                                 break;
                         }
-                        description += `<br/><picture><source srcset="${pic.picUrl.split('/thumbnail/')[0]}/strip/format/webp" type="image/webp"><source srcset="${
-                            pic.picUrl.split('?imageMogr2/')[0]
-                        }" type="image/${type}"><img src="${pic.picUrl.split('?imageMogr2/')[0]}"></picture>`;
+                        const imgUrl = pic.picUrl.match(/\.[a-z0-9]+?\?imageMogr2/) ? pic.picUrl.split('?imageMogr2/')[0] : pic.picUrl.replace(/thumbnail\/.+/, '');
+                        description += `<br/><picture><source srcset="${pic.picUrl.split('/thumbnail/')[0]}/strip/format/webp" type="image/webp"><source srcset="${imgUrl}" type="image/${type}"><img src="${imgUrl}"></picture>`;
                     }
                 });
             }


### PR DESCRIPTION
- 翻车的图片是 https://cdn.ruguoapp.com/FmPwBqyD-hbbTUTxSC_UsmmDD-jR?imageMogr2/auto-orient/heic-exif/1/format/jpeg/thumbnail/1329336@ 这种格式，`?imageMogr2` 前并没有 `.后缀名` 这样的跟着，直接 `split('?imageMogr2/')` 后图片无法访问。试了下也找不到原始的文件是怎样的，因此目前的处理方式是判断到 `?imageMogr2` 前有  `.后缀名` 才进行 `split` 操作，没有的话直接使用不带 `thumbnail` 的部分
- Closes #1282 