### PR TITLE
feat: 新增配置项 DOCS_EXAMPLE_WEBSITE

### DIFF
--- a/docs/.vuepress/components/Route.vue
+++ b/docs/.vuepress/components/Route.vue
@@ -7,7 +7,7 @@
     作者: <a v-for="uid in author.split(' ')" :href="`https://github.com/${uid}`" target="_blank"> @{{ uid }} </a>
   </p>
   <p class="example">
-    举例: <a :href="'https://rsshub.app'+ example " target="_blank">https://rsshub.app{{example}}</a>
+    举例: <a :href="exampleWebsite + example " target="_blank">{{exampleWebsite}}{{example}}</a>
   </p>
   <p class="path">
     路由: <code>{{ path }}</code>
@@ -56,6 +56,18 @@ export default {
       type: String,
       default: null
     },
+  },
+  computed: {
+    exampleWebsite () {
+      const re = /^(.*)\/$/
+      const value = process.env.DOCS_EXAMPLE_WEBSITE
+      if (value) {
+        // https://rsshub.app/  =>  https://rsshub.app
+        return value.replace(re, '$1')
+      } else {
+        return 'https://rsshub.app'
+      }
+    }
   },
   methods: {
     renderMarkdown(item) {

--- a/docs/.vuepress/components/RouteEn.vue
+++ b/docs/.vuepress/components/RouteEn.vue
@@ -7,7 +7,7 @@
     Author: <a v-for="uid in author.split(' ')" :href="`https://github.com/${uid}`" target="_blank"> @{{ uid }} </a>
   </p>
   <p  class="example">
-    Example: <a :href="'https://rsshub.app'+ example " target="_blank">https://rsshub.app{{example}}</a>
+    Example: <a :href="exampleWebsite + example " target="_blank">{{exampleWebsite}}{{example}}</a>
   </p>
   <p class="path">
     Route: <code>{{ path }}</code>
@@ -56,6 +56,18 @@ export default {
       type: String,
       default: null
     },
+  },
+  computed: {
+    exampleWebsite () {
+      const re = /^(.*)\/$/
+      const value = process.env.DOCS_EXAMPLE_WEBSITE
+      if (value) {
+        // https://rsshub.app/  =>  https://rsshub.app
+        return value.replace(re, '$1')
+      } else {
+        return 'https://rsshub.app'
+      }
+    }
   },
   methods: {
     renderMarkdown(item) {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,3 +1,6 @@
+var webpack = require('webpack');
+require('dotenv').config();
+const envs = process.env;
 const pinyin = require('pinyin');
 const { slugify: _slugify } = require('@vuepress/shared-utils');
 
@@ -198,5 +201,14 @@ module.exports = {
                 },
             },
         },
+    },
+    configureWebpack: (config, isServer) => {
+        return {
+            plugins: [
+                new webpack.DefinePlugin({
+                    'process.env.DOCS_EXAMPLE_WEBSITE': envs.DOCS_EXAMPLE_WEBSITE ? '"' + envs.DOCS_EXAMPLE_WEBSITE + '"' : undefined,
+                }),
+            ],
+        };
     },
 };

--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -304,6 +304,8 @@ Use environment variables is recommended to avoid conflicts during upgrade.
 
 `SENTRY`: [Sentry](https://sentry.io) dsn, used for error tracking
 
+`DOCS_EXAMPLE_WEBSITE`: website of example, default to `https://rsshub.app`
+
 ### User Authentication
 
 Routes in `protected_route.js` will be protected using HTTP Basic Authentication.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -372,6 +372,8 @@ RSSHub 支持 `memory` 和 `redis` 两种缓存方式
 
 `SENTRY`: [Sentry](https://sentry.io) dsn，用于错误追踪
 
+`DOCS_EXAMPLE_WEBSITE`: 文档中的举例的网站，默认 `https://rsshub.app`
+
 ### 部分 RSS 模块配置
 
 -   pixiv 全部路由: [注册地址](https://accounts.pixiv.net/signup)


### PR DESCRIPTION
新增`DOCS_EXAMPLE_WEBSITE`配置项。方便在自己部署文档的时候，可以直接复制例子的链接，而不用再次修改域名。