### PR TITLE
feat: Add tag support for 9to5

### DIFF
--- a/docs/en/new-media.md
+++ b/docs/en/new-media.md
@@ -8,10 +8,10 @@ pageClass: routes
 
 ### 9To5 Sub-site
 
-<RouteEn author="HenryQW" example="/9to5/mac" path="/9to5/:type" :paramsDesc="['The sub-site name']">
+<RouteEn author="HenryQW" example="/9to5/mac/aapl" path="/9to5/:subsite/:category?" :paramsDesc="['Required - Subsite name', 'Optional - Tag name inside the url of the tag page']">
 
 Supported sub-sites：
-| Mac | Google | Toys |
+| 9To5Mac | 9To5Google | 9To5Toys |
 | --- | ------ | ---- |
 | Mac | Google | Toys |
 

--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -18,10 +18,10 @@ pageClass: routes
 
 ### 9To5 分站
 
-<Route author="HenryQW" example="/9to5/mac" path="/9to5/:type" :paramsDesc="['分站名字']">
+<Route author="HenryQW" example="/9to5/mac/aapl" path="/9to5/:subsite/:tag?" :paramsDesc="['必选 - 分站名字','标签 - 可选，可在文章标签 URL 中找到']">
 
 支持分站：
-| Mac | Google | Toys |
+| 9To5Mac | 9To5Google | 9To5Toys |
 | --- | ------ | ---- |
 | Mac | Google | Toys |
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -955,7 +955,7 @@ router.get('/gitea/blog', require('./routes/gitea/blog'));
 router.get('/idownloadblog', require('./routes/idownloadblog/index'));
 
 // 9to5
-router.get('/9to5/:type', require('./routes/9to5/subsite'));
+router.get('/9to5/:subsite/:tag?', require('./routes/9to5/subsite'));
 
 // TesterHome
 router.get('/testerhome/newest', require('./routes/testerhome/newest'));

--- a/lib/routes/9to5/subsite.js
+++ b/lib/routes/9to5/subsite.js
@@ -7,27 +7,34 @@ module.exports = async (ctx) => {
         link,
         description;
 
-    switch (ctx.params.type) {
+    switch (ctx.params.subsite) {
         case 'mac':
-            link = 'https://9to5mac.com/feed';
+            link = 'https://9to5mac.com';
             title += 'Mac';
             description = 'Apple News & Mac Rumors Breaking All Day';
             break;
 
         case 'google':
-            link = 'https://9to5google.com/feed';
+            link = 'https://9to5google.com';
             title += 'Google';
             description = 'Google, Pixel news, Android, Home, Chrome OS, apps, more';
             break;
 
         case 'toys':
-            link = 'https://9to5toys.com/feed';
+            link = 'https://9to5toys.com';
             title += 'Toys';
             description = 'New Gear, reviews and deals';
             break;
 
         default:
             break;
+    }
+
+    if (ctx.params.tag) {
+        link = `${link}/guides/${ctx.params.tag}/feed`;
+        title = `${ctx.params.tag} | ${title}`;
+    } else {
+        link = `${link}/feed`;
     }
 
     const feed = await parser.parseURL(link);


### PR DESCRIPTION
Added a new param `:tag` to provide optional tag support for 9to5 sites, e.g. `https://9to5mac.com/guides/aapl/`.
Changed param name `:type` to `:subsite` to prevent confusion.