### PR TITLE
fix: ignore the latest chapter when not updated

### DIFF
--- a/lib/routes/novel/axdzs.js
+++ b/lib/routes/novel/axdzs.js
@@ -20,13 +20,33 @@ module.exports = async (ctx) => {
     const lastChapter = $('.chapter')
         .last()
         .children();
-    const chapterUrl = novelUrl + lastChapter.attr('href');
-    const chapterTitle = lastChapter.text();
-    const chapterContent = await ctx.cache.tryGet(chapterUrl, async () => {
-        const lastChapter = await got.get(chapterUrl);
-        const $ = cheerio.load(lastChapter.data);
+    const secondChapter = $('.chapter')
+        .last()
+        .prev()
+        .children();
+    const lastChapterUrl = novelUrl + lastChapter.attr('href');
+    const secondChapterUrl = novelUrl + secondChapter.attr('href');
+    const lastChapterContent = await ctx.cache.tryGet(lastChapterUrl, async () => {
+        const lastChapter = await got.get(lastChapterUrl);
+        const $ = cheerio.load(lastChapter.data, { decodeEntities: false });
         return $('.content').html();
     });
+    // 以下需要判断最新章节是否已填充内容
+    let chapterTitle, chapterUrl, chapterContent;
+    // 判断新章节内是否存在无内容的提示信息，如存在则请求上一章节数据
+    if (lastChapterContent.indexOf('鍦ㄦ洿鏂颁腑锛岃绋嶅悗鍒锋') === -1) {
+        chapterTitle = lastChapter.text();
+        chapterUrl = lastChapterUrl;
+        chapterContent = lastChapterContent;
+    } else {
+        chapterTitle = secondChapter.text();
+        chapterUrl = secondChapterUrl;
+        chapterContent = await ctx.cache.tryGet(secondChapterUrl, async () => {
+            const secondChapter = await got.get(secondChapterUrl);
+            const $ = cheerio.load(secondChapter.data, { decodeEntities: false });
+            return $('.content').html();
+        });
+    }
     ctx.state.data = {
         title: `爱下电子书-${title}`,
         description: description,


### PR DESCRIPTION
很多情况下，`爱下电子书`会首先更新章节列表，最新章节内容并不实时更新，而是显示
```c
鍦ㄦ洿鏂颁腑锛岃绋嶅悗鍒锋柊鏌ョ湅锛（即：在更新中，�稍后刷新查看�）
```
所以修改为：在请求最新章节内容时，如果发现这部分内容则说明章节内容未更新，转而请求上一章节。