### PR TITLE
fix: 修复当仓库 description 和 primary language 为 null 时的异常

### DIFF
--- a/lib/routes/github/starred_repos.js
+++ b/lib/routes/github/starred_repos.js
@@ -52,7 +52,9 @@ module.exports = async (ctx) => {
         description: `${user}’s starred repositories`,
         item: data.map((repo) => ({
             title: `${user} starred ${repo.node.name}`,
-            description: `${repo.node.description} <br> primary language: ${repo.node.primaryLanguage.name} <br> stargazers: ${repo.node.stargazers.totalCount} <br> <img sytle="width:50px;" src='${repo.node.openGraphImageUrl}'>`,
+            description: `${repo.node.description === null ? 'no description' : repo.node.description} <br> primary language: ${
+                repo.node.primaryLanguage === null ? 'no primary language' : repo.node.primaryLanguage.name
+            } <br> stargazers: ${repo.node.stargazers.totalCount} <br> <img sytle="width:50px;" src='${repo.node.openGraphImageUrl}'>`,
             pubDate: new Date(`${repo.starredAt}`).toUTCString(),
             link: `${repo.node.url}`,
         })),


### PR DESCRIPTION
修复当 GitHub 仓库 description 和 primary language 为 null 时的异常