### PR TITLE
fix: 瓦斯author链接更改

### DIFF
--- a/lib/routes/tencent/wechat/wasi.js
+++ b/lib/routes/tencent/wechat/wasi.js
@@ -3,7 +3,7 @@ const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
     const { id } = ctx.params;
-    const url = `https://wx.qnmlgb.tech/authors/${id}`;
+    const url = `https://qnmlgb.tech/authors/${id}`;
 
     const response = await got({
         method: 'get',


### PR DESCRIPTION
之前的author页面跳转到了主页，改成了最新的author页面链接