### PR TITLE
fix: 修复3DM新闻的标题，添加了分类字段

### DIFF
--- a/lib/routes/3dm/news_center.js
+++ b/lib/routes/3dm/news_center.js
@@ -23,6 +23,12 @@ module.exports = async (ctx) => {
             }
             const title = $(item)
                 .find('.text')
+                .find('.bt')
+                .text();
+
+            const category = $(item)
+                .find('.text')
+                .find('.bq')
                 .find('a')
                 .text();
 
@@ -40,6 +46,7 @@ module.exports = async (ctx) => {
 
             const single = {
                 title: title,
+                category: category,
                 description: description,
                 pubDate: time.toUTCString(),
                 link: itemUrl,


### PR DESCRIPTION
```html
<li class="selectpost">
    <a href="https://www.3dmgame.com/news/201910/3772636.html" target="_blank" class="img">
        <img src="/uploads/images/thumbnews/20191002/1570009712_251761.jpg">
    </a>
    <div class="text">
        <a href="https://www.3dmgame.com/news/201910/3772636.html" target="_blank" class="bt">丧子之母哭啸化身
            《仁王2》新女妖“姑获鸟”介绍</a>
        <div class="bq">
            <a href="/news/26126/" target="_blank" class="a">仁王2</a>
            <span class="time">2019-10-02 17:50:20</span>
        </div>
        <div class="miaoshu">
            又到了光荣特库摩旗下动作游戏大作《仁王2》官方的每日挤牙膏时间。今（10月2日）日官方推特带来了妖怪“姑获鸟”的介绍，让我们来看看吧。《仁王2》姑获鸟：妖怪“姑获鸟”是由不能接受婴孩死亡的母亲变幻而来的存在，将头发四散成鸟翅一般飞翔，因此得名。这是一个非常棘手的敌人，其发出的刺耳绝叫会大幅削减气力。从配图中也可以看到，姑获鸟的头发变化成双翼，而四肢则全部爪化，具有和鸟类一样的关节构造。除了尖叫以外，锋利的爪击一定也会给玩家带来麻烦。仁王2》是由黑暗风格的战国动作动作游戏《仁王》的最新续作，背景是以日本战国时代末期为蓝本的世界。玩家需要回到烽火连天的战国时代，握紧屠刀斩断黑暗，讨伐无数被黑暗缠身的妖怪。《仁王2》将于11月1日至11月10日举行为期10天的Beta公测，所有玩家均能够参加，感兴趣的小伙伴们不妨留意
        </div>
    </div>
</li>
```

原来的提取方式，会将标题和标签一起作为标题提取出来，修改之后，分成两个字段（titile, category）分别提取。