### PR TITLE
feat: 优化快知的 feed 条目展示效果

### DIFF
--- a/lib/routes/kzfeed/topic.js
+++ b/lib/routes/kzfeed/topic.js
@@ -1,5 +1,35 @@
+/**
+ * 这里列出部分已知用途且在 Feed 中有用的属性
+ *
+ * @typedef {Object} Card
+ * @property {String} id 卡片 id
+ * @property {String} title 卡片标题
+ * @property {String} text 正文内容，会有换行符，里面的链接会是 <a-link href="..."></a-link> 的形式
+ * @property {String} video 可能是内嵌视频地址
+ * @property {String} video_thumb_img 可能是内嵌视频预览图片
+ * @property {Number} bilibili_video_id 可能是关联的 Bilibili av 号
+ * @property {String[]} images 内嵌图片地址
+ * @property {Card~ImageInfo[]} images_info 内嵌图片信息
+ * @property {String} url 原文网址
+ * @property {String} url_cover 原文头图
+ * @property {String} url_title 原文标题
+ * @property {String} url_desc 原文简介
+ * @property {String} url_host 原文网址的域名
+ * @property {Number} created_time 创建的 Unix 时间戳
+ *
+ * @typedef {Object} Card~ImageInfo
+ * @property {String} url
+ * @property {String} format
+ * @property {String} size
+ * @property {Number} width
+ * @property {Number} height
+ */
+
 const got = require('@/utils/got');
 
+/**
+ * @param {String} ctx.params.id
+ */
 module.exports = async (ctx) => {
     const id = ctx.params.id;
 
@@ -29,18 +59,65 @@ module.exports = async (ctx) => {
             topic_id: id,
         }),
     });
-    const list = cards_res.data.list;
+    const cardList = cards_res.data.list;
 
     ctx.state.data = {
         title: `快知 - ${info.info.name}`,
         description: info.info.description,
         link: `https://kz.sync163.com/web/topic/${id}`,
         image: info.info.icon,
-        item: list.map((item) => ({
-            title: item.title ? item.title : item.url_title,
-            description: `<p style="white-space: pre-line">${item.text}</p><img src="${item.url_cover}" /><p>${item.url_desc}…</p>`,
-            pubDate: new Date(item.created_time * 1000),
-            link: item.url,
-        })),
+        item: cardList.map(buildFeedItem),
     };
 };
+
+/**
+ * @param {Card} cardData
+ */
+function buildFeedItem(cardData) {
+    const description = `
+<p><img src="${cardData.url_cover}" /></p>
+<p>${cardData.url_title}${cardData.url_desc ? ` - ${cardData.url_desc}` : ''}</p>
+<p style="white-space: pre-line">${serializeCardText(cardData.text)}</p>
+${renderImageList(cardData.images)}
+<p><a href="https://kz.sync163.com/web/card/${cardData.id}" style="margin-left: 10px">快知中间页</a></p>
+    `;
+
+    return {
+        title: cardData.title ? cardData.title : cardData.url_title,
+        description,
+        pubDate: new Date(cardData.created_time * 1000),
+        link: cardData.url,
+    };
+}
+
+function renderImageList(images) {
+    return `
+<ul style="
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+">
+  ${images.map(renderItem).join('')}
+</ul>
+`;
+
+    function renderItem(src) {
+        return `
+<li style="width: 30%; margin: 0.5rem">
+  <img style="width: 100%" src="${src}" />
+</li>
+`;
+    }
+}
+
+function serializeCardText(text) {
+    return transformAnchorTagName(text);
+
+    /* 快知的 API 里的 a 标签名字叫做 a-link ，我们要把它改过来 */
+    function transformAnchorTagName(text) {
+        return text.replace(/<a-link/g, '<a').replace(/<\/a-link>/g, '</a>');
+    }
+}


### PR DESCRIPTION
* 在 `description` 里添加一个链接用于打开快知中间页
* 修复快知条目里的 a 标签
* 如果快知的条目里有图片的话要渲染图片