### PR TITLE
改进专栏url

### DIFF
--- a/lib/routes/zhihu/activities.js
+++ b/lib/routes/zhihu/activities.js
@@ -70,7 +70,7 @@ module.exports = async (ctx) => {
                     case 'column':
                         title = detail.title;
                         description = `<p>${detail.intro}</p><p><img referrerpolicy="no-referrer" src="${detail.image_url}"/></p>`;
-                        url = detail.url;
+                        url = `https://zhuanlan.zhihu.com/${detail.url.split('/').pop()}`;
                         break;
                     case 'topic':
                         title = detail.name;


### PR DESCRIPTION
以前的专栏url是这样的：`https://api.zhihu.com/columns/xxx`。我想这并不是用户想要的，点击之后还要修改url。
改进后是正常的url：`https://zhuanlan.zhihu.com/xxx`