### PR TITLE
fix: remove redundant `>`

### DIFF
--- a/lib/views/rss.art
+++ b/lib/views/rss.art
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss  xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"
 {{ if itunes_author }}
- xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
 {{ else if item && item.some((i) => i.media) }}
   xmlns:media="http://search.yahoo.com/mrss/"
 {{ /if }}


### PR DESCRIPTION
There is a redundant `>` before `<channel>` tag
see https://rsshub.app/ximalaya/album/32820143/
