### PR TITLE
feat: 推特列表时间线添加author字段

### DIFF
--- a/lib/routes/twitter/list.js
+++ b/lib/routes/twitter/list.js
@@ -16,12 +16,8 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `Twitter List - ${id}/${name}`,
         link: `https://twitter.com/${id}/lists/${name}`,
-        item: utils.ProcessFeed(
-            {
-                data,
-            },
-            false,
-            true
-        ),
+        item: utils.ProcessFeed({
+            data,
+        }),
     };
 };

--- a/lib/routes/twitter/list.js
+++ b/lib/routes/twitter/list.js
@@ -16,8 +16,12 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `Twitter List - ${id}/${name}`,
         link: `https://twitter.com/${id}/lists/${name}`,
-        item: utils.ProcessFeed({
-            data,
-        }),
+        item: utils.ProcessFeed(
+            {
+                data,
+            },
+            false,
+            true
+        ),
     };
 };

--- a/lib/routes/twitter/utils.js
+++ b/lib/routes/twitter/utils.js
@@ -102,6 +102,7 @@ const ProcessFeed = ({ data = [] }, showAuthor = false) => {
 
         return {
             title: `${showAuthor ? item.user.name + ': ' : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${replaceBreak(item.full_text)}`,
+            author: item.user.name,
             description: `${showAuthor ? `<img width="15px" src="${item.user.profile_image_url_https}"><strong>${item.user.name}:</strong><br><br>` : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${
                 item.full_text
             }${url}${img}${quote}`,

--- a/lib/routes/twitter/utils.js
+++ b/lib/routes/twitter/utils.js
@@ -2,7 +2,7 @@ const URL = require('url');
 const config = require('@/config').value;
 const Twit = require('twit');
 
-const ProcessFeed = ({ data = [] }, showAuthor = false, showAuthorField = false) => {
+const ProcessFeed = ({ data = [] }, showAuthor = false) => {
     const getQueryParams = (url) => URL.parse(url, true).query;
     const getOrigionImg = (url) => {
         // https://greasyfork.org/zh-CN/scripts/2312-resize-image-on-open-image-in-new-tab/code#n150
@@ -102,7 +102,6 @@ const ProcessFeed = ({ data = [] }, showAuthor = false, showAuthorField = false)
 
         return {
             title: `${showAuthor ? item.user.name + ': ' : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${replaceBreak(item.full_text)}`,
-            author: showAuthorField ? item.user.name : '',
             description: `${showAuthor ? `<img width="15px" src="${item.user.profile_image_url_https}"><strong>${item.user.name}:</strong><br><br>` : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${
                 item.full_text
             }${url}${img}${quote}`,

--- a/lib/routes/twitter/utils.js
+++ b/lib/routes/twitter/utils.js
@@ -2,7 +2,7 @@ const URL = require('url');
 const config = require('@/config').value;
 const Twit = require('twit');
 
-const ProcessFeed = ({ data = [] }, showAuthor = false) => {
+const ProcessFeed = ({ data = [] }, showAuthor = false, showAuthorField = false) => {
     const getQueryParams = (url) => URL.parse(url, true).query;
     const getOrigionImg = (url) => {
         // https://greasyfork.org/zh-CN/scripts/2312-resize-image-on-open-image-in-new-tab/code#n150
@@ -102,6 +102,7 @@ const ProcessFeed = ({ data = [] }, showAuthor = false) => {
 
         return {
             title: `${showAuthor ? item.user.name + ': ' : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${replaceBreak(item.full_text)}`,
+            author: showAuthorField ? item.user.name : '',
             description: `${showAuthor ? `<img width="15px" src="${item.user.profile_image_url_https}"><strong>${item.user.name}:</strong><br><br>` : ''}${item.in_reply_to_screen_name ? 'Re ' : ''}${
                 item.full_text
             }${url}${img}${quote}`,


### PR DESCRIPTION
fix #3205 

twitter来源本身已支持在标题和内容中显示作者，只需打开即可。

但个人觉得这样子标题显得过于冗长，而使用普遍支持的author字段似乎没什么不好。