### PR TITLE
:zap: 增强 ReadHub

### DIFF
--- a/lib/routes/readhub/category.js
+++ b/lib/routes/readhub/category.js
@@ -1,4 +1,5 @@
 const axios = require('../../utils/axios');
+const dayjs = require('dayjs');
 
 module.exports = async (ctx) => {
     const category = ctx.params.category;
@@ -29,22 +30,63 @@ module.exports = async (ctx) => {
         path = 'topic/daily';
     }
 
-    const response = await axios({
+    const {
+        data: { data },
+    } = await axios({
         method: 'get',
         url: `https://api.readhub.cn/${path}`,
     });
 
-    const data = response.data;
+    const promises = data.map(async (news) => {
+        const id = news.id;
+        if (category === 'topic' || category === 'daily') {
+            const link = `https://readhub.cn/topic/${id}`;
+            const cache = ctx.cache.get(link);
+            if (cache) {
+                return cache;
+            }
+            const { data } = await axios.get(`https://api.readhub.cn/topic/${id}`);
+            let description = data.summary;
+            if (data.newsArray) {
+                description += '<br/><br/>媒体报道：';
+                for (const one of data.newsArray) {
+                    description += `<br/>${dayjs(new Date(one.publishDate)).format('YY-MM-DD')} ${one.siteName}: <a href='${one.mobileUrl || one.url}'>${one.title}</a>`;
+                }
+            }
+            if (data.timeline && data.timeline.topics) {
+                let type = '相关事件';
+                if (data.timeline.commonEntities && data.timeline.commonEntities.length > 0) {
+                    type = '事件追踪';
+                }
+                description += `<br/><br/>${type}：`;
+                for (const one of data.timeline.topics) {
+                    description += `<br/>${dayjs(new Date(one.createdAt)).format('YY-MM-DD')} <a href='https://readhub.cn/topic/${one.id}'>${one.title.trim()}</a>`;
+                }
+            }
+            const item = {
+                title: data.title,
+                description: description.replace(new RegExp('\n', 'g'), '<br/>'),
+                pubDate: data.publishDate,
+                guid: id,
+                link,
+            };
+            ctx.cache.set(link, description);
+            return item;
+        } else {
+            const description = news.summaryAuto || news.summary || news.title;
+            return {
+                title: news.title,
+                description: description.replace(new RegExp('\n', 'g'), '<br/>'),
+                pubDate: news.publishDate,
+                guid: id,
+                link: news.url || news.mobileUrl,
+            };
+        }
+    });
 
     ctx.state.data = {
         title: `Readhub-${title}`,
         link: 'https://readhub.cn',
-        item: data.data.map((item) => ({
-            title: item.title,
-            pubDate: new Date(item.publishDate || Date.now()).toUTCString(),
-            description: item.summary || item.title,
-            guid: `/${category}/${item.id}`,
-            link: category === 'daily' ? `https://readhub.cn/topic/${item.id}` : item.url || item.newsArray[0].url,
-        })),
+        item: await Promise.all(promises),
     };
 };

--- a/lib/routes/readhub/category.js
+++ b/lib/routes/readhub/category.js
@@ -5,22 +5,28 @@ module.exports = async (ctx) => {
     const category = ctx.params.category;
 
     let title;
+    let link;
     let path = category;
     switch (category) {
         case 'topic':
             title = '热门话题';
+            link = 'https://readhub.cn/topics';
             break;
         case 'news':
             title = '科技动态';
+            link = 'https://readhub.cn/news';
             break;
         case 'technews':
             title = '开发者资讯';
+            link = 'https://readhub.cn/tech';
             break;
         case 'blockchain':
             title = '区块链快讯';
+            link = 'https://readhub.cn/blockchain';
             break;
         case 'daily':
             title = '每日早报';
+            link = 'https://readhub.cn/daily';
             break;
         default:
             break;
@@ -86,7 +92,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `Readhub-${title}`,
-        link: 'https://readhub.cn',
+        link,
         item: await Promise.all(promises),
     };
 };


### PR DESCRIPTION
对 ReadHub 下的不同分类做特定的处理：
1. [科技动态](https://readhub.cn/news)、[https://readhub.cn/tech](开发者咨询) 和 [区块链快讯](https://readhub.cn/blockchain)：这三个分类没有细分内容，直接显示概要。 Reeder 下表现：

![image](https://user-images.githubusercontent.com/21376471/51958951-56fe3600-248d-11e9-9ec7-86a5e312ed7e.png)

2. [热门话题](https://readhub.cn/topics) 和 [每日早报](https://readhub.cn/daily) 显示包括媒体报道、相关事件、事件追踪、原文链接在内的细分内容。Reeder 下表现如下：

![image](https://user-images.githubusercontent.com/21376471/51959007-8a40c500-248d-11e9-8114-612f11e913f1.png)
