### PR TITLE
fix: remove a redundant if block

### DIFF
--- a/lib/routes/sexinsex/index.js
+++ b/lib/routes/sexinsex/index.js
@@ -77,10 +77,6 @@ module.exports = async (ctx) => {
                     });
                     const result = parseContent(response.data);
 
-                    if (false === result) {
-                        return Promise.resolve('');
-                    }
-
                     single.author = result.author;
                     single.description = result.description;
                     single.pubDate = result.pubDate;


### PR DESCRIPTION
Condition 'false === result' is always false. The value of variable 'result' is originated from the return value of 'parseContent()' defined at line 22 