### PR TITLE
feat: 增加动漫之家最近更新信息

### DIFF
--- a/docs/anime.md
+++ b/docs/anime.md
@@ -211,6 +211,16 @@ pageClass: routes
 
 <Route author="KellyHwong" path="/cartoonmad/comic/:id" example="/cartoonmad/comic/5827" :paramsDesc="['漫画ID']"/>
 
+## 动漫之家
+
+### 漫画更新
+
+<Route author="dev-techmoe" path="/dmzj/comics/:name" example="/dmzj/comics/xingyunxing" :paramsDesc="['原站链接中的漫画拼音部分']"/>
+
+例：漫画地址为`http://manhua.dmzj.com/xingyunxing`，则对应的`name`值为`xingyunxing`。
+
+仅能够抓取**未登录用户可见**的漫画条目。
+
 ## 海猫吧
 
 ### 漫画更新

--- a/lib/router.js
+++ b/lib/router.js
@@ -1936,4 +1936,7 @@ router.get('/gov/cnca/hydt', require('./routes/gov/cnca/hydt'));
 
 router.get('/gov/cnca/zxtz', require('./routes/gov/cnca/zxtz'));
 
+// 动漫之家
+router.get('/dmzj/comics/:name', require('./routes/dongmanzhijia/dongmanzhijia'));
+
 module.exports = router;

--- a/lib/routes/dongmanzhijia/dongmanzhijia.js
+++ b/lib/routes/dongmanzhijia/dongmanzhijia.js
@@ -1,0 +1,36 @@
+const cheerio = require('cheerio');
+const got = require('@/utils/got');
+
+const baseURL = 'http://manhua.dmzj.com';
+
+module.exports = async (ctx) => {
+    const { name } = ctx.params;
+    const targetURL = `${baseURL}/${name}`;
+
+    const { data } = await got.get(targetURL);
+    const $ = cheerio.load(data);
+
+    const bookTitle = $('.anim_title_text a').text();
+    const bookIntro = $('.middleright_mr.margin_top_10px .line_height_content')
+        .text()
+        .trim();
+    const coverImgSrc = $('.anim_intro_ptext img').attr('src');
+
+    const items = $('.cartoon_online_border ul li a')
+        .map((i, d) => ({
+            link: baseURL + $(d).attr('href'),
+            title: $(d).text(),
+            description: `
+                <h1>${$(d).text()}</h1>
+                <img src="${coverImgSrc}" />
+            `,
+        }))
+        .get();
+
+    ctx.state.data = {
+        title: `动漫之家 - ${bookTitle}`,
+        link: targetURL,
+        description: bookIntro,
+        item: items,
+    };
+};


### PR DESCRIPTION
参考了其他人的实现，为RSSHub增加了动漫之家漫画站（[manhua.dmzj.com](manhua.dmzj.com)）的更新抓取功能。  
求Review