### PR TITLE
Fix: cache null not work

### DIFF
--- a/lib/middleware/cache.js
+++ b/lib/middleware/cache.js
@@ -111,25 +111,27 @@ module.exports = function(app, options = {}) {
         available = true;
     }
 
-    app.context.cache.tryGet = async function(key, getValueFunc, maxAge = 24 * 60 * 60) {
-        let v = await this.get(key);
-        if (!v) {
-            v = await getValueFunc();
-            this.set(key, v, maxAge);
-        } else {
-            let parsed;
-            try {
-                parsed = JSON.parse(v);
-            } catch (e) {
-                parsed = null;
+    if (config.cacheType !== null) {
+        app.context.cache.tryGet = async function(key, getValueFunc, maxAge = 24 * 60 * 60) {
+            let v = await this.get(key);
+            if (!v) {
+                v = await getValueFunc();
+                this.set(key, v, maxAge);
+            } else {
+                let parsed;
+                try {
+                    parsed = JSON.parse(v);
+                } catch (e) {
+                    parsed = null;
+                }
+                if (parsed) {
+                    v = parsed;
+                }
             }
-            if (parsed) {
-                v = parsed;
-            }
-        }
 
-        return v;
-    };
+            return v;
+        };
+    }
 
     async function getCache(ctx, key, tkey) {
         const value = await globalCache.get(key);


### PR DESCRIPTION
当cache类型设置为null，app.context.cache未定义
fix #1728 