### PR TITLE
feat: add Outage.Report 在线服务/本地设施停服通知

### DIFF
--- a/docs/forecast.md
+++ b/docs/forecast.md
@@ -84,7 +84,7 @@ pageClass: routes
 
 ### Outage.Report
 
-<Route author="cxumol" example="/outagereport/ubisoft/5" path="/outagereport/:name/:count?" :paramsDesc="['服务名称, 拼写格式须与 URL 保持一致', '计数门槛｡ 仅当报告停服的人不低于此数量时, 才会写进 RSS']">
+<Route author="cxumol" example="/outagereport/ubisoft/5" path="/outagereport/:name/:count?" :paramsDesc="['服务名称｡ 拼写格式须与 URL 保持一致', '计数门槛｡ 仅当报告停服的人不低于此数量时, 才会写进 RSS']">
  
 其中 name 参数, 请略过本地服务的区域码, 例如 `https://outage.report/us/verizon-wireless` 填入 `verizon-wireless` 即可｡ 
 

--- a/docs/forecast.md
+++ b/docs/forecast.md
@@ -79,3 +79,13 @@ pageClass: routes
 可通过全局过滤参数订阅您感兴趣的地区.
 
 </Route>
+
+## 在线服务/本地设施 停服通知
+
+### Outage.Report
+
+<Route author="cxumol" example="/outagereport/ubisoft/5" path="/outagereport/:name/:count?" :paramsDesc="['服务名称, 拼写格式须与 URL 保持一致', '计数门槛｡ 仅当报告停服的人不低于此数量时, 才会写进 RSS']">
+ 
+其中 name 参数, 请略过本地服务的区域码, 例如 `https://outage.report/us/verizon-wireless` 填入 `verizon-wireless` 即可｡ 
+
+</Route>

--- a/docs/forecast.md
+++ b/docs/forecast.md
@@ -60,6 +60,16 @@ pageClass: routes
 
 <Route author="calpa" example="/hko/weather" path="/hko/weather"/>
 
+## 在线服务/本地设施 停服通知
+
+### Outage.Report
+
+<Route author="cxumol" example="/outagereport/ubisoft/5" path="/outagereport/:name/:count?" :paramsDesc="['服务名称｡ 拼写格式须与 URL 保持一致', '计数门槛｡ 仅当报告停服的人不低于此数量时, 才会写进 RSS']">
+ 
+其中 name 参数, 请略过本地服务的区域码, 例如 `https://outage.report/us/verizon-wireless` 填入 `verizon-wireless` 即可｡
+
+</Route>
+
 ## 中国地震局
 
 ### 地震速报
@@ -77,15 +87,5 @@ pageClass: routes
 <Route author="ylc395" example="/weatheralarm" path="/weatheralarm">
 
 可通过全局过滤参数订阅您感兴趣的地区.
-
-</Route>
-
-## 在线服务/本地设施 停服通知
-
-### Outage.Report
-
-<Route author="cxumol" example="/outagereport/ubisoft/5" path="/outagereport/:name/:count?" :paramsDesc="['服务名称｡ 拼写格式须与 URL 保持一致', '计数门槛｡ 仅当报告停服的人不低于此数量时, 才会写进 RSS']">
- 
-其中 name 参数, 请略过本地服务的区域码, 例如 `https://outage.report/us/verizon-wireless` 填入 `verizon-wireless` 即可｡ 
 
 </Route>

