### PR TITLE
fix: typo bangumi/group/topic.js

### DIFF
--- a/lib/routes/bangumi/group/topic.js
+++ b/lib/routes/bangumi/group/topic.js
@@ -19,7 +19,7 @@ module.exports = async (ctx) => {
                 link: resolve_url(base_url, $('.subject a', elem).attr('href')),
                 title: $('.subject a', elem).attr('title'),
                 pubDate: new Date($('.lastpost .time', elem).text()).toUTCString(),
-                description: 'Author: ' + $('.author a', elem).text() + '<br>' + 'Replay: ' + $('.posts', elem).text(),
+                description: 'Author: ' + $('.author a', elem).text() + '<br>' + 'Reply: ' + $('.posts', elem).text(),
             }))
             .get(),
     };


### PR DESCRIPTION
描述文本拼写错误。回复的英文是reply，或者直接用中文'回复：'。