### PR TITLE
feat: add pubDate in appstore update

### DIFF
--- a/lib/routes/apple/appstore/update.js
+++ b/lib/routes/apple/appstore/update.js
@@ -9,6 +9,12 @@ module.exports = async (ctx) => {
     const res = await got.get(url);
     const $ = cheerio.load(res.data);
 
+    const data = $('script#shoebox-ember-data-store').html();
+    const jsonObject = JSON.parse(data);
+    const versions = jsonObject.data.attributes.versionHistory;
+    let date;
+    date = versions[0].releaseDate;
+
     const titleTags = $('h1').attr('class', 'product-header__title');
     titleTags.find('span').remove();
     const platform = $('.we-localnav__title__product').text();
@@ -26,10 +32,10 @@ module.exports = async (ctx) => {
             item.description = $('.whats-new__content .we-truncate').html();
             item.link = url;
             item.guid = id + version;
+            item.pubDate = date;
             items.push(item);
         });
     }
-
     ctx.state.data = {
         title,
         link: url,


### PR DESCRIPTION
APPstore的更新没有发布时间，在很多时候更新的发布时间还是很重要的，给接收方进行比对。
appstore lack the published time. For user, the time always is useful.