### PR TITLE
chore: 修改Dockerfile.arm32v7，添加Dockerfile.arm64

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,18 +1,11 @@
-FROM arm32v7/node:8.16-slim 
-MAINTAINER junfeng <junfeng_pan96@qq.com>
+FROM arm32v7/node:8.16-alpine 
 
-# 使用163镜像，若不需要可以注释
-RUN echo -e "deb http://mirrors.ustc.edu.cn/debian/ stretch main \ndeb http://mirrors.ustc.edu.cn/debian/ stretch-updates main " > /etc/apt/sources.list
-
-# 复用缓存, 如果github文件下载失败，可以手动下载，放至项目根目录，注释下方ADD语句，改用下方COPY语句
-ADD https://github.com/junfengP/dumb-init/releases/download/v1.2.0/dumb-init-armhf  /usr/local/bin/dumb-init
-# COPY dumb-init-armhf  /usr/local/bin/dumb-init
-RUN chmod +x /usr/local/bin/dumb-init
-
-ARG USE_CHINA_NPM_REGISTRY=1;
+ARG USE_CHINA_NPM_REGISTRY=0;
 ENV NODE_ENV production
 
 WORKDIR /app
+
+RUN apk add dumb-init git python vips-dev fftw-dev build-base --update-cache --repository https://alpine.global.ssl.fastly.net/alpine/edge/community/ --repository https://alpine.global.ssl.fastly.net/alpine/edge/main
 
 COPY package.json /app
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,26 @@
+FROM arm64v8/node:8.16-alpine 
+
+
+RUN apk add dumb-init git python vips-dev fftw-dev build-base --update-cache --repository https://alpine.global.ssl.fastly.net/alpine/edge/community/ --repository https://alpine.global.ssl.fastly.net/alpine/edge/main 
+  
+
+ARG USE_CHINA_NPM_REGISTRY=0
+ENV NODE_ENV production
+
+WORKDIR /app
+
+COPY package.json /app
+
+RUN if [ "$USE_CHINA_NPM_REGISTRY" = 1 ]; then \
+    echo 'use npm mirror'; npm config set registry https://registry.npm.taobao.org; \
+    fi;
+
+# 跳过Chromium下载，puppeteer不会下载chrome-arm
+RUN export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    && npm install --production
+
+COPY . /app
+
+EXPOSE 1200
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
使用原来的dockerfile文件编译失败，发现dumb-init的存储库已经没了，于是直接改用基于alpine的node镜像来打包，安装更简单明了，而且发现最后打的镜像包的大小也减少了，因为我有个树莓派是基于64位系统的，于是顺便也添加了个arm64的。