### PR TITLE
display author name as dc:creator for Twitter feeds

### DIFF
--- a/lib/routes/twitter/utils.js
+++ b/lib/routes/twitter/utils.js
@@ -98,6 +98,7 @@ const ProcessFeed = ({ data = [] }) => {
         }
 
         return {
+            creator: item.user.name,
             title: `${item.in_reply_to_screen_name ? 'Re ' : ''}${formatText(item.full_text)}`,
             description: `${item.in_reply_to_screen_name ? 'Re ' : ''}${formatText(item.full_text)}${url}${img}${quote}`,
             pubDate: new Date(item.created_at).toUTCString(),

--- a/lib/views/rss.art
+++ b/lib/views/rss.art
@@ -2,7 +2,7 @@
 {{ if itunes_author }}
 <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
 {{else}}
-<rss version="2.0">
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
 {{ /if }}
     <channel>
         <title><![CDATA[{{@ title || 'RSSHub' }}]]></title>
@@ -24,6 +24,7 @@
         <ttl>{{ ttl }}</ttl>
         {{ each item }}
         <item>
+            <dc:creator><![CDATA[{{@ $value.creator }}]]></dc:creator>
             <title><![CDATA[{{@ $value.title }}]]></title>
             <description><![CDATA[{{@ $value.description || $value.title }}]]></description>
             {{ if $value.pubDate }}<pubDate>{{ $value.pubDate }}</pubDate>{{ /if }}


### PR DESCRIPTION
# Why
RSS readers are capable of displaying author names. Usually this comes from [the `dc:creator` element](http://www.rssboard.org/rss-profile#namespace-elements-dublin-creator).

# Notes
It's necessary to [add the proper namespace for Dublin Core](http://www.lowter.com/blogs/2008/2/9/rss-dccreator-author).