### PR TITLE
fix: 哈尔滨工程大学 docs 标题

### DIFF
--- a/docs/university.md
+++ b/docs/university.md
@@ -288,6 +288,7 @@ xskb1 对应 http://www.auto.uestc.edu.cn/index/xskb1.htm
 注 1: 不要吐槽拼音缩写，缩写原本的 URL 构成就这样。
 
 </Route>
+
 ## 哈尔滨工程大学
 
 ### 本科生院工作通知


### PR DESCRIPTION

因为`npm run format`自动移动 桂电部分docs时，插入的
 `</Route>` 和 `## 哈尔滨工程大学`之间**没有空行**
导致## 标题失效