### PR TITLE
fix: 去除Dockone标题中无效信息

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -125,6 +125,12 @@ pageClass: routes
 
 <Route author="Cerebrater" example="/matters/author/az" path="/matters/author/:uid" :paramsDesc="['作者 id，可在作者主頁的 URL 找到']"/>
 
+## Nautilus
+
+### 话题
+
+<Route author="emdoe" example="/nautilus/topic/Art" path="/nautilus/topic/:tid" :paramsDesc="['话题 id, 可在页面上方 TOPICS 栏目处找到']"/>
+
 ## Readhub
 
 ### 分类
@@ -478,12 +484,6 @@ pageClass: routes
 ### 新闻
 
 <Route author="crispgm" example="/nogizaka46/news" path="/nogizaka46/news" />
-
-## Nautilus
-
-### 话题
-
-<Route author="emdoe" example="/nautilus/topic/Art" path="/nautilus/topic/:tid" :paramsDesc="['话题 id, 可在页面上方 TOPICS 栏目处找到']"/>
 
 ## 派代
 

--- a/lib/routes/dockone/weekly.js
+++ b/lib/routes/dockone/weekly.js
@@ -25,7 +25,7 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         list.map(async (item) => {
             const $ = cheerio.load(item);
-            const $a = $('.aw-question-content a');
+            const $a = $('.aw-question-content > h4 > a');
             const link = $a.attr('href');
 
             const cache = await ctx.cache.get(link);

--- a/lib/routes/dockone/weekly.js
+++ b/lib/routes/dockone/weekly.js
@@ -52,7 +52,7 @@ module.exports = async (ctx) => {
     );
 
     ctx.state.data = {
-        title: $('title').text(),
+        title: 'DockOne.io',
         link: baseUrl,
         description: $('meta[name="description"]').attr('content') || $('title').text(),
         item: items,


### PR DESCRIPTION
before

<img width="885" alt="屏幕快照 2019-10-16 17 25 34" src="https://user-images.githubusercontent.com/9067094/66908060-0c354600-f03d-11e9-820d-abe6b32bc52f.png">

now

<img width="885" alt="屏幕快照 2019-10-16 17 47 22" src="https://user-images.githubusercontent.com/9067094/66908148-2bcc6e80-f03d-11e9-8ae7-d957c505f121.png">

