### PR TITLE
Fix manhuagui close #1381

### DIFF
--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -3,7 +3,7 @@ const cheerio = require('cheerio');
 const axios = require('../../utils/axios');
 
 const getChapters = ($) =>
-    $('#chapter-list-0 > ul li')
+    $('.chapter-list > ul li')
         .map((_, ele) => {
             const a = $(ele).children('a');
             return {


### PR DESCRIPTION
如果漫画话数不多的情况下用原方案是可以的，
但是如果话数多了之后会分页，
div 的 id 会变为 `#chapter-list-1` 就不可用了

直接修改成 class `.chapter-list` 就同时兼容了这两部分了。