### PR TITLE
Hotfix: 修复文档标签闭合错误

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1956,10 +1956,6 @@ Category 列表:
 
 ### 卫报 The Guardian
 
-<route name="Editorial" author="HenryQW" example="/guardian/editorial" path="/guardian/editorial">
-
-<route name="China" author="Polynomia" example="/guardian/china" path="/guardian/china">
-
 ::: tip 提示
 
 由于众所周知的原因，文章内的图片在中国大陆可能无法正常显示。
@@ -1968,7 +1964,9 @@ Category 列表:
 
 通过提取文章全文，以提供比官方源更佳的阅读体验。
 
-</route>
+<route name="Editorial" author="HenryQW" example="/guardian/editorial" path="/guardian/editorial"/>
+
+<route name="China" author="Polynomia" example="/guardian/china" path="/guardian/china"/>
 
 ### 多维新闻网
 


### PR DESCRIPTION
- 搜了下好像是 3a30d5d5a3731150c9ed08d6d8342b52a364ba88 这个提交导致的`route`标签嵌套/闭合错误会使本地`npm run docs:dev`飘红~
- 顺便调整了下提示文案位置，放到最开头的地方