### PR TITLE
fix: restore github api querystring

### DIFF
--- a/lib/routes/github/file.js
+++ b/lib/routes/github/file.js
@@ -1,5 +1,6 @@
 const got = require('@/utils/got');
 const config = require('@/config').value;
+const queryString = require('query-string');
 
 module.exports = async (ctx) => {
     const user = ctx.params.user;
@@ -14,6 +15,10 @@ module.exports = async (ctx) => {
         headers.Authorization = `token ${config.github.access_token}`;
     }
     const res = await got.get(`https://api.github.com/repos/${user}/${repo}/commits`, {
+        searchParams: queryString.stringify({
+            sha: branch,
+            path: filepath,
+        }),
         headers,
     });
     const list = res.data;


### PR DESCRIPTION
Fix #3962

https://github.com/DIYgod/RSSHub/commit/120d1ed38a6f36835191122b0a81e9641bba9983#diff-7bf72f9bacdd99e5af9323d22819a61aL14