### PR TITLE
修改牛客网帖子内容（description）解析方案

### DIFF
--- a/lib/routes/nowcoder/discuss.js
+++ b/lib/routes/nowcoder/discuss.js
@@ -49,7 +49,7 @@ module.exports = async (ctx) => {
                 .text()
                 .split('  ')[1];
 
-            const description = $('.post-topic-main')
+            const description = $('.nc-post-content')
                 .html()
                 .trim();
 


### PR DESCRIPTION
目前抓取的description数据，包含赞数和收藏数等，且会不断更新。这个 PR 把这些变化的数字去掉。

原先每个帖子都有

```html
收藏(43)</a></li><li class="oprt-item-share"><a class="oprt-item oprt-share js-share-oprt-item" href="javascript:void(0);">分享</a><div class="tooltip top js-share-tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"><span class="q-share-to"><a href="javascript:void(0);" class="js-share-link share-wb" data-share="weibo"></a><a href="javascript:void(0);" class="js-share-link share-tx" data-share="qzone"></a><a href="javascript:void(0);" class="js-share-wx share-wx"></a></span></div></div></li><li><a href="javascript:void(0);" class="js-post-like nc-req-auth oprt-item oprt-like">赞(0)
```

全都去掉了。