### PR TITLE
fix: 修复国家电网通知

### DIFF
--- a/docs/forecast.md
+++ b/docs/forecast.md
@@ -10,9 +10,9 @@ pageClass: routes
 
 ### 国家电网
 
-<Route author="xyqfer" example="/tingdiantz/95598/36401/36101" path="/tingdiantz/95598/:orgNo/:provinceNo/:scope?" :paramsDesc="['所属省供电公司编码', '所属地市供电公司编码', '停电范围关键字']"/>
+<Route author="xyqfer moonbegonia" example="/tingdiantz/95598/36401/36101" path="/tingdiantz/95598/:orgNo/:provinceNo/:scope?" :paramsDesc="['所属省供电公司编码', '所属地市供电公司编码', '停电范围关键字']"/>
 
-> 以上参数可从[查询页面](http://m.95598.cn/95598/woutageNotice/winitOutageNotice)打开控制台抓包获得
+> 以上参数可从[查询页面](http://www.95598.cn/95598/outageNotice/initOutageNotice)打开控制台抓包获得
 
 ### 南京市
 

--- a/lib/routes/tingdiantz/95598.js
+++ b/lib/routes/tingdiantz/95598.js
@@ -2,27 +2,29 @@ const axios = require('@/utils/axios');
 const qs = require('querystring');
 
 module.exports = async (ctx) => {
-    const { orgNo, provinceNo, scope = '' } = ctx.params;
+    const { orgNo, provinceNo, scope = '', typeCode = '', lineName = '' } = ctx.params;
     let { outageStartTime, outageEndTime } = ctx.params;
     if (!outageStartTime) {
-        outageStartTime = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+        outageStartTime = new Date(Date.now()).toISOString().slice(0, 10);
     }
     if (!outageEndTime) {
-        outageEndTime = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+        outageEndTime = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
     }
     const anHui = provinceNo === '34101' ? '01' : '02';
     const response = await axios({
         method: 'post',
-        url: 'http://m.95598.cn/95598/woutageNotice/wqueryOutageNoticeList?partNo=BM08001',
+        url: 'http://www.95598.cn/95598/outageNotice/queryOutageNoticeList',
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
         },
         data: qs.stringify({
             orgNo,
-            provinceNo,
             outageStartTime,
             outageEndTime,
             scope,
+            provinceNo,
+            typeCode,
+            lineName,
             anHui,
         }),
     });
@@ -49,7 +51,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: '国家电网停电通知',
-        link: 'http://m.95598.cn/95598/woutageNotice/winitOutageNotice',
+        link: 'http://www.95598.cn/95598/outageNotice/initOutageNotice',
         item: items,
     };
 };


### PR DESCRIPTION
原来的抓取网址不翻墙打不开且参数已修改，修复抓取时间为前一天的错误。