### PR TITLE
feat: add 清华大学

### DIFF
--- a/docs/university.md
+++ b/docs/university.md
@@ -776,6 +776,18 @@ https://rsshub.app/**nuist**/`bulletin` 或 https://rsshub.app/**nuist**/`bullet
 
 </Route>
 
+## 清华大学
+
+### 清华大学校内信息发布平台
+
+<Route author="prnake" example="/thu/zhongyao" path="/thu/:type" :paramsDesc="['默认为重要公告']">
+
+| 重要公告 | 教务公告 | 科研通知 | 办公通知 | 海报列表 | 疫情防控 |
+| -------- | -------- | -------- | -------- | -------- | :------: |
+| zhongyao | jiaowu   | keyan    | bangong  | haibao   |  yiqing  |
+
+</Route>
+
 ## 山东大学
 
 ### 软件学院通知

--- a/lib/router.js
+++ b/lib/router.js
@@ -583,6 +583,9 @@ router.get('/lit/jwc', require('./routes/universities/lit/jwc'));
 router.get('/lit/xwzx/:name?', require('./routes/universities/lit/xwzx'));
 router.get('/lit/tw/:name?', require('./routes/universities/lit/tw'));
 
+// 清华大学
+router.get('/thu/:type', require('./routes/universities/thu/index'));
+
 // 北京大学
 router.get('/pku/eecs/:type?', require('./routes/universities/pku/eecs'));
 router.get('/pku/rccp/mzyt', require('./routes/universities/pku/rccp/mzyt'));

--- a/lib/routes/universities/thu/index.js
+++ b/lib/routes/universities/thu/index.js
@@ -1,0 +1,92 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const resolve_url = require('url').resolve;
+
+const base_url = 'https://thu.pka.moe';
+const news_url = 'https://thu.pka.moe/http/77726476706e69737468656265737421e0f852882e3e6e5f301c9aa596522b2043f84ba24ebecaf8/f/';
+
+module.exports = async (ctx) => {
+    const type = ctx.params.type;
+    let title,
+        path,
+        kind = 0;
+    switch (type) {
+        case 'zhongyao':
+            title = '重要公告';
+            path = 'zhongyaogonggao/more';
+            kind = 1;
+            break;
+        case 'keyan':
+            title = '科研通知';
+            path = 'keyantongzhi/more';
+            break;
+        case 'bangong':
+            title = '办公通知';
+            path = 'bangongtongzhi/more';
+            break;
+        case 'jiaowu':
+            title = '教务公告';
+            path = 'jiaowugonggao/more';
+            break;
+        case 'haibao':
+            title = '海报列表';
+            path = 'haibao/more';
+            break;
+        case 'yiqing':
+            title = '疫情防控';
+            path = 'yiqingfangkong/more';
+            kind = 1;
+            break;
+        default:
+            title = '重要公告';
+            path = 'zhongyaogonggao/more';
+            kind = 1;
+    }
+
+    const response = await got({
+        method: 'get',
+        url: news_url + path,
+        headers: {
+            Referer: base_url,
+        },
+    });
+
+    const $ = cheerio.load(response.data);
+    if (kind === 1) {
+        ctx.state.data = {
+            title: '清华大学 - ' + title,
+            link: news_url + path,
+            description: '清华大学内网信息发布平台 - ' + title,
+            item: $('table>tbody>tr')
+                .slice(0, 10)
+                .map((_, elem) => ({
+                    link: resolve_url(base_url, $('td>a', elem).attr('href')),
+                    title: $('td>a', elem).text(),
+                    pubDate: new Date(
+                        $('td>font>span', elem)
+                            .text()
+                            .replace(/(\d+).(\d+).(\d+).(\d+)/, '2020-$1-$2T$3:$4')
+                    ).toUTCString(),
+                }))
+                .get(),
+        };
+    } else {
+        ctx.state.data = {
+            title: '清华大学 - ' + title,
+            link: news_url + path,
+            description: '清华大学内网信息发布平台 - ' + title,
+            item: $('.cont_list>li')
+                .slice(0, 10)
+                .map((_, elem) => ({
+                    link: resolve_url(base_url, $('a', elem).attr('href')),
+                    title: $('a', elem).text(),
+                    pubDate: new Date(
+                        $('time', elem)
+                            .text()
+                            .replace(/(\d+).(\d+).(\d+)/, '$1-$2-$3')
+                    ).toUTCString(),
+                }))
+                .get(),
+        };
+    }
+};


### PR DESCRIPTION
由于[清华信息门户](http://info.tsinghua.edu.cn/)屏蔽非校内网访问，因此使用了一个反向代理（见https://psmoe.com/474.html）。
[清华大学新闻网](https://news.tsinghua.edu.cn/)由于没有需求，暂时未加入。