### PR TITLE
fix: error in nowcoder/discuss

### DIFF
--- a/lib/routes/nowcoder/discuss.js
+++ b/lib/routes/nowcoder/discuss.js
@@ -25,10 +25,8 @@ module.exports = async (ctx) => {
                     .trim()
                     .replace('\n', ' '),
                 link: $(this)
-                    .find('div.discuss-main.clearfix a')
-                    .attr('href')
-                    .match(/^\/discuss\/[0-9]*/gm)
-                    .toString(),
+                    .find('div.discuss-main.clearfix a[rel]')
+                    .attr('href'),
             };
             return info;
         })
@@ -51,9 +49,7 @@ module.exports = async (ctx) => {
                 .text()
                 .split('  ')[1];
 
-            const description = $('.nc-post-content')
-                .html()
-                .trim();
+            const description = $('.nc-post-content').html();
 
             const single = {
                 title: title,


### PR DESCRIPTION
close #3873

### 报错原因
原路由`link` 使用正则匹配过滤，部分正确`link`不匹配正则表达式，导致空指针异常。

### 解决方法
使用CSS选择器限定正确链接元素