### PR TITLE
Add pubTime for New York Times

### DIFF
--- a/lib/routes/nytimes/morning_post.js
+++ b/lib/routes/nytimes/morning_post.js
@@ -25,13 +25,14 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         post.map(async (item) => {
             const link = item.link;
-            const description = await ctx.cache.tryGet(`nyt: ${link}`, async () => {
+            const result = await ctx.cache.tryGet(`nyt: ${link}`, async () => {
                 const response = await got.get(link);
 
-                return utils.ProcessFeed(response.data).description;
+                return utils.ProcessFeed(response.data);
             });
 
-            item.description = description;
+            item.pubDate = result.pubDate;
+            item.description = result.description;
             return Promise.resolve(item);
         })
     );

--- a/lib/routes/nytimes/utils.js
+++ b/lib/routes/nytimes/utils.js
@@ -71,6 +71,11 @@ const ProcessFeed = (data, hasEnVersion = false) => {
         }
     }
 
+    const time = $('time').attr('datetime');
+    if (time) {
+        result.pubDate = new Date(time).toUTCString();
+    }
+
     result.description = content.html();
 
     return result;


### PR DESCRIPTION
The publish time is extracted from the `dateTime` property of `time` element.