### PR TITLE
feat: 添加中国石油大学（华东）的路由

### DIFF
--- a/docs/university.md
+++ b/docs/university.md
@@ -267,7 +267,7 @@ xskb1 对应 http://www.auto.uestc.edu.cn/index/xskb1.htm
 
 ### 东南大学计算机技术与工程学院
 
-<Route author="LogicJake" example="/seu/cse/xyxw" path="/universities/seu/cse/:type?" :paramsDesc="['分类名(默认为xyxw)']"/>
+<Route author="LogicJake" example="/seu/cse/xyxw" path="/universities/seu/cse/:type?" :paramsDesc="['分类名(默认为xyxw)']">
 
 | 学院新闻 | 通知公告 | 教务信息 | 就业信息 | 学工事务 |
 | -------- | -------- | -------- | -------- | -------- |

--- a/docs/university.md
+++ b/docs/university.md
@@ -542,7 +542,7 @@ category 列表：
 
 ### 计算机科学与技术学院
 
-<Route author="LogicJake" example="/nuaa/cs/kydt" path="/universities/nuaa/cs/:type?" :paramsDesc="['分类名']"/>
+<Route author="LogicJake" example="/nuaa/cs/kydt" path="/universities/nuaa/cs/:type?" :paramsDesc="['分类名']">
 
 | 通知公告 | 新闻动态 | 科研动态 | 教学动态 | 学生工作 | 招生信息 | 就业信息 |
 | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
@@ -552,7 +552,7 @@ category 列表：
 
 ### 研究生院
 
-<Route author="junfengP" example="/nuaa/yjsy/latest" path="/universities/nuaa/yjsy/:type?" :paramsDesc="['分类名']"/>
+<Route author="junfengP" example="/nuaa/yjsy/latest" path="/universities/nuaa/yjsy/:type?" :paramsDesc="['分类名']">
 
 | 最近动态 | 研院新闻 | 上级文件 | 管理文件 | 信息服务 |
 | -------- | -------- | -------- | -------- | -------- |

--- a/docs/university.md
+++ b/docs/university.md
@@ -273,6 +273,8 @@ xskb1 对应 http://www.auto.uestc.edu.cn/index/xskb1.htm
 | -------- | -------- | -------- | -------- | -------- |
 | xyxw     | tzgg     | jwxx     | jyxx     | xgsw     |
 
+</Route>
+
 ## 广东工业大学
 
 ### 校内新闻网
@@ -546,6 +548,8 @@ category 列表：
 | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
 | tzgg     | xwdt     | kydt     | jxdt     | xsgz     | zsxx     | jyxx     |
 
+</Route>
+
 ### 研究生院
 
 <Route author="junfengP" example="/nuaa/yjsy/latest" path="/universities/nuaa/yjsy/:type?" :paramsDesc="['分类名']"/>
@@ -553,6 +557,8 @@ category 列表：
 | 最近动态 | 研院新闻 | 上级文件 | 管理文件 | 信息服务 |
 | -------- | -------- | -------- | -------- | -------- |
 | latest   | yyxw     | sjwj     | glwj     | xxfw     |
+
+</Route>
 
 ## 南京理工大学
 
@@ -1116,7 +1122,6 @@ https://rsshub.app/**nuist**/`bulletin` 或 https://rsshub.app/**nuist**/`bullet
 ### 数据科学与计算机学院动态
 
 <Route author="Neutrino3316 MegrezZhu" example="/sysu/sdcs" path="/sysu/sdcs" />
-
 
 ## 中国石油大学（华东）
 

--- a/docs/university.md
+++ b/docs/university.md
@@ -1116,3 +1116,22 @@ https://rsshub.app/**nuist**/`bulletin` 或 https://rsshub.app/**nuist**/`bullet
 ### 数据科学与计算机学院动态
 
 <Route author="Neutrino3316 MegrezZhu" example="/sysu/sdcs" path="/sysu/sdcs" />
+
+
+## 中国石油大学（华东）
+
+### 主页
+
+<Route author="Veagau" example="/upc/main" path="/upc/main/:type" :paramsDesc="['分类, 见下表']">
+
+| 通知公告 | 学术动态 |
+| -------- | -------- |
+| notice   | scholar  |
+
+### 计算机科学与技术学院
+
+<Route author="Veagau" example="/upc/jsj" path="/upc/jsj/:type" :paramsDesc="['分类, 见下表']">
+
+| 学院新闻 | 学术关注 | 学工动态 | 通知公告 |
+| -------- | -------- | -------- | -------- |
+| news     | scholar  | states   | notice   |

