### PR TITLE
fix: hackerone hacktivity replace null severity

### DIFF
--- a/lib/routes/hackerone/hacktivity.js
+++ b/lib/routes/hackerone/hacktivity.js
@@ -32,7 +32,7 @@ module.exports = async (ctx) => {
             const author = item.node.reporter.username;
             const vendor = item.node.team.name;
             const state = item.node.report.substate.replace(/^[a-z]/g, (L) => L.toUpperCase());
-            const severity = item.node.severity_rating.replace(/^[a-z]/g, (L) => L.toUpperCase());
+            const severity = item.node.severity_rating ? item.node.severity_rating.replace(/^[a-z]/g, (L) => L.toUpperCase()) : 'No Rating';
             const awarded = item.node.total_awarded_amount ? item.node.total_awarded_amount : 0;
             return {
                 title: item.node.report.title,


### PR DESCRIPTION
修复了当 severity 为 null 时的报错