### PR TITLE
fix: hackerone hacktivity fix username empty

### DIFF
--- a/lib/routes/hackerone/hacktivity.js
+++ b/lib/routes/hackerone/hacktivity.js
@@ -29,7 +29,7 @@ module.exports = async (ctx) => {
         title: 'HackerOne Hacker Activity',
         link: 'https://hackerone.com/hacktivity',
         item: response.data.data.hacktivity_items.edges.map((item) => {
-            const author = item.node.reporter.username ? item.node.reporter.username : 'Someone';
+            const author = item.node.reporter ? item.node.reporter.username : 'Someone';
             const vendor = item.node.team.name;
             const state = item.node.report.substate.replace(/^[a-z]/g, (L) => L.toUpperCase());
             const severity = item.node.severity_rating ? item.node.severity_rating.replace(/^[a-z]/g, (L) => L.toUpperCase()) : 'No Rating';

--- a/lib/routes/hackerone/hacktivity.js
+++ b/lib/routes/hackerone/hacktivity.js
@@ -29,7 +29,7 @@ module.exports = async (ctx) => {
         title: 'HackerOne Hacker Activity',
         link: 'https://hackerone.com/hacktivity',
         item: response.data.data.hacktivity_items.edges.map((item) => {
-            const author = item.node.reporter.username;
+            const author = item.node.reporter.username ? item.node.reporter.username : 'Someone';
             const vendor = item.node.team.name;
             const state = item.node.report.substate.replace(/^[a-z]/g, (L) => L.toUpperCase());
             const severity = item.node.severity_rating ? item.node.severity_rating.replace(/^[a-z]/g, (L) => L.toUpperCase()) : 'No Rating';


### PR DESCRIPTION
当提交者用户名为空时，目前的程序会报错

本 PR 修改用户名为空时（参考 https://hackerone.com/reports/891267 ）显示 `Someone` 

