### PR TITLE
fix: nytimes can't use proxy

### DIFF
--- a/lib/utils/rss-parser.js
+++ b/lib/utils/rss-parser.js
@@ -1,5 +1,6 @@
 const config = require('@/config');
 const Parser = require('rss-parser');
+const got = require('@/utils/got');
 
 const parser = new Parser({
     customFields: {
@@ -10,5 +11,10 @@ const parser = new Parser({
         'X-APP': 'RSSHub',
     },
 });
+
+parser.parseURL = async (url) => {
+    const response = await got.get(url);
+    return parser.parseString(response.data);
+};
 
 module.exports = parser;

--- a/test/middleware/parameter.js
+++ b/test/middleware/parameter.js
@@ -142,5 +142,5 @@ describe('fulltext_mode', () => {
         expect(response.status).toBe(200);
         const parsed = await parser.parseString(response.text);
         expect(parsed.items[0].content).not.toBe(undefined);
-    });
+    }, 20000);
 });

--- a/test/utils/rss-parser.js
+++ b/test/utils/rss-parser.js
@@ -1,0 +1,8 @@
+const parser = require('../../lib/utils/rss-parser');
+
+describe('parser', () => {
+    it('parseURL', async () => {
+        const rss = await parser.parseURL('https://rsshub.app/rsshub/rss');
+        expect(rss.link).toBe('https://docs.rsshub.app');
+    });
+});


### PR DESCRIPTION
fix #2647 