### PR TITLE
fix: douban pubDate

### DIFF
--- a/lib/routes/douban/people/status.js
+++ b/lib/routes/douban/people/status.js
@@ -64,7 +64,7 @@ module.exports = async (ctx) => {
                 return {
                     title: r.title,
                     link: item.status.sharing_url,
-                    pubDate: item.status.create_time,
+                    pubDate: new Date(Date.parse(item.status.create_time + ' GMT+0800')).toUTCString(),
                     description: r.description,
                 };
             }),


### PR DESCRIPTION
豆瓣给出的时间是 `2019-10-04 08:54:59` 格式，不含有时区信息，被 rss 阅读器抓取之后默认是标准时区。但是这个时间是默认的GMT+8，所以需要附带时区。

（还好豆瓣时间格式简单，不然 js 还真难处理时区，不知道会默认使用标准时区，还是本地时区。）