### PR TITLE
fix: docker hub get tag api directly

### DIFF
--- a/lib/routes/dockerhub/build.js
+++ b/lib/routes/dockerhub/build.js
@@ -7,23 +7,23 @@ module.exports = async (ctx) => {
 
     const link = `https://hub.docker.com/r/${namespace}`;
 
-    const data = await got.get(`https://hub.docker.com/v2/repositories/${namespace}/tags/?page_size=5`);
-    const metadata = await got.get(`https://hub.docker.com/v2/repositories/${namespace}`);
+    const data = await got.get(`https://hub.docker.com/v2/repositories/${namespace}/tags/${tag}`);
+    const metadata = await got.get(`https://hub.docker.com/v2/repositories/${namespace}/`);
 
-    const list = data.data.results.filter((a) => a.name === tag);
-
-    const out = list.map((item) => ({
-        title: `${namespace}:${tag} was built. ${(item.images[0].size / 1000000).toFixed(2)} MB`,
-        link,
-        author: owner,
-        pubDate: new Date(item.last_updated).toUTCString(),
-        guid: item.last_updated,
-    }));
+    const item = data.data;
 
     ctx.state.data = {
         title: `${namespace}:${tag} build history`,
-        description: metadata.description,
+        description: metadata.data.description,
         link,
-        item: out,
+        item: [
+            {
+                title: `${namespace}:${tag} was built. ${(item.images[0].size / 1000000).toFixed(2)} MB`,
+                link: `https://hub.docker.com/layers/docker/${namespace}/${tag}/images/${item.images[0].digest.replace(':', '-')}`,
+                author: owner,
+                pubDate: new Date(item.last_updated).toUTCString(),
+                guid: item.last_updated,
+            },
+        ],
     };
 };


### PR DESCRIPTION
Fix #4300