### PR TITLE
fix: show lofter user title

### DIFF
--- a/assets/radar-rules.js
+++ b/assets/radar-rules.js
@@ -1879,4 +1879,15 @@
             },
         ],
     },
+    'lofter.com': {
+        _name: 'Lofter',
+        www: [
+            {
+                title: '话题 (标签)',
+                docs: 'https://docs.rsshub.app/social-media.html#lofter',
+                source: ['/tag/:name', '/tag/:name/:type'],
+                target: (params) => `/lofter/tag/${params.name}/${params.type || ''}`,
+            },
+        ],
+    },
 });

--- a/lib/routes/lofter/posts.js
+++ b/lib/routes/lofter/posts.js
@@ -21,11 +21,17 @@ module.exports = async (ctx) => {
             supportposttypes: '1,2,3,4,5,6',
         },
     });
+    if (!response.data.response || response.data.response.posts.length === 0) {
+        throw 'Blog Not Found';
+    }
     const data = response.data.response.posts;
+    const blogNickName = data[0].post.blogInfo.blogNickName;
+    const selfIntro = data[0].post.blogInfo.selfIntro;
+
     ctx.state.data = {
-        title: `${ctx.params.username}.lofter.com`,
-        link: blogdomain,
-        description: `${ctx.params.username}.lofter.com`,
+        title: `${blogNickName} - lofter`,
+        link: `https://${blogdomain}`,
+        description: selfIntro,
         item: data.map((item) => {
             let content = item.post.content;
             const title = item.post.title || item.post.noticeLinkTitle;
@@ -41,7 +47,7 @@ module.exports = async (ctx) => {
                 pubDate: new Date(item.post.publishTime).toUTCString(),
                 link: item.post.blogPageUrl,
                 guid: item.post.blogPageUrl,
-                author: item.post.blogInfo.blogNickName,
+                author: blogNickName,
             };
         }),
     };


### PR DESCRIPTION
- show lofter user title
- add radar rule for lofter tag

The rule for lofter user (e.g., `tingtingtingtingzhi.lofter.com`) is ignored since RSSHub Radar doesn't support wildcard subdomain.