### PR TITLE
feat: 增加财新博客全文输出

### DIFF
--- a/docs/other.md
+++ b/docs/other.md
@@ -550,3 +550,11 @@ type 为 all 时，category 参数不支持 cost 和 free
 <Route name="首页" author="qiwihui" example="/paidai" path="/paidao" />
 <Route name="论坛" author="qiwihui" example="/paidai/bbs" path="/paidao/bbs" />
 <Route name="商道" author="qiwihui" example="/paidai/news" path="/paidao/news" />
+
+## 财新博客
+
+<Route name="用户博客" author="Maecenas" example="/caixin/blog/zhangwuchang" path="/caixin/blog/:column" :paramsDesc="['博客名称，可在博客主页的 URL 找到']">
+
+通过提取文章全文，以提供比官方源更佳的阅读体验.
+
+</Route>

--- a/docs/other.md
+++ b/docs/other.md
@@ -553,7 +553,7 @@ type 为 all 时，category 参数不支持 cost 和 free
 
 ## 财新博客
 
-<Route name="用户博客" author="Maecenas" example="/caixin.blog/zhangwuchang" path="/caixin.blog/:column" :paramsDesc="['博客名称，可在博客主页的 URL 找到']">
+<Route name="用户博客" author="Maecenas" example="/caixin/blog/zhangwuchang" path="/caixin/blog/:column" :paramsDesc="['博客名称，可在博客主页的 URL 找到']">
 
 通过提取文章全文，以提供比官方源更佳的阅读体验.
 

--- a/docs/other.md
+++ b/docs/other.md
@@ -553,7 +553,7 @@ type 为 all 时，category 参数不支持 cost 和 free
 
 ## 财新博客
 
-<Route name="用户博客" author="Maecenas" example="/caixin/blog/zhangwuchang" path="/caixin/blog/:column" :paramsDesc="['博客名称，可在博客主页的 URL 找到']">
+<Route name="用户博客" author="Maecenas" example="/caixin.blog/zhangwuchang" path="/caixin.blog/:column" :paramsDesc="['博客名称，可在博客主页的 URL 找到']">
 
 通过提取文章全文，以提供比官方源更佳的阅读体验.
 

--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -14,7 +14,7 @@
 
 > 网站部分内容需要付费订阅, RSS 仅做更新提醒, 不含付费内容.
 
-<Route name="新闻分类" author="idealclover" example="/caixin/finance/regulation" path="/caixin/:column/:category" :paramsDesc="['栏目名', '栏目下的子分类名']">
+<Route name="新闻分类" author="idealclover" example="/caixin/news/finance/regulation" path="/caixin/news/:column/:category" :paramsDesc="['栏目名', '栏目下的子分类名']">
 
 Column 列表:
 

--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -14,7 +14,7 @@
 
 > 网站部分内容需要付费订阅, RSS 仅做更新提醒, 不含付费内容.
 
-<Route name="新闻分类" author="idealclover" example="/caixin/news/finance/regulation" path="/caixin/news/:column/:category" :paramsDesc="['栏目名', '栏目下的子分类名']">
+<Route name="新闻分类" author="idealclover" example="/caixin/finance/regulation" path="/caixin/:column/:category" :paramsDesc="['栏目名', '栏目下的子分类名']">
 
 Column 列表:
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -405,10 +405,10 @@ router.get('/mihoyo/bh2/:type', require('./routes/mihoyo/bh2'));
 // 央视新闻
 router.get('/cctv/:category', require('./routes/cctv/category'));
 
+// 财新博客
+router.get('/caixin/blog/:column', require('./routes/caixin/blog'));
 // 财新
 router.get('/caixin/:column/:category', require('./routes/caixin/category'));
-// 财新博客
-router.get('/caixin.blog/:column', require('./routes/caixin/blog'));
 
 // 草榴社区
 router.get('/t66y/post/:tid', require('./routes/t66y/post'));

--- a/lib/router.js
+++ b/lib/router.js
@@ -406,9 +406,9 @@ router.get('/mihoyo/bh2/:type', require('./routes/mihoyo/bh2'));
 router.get('/cctv/:category', require('./routes/cctv/category'));
 
 // 财新
-router.get('/caixin/news/:column/:category', require('./routes/caixin/category'));
+router.get('/caixin/:column/:category', require('./routes/caixin/category'));
 // 财新博客
-router.get('/caixin/blog/:column', require('./routes/caixin/blog'));
+router.get('/caixin.blog/:column', require('./routes/caixin/blog'));
 
 // 草榴社区
 router.get('/t66y/post/:tid', require('./routes/t66y/post'));

--- a/lib/router.js
+++ b/lib/router.js
@@ -406,7 +406,9 @@ router.get('/mihoyo/bh2/:type', require('./routes/mihoyo/bh2'));
 router.get('/cctv/:category', require('./routes/cctv/category'));
 
 // 财新
-router.get('/caixin/:column/:category', require('./routes/caixin/category'));
+router.get('/caixin/news/:column/:category', require('./routes/caixin/category'));
+// 财新博客
+router.get('/caixin/blog/:column', require('./routes/caixin/blog'));
 
 // 草榴社区
 router.get('/t66y/post/:tid', require('./routes/t66y/post'));

