### PR TITLE
fix: 404 for pm2 docs

### DIFF
--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -160,7 +160,7 @@ Or
 $ yarn start
 ```
 
-Or use [PM2](https://pm2.io/doc/zh/runtime/quick-start/)
+Or use [PM2](https://pm2.io/docs/plus/quick-start/)
 
 ```bash
 $ pm2 start lib/index.js --name rsshub


### PR DESCRIPTION
Hi, this here fxes an 404 on the docs page to pm2

Thanks 