### PR TITLE
fix: agefans title typo and link double slash

### DIFF
--- a/lib/routes/agefans/detail.js
+++ b/lib/routes/agefans/detail.js
@@ -15,13 +15,13 @@ module.exports = async (ctx) => {
         .map((idx, item) => ({
             title: $(item).text(),
             description: $(item).text(),
-            link: `https://www.agefans.tv/${$(item).attr('href')}`,
+            link: `https://www.agefans.tv${$(item).attr('href')}`,
         }))
         .get();
     items.reverse();
 
     ctx.state.data = {
-        title: `ACG动漫 - ${$('.detail_imform_name').text()}`,
+        title: `AGE动漫 - ${$('.detail_imform_name').text()}`,
         link: `https://www.agefans.tv/detail/${ctx.params.id}`,
         description: $('.detail_imform_desc_pre').text(),
         item: items,


### PR DESCRIPTION
1. title typo: `ACG动漫` should be `AGE动漫`.
1. double slash: `$(item).attr('href')` already starts with slash.