### PR TITLE
docs: fix url anchor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Logo designed by [sheldonrrr](https://dribbble.com/sheldonrrr)
 
 **Q: RSSHub Radar 是如何工作的？**
 
-**A:** 进入新页面时， RSSHub Radar 先根据页面 link 标签[寻找](https://github.com/DIYgod/RSSHub-Radar/blob/master/src/js/content/utils.js#L14)页面自带 RSS，再根据远程更新的[规则](https://github.com/DIYgod/RSSHub/blob/master/assets/radar-rules.js)寻找适用当前页面和当前网站的 RSSHub 路由；再加一点点魔法。
+**A:** 进入新页面时， RSSHub Radar 先根据页面 link 标签[寻找](https://github.com/DIYgod/RSSHub-Radar/blob/master/src/js/content/utils.js#L25)页面自带 RSS，再根据远程更新的[规则](https://github.com/DIYgod/RSSHub/blob/master/assets/radar-rules.js)寻找适用当前页面和当前网站的 RSSHub 路由；再加一点点魔法。
 
 **Q: 演示地址可以用么？**
 


### PR DESCRIPTION
为了确保带锚点的链接结果不会因为后续 commit 改变，也可以在页面上[按`y`获得永久链接](https://help.github.com/en/articles/getting-permanent-links-to-files)：
<https://github.com/DIYgod/RSSHub-Radar/blob/d8fb35447588cf51f4b4e797c171f541ebe2573c/src/js/content/utils.js#L25>