### PR TITLE
feat: Add a bit more error checking to the Vulture tag exclus...

### DIFF
--- a/lib/routes/vulture/utils.js
+++ b/lib/routes/vulture/utils.js
@@ -63,7 +63,8 @@ function FilterItemsWithTags(feed, tagsToExclude) {
     return feed.filter(function (item) {
         for (const index in tagsToExclude) {
             const tagToExclude = tagsToExclude[index];
-            if (item.tags.includes(tagToExclude)) {
+            const itemTags = item.tags;
+            if (itemTags !== undefined && itemTags.includes(tagToExclude)) {
                 return false;
             }
         }


### PR DESCRIPTION
For some reason, visiting the route vulture/movies/comedy on rsshub.app is giving me the error

```
TypeError: Cannot read property 'includes' of undefined
    at /data/wwwroot/do02.rsshub.app/lib/routes/vulture/utils.js:66:27
```

However, my locally running instance isn't giving me this error.  I'm not sure why this is happening, so I'm starting by adding this bit of error handling to prevent the error from happening.
