### PR TITLE
feat:果壳 物种日历

### DIFF
--- a/docs/other.md
+++ b/docs/other.md
@@ -539,6 +539,10 @@ type 为 all 时，category 参数不支持 cost 和 free
 
 <Route author="alphardex" example="/guokr/scientific" path="/guokr/scientific"/>
 
+### 物种日历
+
+<Route author="DHPO" example="/guokr/calendar" path="/guokr/calendar"/>
+
 ## 后续
 
 ### Live

--- a/docs/other.md
+++ b/docs/other.md
@@ -539,9 +539,13 @@ type 为 all 时，category 参数不支持 cost 和 free
 
 <Route author="alphardex" example="/guokr/scientific" path="/guokr/scientific"/>
 
-### 物种日历
+### 果壳网专栏
 
-<Route author="DHPO" example="/guokr/calendar" path="/guokr/calendar"/>
+<Route author="DHPO" example="/guokr/calendar" path="/guokr/:category" :paramsDesc="['专栏类别']">
+| 物种日历 | 吃货研究所 | 美丽也是技术活 |
+| ------- | ---------| ------------ |
+| calendar | institute | beauty |
+</Route>
 
 ## 后续
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -696,6 +696,7 @@ router.get('/ifanr/:channel?', require('./routes/ifanr/index'));
 
 // 果壳网
 router.get('/guokr/scientific', require('./routes/guokr/scientific'));
+router.get('/guokr/calendar', require('./routes/guokr/calendar'));
 
 // 联合早报
 router.get('/zaobao/realtime/:type?', require('./routes/zaobao/realtime'));

--- a/lib/router.js
+++ b/lib/router.js
@@ -696,7 +696,7 @@ router.get('/ifanr/:channel?', require('./routes/ifanr/index'));
 
 // 果壳网
 router.get('/guokr/scientific', require('./routes/guokr/scientific'));
-router.get('/guokr/calendar', require('./routes/guokr/calendar'));
+router.get('/guokr/:category', require('./routes/guokr/calendar'));
 
 // 联合早报
 router.get('/zaobao/realtime/:type?', require('./routes/zaobao/realtime'));

--- a/lib/routes/guokr/calendar.js
+++ b/lib/routes/guokr/calendar.js
@@ -1,0 +1,32 @@
+const got = require('@/utils/got');
+
+async function loadFullPage(id) {
+    const res = await got.get(`https://apis.guokr.com/minisite/article/${id}.json`);
+    const content = res.data.result.content;
+    return content;
+}
+
+module.exports = async (ctx) => {
+    const response = await got.get('https://www.guokr.com/calendar');
+
+    const rule = /(?<=<script>\s*window\.INITIAL_STORE=)[\s\S]*?(?=<\/script>)/g; // 在某个script标签下可以找到文章信息
+    const data = JSON.parse(rule.exec(response.data)[0]);
+    const items = data.calendarArticleListStore.articleList;
+    items.pop(); // remove ad
+
+    const result = await Promise.all(
+        items.map(async (item) => ({
+            title: item.title,
+            description: await loadFullPage(item.id), // Mercury 无法正确解析全文，故这里手动加载
+            pubDate: item.date_published,
+            link: item.url,
+        }))
+    );
+
+    ctx.state.data = {
+        title: '果壳网 物种日历',
+        link: 'https://www.guokr.com/calendar',
+        description: '果壳网 物种日历',
+        item: result,
+    };
+};

--- a/lib/routes/guokr/calendar.js
+++ b/lib/routes/guokr/calendar.js
@@ -6,13 +6,23 @@ async function loadFullPage(id) {
     return content;
 }
 
+const categoryMap = {
+    calendar: '物种日历',
+    institute: '吃货研究所',
+    beauty: '美丽也是技术活',
+};
+
 module.exports = async (ctx) => {
-    const response = await got.get('https://www.guokr.com/calendar');
+    const category = ctx.params.category;
+    if (categoryMap[category] === undefined) {
+        throw new Error(`Unknown category ${category}`);
+    }
+
+    const response = await got.get(`https://www.guokr.com/${category}`);
 
     const rule = /(?<=<script>\s*window\.INITIAL_STORE=)[\s\S]*?(?=<\/script>)/g; // 在某个script标签下可以找到文章信息
     const data = JSON.parse(rule.exec(response.data)[0]);
-    const items = data.calendarArticleListStore.articleList;
-    items.pop(); // remove ad
+    const items = data[`${category}ArticleListStore`].articleList;
 
     const result = await Promise.all(
         items.map(async (item) => ({
@@ -24,9 +34,9 @@ module.exports = async (ctx) => {
     );
 
     ctx.state.data = {
-        title: '果壳网 物种日历',
+        title: `果壳网 ${categoryMap[category]}`,
         link: 'https://www.guokr.com/calendar',
-        description: '果壳网 物种日历',
+        description: `果壳网 ${categoryMap[category]}`,
         item: result,
     };
 };

--- a/lib/routes/guokr/calendar.js
+++ b/lib/routes/guokr/calendar.js
@@ -1,8 +1,11 @@
 const got = require('@/utils/got');
 
-async function loadFullPage(id) {
-    const res = await got.get(`https://apis.guokr.com/minisite/article/${id}.json`);
-    const content = res.data.result.content;
+async function loadFullPage(ctx, id) {
+    const link = `https://apis.guokr.com/minisite/article/${id}.json`;
+    const content = await ctx.cache.tryGet(link, async () => {
+        const res = await got.get(link);
+        return res.data.result.content;
+    });
     return content;
 }
 
@@ -27,9 +30,10 @@ module.exports = async (ctx) => {
     const result = await Promise.all(
         items.map(async (item) => ({
             title: item.title,
-            description: await loadFullPage(item.id), // Mercury 无法正确解析全文，故这里手动加载
+            description: await loadFullPage(ctx, item.id), // Mercury 无法正确解析全文，故这里手动加载
             pubDate: item.date_published,
             link: item.url,
+            author: item.external_author.nickname,
         }))
     );
 


### PR DESCRIPTION
增加了物种日历订阅源。

尝试过 #2738 ，发现Mercury不能正确解析全文页，因此我自己实现了全文输出。

我不太清楚项目中的缓存机制，所以如果全文输出实现有误，还请指出。