### PR TITLE
Rewrite the Dribbble route.

### DIFF
--- a/lib/routes/dribbble/user.js
+++ b/lib/routes/dribbble/user.js
@@ -1,7 +1,30 @@
-const utils = require('./utils');
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const util = require('./utils');
 
 module.exports = async (ctx) => {
     const name = ctx.params.name;
+    const url = `https://dribbble.com/${name}`;
 
-    ctx.state.data = await utils.getData(name, `https://dribbble.com/${name}`);
+    const response = await got({
+        method: 'get',
+        url: url,
+        headers: {
+            Referer: url,
+        },
+    });
+
+    const data = response.data;
+
+    const $ = cheerio.load(data);
+    const list = $('ol.dribbbles.group li.group').get();
+
+    const result = await util.ProcessFeed(list, ctx.cache);
+
+    ctx.state.data = {
+        title: `Dribbble - ${name}`,
+        link: url,
+        description: $('meta[name="description"]').attr('content'),
+        item: result,
+    };
 };

--- a/lib/routes/dribbble/utils.js
+++ b/lib/routes/dribbble/utils.js
@@ -1,49 +1,52 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
+const url = require('url');
+
+async function load(link) {
+    const response = await got.get(link);
+    const $ = cheerio.load(response.data);
+
+    const shotMedia = $('.media-shot').html();
+    const shotDescription = $('.shot-desc').html();
+
+    const description = `${shotMedia}<br />
+	                        ${shotDescription}<br />
+	                        ${$('.shot-views').text()}<br />
+	                        ${$('.shot-likes').text()}<br />
+	                        ${$('.shot-saves').text()}`;
+
+    return { description };
+}
+
+const ProcessFeed = async (list, caches) => {
+    const host = 'https://dribbble.com';
+
+    return await Promise.all(
+        list.map(async (item) => {
+            const $ = cheerio.load(item);
+
+            const itemUrlPath =
+                $('.animated-target').attr('href') ||
+                $('.extras > a')
+                    .attr('href')
+                    .replace('/rebounds', '');
+            const itemUrl = url.resolve(host, itemUrlPath);
+
+            const single = {
+                title: $('.dribbble-over strong').text(),
+                link: itemUrl,
+                author: ($('.attribution-team').text() ? $('.attribution-team').text() + ' -' : '') + $('.attribution-user').text(),
+                guid: itemUrl,
+                pubDate: new Date($('.timestamp').text()).toUTCString(),
+            };
+
+            const other = await caches.tryGet(itemUrl, async () => await load(itemUrl));
+
+            return Promise.resolve(Object.assign({}, single, other));
+        })
+    );
+};
 
 module.exports = {
-    getData: async (name, url) => {
-        const response = await got({
-            method: 'get',
-            url: url,
-            headers: {
-                Referer: url,
-            },
-        });
-
-        const data = response.data;
-
-        const $ = cheerio.load(data);
-        const list = $('ol.dribbbles.group li.group');
-
-        return {
-            title: `${name} - Dribbble`,
-            link: url,
-            description: $('meta[name="description"]').attr('content'),
-            item:
-                list &&
-                list
-                    .map((index, item) => {
-                        item = $(item);
-                        return {
-                            title: item.find('.dribbble-over strong').text(),
-                            description: `<img src="${item
-                                .find('.dribbble-link img')
-                                .attr('src')
-                                .replace('_teaser', '')}"><br>
-                                ${item.find('.comment').text()}<br>
-                                <strong>Author:</strong> ${item.find('.attribution-team') ? item.find('.attribution-team').text() + ' -' : ''}${item.find('.attribution-user').text()}<br>
-                                <strong>Views:</strong> ${item.find('.views').text()}<br>
-                                <strong>Comment:</strong> ${item.find('.cmnt').text()}<br>
-                                <strong>Favor:</strong> ${item.find('.fav').text()}`,
-                            link: `https://dribbble.com${item.find('.animated-target').attr('href') ||
-                                item
-                                    .find('.extras > a')
-                                    .attr('href')
-                                    .replace('/rebounds', '')}`,
-                        };
-                    })
-                    .get(),
-        };
-    },
+    ProcessFeed,
 };


### PR DESCRIPTION
Completely rewrite the Dribbble route, to better conform to standard practices and to fix some issues.

- rewrote to acquire data via HTML page using got, as recommended in the Join Us documentation.  Also reformatted to be structured like the jianshu example.
- fixed the `pubDate` for each item
- show the full-size media in each item