### PR TITLE
fix: 开眼RSS URL为空

### DIFF
--- a/lib/routes/kaiyan/index.js
+++ b/lib/routes/kaiyan/index.js
@@ -46,7 +46,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `开眼精选`,
-        link: '',
+        link: 'https://www.kaiyanapp.com/',
         description: '开眼每日精选',
         item: out,
     };


### PR DESCRIPTION
Fix #3528