### PR TITLE
fix: wasi url again

### DIFF
--- a/lib/routes/tencent/wechat/wasi.js
+++ b/lib/routes/tencent/wechat/wasi.js
@@ -33,7 +33,7 @@ module.exports = async (ctx) => {
                             .text()
                             .trim(),
                         link: `https://q.qnmlgb.tech/w/api${link}`,
-                        guid: link,
+                        guid: `https://q.qnmlgb.tech/w/api${link}`,
                     };
                 })
                 .get(),

--- a/lib/routes/tencent/wechat/wasi.js
+++ b/lib/routes/tencent/wechat/wasi.js
@@ -32,7 +32,7 @@ module.exports = async (ctx) => {
                         title: $('.pretty')
                             .text()
                             .trim(),
-                        link: `https://wx.qnmlgb.tech${link}`,
+                        link: `https://q.qnmlgb.tech/w/api${link}`,
                         guid: link,
                     };
                 })


### PR DESCRIPTION
之前fix的url是瓦斯的feed url，修改成了api url，直接链接到微信文章