### PR TITLE
feat: twitter 回复和转推

### DIFF
--- a/docs/en/social-media.md
+++ b/docs/en/social-media.md
@@ -112,7 +112,7 @@ Due to Telegram restrictions, some channels involving pornography, copyright, an
 
 ### User timeline
 
-<RouteEn path="/twitter/user/:id/:type?" example="/twitter/user/DIYgod" :paramsDesc="['user id', 'Extra options `include_replies` Include replies,`include_rts` Include retweets,`include_rts_replies` Include replies and retweets，for default `include_replies` include replies']" radar="1" />
+<RouteEn path="/twitter/user/:id/:type?" example="/twitter/user/DIYgod" :paramsDesc="['user id', 'Extra options `exclude_replies` exclude replies,`exclude_rts` exclude retweets,`exclude_rts_replies` exclude replies and retweets, for default include all.']" radar="1" />
 
 ## User following timeline
 

--- a/docs/en/social-media.md
+++ b/docs/en/social-media.md
@@ -112,7 +112,7 @@ Due to Telegram restrictions, some channels involving pornography, copyright, an
 
 ### User timeline
 
-<RouteEn path="/twitter/user/:id" example="/twitter/user/DIYgod" :paramsDesc="['user id']" radar="1" />
+<RouteEn path="/twitter/user/:id/:type?" example="/twitter/user/DIYgod" :paramsDesc="['user id', 'Extra options `include_replies` Include replies,`include_rts` Include retweets,`include_rts_replies` Include replies and retweets，for default `include_replies` include replies']" radar="1" />
 
 ## User following timeline
 

--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -382,7 +382,7 @@ Tiny Tiny RSS 会给所有 iframe 元素添加 `sandbox="allow-scripts"` 属性�
 
 ### 用户时间线
 
-<Route author="DIYgod" example="/twitter/user/DIYgod" path="/twitter/user/:id/:type?" :paramsDesc="['用户名', '额外选项 `include_replies`包含回复，`include_rts`包含转推，`include_rts_replies`全部包含，默认 `include_replies`包含回复']" radar="1"/>
+<Route author="DIYgod" example="/twitter/user/DIYgod" path="/twitter/user/:id/:type?" :paramsDesc="['用户名', '额外选项 `exclude_replies`去除回复，`exclude_rts`去除转推，`exclude_rts_replies`去除回复和转推，默认包含全部回复和转推。']" radar="1"/>
 
 ### 用户关注时间线
 

--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -382,7 +382,7 @@ Tiny Tiny RSS 会给所有 iframe 元素添加 `sandbox="allow-scripts"` 属性�
 
 ### 用户时间线
 
-<Route author="DIYgod" example="/twitter/user/DIYgod" path="/twitter/user/:id" :paramsDesc="['用户名']" radar="1"/>
+<Route author="DIYgod" example="/twitter/user/DIYgod" path="/twitter/user/:id/:type?" :paramsDesc="['用户名', '额外选项 `include_replies`包含回复，`include_rts`包含转推，`include_rts_replies`全部包含，默认 `include_replies`包含回复']" radar="1"/>
 
 ### 用户关注时间线
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -196,7 +196,7 @@ router.get('/jinritoutiao/keyword/:keyword', require('./routes/jinritoutiao/keyw
 router.get('/disqus/posts/:forum', require('./routes/disqus/posts'));
 
 // Twitter
-router.get('/twitter/user/:id', require('./routes/twitter/user'));
+router.get('/twitter/user/:id/:type?', require('./routes/twitter/user'));
 router.get('/twitter/list/:id/:name', require('./routes/twitter/list'));
 router.get('/twitter/likes/:id', require('./routes/twitter/likes'));
 router.get('/twitter/followings/:id', require('./routes/twitter/followings'));

--- a/lib/routes/twitter/user.js
+++ b/lib/routes/twitter/user.js
@@ -7,18 +7,20 @@ module.exports = async (ctx) => {
     }
 
     const id = ctx.params.id;
-    const type = ctx.params.type || 'include_replies';
+    const type = ctx.params.type;
     let exclude_replies = false;
-    let include_rts = false;
-    if (type === 'include_replies') {
-        exclude_replies = false;
+    let include_rts = true;
+    if (type === 'exclude_rts_replies' || type === 'exclude_replies_rts') {
+        exclude_replies = true;
         include_rts = false;
-    } else if (type === 'include_rts') {
+    }
+    if (type === 'exclude_replies') {
         exclude_replies = true;
         include_rts = true;
-    } else if (type === 'include_rts_replies') {
+    }
+    if (type === 'exclude_rts') {
         exclude_replies = false;
-        include_rts = true;
+        include_rts = false;
     }
     const result = await utils.getTwit().get('statuses/user_timeline', {
         screen_name: id,

--- a/lib/routes/twitter/user.js
+++ b/lib/routes/twitter/user.js
@@ -7,9 +7,24 @@ module.exports = async (ctx) => {
     }
 
     const id = ctx.params.id;
+    const type = ctx.params.type || 'include_replies';
+    let exclude_replies = false;
+    let include_rts = false;
+    if (type === 'include_replies') {
+        exclude_replies = false;
+        include_rts = false;
+    } else if (type === 'include_rts') {
+        exclude_replies = true;
+        include_rts = true;
+    } else if (type === 'include_rts_replies') {
+        exclude_replies = false;
+        include_rts = true;
+    }
     const result = await utils.getTwit().get('statuses/user_timeline', {
         screen_name: id,
         tweet_mode: 'extended',
+        exclude_replies,
+        include_rts,
     });
     const data = result.data;
     const userInfo = data[0].user;


### PR DESCRIPTION
close #3808 

路由改为 `/twitter/user/:id/:type?`

#### 参数 type
额外选项 `exclude_replies`去除回复，`exclude_rts`去除转推，`exclude_rts_replies`去除回复和转推，默认包含全部回复和转推。

不会影响原本的订阅。