### PR TITLE
feat: 添加码农周刊

### DIFF
--- a/docs/programming.md
+++ b/docs/programming.md
@@ -582,3 +582,9 @@ GitHub 官方也提供了一些 RSS:
 ### 热门
 
 <Route author="SirM2z" example="/zcfy/hot" path="/zcfy/hot"/>
+
+## 码农周刊
+
+### issues
+
+<Route author="tonghs" example="/manong-weekly" path="/manong-weekly" />

--- a/docs/programming.md
+++ b/docs/programming.md
@@ -471,6 +471,12 @@ GitHub 官方也提供了一些 RSS:
 
 </Route>
 
+## 码农周刊
+
+### issues
+
+<Route author="tonghs" example="/manong-weekly" path="/manong-weekly" />
+
 ## 前端艺术家&&飞冰早报
 
 ### 列表
@@ -582,9 +588,3 @@ GitHub 官方也提供了一些 RSS:
 ### 热门
 
 <Route author="SirM2z" example="/zcfy/hot" path="/zcfy/hot"/>
-
-## 码农周刊
-
-### issues
-
-<Route author="tonghs" example="/manong-weekly" path="/manong-weekly" />

--- a/docs/study.md
+++ b/docs/study.md
@@ -33,6 +33,12 @@ pageClass: routes
 
 </Route>
 
+## 码农周刊
+
+### issues
+
+<Route author="tonghs" example="/manong-weekly" path="/manong-weekly" />
+
 ## 扇贝
 
 ### 用户打卡

--- a/lib/router.js
+++ b/lib/router.js
@@ -1871,4 +1871,7 @@ router.get('/mcbbs/post/:tid/:authorid?', require('./routes/mcbbs/post'));
 // Pocket
 router.get('/pocket/trending', require('./routes/pocket/trending'));
 
+// 码农周刊
+router.get('/manong-weekly', require('./routes/manong-weekly/issues'));
+
 module.exports = router;

--- a/lib/routes/manong-weekly/issues.js
+++ b/lib/routes/manong-weekly/issues.js
@@ -1,0 +1,33 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+
+module.exports = async (ctx) => {
+    const url = 'https://weekly.manong.io/issues/';
+    const response = await got({
+        rejectUnauthorized: false,
+        method: 'get',
+        url,
+    });
+    const $ = cheerio.load(response.data);
+    const resultItem = $('.issue')
+        .map((index, elem) => {
+            elem = $(elem);
+            const $link = elem.find('a');
+            const title = $link.text();
+            const link = $link.attr('href');
+            const description = elem.find('p').text();
+
+            return {
+                title,
+                link,
+                description,
+            };
+        })
+        .get();
+
+    ctx.state.data = {
+        title: '码农周刊',
+        link: url,
+        item: resultItem,
+    };
+};


### PR DESCRIPTION
码农周刊：https://weekly.manong.io/issues/

由于【unable to verify the first certificate】问题（详见：https://github.com/DIYgod/RSSHub/issues/304 ），所以在请求时设置了 `rejectUnauthorized: false`