### PR TITLE
feat: 增加北京邮电大学的路由

### DIFF
--- a/docs/university.md
+++ b/docs/university.md
@@ -106,13 +106,11 @@ pageClass: routes
 
 ### 信息门户
 
-<Route author="RicardoMing" example="/bupt/portal" path="/bupt/portal" />
+<Route author="RicardoMing wzekin" example="/bupt/portal" path="/bupt/portal" />
 
-::: warning 注意
-信息门户的通知需要通过统一身份认证后才能获取，因此需要在校园网或校园 VPN 环境下自建。
+### 校园新闻
 
-设置环境变量: `BUPT_USERNAME` 用户名为学号， `BUPT_PASSWORD` 统一身份认证的密码。
-:::
+<Route author="wzekin" example="/bupt/news" path="/bupt/news" />
 
 ## 常州大学
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -1321,6 +1321,7 @@ router.get('/21caijing/channel/:name', require('./routes/21caijing/channel'));
 router.get('/bupt/yz/:type', require('./routes/universities/bupt/yz'));
 router.get('/bupt/grs', require('./routes/universities/bupt/grs'));
 router.get('/bupt/portal', require('./routes/universities/bupt/portal'));
+router.get('/bupt/news', require('./routes/universities/bupt/news'));
 
 // VOCUS 方格子
 router.get('/vocus/publication/:id', require('./routes/vocus/publication'));

--- a/lib/routes/universities/bupt/news.js
+++ b/lib/routes/universities/bupt/news.js
@@ -3,7 +3,7 @@ const got = require('@/utils/got');
 module.exports = async (ctx) => {
     const response = await got({
         method: 'get',
-        url: `https://webapp.bupt.edu.cn/extensions/wap/news/get-list.html?p=1&type=tzgg`,
+        url: `https://webapp.bupt.edu.cn/extensions/wap/news/get-list.html?p=1&type=xnxw`,
     });
     const out = [];
     const data = response.data.data;
@@ -13,15 +13,15 @@ module.exports = async (ctx) => {
                 title: item.title,
                 description: item.desc,
                 pubDate: new Date(item.created * 1000).toUTCString(),
-                link: `https://webapp.bupt.edu.cn/extensions/wap/news/detail.html?id=${item.id}&classify_id=tzgg`,
+                link: `https://webapp.bupt.edu.cn/extensions/wap/news/detail.html?id=${item.id}&classify_id=xnxw`,
                 author: item.author,
             });
         });
     });
 
     ctx.state.data = {
-        title: '北京邮电大学信息门户',
-        link: 'https://webapp.bupt.edu.cn/extensions/wap/news/list.html?p=1&type=tzgg',
+        title: '北京邮电大学校校园新闻',
+        link: 'https://webapp.bupt.edu.cn/extensions/wap/news/list.html?p=1&type=xnxw',
         item: out,
     };
 };


### PR DESCRIPTION
主要改动：

1. 添加校园新闻RSS
2. 修改信息门户的来源，使其不需要登录