### PR TITLE
fix: #1982 修正mp4ba 旧站404错误

### DIFF
--- a/lib/routes/mp4ba/index.js
+++ b/lib/routes/mp4ba/index.js
@@ -1,7 +1,7 @@
 const axios = require('../../utils/axios');
 const cheerio = require('cheerio');
 
-const baseUrl = 'http://www.mp4ba.com';
+const baseUrl = 'http://ww.mp4ba.com';
 
 class ParamType {
     static get paramType() {


### PR DESCRIPTION
原来的 www.mp4ba.com 进行了改版，新站地址不变，旧站变为 ww.mp4ba.com。