### PR TITLE
fix: remove pubDate due to i18n date string parsing issue

### DIFF
--- a/lib/routes/apple/exchange_repair.js
+++ b/lib/routes/apple/exchange_repair.js
@@ -25,13 +25,13 @@ module.exports = async (ctx) => {
         .map((i, e) => $(e).text())
         .get();
 
-    const datelist = $('tr td p')
-        .map((i, e) =>
-            $(e)
-                .text()
-                .trim()
-        )
-        .get();
+    // const datelist = $('tr td p')
+    //     .map((i, e) =>
+    //         $(e)
+    //             .text()
+    //             .trim()
+    //     )
+    //     .get();
 
     const out = await Promise.all(
         list.map(async (itemUrl, index) => {
@@ -54,7 +54,7 @@ module.exports = async (ctx) => {
                 link: itemUrl,
                 author: 'Apple Inc.',
                 description: description,
-                pubDate: new Date(datelist[index].replace(/(\d+) 年 (\d+) 月 (\d+) 日/, '$1-$2-$3')).toISOString(),
+                // pubDate: new Date(datelist[index].replace(/(\d+) 年 (\d+) 月 (\d+) 日/, '$1-$2-$3')).toISOString(),
             };
 
             ctx.cache.set(itemUrl, JSON.stringify(single));


### PR DESCRIPTION
多语言日期格式很难全部照顾到，想过用 regex 处理：

```js
date = date.replace(/\D+/g, '-').replace(/^-?|-?$/g, '');
```
kr: 2019년 4월 25일 返回：2018-04-25
ru: 9 ноября 2018 г. 返回：9-2018

moment 也无法解析，只能暂时移除。

Close #2141.