--- a/docs/university.md
+++ b/docs/university.md
@@ -1128,6 +1128,8 @@ https://rsshub.app/**nuist**/`bulletin` 或 https://rsshub.app/**nuist**/`bullet
 | -------- | -------- |
 | notice   | scholar  |
 
+</Route>
+
 ### 计算机科学与技术学院
 
 <Route author="Veagau" example="/upc/jsj" path="/upc/jsj/:type" :paramsDesc="['分类, 见下表']">
@@ -1135,3 +1137,5 @@ https://rsshub.app/**nuist**/`bulletin` 或 https://rsshub.app/**nuist**/`bullet
 | 学院新闻 | 学术关注 | 学工动态 | 通知公告 |
 | -------- | -------- | -------- | -------- |
 | news     | scholar  | states   | notice   |
+
+</Route>

--- a/lib/router.js
+++ b/lib/router.js
@@ -705,6 +705,10 @@ router.get('/ustb/tj/news/:type?', require('./routes/universities/ustb/tj/news')
 // 深圳大学
 router.get('/szu/yz/:type?', require('./routes/universities/szu/yz'));
 
+// 中国石油大学（华东）
+router.get('/upc/main/:type?', require('./routes/universities/upc/main'));
+router.get('/upc/jsj/:type?', require('./routes/universities/upc/jsj'));
+
 // ifanr
 router.get('/ifanr/:channel?', require('./routes/ifanr/index'));
 

--- a/lib/routes/universities/upc/jsj.js
+++ b/lib/routes/universities/upc/jsj.js
@@ -42,7 +42,7 @@ module.exports = async (ctx) => {
             if (re.exec(itemSingle.html()) !== null) {
                 singleUrl = RegExp.$1;
             }
-            if (singleUrl.search('http') == -1) {
+            if (singleUrl.search('http') === -1) {
                 singleUrl = baseurl + singleUrl;
             }
             const cache = await ctx.cache.get(singleUrl); // ### 得到全局中的缓存信息

--- a/lib/routes/universities/upc/jsj.js
+++ b/lib/routes/universities/upc/jsj.js
@@ -1,0 +1,81 @@
+// 计算机科学与技术学院：http://computer.upc.edu.cn/
+// - 学院新闻：http://computer.upc.edu.cn/6277/list.htm
+// - 学术关注：http://computer.upc.edu.cn/6278/list.htm
+// - 学工动态：http://computer.upc.edu.cn/6279/list.htm
+// - 通知公告：http://computer.upc.edu.cn/6280/list.htm
+
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const baseurl = 'http://computer.upc.edu.cn/';
+// 地址映射
+const MAP = {
+    news: '6277',
+    scholar: '6278',
+    states: '6279',
+    notice: '6280',
+};
+// 头部信息
+const HEAD = {
+    news: '学院新闻',
+    scholar: '学术关注',
+    states: '学工动态',
+    notice: '通知公告',
+};
+
+module.exports = async (ctx) => {
+    const type = ctx.params.type;
+    const response = await got({
+        method: 'get',
+        url: baseurl + MAP[type] + '/list.htm',
+    });
+    const $ = cheerio.load(response.data);
+    // ## 获取列表
+    const list = $('#wp_news_w15 > table > tbody > tr > td > table > tbody > tr > td > a').get();
+    // ## 定义输出的item
+    const out = await Promise.all(
+        // ### 遍历列表，筛选出自己想要的内容
+        list.map(async (item) => {
+            const itemSingle = cheerio.load(item);
+            const title = itemSingle.text();
+            const re = /<a[^>]*href=['"]([^"]*)['"][^>]*>(.*?)<\/a>/g;
+            let singleUrl = '';
+            if (re.exec(itemSingle.html()) !== null) {
+                singleUrl = RegExp.$1;
+            }
+            if (singleUrl.search('http') == -1) {
+                singleUrl = baseurl + singleUrl;
+            }
+            const cache = await ctx.cache.get(singleUrl); // ### 得到全局中的缓存信息
+            // ### 判断缓存是否存在，如果存在即跳过此次获取的信息
+            if (cache) {
+                return Promise.resolve(JSON.parse(cache));
+            }
+            // 获取详情页面的介绍
+            const detail_response = await got({
+                method: 'get',
+                url: singleUrl,
+            });
+            const $ = cheerio.load(detail_response.data);
+            const detail_content = $('div.contain > div.main > div.right_cont > article').html();
+            // ### 设置 RSS feed item
+            const single = {
+                title: title,
+                link: singleUrl,
+                // author: author,
+                description: detail_content,
+                // pubDate: updateDate,
+            };
+            // // ### 设置缓存
+            ctx.cache.set(singleUrl, JSON.stringify(single));
+            return Promise.resolve(single);
+            // }
+        })
+    );
+
+    ctx.state.data = {
+        title: HEAD[type] + `-计算机科学与技术学院`,
+        link: baseurl + MAP[type] + '.htm',
+        description: HEAD[type] + `-计算机科学与技术学院`,
+        item: out,
+    };
+};

--- a/lib/routes/universities/upc/main.js
+++ b/lib/routes/universities/upc/main.js
@@ -1,5 +1,4 @@
 // 学校官网：http://www.upc.edu.cn/
-
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const baseurl = 'http://news.upc.edu.cn/';

--- a/lib/routes/universities/upc/main.js
+++ b/lib/routes/universities/upc/main.js
@@ -1,0 +1,73 @@
+// 学校官网：http://www.upc.edu.cn/
+
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const baseurl = 'http://news.upc.edu.cn/';
+// 地址映射
+const MAP = {
+    notice: 'tzgg',
+    scholar: 'xsdt',
+};
+// 头部信息
+const HEAD = {
+    notice: '通知公告',
+    scholar: '学术动态',
+};
+
+module.exports = async (ctx) => {
+    const type = ctx.params.type;
+    const response = await got({
+        method: 'get',
+        url: baseurl + MAP[type] + '.htm',
+    });
+    const $ = cheerio.load(response.data);
+    // ## 获取列表
+    const list = $('div.container > div.main-ny > div.main-ny-cont > div.main-ny-cont-box > div.main-list-box > div.main-list-box-left > ul > li > div.li-right > div.li-right-bt > a').get();
+    // ## 定义输出的item
+    const out = await Promise.all(
+        // ### 遍历列表，筛选出自己想要的内容
+        list.map(async (item) => {
+            const itemSingle = cheerio.load(item);
+            const title = itemSingle.text();
+            const re = /<a[^>]*href=['"]([^"]*)['"][^>]*>(.*?)<\/a>/g;
+            let singleUrl = '';
+            if (re.exec(itemSingle.html()) !== null) {
+                singleUrl = RegExp.$1;
+            }
+            if (singleUrl.search('http') == -1) {
+                singleUrl = `http://news.upc.edu.cn/` + singleUrl;
+            }
+            const cache = await ctx.cache.get(singleUrl); // ### 得到全局中的缓存信息
+            // ### 判断缓存是否存在，如果存在即跳过此次获取的信息
+            if (cache) {
+                return Promise.resolve(JSON.parse(cache));
+            }
+            // 获取详情页面的介绍
+            const detail_response = await got({
+                method: 'get',
+                url: singleUrl,
+            });
+            const $ = cheerio.load(detail_response.data);
+            const detail_content = $('div.container > div.main-ny > div.main-ny-cont > div.main-ny-cont-box > div.main-content-box > form').html();
+            // ### 设置 RSS feed item
+            const single = {
+                title: title,
+                link: singleUrl,
+                // author: author,
+                description: detail_content,
+                // pubDate: updateDate,
+            };
+            // // ### 设置缓存
+            ctx.cache.set(singleUrl, JSON.stringify(single));
+            return Promise.resolve(single);
+            // }
+        })
+    );
+
+    ctx.state.data = {
+        title: HEAD[type] + `-中国石油大学（华东）`,
+        link: baseurl + MAP[type] + '.htm',
+        description: HEAD[type] + `-中国石油大学（华东）`,
+        item: out,
+    };
+};

--- a/lib/routes/universities/upc/main.js
+++ b/lib/routes/universities/upc/main.js
@@ -34,7 +34,7 @@ module.exports = async (ctx) => {
             if (re.exec(itemSingle.html()) !== null) {
                 singleUrl = RegExp.$1;
             }
-            if (singleUrl.search('http') == -1) {
+            if (singleUrl.search('http') === -1) {
                 singleUrl = `http://news.upc.edu.cn/` + singleUrl;
             }
             const cache = await ctx.cache.get(singleUrl); // ### 得到全局中的缓存信息


### PR DESCRIPTION
具体添加内容包括：
1. 中国石油大学（华东）主页中的通知公告以及学术动态的信息抓取
2. 计算机科学与技术学院网站中的学院新闻、通知公告、学术关注和学工动态的信息的抓取