### PR TITLE
feat: 添加外接大脑作为获取公众号途径

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -1042,7 +1042,7 @@ Supported sub-sites:
 
 <Route author="sanmmm" example="/wechat/ershicimi/59" path="/wechat/ershicimi/:id" :paramsDesc="['公众号id, 打开公众号页, 在 URL 中找到 id']"/>
 
-### 公众号 （外接大脑来源）
+### 公众号 (外接大脑来源)
 
 <Route author="BugWriter2" example="/wechat/wjdn/5d5e683c82339df472988f59" path="/wechat/wjdn/:id" :paramsDesc="['公众号 id, 打开公众号页, 在 URL 中找到 id']"/>
 

--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -1044,7 +1044,7 @@ Supported sub-sites:
 
 ### 公众号 （外接大脑来源）
 
-<Route author="VeryLazyBoy" example="/wechat/5d5e683c82339df472988f59" path="/wechat/:id" :paramsDesc="['公众号 id, 打开公众号页, 在 URL 中找到 id']"/>
+<Route author="BugWriter2" example="/wechat/wjdn/5d5e683c82339df472988f59" path="/wechat/wjdn/:id" :paramsDesc="['公众号 id, 打开公众号页, 在 URL 中找到 id']"/>
 
 ### 公众号栏目 (非推送 & 历史消息)
 

--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -698,7 +698,7 @@ Supported sub-sites:
 
 <Route author="xfangbao" example="/kuai/1" path="/kuai/:id" />
 
-具体栏目编号，去网站上看标签 
+具体栏目编号，去网站上看标签
 
 | 网址                                                                                              | 对应路由 |
 | ------------------------------------------------------------------------------------------------- | -------- |
@@ -1041,6 +1041,10 @@ Supported sub-sites:
 ### 公众号 (二十次幂来源)
 
 <Route author="sanmmm" example="/wechat/ershicimi/59" path="/wechat/ershicimi/:id" :paramsDesc="['公众号id, 打开公众号页, 在 URL 中找到 id']"/>
+
+### 公众号 （外接大脑来源）
+
+<Route author="VeryLazyBoy" example="/wechat/5d5e683c82339df472988f59" path="/wechat/:id" :paramsDesc="['公众号 id, 打开公众号页, 在 URL 中找到 id']"/>
 
 ### 公众号栏目 (非推送 & 历史消息)
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -2850,5 +2850,6 @@ router.get('/futunn/highlights', require('./routes/futunn/highlights'));
 
 // 外接大脑
 router.get('/waijiedanao/article/:caty', require('./routes/waijiedanao/article'));
+router.get('/waijiedanao/wechat/:id', require('./routes/waijiedanao/wechat'));
 
 module.exports = router;

--- a/lib/router.js
+++ b/lib/router.js
@@ -487,6 +487,7 @@ router.get('/wechat/miniprogram/plugins', require('./routes/tencent/wechat/minip
 router.get('/wechat/tgchannel/:id', require('./routes/tencent/wechat/tgchannel'));
 router.get('/wechat/uread/:userid', require('./routes/tencent/wechat/uread'));
 router.get('/wechat/ershicimi/:id', require('./routes/tencent/wechat/ershcimi'));
+router.get('/wechat/wjdn/:id', require('./routes/tencent/wechat/wjdn'));
 router.get('/wechat/mp/homepage/:biz/:hid/:cid?', require('./routes/tencent/wechat/mp'));
 
 // All the Flight Deals
@@ -2850,6 +2851,5 @@ router.get('/futunn/highlights', require('./routes/futunn/highlights'));
 
 // 外接大脑
 router.get('/waijiedanao/article/:caty', require('./routes/waijiedanao/article'));
-router.get('/waijiedanao/wechat/:id', require('./routes/waijiedanao/wechat'));
 
 module.exports = router;

--- a/lib/routes/tencent/wechat/wjdn.js
+++ b/lib/routes/tencent/wechat/wjdn.js
@@ -12,7 +12,7 @@ module.exports = async (ctx) => {
         url: currentUrl,
     });
 
-    const title = response.data.data[0].profile.title
+    const title = response.data.data[0].profile.title;
     const list = response.data.data.map((item) => ({
         title: item.title,
         link: item.link,

--- a/lib/routes/tencent/wechat/wjdn.js
+++ b/lib/routes/tencent/wechat/wjdn.js
@@ -1,17 +1,18 @@
 const got = require('@/utils/got');
 
 module.exports = async (ctx) => {
-    const cfg = ctx.params.id;
-    if (!cfg) {
+    const { id } = ctx.params;
+    if (!id) {
         throw Error('Bad category. See <a href="https://docs.rsshub.app/new-media.html#wai-jie-da-nao-wen-zhang">docs</a>');
     }
 
-    const currentUrl = `https://www.waijiedanao.com/api/posts?profile=${cfg}&page=1&limit=20`;
+    const currentUrl = `https://www.waijiedanao.com/api/posts?profile=${id}&page=1&limit=20`;
     const response = await got({
         method: 'get',
         url: currentUrl,
     });
 
+    const title = response.data.data[0].profile.title
     const list = response.data.data.map((item) => ({
         title: item.title,
         link: item.link,
@@ -20,8 +21,8 @@ module.exports = async (ctx) => {
     }));
 
     ctx.state.data = {
-        title: `外接大脑 - ${cfg.title}`,
-        link: 'https://www.waijiedanao.com/',
+        title: `微信公众号 - ${title}`,
+        link: `https://www.waijiedanao.com/accountArtical?publicAccountId=${id}`,
         item: list,
     };
 };

--- a/lib/routes/tencent/wechat/wjdn.js
+++ b/lib/routes/tencent/wechat/wjdn.js
@@ -3,7 +3,7 @@ const got = require('@/utils/got');
 module.exports = async (ctx) => {
     const { id } = ctx.params;
     if (!id) {
-        throw Error('Bad category. See <a href="https://docs.rsshub.app/new-media.html#wai-jie-da-nao-wen-zhang">docs</a>');
+        throw Error('Bad category. See <a href="https://docs.rsshub.app/new-media.html#wei-xin-gong-zhong-hao-wai-jie-da-nao-lai-yuan">docs</a>');
     }
 
     const currentUrl = `https://www.waijiedanao.com/api/posts?profile=${id}&page=1&limit=20`;

--- a/lib/routes/waijiedanao/wechat.js
+++ b/lib/routes/waijiedanao/wechat.js
@@ -1,0 +1,27 @@
+const got = require('@/utils/got');
+
+module.exports = async (ctx) => {
+    const cfg = ctx.params.id;
+    if (!cfg) {
+        throw Error('Bad category. See <a href="https://docs.rsshub.app/new-media.html#wai-jie-da-nao-wen-zhang">docs</a>');
+    }
+
+    const currentUrl = `https://www.waijiedanao.com/api/posts?profile=${cfg}&page=1&limit=20`;
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+    });
+
+    const list = response.data.data.map((item) => ({
+        title: item.title,
+        link: item.link,
+        description: item.digest,
+        pubDate: new Date(item.publishAt).toUTCString(),
+    }));
+
+    ctx.state.data = {
+        title: `外接大脑 - ${cfg.title}`,
+        link: 'https://www.waijiedanao.com/',
+        item: list,
+    };
+};


### PR DESCRIPTION
目前的外接大脑rss只支持根据文章种类获取内容，修改之后，rss允许根据id获得不同公众号内容