### PR TITLE
fix: 修正微信公众号路由（传送门来源以及CareerEngine来源）中的图片链接

### DIFF
--- a/lib/routes/tencent/wechat/ce.js
+++ b/lib/routes/tencent/wechat/ce.js
@@ -12,10 +12,18 @@ module.exports = async (ctx) => {
             const response = await got.get(item.link);
 
             const $ = cheerio.load(response.data);
+            const post = $('.post');
+
+            post.find('img').each((_, img) => {
+                const dataSrc = $(img).attr('data-src');
+                if (dataSrc) {
+                    $(img).attr('src', dataSrc);
+                }
+            });
 
             const single = {
                 title: item.title,
-                description: $('.post').html(),
+                description: post.html(),
                 pubDate: item.pubDate,
                 link: item.link,
             };

--- a/lib/routes/tencent/wechat/csm.js
+++ b/lib/routes/tencent/wechat/csm.js
@@ -30,7 +30,12 @@ module.exports = async (ctx) => {
 
                 article('#js_content img').each((index, elem) => {
                     const $elem = article(elem);
-                    $elem.attr('referrerpolicy', 'no-referrer');
+
+                    const imgSrc = $elem.attr('data-original');
+                    if (imgSrc) {
+                        const realSrc = imgSrc.replace(/^https:\/\/img.chuansongme.com\//, 'https://mmbiz.qpic.cn/');
+                        $elem.attr('src', realSrc);
+                    }
                 });
 
                 const single = {


### PR DESCRIPTION
这两个微信公众号的路由中，`<img>`的`src`属性都没有给出图像的真实URI。

- 公众号路由（传送门来源）图像的真实URI储存在`<img>`标签的`data-original`属性中，并且需要将传送门的域名更换为腾讯域名；
- 公众号路由（CareerEngine来源）图像的真实URI储存在`<img>`标签的`data-src`属性中。