### PR TITLE
fix: remove a redundant variable assignment

### DIFF
--- a/lib/routes/universities/swust/cs.js
+++ b/lib/routes/universities/swust/cs.js
@@ -10,7 +10,7 @@ module.exports = async (ctx) => {
         responseType: 'buffer',
     });
 
-    let type = ctx.params.type || 1;
+    const type = ctx.params.type || 1;
     let info = '新闻动态';
     let word = 'news';
     if (type === '2') {
@@ -22,8 +22,6 @@ module.exports = async (ctx) => {
     } else if (type === '4') {
         info = '教研动态';
         word = 'Teach_Research';
-    } else {
-        type = '1';
     }
 
     const response = await got_ins.get(host + word);


### PR DESCRIPTION
Value assigned to variable 'type' at this point is not used afterwards.