### PR TITLE
fix: only collect errors which route path was matched

### DIFF
--- a/lib/middleware/debug.js
+++ b/lib/middleware/debug.js
@@ -14,9 +14,9 @@ module.exports = async (ctx, next) => {
     await next();
 
     if (!ctx.debug.routes[ctx._matchedRoute]) {
-        ctx.debug.routes[ctx._matchedRoute] = 0;
+        ctx._matchedRoute && (ctx.debug.routes[ctx._matchedRoute] = 0);
     }
-    ctx.debug.routes[ctx._matchedRoute]++;
+    ctx._matchedRoute && ctx.debug.routes[ctx._matchedRoute]++;
 
     if (ctx.response.get('X-Koa-Redis-Cache') || ctx.response.get('X-Koa-Memory-Cache')) {
         ctx.debug.hitCache++;

--- a/lib/middleware/onerror.js
+++ b/lib/middleware/onerror.js
@@ -51,15 +51,15 @@ module.exports = async (ctx, next) => {
         ctx.debug.errorPaths[ctx.request.path]++;
 
         if (!ctx.debug.errorRoutes[ctx._matchedRoute]) {
-            ctx.debug.errorRoutes[ctx._matchedRoute] = 0;
+            ctx._matchedRoute && (ctx.debug.errorRoutes[ctx._matchedRoute] = 0);
         }
-        ctx.debug.errorRoutes[ctx._matchedRoute]++;
+        ctx._matchedRoute && ctx.debug.errorRoutes[ctx._matchedRoute]++;
 
         if (!ctx.state.debuged) {
             if (!ctx.debug.routes[ctx._matchedRoute]) {
-                ctx.debug.routes[ctx._matchedRoute] = 0;
+                ctx._matchedRoute && (ctx.debug.routes[ctx._matchedRoute] = 0);
             }
-            ctx.debug.routes[ctx._matchedRoute]++;
+            ctx._matchedRoute && ctx.debug.routes[ctx._matchedRoute]++;
 
             if (ctx.response.get('X-Koa-Redis-Cache') || ctx.response.get('X-Koa-Memory-Cache')) {
                 ctx.debug.hitCache++;

--- a/test/middleware/debug.js
+++ b/test/middleware/debug.js
@@ -43,7 +43,7 @@ describe('debug', () => {
                     expect(value).toBe('8');
                     break;
                 case 'hot routes:':
-                    expect(value).toBe('4  undefined<br>3  /test/:id<br>');
+                    expect(value).toBe('3  /test/:id<br>');
                     break;
                 case 'hot paths:':
                     expect(value).toBe('3  /test/1<br>2  /test/2<br>2  /test/empty<br>1  /<br>');
@@ -52,7 +52,7 @@ describe('debug', () => {
                     expect(value).toBe('5  233.233.233.233<br>3  233.233.233.234<br>');
                     break;
                 case 'hot error routes:':
-                    expect(value).toBe('1  /test/:id<br>1  undefined<br>');
+                    expect(value).toBe('1  /test/:id<br>');
                     break;
                 case 'hot error paths:':
                     expect(value).toBe('2  /test/empty<br>');


### PR DESCRIPTION
resolve: https://github.com/DIYgod/RSSHub/issues/4672