### PR TITLE
update: show all GitHub issues

### DIFF
--- a/lib/routes/github/issue.js
+++ b/lib/routes/github/issue.js
@@ -9,7 +9,7 @@ module.exports = async (ctx) => {
     const repo = ctx.params.repo;
 
     const host = `https://github.com/${user}/${repo}/issues`;
-    const url = `https://api.github.com/repos/${user}/${repo}/issues`;
+    const url = `https://api.github.com/repos/${user}/${repo}/issues?state=all`;
 
     const response = await axios({
         method: 'get',


### PR DESCRIPTION
仅显示打开的issue，在issue重开或者关闭时会影响生成rss的数量和排序。调整参数使其获取所有issue