### PR TITLE
fix: url does not exist in 清华大学 & feet: add 洛谷近期比赛 & fix: 洛谷日报

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -593,12 +593,6 @@ Supported sub-sites：
 
 <Route author="xyqfer" example="/laosiji/hotshow/128" path="/laosiji/hotshow/:id" :paramsDesc="['节目 id']"/>
 
-## 洛谷
-
-### 日报
-
-<Route author="LogicJake" example="/luogu/daily" path="/luogu/daily/:id?" :paramsDesc="['年度日报所在帖子id，可在 URL 中找到，不填默认为2019年日报']"/>
-
 ## 镁客网 im2maker
 
 ### 镁客网频道

--- a/docs/programming.md
+++ b/docs/programming.md
@@ -496,6 +496,18 @@ GitHub 官方也提供了一些 RSS:
 
 <Route author="loveely7" example="/oschina/topic/weekly-news" path="/oschina/topic/:topic" :paramsDesc="['主题名, 可从[全部主题](https://www.oschina.net/question/topics)进入主题页, 在 URL 中找到']"/>
 
+## 洛谷
+
+### 日报
+
+<Route author="LogicJake prnake" example="/luogu/daily" path="/luogu/daily/:id?" :paramsDesc="['年度日报所在帖子id，可在 URL 中找到，不填默认为2020年日报']">
+</Route>
+
+### 近期比赛
+
+<Route author="prnake" example="/luogu/contest" path="/luogu/contest">
+</Route>
+
 ## 码农俱乐部
 
 ### 话题

--- a/lib/router.js
+++ b/lib/router.js
@@ -1250,8 +1250,9 @@ router.get('/12306/zxdt/:id?', require('./routes/12306/zxdt'));
 // 北京天文馆每日一图
 router.get('/bjp/apod', require('./routes/bjp/apod'));
 
-// 洛谷日报
+// 洛谷
 router.get('/luogu/daily/:id?', require('./routes/luogu/daily'));
+router.get('/luogu/contest', require('./routes/luogu/contest'));
 
 // 决胜网
 router.get('/juesheng', require('./routes/juesheng'));

--- a/lib/routes/luogu/contest.js
+++ b/lib/routes/luogu/contest.js
@@ -1,0 +1,41 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const resolve_url = require('url').resolve;
+
+module.exports = async (ctx) => {
+    const link = 'https://www.luogu.com.cn/';
+    const response = await got.get(link);
+    const $ = cheerio.load(response.data);
+    const title = '洛谷近期比赛';
+
+    const out = $('.am-panel-hd ')
+        .slice(0, 10)
+        .map(function() {
+            const info = {
+                title:
+                    $(this)
+                        .find('a')
+                        .text() || $(this).text(),
+                description:
+                    $(this).html() +
+                    $(this)
+                        .parent()
+                        .find('.am-panel-bd')
+                        .html(),
+                link: resolve_url(
+                    'https://www.luogu.com.cn',
+                    $(this)
+                        .find('a')
+                        .attr('href')
+                ),
+            };
+            return info;
+        })
+        .get();
+
+    ctx.state.data = {
+        title: title,
+        link: link,
+        item: out,
+    };
+};

--- a/lib/routes/luogu/daily.js
+++ b/lib/routes/luogu/daily.js
@@ -2,12 +2,11 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
-    const id = ctx.params.id || 92685;
-
+    const id = ctx.params.id || 179788;
     const link = `https://www.luogu.org/discuss/show/${id}`;
     const response = await got.get(link);
     const $ = cheerio.load(response.data);
-    const title = $('#app-body-new div h1').text();
+    const title = $('title').text();
 
     const out = $('div.am-comment-main > div > p')
         .slice(0, 10)

--- a/lib/routes/universities/thu/index.js
+++ b/lib/routes/universities/thu/index.js
@@ -60,8 +60,8 @@ module.exports = async (ctx) => {
             item: $('table>tbody>tr')
                 .slice(0, 10)
                 .map((_, elem) => ({
-                    link: resolve_url(base_url, $('td>a', elem).attr('href')),
-                    title: $('td>a', elem).text(),
+                    link: get_link($('td>a', elem).attr('href'), news_url + path),
+                    title: get_title($('td>a', elem).text(), $('td', elem).text()),
                     pubDate: new Date(
                         $('td>font>span', elem)
                             .text()
@@ -78,8 +78,8 @@ module.exports = async (ctx) => {
             item: $('.cont_list>li')
                 .slice(0, 10)
                 .map((_, elem) => ({
-                    link: resolve_url(base_url, $('a', elem).attr('href')),
-                    title: $('a', elem).text(),
+                    link: get_link($('a', elem).attr('href'), news_url + path),
+                    title: get_title($('a', elem).text(), $.text()),
                     pubDate: new Date(
                         $('time', elem)
                             .text()
@@ -90,3 +90,18 @@ module.exports = async (ctx) => {
         };
     }
 };
+
+function get_link(url, alter_url) {
+    if (url !== undefined) {
+        return resolve_url(base_url, url);
+    } else {
+        return alter_url;
+    }
+}
+
+function get_title(title, data) {
+    if (title) {
+        return title;
+    }
+    return data;
+}


### PR DESCRIPTION
**fix: url does not exist in 清华大学**
解决清华新闻列表的不规范引发的Bug，在新闻缺少链接时会使用板块链接替代。
**add 洛谷近期比赛**
由于找不到[洛谷比赛页面](https://www.luogu.com.cn/contest/list)的解析方式故从[洛谷首页](https://www.luogu.com.cn/)获取最近比赛信息（我太菜了）
**fix: 洛谷日报**
将“洛谷”从“新媒体”移动至“编程”页面。
解决目前洛谷日报获取不到标题的问题。
将默认切换至2020年日报。