### PR TITLE
fix: fix konachan rss

### DIFF
--- a/lib/routes/konachan/post_popular_recent.js
+++ b/lib/routes/konachan/post_popular_recent.js
@@ -9,8 +9,7 @@ module.exports = async (ctx) => {
 
     const response = await got({
         method: 'get',
-        prefixUrl: baseUrl,
-        url: '/post/popular_recent.json',
+        url: `${baseUrl}/post/popular_recent.json`,
         searchParams: queryString.stringify({
             period,
         }),


### PR DESCRIPTION
Fix "Error: `input` must not start with a slash when using `prefixUrl`"