### PR TITLE
feat(routes/kzfeed): improve item description style

### DIFF
--- a/lib/routes/kzfeed/topic.js
+++ b/lib/routes/kzfeed/topic.js
@@ -38,7 +38,7 @@ module.exports = async (ctx) => {
         image: info.info.icon,
         item: list.map((item) => ({
             title: item.title ? item.title : item.url_title,
-            description: `<p>${item.text}</p><img src="${item.url_cover}" /><p>${item.url_desc}…</p>`,
+            description: `<p style="white-space: pre-line">${item.text}</p><img src="${item.url_cover}" /><p>${item.url_desc}…</p>`,
             pubDate: new Date(item.created_time * 1000),
             link: item.url,
         })),


### PR DESCRIPTION
kzfeed 的 API 返回的 text 是带换行符的纯文本，如果只用 `<p>` 的话不是很易读，加上 `pre-line` 以后就好多了