### PR TITLE
feat: 哔哩哔哩排行榜功能添加

### DIFF
--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -152,7 +152,7 @@
 
 <Route name="会员购作品" author="DIYgod" example="/bilibili/mall/ip/1_5883" path="/bilibili/mall/ip/:id" :paramsDesc="['作品 id, 可在作品列表页 URL 中找到']"/>
 
-<Route name="排行榜" author="DIYgod" example="/bilibili/ranking/0/3" path="/bilibili/ranking/:tid/:days?" :paramsDesc="['排行榜分区 id, 默认 0', '时间跨度, 可为 1 3 7 30']">
+<Route name="排行榜" author="DIYgod" example="/bilibili/ranking/0/3/1" path="/bilibili/ranking/:tid/:days?/:arc_type?" :paramsDesc="['排行榜分区 id, 默认 0', '时间跨度, 可为 1 3 7 30', '投稿时间, 可为 0(全部投稿) 1(近期投稿) , 默认 1']">
 
 | 全站 | 动画 | 国创相关 | 音乐 | 舞蹈 | 游戏 | 科技 | 生活 | 鬼畜 | 时尚 | 娱乐 | 影视 |
 | ---- | ---- | -------- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |

--- a/lib/router.js
+++ b/lib/router.js
@@ -115,7 +115,7 @@ router.get('/bilibili/fav/:uid/:fid', require('./routes/bilibili/fav'));
 router.get('/bilibili/blackboard', require('./routes/bilibili/blackboard'));
 router.get('/bilibili/mall/new', require('./routes/bilibili/mallNew'));
 router.get('/bilibili/mall/ip/:id', require('./routes/bilibili/mallIP'));
-router.get('/bilibili/ranking/:rid?/:day?', require('./routes/bilibili/ranking'));
+router.get('/bilibili/ranking/:rid?/:day?/:arc_type?', require('./routes/bilibili/ranking'));
 router.get('/bilibili/user/channel/:uid/:cid', require('./routes/bilibili/userChannel'));
 router.get('/bilibili/topic/:topic', require('./routes/bilibili/topic'));
 router.get('/bilibili/audio/:id', require('./routes/bilibili/audio'));

--- a/lib/routes/bilibili/ranking.js
+++ b/lib/routes/bilibili/ranking.js
@@ -4,11 +4,11 @@ module.exports = async (ctx) => {
     const rid = ctx.params.rid || '0';
     const day = ctx.params.day || '3';
     const arc_type = ctx.params.arc_type || '1';
-    const arc_type1 = arc_type=='0' ? "全部投稿" : "近期投稿";
-    const list_rid = ['0','1','168','3','129','4','36','160','119','155','5','181']
-    const list_rid1 = ["全站","动画","国创相关","音乐","舞蹈","游戏","科技","生活","鬼畜","时尚","娱乐","影视"]
-    const list_i= list_rid.indexOf(rid)
-    const list_type=list_rid1[list_i]
+    const arc_type1 = arc_type === '0' ? '全部投稿' : '近期投稿';
+    const rid_1 = ['0', '1', '168', '3', '129', '4', '36', '160', '119', '155', '5', '181'];
+    const rid_2 = ['全站', '动画', '国创相关', '音乐', '舞蹈', '游戏', '科技', '生活', '鬼畜', '时尚', '娱乐', '影视'];
+    const rid_i = rid_1.indexOf(arc_type);
+    const rid_type = rid_2[rid_i];
     const response = await axios({
         method: 'get',
         url: `https://api.bilibili.com/x/web-interface/ranking?jsonp=jsonp&rid=${rid}&day=${day}&type=1&arc_type=${arc_type}&callback=__jp0`,
@@ -29,11 +29,11 @@ module.exports = async (ctx) => {
     }
 
     ctx.state.data = {
-        title: `bilibili ${day}日排行榜-${list_type}-${arc_type1}`,
+        title: `bilibili ${day}日排行榜-${rid_type}-${arc_type1}`,
         link: `https://www.bilibili.com/ranking/all/${rid}/0/${day}`,
         item: list.map((item) => ({
             title: item.title,
-            description: `作者：${item.author}<br>播放量：${item.play}<br>时长：${item.duration}<br>综合得分：${item.pts}<br>${(item.play/10000).toFixed(1)}万播放<br>${(item.video_review/10000).toFixed(1)}万弹幕<br><img referrerpolicy="no-referrer" src="${item.pic}">`,
+            description: `作者：${item.author}<br>播放量：${item.play}<br>时长：${item.duration}<br>综合得分：${item.pts}<br>弹幕：${item.video_review}<br><img referrerpolicy="no-referrer" src="${item.pic}">`,
             link: `https://www.bilibili.com/video/av${item.aid}`,
         })),
     };

--- a/lib/routes/bilibili/ranking.js
+++ b/lib/routes/bilibili/ranking.js
@@ -3,12 +3,17 @@ const axios = require('../../utils/axios');
 module.exports = async (ctx) => {
     const rid = ctx.params.rid || '0';
     const day = ctx.params.day || '3';
-
+    const arc_type = ctx.params.arc_type || '1';
+    const arc_type1 = arc_type=='0' ? "全部投稿" : "近期投稿";
+    const list_rid = ['0','1','168','3','129','4','36','160','119','155','5','181']
+    const list_rid1 = ["全站","动画","国创相关","音乐","舞蹈","游戏","科技","生活","鬼畜","时尚","娱乐","影视"]
+    const list_i= list_rid.indexOf(rid)
+    const list_type=list_rid1[list_i]
     const response = await axios({
         method: 'get',
-        url: `https://api.bilibili.com/x/web-interface/ranking?jsonp=jsonp&rid=${rid}&day=${day}&type=1&arc_type=0&callback=__jp0`,
+        url: `https://api.bilibili.com/x/web-interface/ranking?jsonp=jsonp&rid=${rid}&day=${day}&type=1&arc_type=${arc_type}&callback=__jp0`,
         headers: {
-            Referer: `https://www.bilibili.com/ranking/all/${rid}/0/${day}`,
+            Referer: `https://www.bilibili.com/ranking/all/${rid}/${arc_type}/${day}`,
         },
     });
 
@@ -24,11 +29,11 @@ module.exports = async (ctx) => {
     }
 
     ctx.state.data = {
-        title: `bilibili ${day}日排行榜-${rid}`,
+        title: `bilibili ${day}日排行榜-${list_type}-${arc_type1}`,
         link: `https://www.bilibili.com/ranking/all/${rid}/0/${day}`,
         item: list.map((item) => ({
             title: item.title,
-            description: `作者：${item.author}<br>播放量：${item.play}<br>时长：${item.duration}<br><img referrerpolicy="no-referrer" src="${item.pic}">`,
+            description: `作者：${item.author}<br>播放量：${item.play}<br>时长：${item.duration}<br>综合得分：${item.pts}<br>${(item.play/10000).toFixed(1)}万播放<br>${(item.video_review/10000).toFixed(1)}万弹幕<br><img referrerpolicy="no-referrer" src="${item.pic}">`,
             link: `https://www.bilibili.com/video/av${item.aid}`,
         })),
     };


### PR DESCRIPTION
feat: 哔哩哔哩排行榜 功能的添加 支持(全部投稿和近期投稿的选择)
fix:title和description的完整化
docs:添加功能描述
before
![before](https://raw.githubusercontent.com/NathanDai/pic_resource/master/img/20190512160836.png)
after
![after](https://raw.githubusercontent.com/NathanDai/pic_resource/master/img/20190512160919.png)