### PR TITLE
feat: Support Proxy URI

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -303,7 +303,29 @@ RSSHub 支持 `memory` 和 `redis` 两种缓存方式
 
 ### 代理配置
 
-部分路由反爬严格，可以配置使用代理抓取
+部分路由反爬严格，可以配置使用代理抓取。
+
+可通过**代理 URI**或**代理选项**两种方式来配置代理，当两种配置方式同时被设置时，RSSHub 将会使用**代理 URI**中的配置。
+
+#### 代理 URI
+
+`PROXY_URI`: 代理 URI，支持 socks4, socks5, http, https
+
+> 代理 URI 的格式为:
+>
+> -   `{protocol}://{host}:{port}`
+> -   `{protocol}://{username}:{password}@{host}:{port}` (带身份凭证)
+>
+> 一些示例:
+>
+> -   `socks4://127.0.0.1:1080`
+> -   `socks5://user:pass@127.0.0.1:1080` (用户名为 `user`, 密码为 `pass`)
+> -   `socks://127.0.0.1:1080` (protocol 为 socks 时表示 `socks5`)
+> -   `http://127.0.0.1:8080`
+> -   `http://user:pass@127.0.0.1:8080`
+> -   `https://127.0.0.1:8443`
+
+#### 代理选项
 
 `PROXY_PROTOCOL`: 使用代理，支持 socks，http，https
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -85,6 +85,7 @@ const calculateValue = () => {
         },
         puppeteerWSEndpoint: envs.PUPPETEER_WS_ENDPOINT,
         loggerLevel: envs.LOGGER_LEVEL || 'info',
+        proxyUri: envs.PROXY_URI,
         proxy: {
             protocol: envs.PROXY_PROTOCOL,
             host: envs.PROXY_HOST,

--- a/lib/utils/request-wrapper.js
+++ b/lib/utils/request-wrapper.js
@@ -1,4 +1,5 @@
 const config = require('@/config').value;
+const HttpsProxyAgent = require('https-proxy-agent');
 const SocksProxyAgent = require('socks-proxy-agent');
 const tunnel = require('tunnel');
 const logger = require('./logger');
@@ -6,7 +7,21 @@ const http = require('http');
 const https = require('https');
 
 let agent = null;
-if (config.proxy && config.proxy.protocol && config.proxy.host && config.proxy.port) {
+if (config.proxyUri && typeof config.proxyUri === 'string') {
+    let proxy = null;
+    if (config.proxyUri.startsWith('http')) {
+        proxy = new HttpsProxyAgent(config.proxyUri);
+    } else if (config.proxyUri.startsWith('socks')) {
+        proxy = new SocksProxyAgent(config.proxyUri);
+    } else {
+        throw 'Unknown proxy-uri format';
+    }
+
+    agent = {
+        http: proxy,
+        https: proxy,
+    };
+} else if (config.proxy && config.proxy.protocol && config.proxy.host && config.proxy.port) {
     agent = {};
     const proxyUrl = `${config.proxy.protocol}://${config.proxy.host}:${config.proxy.port}`;
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "googleapis": "49.0.0",
     "got": "11.0.3",
     "he": "1.2.0",
+    "https-proxy-agent": "5.0.0",
     "iconv-lite": "0.5.1",
     "jsdom": "16.2.2",
     "json-bigint": "0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6175,20 +6175,20 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+https-proxy-agent@5.0.0, https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 https-proxy-agent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
   integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
   dependencies:
     agent-base "5"
-    debug "4"
-
-https-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
-  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
-  dependencies:
-    agent-base "6"
     debug "4"
 
 human-signals@^1.1.1:


### PR DESCRIPTION
支持 URI 格式的代理设置。

* 通过环境变量 `PROXY_URI` 设置代理
  examples:
  - `PROXY_URI=http://localhost:8080`
  - `PROXY_URI=http://username:pwd@localhost:8080`
  - `PROXY_URI=socks5://localhost:1080`
  - `PROXY_URI=socks5://username:pwd@localhost:1080`
* 此代理设置方式支持了 SOCKS 代理认证
* 未破坏原有代理设置方式的兼容性
