### PR TITLE
fix: route appstore/update platform detection

### DIFF
--- a/lib/routes/appstore/update.js
+++ b/lib/routes/appstore/update.js
@@ -13,7 +13,7 @@ module.exports = async (ctx) => {
     titleTags.find('span').remove();
     const platform = $('.we-localnav__title__product').text();
 
-    const title = `${titleTags.text().trim()} for ${platform === 'App Store' ? 'iOS' : 'macOS'} ${country === 'cn' ? '更新' : 'Update'} `;
+    const title = `${titleTags.text().trim()} for ${platform === 'App\u00A0Store' ? 'iOS' : 'macOS'} ${country === 'cn' ? '更新' : 'Update'} `;
 
     const item = {};
     $('.whats-new').each(function() {


### PR DESCRIPTION
修复了路由 appstore/update 不能正确判断应用平台 (iOS / macOS) 的问题。
问题源于 cheerio 的 `.text()` 将 `&nbsp;` 转换为 No-Break Space (U+00A0) 而不是普通空格。