### PR TITLE
fix: host in headers after redirecting request

### DIFF
--- a/lib/utils/request-wrapper.js
+++ b/lib/utils/request-wrapper.js
@@ -105,11 +105,6 @@ const requestWrapper = (url, options) => {
             const urlHandler = new URL(url);
             options.headers.referer = urlHandler.origin;
         }
-        // host
-        if (!options.headers.host && !options.headers.Host) {
-            const urlHandler = new URL(url);
-            options.headers.host = urlHandler.host;
-        }
     } catch (e) {
         // do nothing
     }


### PR DESCRIPTION
resolve: #4655 
resolve: #4631 

302、301 转发的时候 由于headers里定义了host导致最终请求的时候以原始host请求，加上 Got 库并没有对此做处理导致请求部分网站时会无限跳转，就是目前发现以上的两个issues

正常情况下 host 都不应该被主动定义在headers里

@DIYgod  这里定义referer 和 host 是有什么特别的原因吗？