### PR TITLE
fix: X-mol 期刊 修复文章没有相关图片时报错的情况

### DIFF
--- a/lib/routes/x-mol/paper.js
+++ b/lib/routes/x-mol/paper.js
@@ -29,20 +29,22 @@ module.exports = async (ctx) => {
                 const title = a.text();
                 const link = utils.host + a.attr('href');
 
-                const imageId = news
-                    .find('.magazine-pic')
-                    .attr('id')
-                    .substring(9);
-                const getLink = utils.host + '/attachment/getImgUrl';
+                const picId = news.find('.magazine-pic').attr('id');
                 const noPic = utils.host + '/css/images/nothesispic.jpg';
-                const imageUrl = await ctx.cache.tryGet(getLink, async () => {
-                    const result = await got.get(getLink, {
-                        params: {
-                            attachmentId: imageId,
-                        },
-                    });
-                    return result.data;
-                });
+                let imageUrl = noPic;
+                if (picId) {
+                    const imageId = picId.substring(9);
+                    const getLink = utils.host + '/attachment/getImgUrl';
+                    imageUrl =
+                        (await ctx.cache.tryGet(getLink, async () => {
+                            const result = await got.get(getLink, {
+                                params: {
+                                    attachmentId: imageId,
+                                },
+                            });
+                            return result.data;
+                        })) || noPic;
+                }
                 const image = imageUrl || noPic;
                 const text = $(element)
                     .find('.magazine-description')


### PR DESCRIPTION

当一篇文章预览没有相关图片时，图片id为空，图片获取失败于是报错，
增加图片存在判断。