### PR TITLE
feat: Fix link in Github's PR

### DIFF
--- a/lib/routes/github/pulls.js
+++ b/lib/routes/github/pulls.js
@@ -9,6 +9,7 @@ module.exports = async (ctx) => {
     const repo = ctx.params.repo;
 
     const host = `https://github.com/${user}/${repo}/pulls`;
+    const link = `https://github.com/${user}/${repo}/pull`;
     const url = `https://api.github.com/repos/${user}/${repo}/pulls`;
 
     const response = await got({
@@ -28,7 +29,7 @@ module.exports = async (ctx) => {
             title: item.title,
             description: md.render(item.body) || 'No description',
             pubDate: new Date(item.created_at).toUTCString(),
-            link: `${host}/${item.number}`,
+            link: `${link}/${item.number}`,
         })),
     };
 };


### PR DESCRIPTION
The link to the PR list is: https://github.com/DIYgod/RSSHub/pulls
But the link to an individual PR is: https://github.com/DIYgod/RSSHub/pull/{PRnumber}

If the "s" is left, insted of redirecting to 
https://github.com/DIYgod/RSSHub/pull/1
it redirects to
https://github.com/DIYgod/RSSHub/pulls/1