### PR TITLE
Hotfix: nytimes route

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -355,8 +355,8 @@ router.get('/yande.re/post/popular_recent', require('./routes/yande.re/post_popu
 router.get('/yande.re/post/popular_recent/:period', require('./routes/yande.re/post_popular_recent'));
 
 // 纽约时报
-router.get('/nytimes/:lang?', require('./routes/nytimes/index'));
 router.get('/nytimes/morning_post', require('./routes/nytimes/morning_post'));
+router.get('/nytimes/:lang?', require('./routes/nytimes/index'));
 
 // 3dm
 router.get('/3dm/:name/:type', require('./routes/3dm/game'));


### PR DESCRIPTION
由于先前的路由的注册顺序是**先**`/nytimes/:lang?`**后**`/nytimes/morning_post`，且`lang`参数为可选。当访问`/nytimes/morning_post`时实际上是走到了第一个路由也就是`/nytimes/:lang?`里(这种情况下第二个路由其实并没有起作用)，导致输出内容不符合预期

因此调换两个路由的注册顺序可以解决这个问题

Closes #1886 