### PR TITLE
feat: add route coronavirus/sg-moh

### DIFF
--- a/docs/other.md
+++ b/docs/other.md
@@ -430,6 +430,10 @@ type 为 all 时，category 参数不支持 cost 和 free
 | ---- | ---- | ---- |
 | ch   | en   | pt   |
 
+### Singapore Ministry of Health - Past Updates on 2019-nCov Local Situation in Singapore
+
+<Route author="Gnnng" example="/coronavirus/sg-moh" path="/coronavirus/sg-moh"/>
+
 ## 新趣集
 
 > 官方 Feed 地址为: [https://xinquji.com/rss](https://xinquji.com/rss)

--- a/lib/router.js
+++ b/lib/router.js
@@ -2175,6 +2175,7 @@ router.get('/coronavirus/scmp', require('./routes/coronavirus/scmp'));
 router.get('/coronavirus/nhc', require('./routes/coronavirus/nhc'));
 router.get('/coronavirus/mogov-2019ncov/:lang', require('./routes/coronavirus/mogov-2019ncov'));
 router.get('/coronavirus/qq/fact', require('./routes/tencent/factcheck'));
+router.get('/coronavirus/sg-moh', require('./routes/coronavirus/sg-moh'));
 
 // 南京林业大学教务处
 router.get('/njfu/jwc/:category?', require('./routes/universities/njfu/jwc'));

--- a/lib/routes/coronavirus/sg-moh.js
+++ b/lib/routes/coronavirus/sg-moh.js
@@ -1,0 +1,49 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+
+module.exports = async (ctx) => {
+    const dataUrl = 'https://www.moh.gov.sg/2019-ncov-wuhan/past-updates';
+    const response = await got({
+        method: 'get',
+        url: dataUrl,
+    });
+
+    const $ = cheerio.load(response.data);
+    const list = $('section.body-content div.sfContentBlock:nth-of-type(2) table tr').slice(1, 21);
+
+    const items = list
+        .filter((_, item) => {
+            item = $(item);
+            const dateRaw = item
+                .find('td:first-child')
+                .text()
+                .trim();
+            return dateRaw !== 'Date';
+        })
+        .map((_, item) => {
+            item = $(item);
+            const title = `${item
+                .find('a')
+                .first()
+                .text()}`;
+            const dateRaw = item
+                .find('td:first-child')
+                .text()
+                .trim();
+            const pubDate = Date.parse(dateRaw) && dateRaw;
+            const link = item.find('a').attr('href');
+            return {
+                title,
+                pubDate,
+                link,
+            };
+        })
+        .get();
+
+    ctx.state.data = {
+        title: 'Past Updates On 2019-NCOV Local Situation',
+        link: dataUrl,
+        description: 'Past Updates On 2019-NCOV Local Situation',
+        item: items,
+    };
+};


### PR DESCRIPTION
This PR adds another 2019 coronavirus feed about Singapore's local situation. 