### PR TITLE
fix: 崩坏3游戏公告

### DIFF
--- a/docs/game.md
+++ b/docs/game.md
@@ -306,11 +306,11 @@ Example: `https://store.steampowered.com/search/?specials=1&term=atelier` 中的
 
 ### 崩坏 3-游戏公告
 
-<Route author="deepred5" example="/mihoyo/bh3/strategy" path="/mihoyo/bh3/:type" :paramsDesc="['公告种类']">
+<Route author="deepred5 nczitzk" example="/mihoyo/bh3/latest" path="/mihoyo/bh3/:type" :paramsDesc="['公告种类']">
 
-| 最新   | 公告   | 新闻 | 活动     | 攻略     |
-| ------ | ------ | ---- | -------- | -------- |
-| latest | notice | news | activity | strategy |
+| 最新   | 动态 | 公告   | 活动     | 补给     |
+| ------ | ---- | ------ | -------- | -------- |
+| latest | news | notice | activity | strategy |
 
 </Route>
 

--- a/lib/routes/mihoyo/bh3.js
+++ b/lib/routes/mihoyo/bh3.js
@@ -1,50 +1,61 @@
 const got = require('@/utils/got');
-const queryString = require('query-string');
+const cheerio = require('cheerio');
+
+const rootUrl = 'https://www.bh3.com/content/bh3Cn/getContentList?pageSize=10&pageNum=1&channelId=';
+
+const config = {
+    latest: {
+        id: '171',
+        title: '最新',
+    },
+    news: {
+        id: '172',
+        title: '动态',
+    },
+    notice: {
+        id: '173',
+        title: '公告',
+    },
+    activity: {
+        id: '174',
+        title: '活动',
+    },
+    strategy: {
+        id: '175',
+        title: '补给',
+    },
+};
 
 module.exports = async (ctx) => {
-    const url = 'https://www.bh3.com/index.php/news/_more';
-    let type = ctx.params.type;
-
-    const typeMap = {
-        latest: '',
-        news: '新闻',
-        notice: '公告',
-        activity: '活动',
-        strategy: '攻略',
-    };
-
-    type = typeMap[type] || '';
+    const cfg = config[ctx.params.type];
+    if (!cfg) {
+        throw Error(`Bad type: ${ctx.params.type}. See <a href="https://docs.rsshub.app/game.html#beng-huai-3-you-xi-gong-gao">docs</a>`);
+    }
 
     const response = await got({
         method: 'get',
-        url: url,
-        headers: {
-            Referer: url,
-            'x-requested-with': 'XMLHttpRequest',
-        },
-        searchParams: queryString.stringify({
-            begin: new Date(),
-            type: type,
-        }),
+        url: rootUrl + cfg.id,
     });
 
-    const data = response.data.data.data;
-
-    const title = `崩坏3-${type ? type : '最新'}`;
+    const list = response.data.data.list.map((item) => ({
+        title: item.title,
+        link: `https://www.bh3.com/news/${item.contentId}`,
+        pubDate: new Date(item.start_time).toUTCString(),
+    }));
 
     ctx.state.data = {
-        title: title,
-        link: `https://www.bh3.com/index.php/news/?type=${type}`,
-        description: title,
-        item: data.map((item) => {
-            const pubDate = new Date(item.create_time);
-            pubDate.setTime(pubDate.getTime() + 8 * 60 * 60 * 1000);
-            return {
-                title: item.title_short ? item.title_short : item.title,
-                description: item.summary,
-                pubDate: pubDate.toUTCString(),
-                link: `https://www.bh3.com/index.php/news/${item.id}`,
-            };
-        }),
+        title: `崩坏3作战资讯 - ${cfg.title}`,
+        link: `https://www.bh3.com/news/cate/${cfg.id}`,
+        item: await Promise.all(
+            list.map(
+                async (item) =>
+                    await ctx.cache.tryGet(item.link, async () => {
+                        const contentResponse = await got({ method: 'get', url: item.link });
+                        const content = cheerio.load(contentResponse.data);
+                        item.description = content('div.article__bd').html();
+                        return item;
+                    })
+            )
+        ),
     };
 };


### PR DESCRIPTION
崩坏3作战资讯 [原网址](https://www.bh3.com/index.php/news) 更换为 [新网址](https://www.bh3.com/news)（原网址访问404）且原五个类目有小改动：

* 最新 /latest
* 新闻 /news -> 动态
* 公告 /notice
* 活动 /activity
* 攻略 /strategy -> 补给

原路由暂不改动，仅在文档中更新公告种类。