### PR TITLE
fix: route to github website instead of baidu when error

### DIFF
--- a/lib/routes/universities/tjpyu/ooa.js
+++ b/lib/routes/universities/tjpyu/ooa.js
@@ -2,7 +2,7 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 
 const ooa_base_url = 'http://oaa.tju.edu.cn/';
-const repo_url = 'https://www.baidu.com';
+const repo_url = 'https://github.com/DIYgod/RSSHub/issues';
 
 module.exports = async (ctx) => {
     const type = ctx.params && ctx.params.type;


### PR DESCRIPTION
I forgot to change the trouble shooting URL to this github repo's issues URL before, and sometimes rsshub can not response the request from my feedom client in time, it lists baidu's URL and looks very strange...