### PR TITLE
fix: 浙江大学软件学院项目链接bug

### DIFF
--- a/lib/routes/universities/zju/cst/index.js
+++ b/lib/routes/universities/zju/cst/index.js
@@ -53,14 +53,14 @@ module.exports = async (ctx) => {
         });
         ctx.state.data = {
             title: '浙大软件学院-全部通知',
-            link: host + 'NULL',
+            link: host,
             item: items,
         };
     } else {
         const id = map.get(type).id;
         ctx.state.data = {
             title: map.get(type).title,
-            link: host + `${id}`,
+            link: host + `${id}` + '/list.htm',
             item: await getPage(id),
         };
     }


### PR DESCRIPTION
修复了浙江大学软件学院所有项目链接bug

修复前：
![image](https://tva1.sinaimg.cn/large/0082zybpgy1gc3tswb1bzj311j0u0akt.jpg)

修复后：
![image](https://tva1.sinaimg.cn/large/0082zybpgy1gc3tznn0nyj31i40o4tg0.jpg)

这个fix或许可以解决「当前页面上的 RSS不显示」的问题。

![image](https://tva1.sinaimg.cn/large/0082zybpgy1gc3tqiyv6zj31j90u07pu.jpg)