### PR TITLE
feat: Support itunes_category and itunes_explicit

### DIFF
--- a/lib/routes/ximalaya/album.js
+++ b/lib/routes/ximalaya/album.js
@@ -66,6 +66,8 @@ module.exports = async (ctx) => {
                 enclosure_url: enclosure_url,
                 enclosure_length: enclosure_length,
                 enclosure_type: 'audio/x-m4a',
+                itunes_category: album_category,
+                itunes_explicit: 'clean', // 内容是否为限制级
             };
             return Promise.resolve(resultItem);
         })

--- a/lib/views/rss.art
+++ b/lib/views/rss.art
@@ -35,6 +35,8 @@
             {{ if $value.itunes_item_image }}<itunes:image href="{{ $value.itunes_item_image }}"/>{{ /if }}
             {{ if $value.enclosure_url }}<enclosure url="{{ $value.enclosure_url }}" {{ if $value.enclosure_length }}length="{{ $value.enclosure_length }}"{{ /if }} {{ if $value.enclosure_type }}type="{{ $value.enclosure_type }}"{{ /if }} />{{ /if }}
             {{ if itunes_author && $value.itunes_duration }}<itunes:duration>{{ $value.itunes_duration }}</itunes:duration> {{ /if }}
+            {{ if itunes_author && $value.itunes_category }}<itunes:category>{{ $value.itunes_category }}</itunes:category> {{ /if }}
+            {{ if itunes_author && $value.itunes_explicit }}<itunes:explicit>{{ $value.itunes_explicit }}</itunes:explicit> {{ /if }}
             {{ if $value.author }}<author><![CDATA[{{ $value.author }}]]></author>{{ /if }}
             {{ if typeof $value.category === 'string' }}
             <category>{{ $value.category }}</category>


### PR DESCRIPTION
支持提交到 itunes podcast 审核，需要再添加这两个标签

其中 itunes_explicit 标记内容是 true 则是露骨成人内容，如果是 clean 或者 false 则代表清洁版

参考地址：
https://rfwilmut.net/notes/itunestags.html