--- a/lib/routes/caixin/blog.js
+++ b/lib/routes/caixin/blog.js
@@ -1,0 +1,61 @@
+const axios = require('../../utils/axios');
+const cheerio = require('cheerio');
+const Parser = require('rss-parser');
+const parser = new Parser({
+    headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36' },
+});
+
+async function load(link, caches, need_feed_description) {
+    const response = await axios.get(link);
+    const $ = cheerio.load(response.data);
+    const article = $('.blog_content').removeAttr('style');
+    article.find('img').removeAttr('style');
+    $('div', article)
+        // Non-breaking space U+00A0, `&nbsp;` in html
+        // element.children[0].data === $(element, article).text()
+        .filter((_, element) => element.children[0].data === String.fromCharCode(160))
+        .remove();
+    const description = article.html();
+
+    const item = { description };
+    caches.set(link, item);
+
+    if (need_feed_description) {
+        const author = $('div.widget.author_detail p:nth-child(2)');
+        // workaround to split author name and author article
+        const author_name = author.find('strong');
+        author_name.text(author_name.text() + '，');
+        item.feed_description = author.text();
+    }
+    return item;
+}
+
+module.exports = async (ctx) => {
+    const { column } = ctx.params;
+    const link = `http://${column}.blog.caixin.com`;
+    const feed_url = `${link}/feed`;
+    const feed = await parser.parseURL(feed_url);
+
+    const title = `财新博客 - ${/[^»]*$/.exec(feed.title)[0]}`;
+
+    const items = await Promise.all(
+        feed.items.slice(0, 10).map(async (item, index) => {
+            const link = item.link;
+            const single = {
+                title: item.title,
+                pubDate: item.pubDate,
+                link,
+                author: item['dc:creator'],
+            };
+            const other = await ctx.cache.tryGet(link, async () => await load(link, ctx.cache, index === 0));
+            return Promise.resolve(Object.assign({}, single, other));
+        })
+    );
+
+    ctx.state.data = {
+        title,
+        link,
+        description: items[0].feed_description,
+        item: items,
+    };
+};

--- a/lib/routes/caixin/blog.js
+++ b/lib/routes/caixin/blog.js
@@ -9,7 +9,7 @@ async function load(link, caches, need_feed_description) {
     const $ = cheerio.load(response.data);
     const article = $('.blog_content').removeAttr('style');
     article.find('img').removeAttr('style');
-    $('div', article)
+    article.find('div')
         // Non-breaking space U+00A0, `&nbsp;` in html
         // element.children[0].data === $(element, article).text()
         .filter((_, element) => element.children[0].data === String.fromCharCode(160))

--- a/lib/routes/caixin/blog.js
+++ b/lib/routes/caixin/blog.js
@@ -9,7 +9,8 @@ async function load(link, caches, need_feed_description) {
     const $ = cheerio.load(response.data);
     const article = $('.blog_content').removeAttr('style');
     article.find('img').removeAttr('style');
-    article.find('div')
+    article
+        .find('div')
         // Non-breaking space U+00A0, `&nbsp;` in html
         // element.children[0].data === $(element, article).text()
         .filter((_, element) => element.children[0].data === String.fromCharCode(160))

--- a/lib/routes/caixin/blog.js
+++ b/lib/routes/caixin/blog.js
@@ -1,9 +1,8 @@
 const axios = require('../../utils/axios');
 const cheerio = require('cheerio');
+const { ua } = require('../../config');
 const Parser = require('rss-parser');
-const parser = new Parser({
-    headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36' },
-});
+const parser = new Parser({ headers: { 'User-Agent': ua } });
 
 async function load(link, caches, need_feed_description) {
     const response = await axios.get(link);

--- a/lib/routes/caixin/blog.js
+++ b/lib/routes/caixin/blog.js
@@ -4,7 +4,7 @@ const { ua } = require('../../config');
 const Parser = require('rss-parser');
 const parser = new Parser({ headers: { 'User-Agent': ua } });
 
-async function load(link, caches, need_feed_description) {
+async function load(link, need_feed_description) {
     const response = await axios.get(link);
     const $ = cheerio.load(response.data);
     const article = $('.blog_content').removeAttr('style');
@@ -46,7 +46,7 @@ module.exports = async (ctx) => {
                 link,
                 author: item['dc:creator'],
             };
-            const other = await ctx.cache.tryGet(link, async () => await load(link, ctx.cache, index === 0));
+            const other = await ctx.cache.tryGet(link, async () => await load(link, index === 0));
             return Promise.resolve(Object.assign({}, single, other));
         })
     );

--- a/lib/routes/caixin/blog.js
+++ b/lib/routes/caixin/blog.js
@@ -18,7 +18,6 @@ async function load(link, caches, need_feed_description) {
     const description = article.html();
 
     const item = { description };
-    caches.set(link, item);
 
     if (need_feed_description) {
         const author = $('div.widget.author_detail p:nth-child(2)');


### PR DESCRIPTION
同时更改了原财新网的路由，不知道有没有问题。

**Development**:
<img width="1516" alt="Dev" src="https://user-images.githubusercontent.com/26927236/57440979-f77da680-7283-11e9-9e22-835543008fcf.png">

文档部分：本地 `npm run docs:dev` 跑起来后，`localhost:8080` 没有相应的返回结果，路由是目测写的。不知道是不是本地环境的问题。

希望加入 `feed.description`，只能通过解析页面获得，看了一下 `ctx.cache.tryGet()` 的实现，手动设置缓存是为了避免引入额外的信息。