--- a/lib/router.js
+++ b/lib/router.js
@@ -1412,4 +1412,7 @@ router.get('/metacritic/release/:platform/:type/:sort?', require('./routes/metac
 // 快科技（原驱动之家）
 router.get('/kkj/news', require('./routes/kkj/news'));
 
+// Outage.Report
+router.get('/outagereport/:name/:count?', require('./routes/outagereport/service'));
+
 module.exports = router;

--- a/lib/routes/outagereport/service.js
+++ b/lib/routes/outagereport/service.js
@@ -4,7 +4,7 @@ const baseUrl = "https://outage.report/";
 
 module.exports = async (ctx) => {
     const serviceName = ctx.params.name; // Which service do you want to monitor? Have to be the same as what it appears in URL. 
-    const watchCount = ctx.params.count || 20; // How many reports is received during last 20 minutes? 20 reports as default.
+    const watchCount = ctx.params.count || 10; // How many reports is received during last 20 minutes? 20 reports as default.
     const URL = `${baseUrl}${serviceName}`;
     const response = await got({
         method: 'get',

--- a/lib/routes/outagereport/service.js
+++ b/lib/routes/outagereport/service.js
@@ -1,42 +1,43 @@
 const got = require('@/utils/got');
 
-const baseUrl = "https://outage.report/";
+const baseUrl = 'https://outage.report/';
 
 module.exports = async (ctx) => {
-    const serviceName = ctx.params.name; // Which service do you want to monitor? Have to be the same as what it appears in URL. 
+    const serviceName = ctx.params.name; // Which service do you want to monitor? Have to be the same as what it appears in URL.
     const watchCount = ctx.params.count || 10; // How many reports is received during last 20 minutes? 20 reports as default.
     const URL = `${baseUrl}${serviceName}`;
     const response = await got({
         method: 'get',
-        url: URL
-    })
+        url: URL,
+    });
 
     const html = response.data;
-    
+
     // use RegExp because of irregular class name
     const gaugeRegexp = new RegExp(`class="Gauge__Count.*?>(\\d+)</text>`); // Core Pattern
     const gaugeTextRegexp = new RegExp(`class="Gauge__MessageWrapper.*?class="Gauge__Message.*?>(.*?)</span>`); // Core Pattern
     const rssDescribeRegexp = new RegExp(`<p class="PageSubheader.*?>(.*?)</p>`);
-    
+
     // data to be shown on RSS feed and RSS items
-    const gaugeCount = Number( html.match(gaugeRegexp)[1] );
+    const gaugeCount = Number(html.match(gaugeRegexp)[1]);
     const gaugeText = html.match(gaugeTextRegexp)[1];
     const rssDescribe = html.match(rssDescribeRegexp)[1];
-    
-    // list ("Array" in js, though) of items 
+
+    // list ("Array" in js, though) of items
     const outageHistory = [];
-    
-    if (gaugeCount >= watchCount){ // alert only when it counts
+
+    if (gaugeCount >= watchCount) {
+        // alert only when it counts
         const outageReportItem = {
-            title:  `${serviceName} appear to be (partially) down`,
-            description: String(gaugeCount)+' '+gaugeText,
+            title: `${serviceName} appear to be (partially) down`,
+            description: String(gaugeCount) + ' ' + gaugeText,
             pubDate: new Date().toUTCString(),
             guid: new Date().getTime(),
-            link: URL
+            link: URL,
         };
         outageHistory.push(outageReportItem);
     }
-    
+
     // how this RSS feed looks like
     ctx.state.data = {
         title: `Is ${serviceName} Down Right Now?`,

--- a/lib/routes/outagereport/service.js
+++ b/lib/routes/outagereport/service.js
@@ -1,0 +1,47 @@
+const got = require('@/utils/got');
+
+const baseUrl = "https://outage.report/";
+
+module.exports = async (ctx) => {
+    const serviceName = ctx.params.name; // Which service do you want to monitor? Have to be the same as what it appears in URL. 
+    const watchCount = ctx.params.count || 20; // How many reports is received during last 20 minutes? 20 reports as default.
+    const URL = `${baseUrl}${serviceName}`;
+    const response = await got({
+        method: 'get',
+        url: URL
+    })
+
+    const html = response.data;
+    
+    // use RegExp because of irregular class name
+    const gaugeRegexp = new RegExp(`class="Gauge__Count.*?>(\\d+)</text>`); // Core Pattern
+    const gaugeTextRegexp = new RegExp(`class="Gauge__MessageWrapper.*?class="Gauge__Message.*?>(.*?)</span>`); // Core Pattern
+    const rssDescribeRegexp = new RegExp(`<p class="PageSubheader.*?>(.*?)</p>`);
+    
+    // data to be shown on RSS feed and RSS items
+    const gaugeCount = Number( html.match(gaugeRegexp)[1] );
+    const gaugeText = html.match(gaugeTextRegexp)[1];
+    const rssDescribe = html.match(rssDescribeRegexp)[1];
+    
+    // list ("Array" in js, though) of items 
+    const outageHistory = [];
+    
+    if (gaugeCount >= watchCount){ // alert only when it counts
+        const outageReportItem = {
+            title:  `${serviceName} appear to be (partially) down`,
+            description: String(gaugeCount)+' '+gaugeText,
+            pubDate: new Date().toUTCString(),
+            guid: new Date().getTime(),
+            link: URL
+        };
+        outageHistory.push(outageReportItem);
+    }
+    
+    // how this RSS feed looks like
+    ctx.state.data = {
+        title: `Is ${serviceName} Down Right Now?`,
+        link: URL,
+        description: rssDescribe,
+        item: outageHistory,
+    };
+};


### PR DESCRIPTION
> https://outage.report/ 是个监控互联网公共服务/本地基础设施可用性的网站, 数据来源为用户报告｡ 

当某项服务被用户报告停止工作, 且 20  分钟内次数超过一定数量 (默认为 10 次) 时, 会被 RSS 记录｡ 

使用场景举例: 某某家的土豆服务器又炸了｡ 

因为网站原文为英文, 所以输出的相关信息, 也用英文书写｡ 但考虑 RssHub 多为中文用户, 可以考虑将来增加多语言选项｡ 