### PR TITLE
chore: update base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.13.0-slim
+FROM node:10.15-slim
 LABEL MAINTAINER https://github.com/DIYgod/RSSHub/
 
 RUN apt-get update && apt-get install -yq libgconf-2-4 apt-transport-https


### PR DESCRIPTION
Debian jessie has been archived.
Fix #1833.