### PR TITLE
fix: remove douban event error pubDate

### DIFF
--- a/lib/routes/douban/event/hot.js
+++ b/lib/routes/douban/event/hot.js
@@ -15,8 +15,7 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `豆瓣同城-热门活动-${locationId}`,
         link: referer,
-        item: response.data.subject_collection_items.map(({ title, url, date, cover, subtype, info, price_range }) => {
-            const pubDate = new Date(date).toUTCString();
+        item: response.data.subject_collection_items.map(({ title, url, cover, subtype, info, price_range }) => {
             const description = `<img referrerpolicy="no-referrer" src="${cover.url}"><br>
               ${info}/${subtype}/${price_range}
             `;
@@ -24,7 +23,6 @@ module.exports = async (ctx) => {
             return {
                 title,
                 description,
-                pubDate,
                 link: url,
             };
         }),


### PR DESCRIPTION
fix #2754 
不管从网页里还是接口里都没找到发布时间，索性把字段删了 各个阅读器会把抓取时间定义成发布时间 虽然还有误差 但总比原来误差那么大好