### PR TITLE
[Dockerhub] Fix date and guid

### DIFF
--- a/lib/routes/dockerhub/build.js
+++ b/lib/routes/dockerhub/build.js
@@ -16,7 +16,8 @@ module.exports = async (ctx) => {
         title: `${namespace}:${tag} was built. ${(item.images[0].size / 1000000).toFixed(2)} MB`,
         link,
         author: owner,
-        pubDate: item.last_updated,
+        pubDate: new Date(item.last_updated).toUTCString(),
+        guid: item.last_updated,
     }));
 
     ctx.state.data = {


### PR DESCRIPTION
1. 原来的 `pubDate` 为 `2019-03-08T04:10:53.381143Z` 格式，现修改成 UTC 格式
2. 原来的 `guid` 为 link ，每次有新的 build 都是返回同一个 link ，现从接口中找了个不会重复的参数即 `pubDate` 作为 guid