### PR TITLE
fix: handle docker images without build history

### DIFF
--- a/lib/routes/dockerhub/build.js
+++ b/lib/routes/dockerhub/build.js
@@ -5,20 +5,20 @@ module.exports = async (ctx) => {
 
     const namespace = `${owner}/${image}`;
 
-    const data = await axios.get(`https://hub.docker.com/v2/repositories/${namespace}/buildhistory/?page_size=5`);
+    const data = await axios.get(`https://hub.docker.com/v2/repositories/${namespace}/tags/?page_size=5`);
     const metadata = await axios.get(`https://hub.docker.com/v2/repositories/${namespace}`);
 
-    const list = data.data.results.filter((a) => a.status === 10 && a.dockertag_name === tag);
+    const list = data.data.results.filter((a) => a.name === tag);
 
     const out = list.map((item) => ({
-        title: `${namespace}:${tag} was built successfully`,
-        link: `https://hub.docker.com/r/wangqiru/ttrss/builds`,
+        title: `${namespace}:${tag} was built. ${(item.images[0].size / 1000000).toFixed(2)} MB`,
+        link: `https://hub.docker.com/r/wangqiru/ttrss/`,
         author: owner,
         pubDate: item.last_updated,
     }));
 
     ctx.state.data = {
-        title: `Docker image build history: ${namespace}:${tag}`,
+        title: `${namespace}:${tag} build history`,
         description: metadata.description,
         link: `https://hub.docker.com/r/${namespace}`,
         item: out,


### PR DESCRIPTION
Fetch build stats via `tags` api