### PR TITLE
fix: conditional cache in wenxuemi router

### DIFF
--- a/lib/routes/novel/wenxuemi.js
+++ b/lib/routes/novel/wenxuemi.js
@@ -39,14 +39,19 @@ module.exports = async (ctx) => {
                 const articleHtml = await got_ins.get(link);
                 const article = iconv.decode(articleHtml.data, 'GBK');
                 const $1 = cheerio.load(article);
-                const res = $1('div#content').html();
+                const res = $1('div#content');
 
                 resultItem = {
                     title: $item.text(),
-                    description: res,
+                    description: res.html(),
                     link: link,
                 };
-                if (res.slice(0, 10).includes('正在手打中') === false) {
+                if (
+                    res
+                        .text()
+                        .slice(0, 10)
+                        .includes('正在手打中') === false
+                ) {
                     ctx.cache.set(link, JSON.stringify(resultItem));
                 }
             }


### PR DESCRIPTION
`html()` method returns HTML Entities, which can't include chinese characters.
So I use `text()` instead. 