### PR TITLE
fix: full text error in discuz

### DIFF
--- a/lib/routes/discuz/discuz.js
+++ b/lib/routes/discuz/discuz.js
@@ -25,11 +25,14 @@ async function load(baseUrl, itemLink, ctx, charset) {
     // 处理编码问题
     let responseData;
     if (charset === 'utf-8') {
-        responseData = await got.get(itemLink).data;
+        responseData = (await got.get(itemLink)).data;
     } else {
         responseData = iconv.decode((await got.get({ url: itemLink, responseType: 'buffer' })).data, charset);
     }
-
+    if (!responseData) {
+        const description = '获取详细内容失败';
+        return { description };
+    }
     const $ = cheerio.load(responseData);
     // 只抓取论坛1楼消息
     const description = $('div#postlist div[id^=post] td[id^=postmessage]')


### PR DESCRIPTION
- 增加对正文页面内容获取失败进行判断，防止获取失败导致路由故障
- 修复对UTF-8编码的正文内容获取失败