### PR TITLE
fix: wenxuemi remove slice for cache check

### DIFF
--- a/lib/routes/novel/wenxuemi.js
+++ b/lib/routes/novel/wenxuemi.js
@@ -44,7 +44,7 @@ module.exports = async (ctx) => {
                     description: res.html(),
                     link: link,
                 };
-                if (res.text().slice(0, 10).includes('正在手打中') === false) {
+                if (res.text().includes('正在手打中') === false) {
                     ctx.cache.set(link, JSON.stringify(resultItem));
                 }
             }


### PR DESCRIPTION
The message, which hints the article is not ready, is like this:
```
看最快更新无错小说，请记住 https://www.wenxuemi6.com/！章节内容正在手打中，请稍等片刻，内容更新后，请重新刷新页面，即可获取最新更新！
```
The router check if there is a "正在手打中" in the first ten chars of text, so the check doesn't work as expected.
I remove the `slice` to fix the problem.