### PR TITLE
fix: xueqiu fund cache issue

### DIFF
--- a/lib/routes/xueqiu/fund.js
+++ b/lib/routes/xueqiu/fund.js
@@ -6,7 +6,7 @@ module.exports = async (ctx) => {
     const cache = await ctx.cache.get(guid);
 
     if (cache) {
-        return JSON.parse(cache);
+        return Promise.resolve(JSON.parse(cache));
     } else {
         const url = `https://xueqiu.com/S/F${ctx.params.id}`;
 


### PR DESCRIPTION
@HenryQW 

**目前命中缓存的时候 RSS 结果会 undefined**

然后我顺便看了下 content cache 的代码，如果命中 cache 会继续给这个缓存增加缓存时间，那样的话极端情况如果在 cache 失效前一直被访问的话，这个 RSS 可能一直不会更新？要不然就干脆把这个脚本里 content cache 的逻辑删了，只依赖下 router cache 是不是问题也不是太大。