### PR TITLE
fea: yimg

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
     "extends": ["eslint:recommended", "plugin:prettier/recommended"],
-    "plugins": ["prettier"],
+    "plugins": ["prettier", "sort-keys-fix"],
     "parserOptions": {
         "ecmaVersion": 2018,
         "sourceType": "module"
@@ -9,6 +9,14 @@
         "node": true,
         "es6": true
     },
+    "overrides": [
+        {
+            "files": ["assets/radar-rules.js"],
+            "rules": {
+                "sort-keys-fix/sort-keys-fix": [1, "asc", {"natural": true}]
+            }
+        }
+    ],
     "rules": {
         "no-console": 1,
         "block-scoped-var": 1,

--- a/assets/radar-rules.js
+++ b/assets/radar-rules.js
@@ -1,381 +1,140 @@
 ({
-    'bilibili.com': {
-        _name: 'bilibili',
-        www: [
+    'algocasts.io': {
+        '.': [
             {
-                title: '分区视频',
-                docs: 'https://docs.rsshub.app/social-media.html#bilibili',
-                source: ['/v/*tpath', '/documentary', '/movie', '/tv'],
+                docs: 'https://docs.rsshub.app/programming.html#algocasts',
+                source: '/episodes',
+                target: '/algocasts',
+                title: '视频更新',
+            },
+        ],
+        _name: 'AlgoCasts',
+    },
+    'anime1.me': {
+        '.': [
+            {
+                docs: 'https://docs.rsshub.app/anime.html#anime1',
+                source: '/category/:time/:name',
+                target: '/anime1/anime/:time/:name',
+                title: '動畫',
             },
             {
-                title: '视频评论',
+                docs: 'https://docs.rsshub.app/anime.html#anime1',
+                script: "({keyword: new URLSearchParams(location.search).get('s')})",
+                source: '/',
+                target: '/anime1/search/:keyword',
+                title: '搜尋',
+                verification: (params) => params.keyword,
+            },
+        ],
+        _name: 'Anime1',
+    },
+    'bilibili.com': {
+        _name: 'bilibili',
+        space: [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#bilibili',
+                source: '/:uid',
+                target: '/bilibili/user/dynamic/:uid',
+                title: 'UP 主动态',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#bilibili',
+                source: '/:uid',
+                target: '/bilibili/user/video/:uid',
+                title: 'UP 主投稿',
+            },
+        ],
+        www: [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#bilibili',
+                source: ['/v/*tpath', '/documentary', '/movie', '/tv'],
+                title: '分区视频',
+            },
+            {
                 docs: 'https://docs.rsshub.app/social-media.html#bilibili',
                 source: '/video/:aid',
                 target: (params) => `/bilibili/video/reply/${params.aid.replace('av', '')}`,
+                title: '视频评论',
             },
             {
-                title: '视频弹幕',
                 docs: 'https://docs.rsshub.app/social-media.html#bilibili',
                 source: '/video/:aid',
                 target: (params, url) => {
                     const pid = new URL(url).searchParams.get('p');
                     return `/bilibili/video/danmaku/${params.aid.replace('av', '')}/${pid ? pid : 1}`;
                 },
-            },
-        ],
-        space: [
-            {
-                title: 'UP 主动态',
-                docs: 'https://docs.rsshub.app/social-media.html#bilibili',
-                source: '/:uid',
-                target: '/bilibili/user/dynamic/:uid',
-            },
-            {
-                title: 'UP 主投稿',
-                docs: 'https://docs.rsshub.app/social-media.html#bilibili',
-                source: '/:uid',
-                target: '/bilibili/user/video/:uid',
-            },
-        ],
-    },
-    'weibo.com': {
-        _name: '微博',
-        '.': [
-            {
-                title: '博主',
-                docs: 'https://docs.rsshub.app/social-media.html#%E5%BE%AE%E5%8D%9A',
-                source: ['/u/:id', '/:id'],
-                target: '/weibo/user/:uid',
-                script: "({uid: document.querySelector('head').innerHTML.match(/\\$CONFIG\\['oid']='(\\d+)'/)[1]})",
-                verification: (params) => params.uid,
-            },
-        ],
-    },
-    'pixiv.net': {
-        _name: 'Pixiv',
-        www: [
-            {
-                title: '用户收藏',
-                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
-                source: '/bookmark.php',
-                target: (params, url) => `/pixiv/user/bookmarks/${new URL(url).searchParams.get('id')}`,
-            },
-            {
-                title: '用户动态',
-                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
-                source: '/member.php',
-                target: (params, url) => `/pixiv/user/${new URL(url).searchParams.get('id')}`,
-            },
-            {
-                title: '排行榜',
-                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
-                source: '/ranking.php',
-            },
-            {
-                title: '关键词',
-                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
-                source: '/search.php',
-            },
-            {
-                title: '关注的新作品',
-                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
-                source: '/bookmark_new_illust.php',
-                target: '/pixiv/user/illustfollows',
-            },
-        ],
-    },
-    'twitter.com': {
-        _name: 'Twitter',
-        '.': [
-            {
-                title: '用户时间线',
-                docs: 'https://docs.rsshub.app/social-media.html#twitter',
-                source: '/:id',
-                target: '/twitter/user/:id',
-                verification: (params) => params.id !== 'home' && params.id !== 'explore' && params.id !== 'notifications' && params.id !== 'messages' && params.id !== 'explore',
-            },
-            {
-                title: '用户关注时间线',
-                docs: 'https://docs.rsshub.app/social-media.html#twitter',
-                source: '/:id',
-                target: '/twitter/followings/:id',
-                verification: (params) => params.id !== 'home' && params.id !== 'explore' && params.id !== 'notifications' && params.id !== 'messages' && params.id !== 'explore',
-            },
-            {
-                title: '用户喜欢列表',
-                docs: 'https://docs.rsshub.app/social-media.html#twitter',
-                source: '/:id',
-                target: '/twitter/likes/:id',
-                verification: (params) => params.id !== 'home' && params.id !== 'explore' && params.id !== 'notifications' && params.id !== 'messages' && params.id !== 'explore',
-            },
-            {
-                title: '列表时间线',
-                docs: 'https://docs.rsshub.app/social-media.html#twitter',
-                source: '/:id/lists/:name',
-                target: '/twitter/list/:id/:name',
-                verification: (params) => params.id !== 'home' && params.id !== 'explore' && params.id !== 'notifications' && params.id !== 'messages' && params.id !== 'explore',
-            },
-        ],
-    },
-    'youtube.com': {
-        _name: 'Youtube',
-        www: [
-            {
-                title: '用户',
-                docs: 'https://docs.rsshub.app/social-media.html#youtube',
-                source: '/user/:username',
-                target: '/youtube/user/:username',
-            },
-            {
-                title: '频道',
-                docs: 'https://docs.rsshub.app/social-media.html#youtube',
-                source: '/channel/:id',
-                target: '/youtube/channel/:id',
-            },
-            {
-                title: '播放列表',
-                docs: 'https://docs.rsshub.app/social-media.html#youtube',
-                source: '/playlist',
-                target: (params, url) => `/youtube/playlist/${new URL(url).searchParams.get('list')}`,
+                title: '视频弹幕',
             },
         ],
     },
     'github.com': {
-        _name: 'GitHub',
         '.': [
             {
-                title: '用户仓库',
                 docs: 'https://docs.rsshub.app/programming.html#github',
                 source: '/:user',
                 target: '/github/repos/:user',
+                title: '用户仓库',
             },
             {
-                title: '用户 Followers',
                 docs: 'https://docs.rsshub.app/programming.html#github',
                 source: '/:user',
                 target: '/github/user/followers/:user',
+                title: '用户 Followers',
             },
             {
-                title: 'Trending',
                 docs: 'https://docs.rsshub.app/programming.html#github',
                 source: '/trending',
                 target: '/github/trending/:since',
+                title: 'Trending',
             },
             {
-                title: '仓库 Issue',
                 docs: 'https://docs.rsshub.app/programming.html#github',
                 source: ['/:user/:repo/issues', '/:user/:repo/issues/:id', '/:user/:repo'],
                 target: '/github/issue/:user/:repo',
+                title: '仓库 Issue',
             },
             {
-                title: '仓库 Pull Requests',
                 docs: 'https://docs.rsshub.app/programming.html#github',
                 source: ['/:user/:repo/pulls', '/:user/:repo/pulls/:id', '/:user/:repo'],
                 target: '/github/pull/:user/:repo',
+                title: '仓库 Pull Requests',
             },
             {
-                title: '仓库 Stars',
                 docs: 'https://docs.rsshub.app/programming.html#github',
                 source: ['/:user/:repo/stargazers', '/:user/:repo'],
                 target: '/github/stars/:user/:repo',
+                title: '仓库 Stars',
             },
             {
-                title: '仓库 Branches',
                 docs: 'https://docs.rsshub.app/programming.html#github',
                 source: ['/:user/:repo/branches', '/:user/:repo'],
                 target: '/github/branches/:user/:repo',
+                title: '仓库 Branches',
             },
             {
-                title: '文件 Commits',
                 docs: 'https://docs.rsshub.app/programming.html#github',
                 source: '/:user/:repo/blob/:branch/*filepath',
                 target: '/github/file/:user/:repo/:branch/:filepath',
+                title: '文件 Commits',
             },
             {
-                title: '用户 Starred Repositories',
                 docs: 'https://docs.rsshub.app/programming.html#github',
                 source: '/:user',
                 target: '/github/starred_repos/:user',
+                title: '用户 Starred Repositories',
             },
         ],
+        _name: 'GitHub',
     },
-    'zhihu.com': {
-        _name: '知乎',
+    'haimaoba.com': {
+        _name: '海猫吧',
         www: [
             {
-                title: '收藏夹',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/collection/:id',
-                target: '/zhihu/collection/:id',
-            },
-            {
-                title: '用户动态',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/people/:id/activities',
-                target: '/zhihu/people/activities/:id',
-            },
-            {
-                title: '用户回答',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/people/:id/answers',
-                target: '/zhihu/people/answers/:id',
-            },
-            {
-                title: '用户想法',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/people/:id/pins',
-                target: '/zhihu/people/pins/:id',
-            },
-            {
-                title: '热榜',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/hot',
-                target: '/zhihu/hotlist',
-            },
-            {
-                title: '想法热榜',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                target: '/zhihu/pin/hotlist',
-            },
-            {
-                title: '问题',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/question/:questionId',
-                target: '/zhihu/question/:questionId',
-            },
-            {
-                title: '话题',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/topic/:topicId/:type',
-                target: '/zhihu/topic/:topicId',
-            },
-            {
-                title: '新书',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/zhihu/bookstore/newest',
-                target: '/zhihu/pin/hotlist',
-            },
-            {
-                title: '想法-24 小时新闻汇总',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/pin/special/972884951192113152',
-                target: '/zhihu/pin/daily',
-            },
-            {
-                title: '书店-周刊',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/pub/weekly',
-                target: '/zhihu/weekly',
-            },
-        ],
-        zhuanlan: [
-            {
-                title: '专栏',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/:id',
-                target: '/zhihu/zhuanlan/:id',
-            },
-        ],
-        daily: [
-            {
-                title: '日报',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '',
-                target: '/zhihu/daily',
-            },
-            {
-                title: '日报',
-                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
-                source: '/*tpath',
-                target: '/zhihu/daily',
-            },
-        ],
-    },
-    'smzdm.com': {
-        _name: '什么值得买',
-        www: [
-            {
-                title: '关键词',
-                docs: 'https://docs.rsshub.app/shopping.html#%E4%BB%80%E4%B9%88%E5%80%BC%E5%BE%97%E4%B9%B0',
-                target: '/smzdm/keyword/:keyword',
-            },
-            {
-                title: '排行榜',
-                docs: 'https://docs.rsshub.app/shopping.html#%E4%BB%80%E4%B9%88%E5%80%BC%E5%BE%97%E4%B9%B0',
-                source: '/top',
-            },
-        ],
-    },
-    'rsshub.app': {
-        _name: 'RSSHub',
-        docs: [
-            {
-                title: '有新路由啦',
-                docs: 'https://docs.rsshub.app/program-update.html#rsshub',
-                source: ['', '/*tpath'],
-                target: '/rsshub/rss',
-            },
-        ],
-    },
-    'ximalaya.com': {
-        _name: '喜马拉雅',
-        www: [
-            {
-                title: '专辑',
-                docs: 'https://docs.rsshub.app/multimedia.html#%E5%96%9C%E9%A9%AC%E6%8B%89%E9%9B%85',
-                source: '/:type/:id',
-                target: '/ximalaya/album/:id/',
-                verification: (params) => parseInt(params.id) + '' === params.id,
-            },
-        ],
-    },
-    'algocasts.io': {
-        _name: 'AlgoCasts',
-        '.': [
-            {
-                title: '视频更新',
-                docs: 'https://docs.rsshub.app/programming.html#algocasts',
-                source: '/episodes',
-                target: '/algocasts',
-            },
-        ],
-    },
-    'soulapp.cn': {
-        _name: 'Soul',
-        '.': [
-            {
-                title: '瞬间更新',
-                docs: 'https://docs.rsshub.app/social-media.html#soul',
-            },
-        ],
-    },
-    'juejin.im': {
-        _name: '掘金',
-        '.': [
-            {
-                title: '专栏',
-                docs: 'https://docs.rsshub.app/programming.html#%E6%8E%98%E9%87%91',
-                source: '/user/:id/posts',
-                target: '/juejin/posts/:id',
-            },
-        ],
-    },
-    'anime1.me': {
-        _name: 'Anime1',
-        '.': [
-            {
-                title: '動畫',
-                docs: 'https://docs.rsshub.app/anime.html#anime1',
-                source: '/category/:time/:name',
-                target: '/anime1/anime/:time/:name',
-            },
-            {
-                title: '搜尋',
-                docs: 'https://docs.rsshub.app/anime.html#anime1',
-                source: '/',
-                script: "({keyword: new URLSearchParams(location.search).get('s')})",
-                target: '/anime1/search/:keyword',
-                verification: (params) => params.keyword,
+                docs: 'https://docs.rsshub.app/anime.html#%E6%B5%B7%E7%8C%AB%E5%90%A7',
+                source: '/catalog/:id',
+                target: '/haimaoba/:id',
+                title: '漫画更新',
             },
         ],
     },
@@ -383,34 +142,17 @@
         _name: 'Instagram',
         www: [
             {
-                title: '用户',
                 docs: 'https://docs.rsshub.app/social-media.html#instagram',
                 source: '/:id',
                 target: '/instagram/user/:id',
+                title: '用户',
                 verification: (params) => params.id !== 'explore' && params.id !== 'developer',
             },
             {
-                title: '标签',
                 docs: 'https://docs.rsshub.app/social-media.html#instagram',
                 source: '/explore/tags/:tag',
                 target: '/instagram/tag/:tag',
-            },
-        ],
-    },
-    'swufe.edu.cn': {
-        _name: '西南财经大学',
-        it: [
-            {
-                title: '经济信息工程学院 - 通知公告',
-                docs: 'https://docs.rsshub.app/university.html#%E7%BB%8F%E6%B5%8E%E4%BF%A1%E6%81%AF%E5%B7%A5%E7%A8%8B%E5%AD%A6%E9%99%A2',
-                source: '/index/tzgg.htm',
-                target: '/universities/swufe/seie/tzgg',
-            },
-            {
-                title: '经济信息工程学院 - 学院新闻',
-                docs: 'https://docs.rsshub.app/university.html#%E7%BB%8F%E6%B5%8E%E4%BF%A1%E6%81%AF%E5%B7%A5%E7%A8%8B%E5%AD%A6%E9%99%A2',
-                source: '/index/xyxw.htm',
-                target: '/universities/swufe/seie/xyxw',
+                title: '标签',
             },
         ],
     },
@@ -418,32 +160,301 @@
         _name: '鼠绘漫画',
         www: [
             {
-                title: '鼠绘漫画',
                 docs: 'https://docs.rsshub.app/anime.html#%E9%BC%A0%E7%BB%98%E6%BC%AB%E7%94%BB',
                 source: '/comics/anime/:id',
                 target: '/shuhui/comics/:id',
+                title: '鼠绘漫画',
             },
         ],
     },
-    'haimaoba.com': {
-        _name: '海猫吧',
-        www: [
+    'juejin.im': {
+        '.': [
             {
-                title: '漫画更新',
-                docs: 'https://docs.rsshub.app/anime.html#%E6%B5%B7%E7%8C%AB%E5%90%A7',
-                source: '/catalog/:id',
-                target: '/haimaoba/:id',
+                docs: 'https://docs.rsshub.app/programming.html#%E6%8E%98%E9%87%91',
+                source: '/user/:id/posts',
+                target: '/juejin/posts/:id',
+                title: '专栏',
             },
         ],
+        _name: '掘金',
     },
     'pgyer.com': {
         _name: '蒲公英应用分发',
         www: [
             {
-                title: 'app更新',
                 docs: 'https://docs.rsshub.app/%E8%92%B2%E5%85%AC%E8%8B%B1%E5%BA%94%E7%94%A8%E5%88%86%E5%8F%91',
                 source: '/:app',
                 target: '/pgyer/:app',
+                title: 'app更新',
+            },
+        ],
+    },
+    'pixiv.net': {
+        _name: 'Pixiv',
+        www: [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
+                source: '/bookmark.php',
+                target: (params, url) => `/pixiv/user/bookmarks/${new URL(url).searchParams.get('id')}`,
+                title: '用户收藏',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
+                source: '/member.php',
+                target: (params, url) => `/pixiv/user/${new URL(url).searchParams.get('id')}`,
+                title: '用户动态',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
+                source: '/ranking.php',
+                title: '排行榜',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
+                source: '/search.php',
+                title: '关键词',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#pixiv',
+                source: '/bookmark_new_illust.php',
+                target: '/pixiv/user/illustfollows',
+                title: '关注的新作品',
+            },
+        ],
+    },
+    'rsshub.app': {
+        _name: 'RSSHub',
+        docs: [
+            {
+                docs: 'https://docs.rsshub.app/program-update.html#rsshub',
+                source: ['', '/*tpath'],
+                target: '/rsshub/rss',
+                title: '有新路由啦',
+            },
+        ],
+    },
+    'smzdm.com': {
+        _name: '什么值得买',
+        www: [
+            {
+                docs: 'https://docs.rsshub.app/shopping.html#%E4%BB%80%E4%B9%88%E5%80%BC%E5%BE%97%E4%B9%B0',
+                target: '/smzdm/keyword/:keyword',
+                title: '关键词',
+            },
+            {
+                docs: 'https://docs.rsshub.app/shopping.html#%E4%BB%80%E4%B9%88%E5%80%BC%E5%BE%97%E4%B9%B0',
+                source: '/top',
+                title: '排行榜',
+            },
+        ],
+    },
+    'soulapp.cn': {
+        '.': [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#soul',
+                title: '瞬间更新',
+            },
+        ],
+        _name: 'Soul',
+    },
+    'swufe.edu.cn': {
+        _name: '西南财经大学',
+        it: [
+            {
+                docs: 'https://docs.rsshub.app/university.html#%E7%BB%8F%E6%B5%8E%E4%BF%A1%E6%81%AF%E5%B7%A5%E7%A8%8B%E5%AD%A6%E9%99%A2',
+                source: '/index/tzgg.htm',
+                target: '/universities/swufe/seie/tzgg',
+                title: '经济信息工程学院 - 通知公告',
+            },
+            {
+                docs: 'https://docs.rsshub.app/university.html#%E7%BB%8F%E6%B5%8E%E4%BF%A1%E6%81%AF%E5%B7%A5%E7%A8%8B%E5%AD%A6%E9%99%A2',
+                source: '/index/xyxw.htm',
+                target: '/universities/swufe/seie/xyxw',
+                title: '经济信息工程学院 - 学院新闻',
+            },
+        ],
+    },
+    'twitter.com': {
+        '.': [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#twitter',
+                source: '/:id',
+                target: '/twitter/user/:id',
+                title: '用户时间线',
+                verification: (params) => params.id !== 'home' && params.id !== 'explore' && params.id !== 'notifications' && params.id !== 'messages' && params.id !== 'explore',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#twitter',
+                source: '/:id',
+                target: '/twitter/followings/:id',
+                title: '用户关注时间线',
+                verification: (params) => params.id !== 'home' && params.id !== 'explore' && params.id !== 'notifications' && params.id !== 'messages' && params.id !== 'explore',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#twitter',
+                source: '/:id',
+                target: '/twitter/likes/:id',
+                title: '用户喜欢列表',
+                verification: (params) => params.id !== 'home' && params.id !== 'explore' && params.id !== 'notifications' && params.id !== 'messages' && params.id !== 'explore',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#twitter',
+                source: '/:id/lists/:name',
+                target: '/twitter/list/:id/:name',
+                title: '列表时间线',
+                verification: (params) => params.id !== 'home' && params.id !== 'explore' && params.id !== 'notifications' && params.id !== 'messages' && params.id !== 'explore',
+            },
+        ],
+        _name: 'Twitter',
+    },
+    'weibo.com': {
+        '.': [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E5%BE%AE%E5%8D%9A',
+                script: "({uid: document.querySelector('head').innerHTML.match(/\\$CONFIG\\['oid']='(\\d+)'/)[1]})",
+                source: ['/u/:id', '/:id'],
+                target: '/weibo/user/:uid',
+                title: '博主',
+                verification: (params) => params.uid,
+            },
+        ],
+        _name: '微博',
+    },
+    'ximalaya.com': {
+        _name: '喜马拉雅',
+        www: [
+            {
+                docs: 'https://docs.rsshub.app/multimedia.html#%E5%96%9C%E9%A9%AC%E6%8B%89%E9%9B%85',
+                source: '/:type/:id',
+                target: '/ximalaya/album/:id/',
+                title: '专辑',
+                verification: (params) => parseInt(params.id) + '' === params.id,
+            },
+        ],
+    },
+    'yimg.net': {
+        _name: 'Y图',
+        www: [
+            {
+                docs: 'https://docs.rsshub.app/picture.html#y-%25E5%259B%25BE',
+                source: '/*path',
+                target: (params) => `/yimg/${params.path.replace('/', '_')}`,
+                title: '',
+            },
+        ],
+    },
+    'youtube.com': {
+        _name: 'Youtube',
+        www: [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#youtube',
+                source: '/user/:username',
+                target: '/youtube/user/:username',
+                title: '用户',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#youtube',
+                source: '/channel/:id',
+                target: '/youtube/channel/:id',
+                title: '频道',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#youtube',
+                source: '/playlist',
+                target: (params, url) => `/youtube/playlist/${new URL(url).searchParams.get('list')}`,
+                title: '播放列表',
+            },
+        ],
+    },
+    'zhihu.com': {
+        _name: '知乎',
+        daily: [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '',
+                target: '/zhihu/daily',
+                title: '日报',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/*tpath',
+                target: '/zhihu/daily',
+                title: '日报',
+            },
+        ],
+        www: [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/collection/:id',
+                target: '/zhihu/collection/:id',
+                title: '收藏夹',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/people/:id/activities',
+                target: '/zhihu/people/activities/:id',
+                title: '用户动态',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/people/:id/answers',
+                target: '/zhihu/people/answers/:id',
+                title: '用户回答',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/people/:id/pins',
+                target: '/zhihu/people/pins/:id',
+                title: '用户想法',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/hot',
+                target: '/zhihu/hotlist',
+                title: '热榜',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                target: '/zhihu/pin/hotlist',
+                title: '想法热榜',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/question/:questionId',
+                target: '/zhihu/question/:questionId',
+                title: '问题',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/topic/:topicId/:type',
+                target: '/zhihu/topic/:topicId',
+                title: '话题',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/zhihu/bookstore/newest',
+                target: '/zhihu/pin/hotlist',
+                title: '新书',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/pin/special/972884951192113152',
+                target: '/zhihu/pin/daily',
+                title: '想法-24 小时新闻汇总',
+            },
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/pub/weekly',
+                target: '/zhihu/weekly',
+                title: '书店-周刊',
+            },
+        ],
+        zhuanlan: [
+            {
+                docs: 'https://docs.rsshub.app/social-media.html#%E7%9F%A5%E4%B9%8E',
+                source: '/:id',
+                target: '/zhihu/zhuanlan/:id',
+                title: '专栏',
             },
         ],
     },

--- a/docs/picture.md
+++ b/docs/picture.md
@@ -72,6 +72,10 @@ pageClass: routes
 
 <Route author="MegrezZhu" example="/tits-guru/category/bikini" path="/tits-guru/category/:type" :paramsDesc="['指定类别，详见[这里](https://tits-guru.com/categories)']"/>
 
+## Y 图
+
+<Route author="machsix" example="/yimg/category_sex" path="/yimg/:path" :paramsDesc="['网页路径。比如原网页路径为[https://www.yimg.net/category/sex/](https://www.yimg.net/category/sex/)，这里的参数就该是category_sex']"/>
+
 ## yande.re
 
 ::: tip 提示

--- a/lib/router.js
+++ b/lib/router.js
@@ -104,6 +104,9 @@ router.get('/zhihu/bookstore/newest', require('./routes/zhihu/bookstore/newest')
 router.get('/zhihu/pin/daily', require('./routes/zhihu/pin/daily'));
 router.get('/zhihu/weekly', require('./routes/zhihu/weekly'));
 
+// Y图.img
+router.get('/yimg/:path', require('./routes/yimg/index'));
+
 // 妹子图
 router.get('/mzitu/home/:type?', require('./routes/mzitu/home'));
 router.get('/mzitu/tags', require('./routes/mzitu/tags'));

--- a/lib/routes/yimg/index.js
+++ b/lib/routes/yimg/index.js
@@ -1,0 +1,29 @@
+const got = require('@/utils/got');
+const Parser = require('rss-parser');
+
+module.exports = async (ctx) => {
+    const domain = 'http://www.yimg.net';
+
+    const path = ctx.params.path;
+    const rssLink = encodeURI(`${domain}/feed/${path.replace('_', '/')}/`);
+
+    const page = await got.get(rssLink);
+    const parser = new Parser();
+    const feed = await parser.parseString(page.body);
+
+    ctx.state.data = {
+        title: feed.title,
+        link: feed.link,
+        description: feed.title,
+        item: feed.items.map((x) => ({
+            title: x.title,
+            link: x.link,
+            pubDate: x.pubDate,
+            description: x['content:encoded']._.replace(/<.*?>/g, '')
+                .split('|')
+                .filter((x) => x.trim().length > 0)
+                .map((x) => `<img referrerpolicy="no-referrer" src="${x}">`)
+                .join('</br>'),
+        })),
+    };
+};

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint": "6.4.0",
     "eslint-config-prettier": "6.3.0",
     "eslint-plugin-prettier": "3.1.1",
+    "eslint-plugin-sort-keys-fix": "1.0.1",
     "jest": "24.9.0",
     "mockdate": "2.0.5",
     "nock": "11.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4037,6 +4037,13 @@ eslint-plugin-prettier@3.1.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-sort-keys-fix@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.0.1.tgz#b80422c643df16e8a662b3e22e1cbc1138fa64fa"
+  integrity sha512-Y9a6Qb7wsa4uF7/5Qq18MEKB4zbIfo1YJjuvEmVwOOhZ4mMkXzJxkoEpEtsIdTC2rXCMXQOCi/1XAJwYFf/YMA==
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-scope@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -9248,6 +9255,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
1. 添加了https://www.yimg.net的router和radar， 网站本身提供rss但是图片显示成链接
2. 添加了[eslint-plugin-sort-keys-fix](https://www.npmjs.com/package/eslint-plugin-sort-keys-fix)包以实现对`radar-rules.js`内规则的排序。虽然sort object by key可能会有[execution order issues](https://github.com/prettier/prettier/issues/1096#issuecomment-289856509)， 但对于这个规则应该没什么问题吧。。其实我很好奇为什么用`object`而不用`array`。另外这样排序后`title`会被放在`docs`, `source`, `target`后，单个人觉得无伤大雅 😄 