### PR TITLE
fix: `LISTEN_INADDR_ANY` environment variable

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,7 @@ const calculateValue = () => {
             contentExpire: parseInt(envs.CACHE_CONTENT_EXPIRE) || 1 * 60 * 60, // 不变内容缓存时间，单位为秒
         },
         ua: envs.UA || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
-        listenInaddrAny: parseInt(envs.LISTEN_INADDR_ANY) || 1, // 是否允许公网连接，取值 0 1
+        listenInaddrAny: envs.LISTEN_INADDR_ANY || 1, // 是否允许公网连接，取值 0 1
         requestRetry: parseInt(envs.REQUEST_RETRY) || 2, // 请求失败重试次数
         // 是否显示 Debug 信息，取值 boolean 'false' 'key' ，取值为 'false' false 时永远不显示，取值为 'key' 时带上 ?debug=key 显示
         debugInfo: envs.DEBUG_INFO || true,


### PR DESCRIPTION
`export LISTEN_INADDR_ANY=0`  does not work as `0` is equal to false in node.  
Simply keeping it as string works, and it is later cast to integer in `index.js` anyway.
 