### PR TITLE
fix: fix replacing logic in #2796

### DIFF
--- a/lib/routes/twitter/utils.js
+++ b/lib/routes/twitter/utils.js
@@ -102,9 +102,9 @@ const ProcessFeed = ({ data = [] }, showAuthor = false) => {
 
         return {
             title: `${showAuthor ? item.user.name + ': ' : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${replaceBreak(item.full_text)}`,
-            description: `${showAuthor ? `<img width="15px" referrerpolicy="no-referrer" src="${item.user.profile_image_url_https}"><strong>${item.user.name}:</strong><br><br>` : ''}${
-                item.in_reply_to_screen_name ? 'Re ' : ''
-            }${item.full_text}${url}${img}${quote}`,
+            description: `${showAuthor ? `<img width="15px" referrerpolicy="no-referrer" src="${item.user.profile_image_url_https}"><strong>${item.user.name}:</strong><br><br>` : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${
+                item.full_text
+            }${url}${img}${quote}`,
             pubDate: new Date(item.created_at).toUTCString(),
             link: `https://twitter.com/${item.user.screen_name}/status/${item.id_str}`,
         };

--- a/lib/routes/twitter/utils.js
+++ b/lib/routes/twitter/utils.js
@@ -27,7 +27,8 @@ const ProcessFeed = ({ data = [] }, showAuthor = false) => {
         }
     };
 
-    const formatText = (text, br = '<br>') => text.replace(/https:\/\/t\.co(.*)/g, '').replace(/\n/g, br);
+    const replaceBreak = (text) => text.replace(/<br><br>|<br>/g, ' ');
+    const formatText = (text) => text.replace(/https:\/\/t\.co(.*)/g, '').replace(/\n/g, '<br>');
     const formatVideo = (media) => {
         let content = '';
         const video = media.video_info.variants.reduce((video, item) => {
@@ -100,10 +101,10 @@ const ProcessFeed = ({ data = [] }, showAuthor = false) => {
         }
 
         return {
-            title: `${showAuthor ? item.user.name + ': ' : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${formatText(item.full_text, '')}`,
+            title: `${showAuthor ? item.user.name + ': ' : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${replaceBreak(item.full_text)}`,
             description: `${showAuthor ? `<img width="15px" referrerpolicy="no-referrer" src="${item.user.profile_image_url_https}"><strong>${item.user.name}:</strong><br><br>` : ''}${
                 item.in_reply_to_screen_name ? 'Re ' : ''
-            }${formatText(item.full_text)}${url}${img}${quote}`,
+            }${item.full_text}${url}${img}${quote}`,
             pubDate: new Date(item.created_at).toUTCString(),
             link: `https://twitter.com/${item.user.screen_name}/status/${item.id_str}`,
         };


### PR DESCRIPTION
非常抱歉再次打扰 😂 没有 Twitter 开发者帐号所以无法跑一个 RSSHub 实例测试代码，一个 PR 能解决的事因为粗心变成了三个 PR
#2796 开的比较随便，没注意到其他地方也调用了 `formatText`，第二天发现弄出了一堆 `undefined`，吓得赶紧开了 #2803 修复
但是推文标题中的 `<br>` 还是没有去掉，再仔细看了看发现 `item.full_text` 之前已经被 `formatText` 过，里面没有 `\n` 只有 `<br>` 了，这个 PR 应该能真正解决问题了。