### PR TITLE
修整两处格式错误

### DIFF
--- a/lib/middleware/utf8.js
+++ b/lib/middleware/utf8.js
@@ -2,5 +2,5 @@
 // https://stackoverflow.com/questions/1497885/remove-control-characters-from-php-string/1497928#1497928
 module.exports = async (ctx, next) => {
     await next();
-    ctx.body = typeof ctx.body !== 'object' ? ctx.body.replace(/[\x00-\x1F\x7F]/g, '') : ctx.body;
+    ctx.body = typeof ctx.body !== 'object' ? ctx.body.replace(/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/g, '') : ctx.body;
 };


### PR DESCRIPTION
在转发 Telegram Channel 到 Mastodon 的过程中，发现有两处格式错误：

1. hashtag 和斜体内容， Mastodon 不支持，就变成 `<i>#tag</i>` 这样的形式了，版式很乱且没必要，这个一般用的也少，干脆就去掉了。
2. 在去除不可见字符的时候，应当保留回车 `\r \n` ，这样可以更好的保持排版格式。（源代码中参照的 stackoverflow 链接中的第二个，回答中的提示也有保留回车的选项，就套过来了。
