### PR TITLE
feat: 改进豆瓣热门图书排行路由

### DIFF
--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -574,11 +574,11 @@ Tiny Tiny RSS 会给所有 iframe 元素添加 `sandbox="allow-scripts"` 属性�
 
 ### 热门图书排行
 
-<Route author="xyqfer" example="/douban/book/rank/fiction" path="/douban/book/rank/:type" :paramsDesc="['图书类型']">
+<Route author="xyqfer queensferryme" example="/douban/book/rank/fiction" path="/douban/book/rank/:type?" :paramsDesc="['图书类型，默认合并列表']">
 
-| 虚构    | 非虚构     |
-| ------- | ---------- |
-| fiction | nonfiction |
+| 全部 | 虚构    | 非虚构     |
+| ---- | ------- | ---------- |
+|      | fiction | nonfiction |
 
 </Route>
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -162,7 +162,7 @@ router.get('/douban/book/latest', require('./routes/douban/latest_book'));
 router.get('/douban/event/hot/:locationId', require('./routes/douban/event/hot'));
 router.get('/douban/commercialpress/latest', require('./routes/douban/commercialpress/latest'));
 router.get('/douban/bookstore', require('./routes/douban/bookstore'));
-router.get('/douban/book/rank/:type', require('./routes/douban/book/rank'));
+router.get('/douban/book/rank/:type?', require('./routes/douban/book/rank'));
 router.get('/douban/doulist/:id', require('./routes/douban/doulist'));
 router.get('/douban/explore/column/:id', require('./routes/douban/explore_column'));
 router.get('/douban/people/:userid/status', require('./routes/douban/people/status.js'));

--- a/lib/routes/douban/book/rank.js
+++ b/lib/routes/douban/book/rank.js
@@ -1,22 +1,24 @@
 const got = require('@/utils/got');
 
 module.exports = async (ctx) => {
-    const { type = 'fiction' } = ctx.params;
-    const referer = `https://m.douban.com/subject_collection/book_${type}_hot_weekly`;
+    const { type = '' } = ctx.params;
+    const referer = `https://m.douban.com/book/${type}`;
 
-    const response = await got({
-        method: 'get',
-        url: `https://m.douban.com/rexxar/api/v2/subject_collection/book_${type}_hot_weekly/items?start=0&count=10`,
-        headers: {
-            Referer: referer,
-        },
-    });
+    const _ = async (type) => {
+        const response = await got({
+            url: `https://m.douban.com/rexxar/api/v2/subject_collection/book_${type}_hot_weekly/items?start=0&count=10`,
+            headers: { Referer: referer },
+        });
+        return response.data.subject_collection_items;
+    };
+
+    const items = type ? await _(type) : [...(await _('fiction')), ...(await _('nonfiction'))];
 
     ctx.state.data = {
-        title: `豆瓣热门图书-${type === 'fiction' ? '虚构类' : '非虚构类'}`,
+        title: `豆瓣热门图书-${type ? (type === 'fiction' ? '虚构类' : '非虚构类') : '全部'}`,
         link: referer,
         description: '每周一更新',
-        item: response.data.subject_collection_items.map(({ title, url, cover, info, rating, null_rating_reason }) => {
+        item: items.map(({ title, url, cover, info, rating, null_rating_reason }) => {
             const rate = rating ? `${rating.value.toFixed(1)}分` : null_rating_reason;
             const description = `<img src="${cover.url}"><br>
               ${title}/${info}/${rate}


### PR DESCRIPTION
> **docs**: https://docs.rsshub.app/social-media.html#re-men-tu-shu-pai-hang

允许将虚构类 `/douban/book/rank/fiction` 与非虚构类 `/douban/book/rank/nonfiction` 合并到一个路由 `/douban/book/rank`，方便同时关注两类热门图书排行的读者订阅。