### PR TITLE
:sparkles: 即刻：对两个新闻主题做特殊处理

### DIFF
--- a/lib/routes/jike/topic.js
+++ b/lib/routes/jike/topic.js
@@ -1,5 +1,7 @@
 const axios = require('../../utils/axios');
 const common = require('./common');
+const cheerio = require('cheerio');
+const dayjs = require('dayjs');
 
 module.exports = async (ctx) => {
     const id = ctx.params.id;
@@ -32,4 +34,34 @@ module.exports = async (ctx) => {
         image: topic.squarePicture.picUrl || topic.squarePicture.middlePicUrl || topic.squarePicture.thumbnailUrl,
         item: common.topicDataHanding(data),
     };
+    if (id === '553870e8e4b0cafb0a1bef68' || id === '55963702e4b0d84d2c30ce6f') {
+        const promises = ctx.state.data.item.map(async (one) => {
+            const item = { ...one };
+            const regResult = /https:\/\/www.okjike.com\/medium\/[a-zA-Z0-9]*/.exec(item.description);
+            if (regResult) {
+                const newsUrl = regResult[0];
+                const cache = ctx.cache.get(newsUrl);
+                if (cache) {
+                    item.description = cache;
+                } else {
+                    const { data } = await axios.get(newsUrl);
+                    const $ = cheerio.load(data);
+                    const upper = $('ul.main > li.item');
+                    const links = upper.find('a').map((_, ele) => $(ele).attr('href'));
+                    const texts = upper.find('span.text').map((_, ele) => $(ele).text());
+                    let description = '';
+                    for (let i = 0; i < links.length; i++) {
+                        description += `${i + 1}、<a href="${links[i]}">${texts[i]}</a><br/>`;
+                    }
+                    if (description) {
+                        item.description = description;
+                        ctx.cache.set(newsUrl, description);
+                    }
+                }
+            }
+            item.title = `${topic.content} ${dayjs(new Date(one.pubDate)).format('MM月DD日')}`;
+            return item;
+        });
+        ctx.state.data.item = await Promise.all(promises);
+    }
 };


### PR DESCRIPTION
修改即刻 Feed，对两个新闻主题 [一觉醒来世界发生了什么](https://web.okjike.com/topic/553870e8e4b0cafb0a1bef68/official) 和 [今天网上都在热议什么](https://web.okjike.com/topic/55963702e4b0d84d2c30ce6f/official) 进行特殊处理：
- 标题改为 `${主题名称} ${日期}` 如 `一觉醒来世界发生了什么 01月30日`
- 为每个新闻添加源文链接

Reader 中效果如下：
![image](https://user-images.githubusercontent.com/21376471/51955323-76419700-247e-11e9-901c-58a3fe2e4ec4.png)

![image](https://user-images.githubusercontent.com/21376471/51955331-7a6db480-247e-11e9-9083-8148f1f41d3d.png)
