### PR TITLE
fix: twitter advanced search by duplicate encode

### DIFF
--- a/docs/en/social-media.md
+++ b/docs/en/social-media.md
@@ -126,6 +126,12 @@ Due to Telegram restrictions, some channels involving pornography, copyright, an
 
 ## Twitter
 
+::: warning
+
+Due to Twitter API restrictions, the Twitter Routes currently supports tweets within 7 days
+
+:::
+
 ### User timeline
 
 <RouteEn path="/twitter/user/:id/:type?" example="/twitter/user/DIYgod" :paramsDesc="['user id', 'Extra options `exclude_replies` exclude replies,`exclude_rts` exclude retweets,`exclude_rts_replies` exclude replies and retweets, for default include all.']" radar="1" />

--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -396,6 +396,12 @@ Tiny Tiny RSS 会给所有 iframe 元素添加 `sandbox="allow-scripts"` 属性�
 
 ## Twitter
 
+::: warning 注意
+
+由于 Twitter Api 限制，关于 Twitter 相关的 RSS 接口目前仅支持 7 天内推文检索
+
+:::
+
 ### 用户时间线
 
 <Route author="DIYgod" example="/twitter/user/DIYgod" path="/twitter/user/:id/:type?" :paramsDesc="['用户名', '额外选项 `exclude_replies`去除回复，`exclude_rts`去除转推，`exclude_rts_replies`去除回复和转推，默认包含全部回复和转推。']" radar="1"/>

--- a/lib/routes/twitter/keyword.js
+++ b/lib/routes/twitter/keyword.js
@@ -7,7 +7,7 @@ module.exports = async (ctx) => {
     }
     const keyword = ctx.params.keyword;
     const result = await utils.getTwit().get('search/tweets', {
-        q: encodeURIComponent(keyword),
+        q: keyword,
         count: 50,
         tweet_mode: 'extended',
         result_type: 'recent',


### PR DESCRIPTION
resolve: #4670 

Twit 库本身会对URI编码一次，所以这里重复编码了