### PR TITLE
feat: scmp

### DIFF
--- a/docs/en/traditional-media.md
+++ b/docs/en/traditional-media.md
@@ -82,6 +82,15 @@ This route adds the missing photo and Link element. (Offical RSS doesn't have Li
 
 </RouteEn>
 
+## SCMP
+
+### News
+
+<RouteEn author="proletarius101" example="/scmp/3" path="/scmp/:category_id" :paramsDesc="['Category']">
+
+See the [official RSS page](https://www.scmp.com/rss) to get the ID of each category. This route provides fulltext that the offical feed doesn't.
+
+</RouteEn>
 ## The Economist
 
 ### Category

--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -302,6 +302,16 @@ category 对应的关键词有
 
 </Route>
 
+## 南华早报 SCMP
+
+### 新闻
+
+<Route author="proletarius101" example="/scmp/3" path="/scmp/:category_id" :paramsDesc="['栏目分类']">
+
+栏目分类对应的数字编号见[官方 RSS](https://www.scmp.com/rss)。相比官方提供的 RSS，多提供了全文输出。
+
+</Route>
+
 ## 纽约时报
 
 ### 新闻

--- a/lib/router.js
+++ b/lib/router.js
@@ -2860,6 +2860,8 @@ router.get('/ems/news', require('./routes/ems/news'));
 
 // 场库
 router.get('/changku', require('./routes/changku/index'));
+// SCMP
+router.get('/scmp/:category_id', require('./routes/scmp/index'));
 
 // 上海市生态环境局
 router.get('/gov/shanghai/sthj', require('./routes/gov/shanghai/sthj'));

--- a/lib/routes/scmp/index.js
+++ b/lib/routes/scmp/index.js
@@ -1,0 +1,116 @@
+const parser = require('@/utils/rss-parser');
+const cheerio = require('cheerio');
+const got = require('@/utils/got');
+
+module.exports = async (ctx) => {
+    const categoryId = ctx.params.category_id;
+    const rssUrl = `https://www.scmp.com/rss/${categoryId}/feed`;
+    const feed = await parser.parseURL(rssUrl);
+    const chromeMobileUserAgent = 'Mozilla/5.0 (Linux; Android 7.0; SM-G892A Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36';
+
+    const items = await Promise.all(
+        feed.items.map(
+            async (item) =>
+                await ctx.cache.tryGet(item.link, async () => {
+                    // Fetch the AMP version
+                    const url = item.link.replace(/^https:\/\/www\.scmp\.com/, 'https://amp.scmp.com');
+                    const response = await got({
+                        url,
+                        method: 'get',
+                        headers: {
+                            'User-Agent': chromeMobileUserAgent,
+                        },
+                    });
+                    const html = response.body;
+                    const $ = cheerio.load(html);
+                    const content = $('div.article-body.clearfix');
+
+                    // Cover
+                    const cover = $('.article-images > amp-carousel > .i-amphtml-slides-container >.i-amphtml-slide-item > amp-img > img');
+
+                    if (cover.length > 0) {
+                        $(`<img src=${cover[0].attribs.content}>`).insertBefore(content[0].childNodes[0]);
+                        $(cover).remove();
+                    }
+
+                    // Summary
+                    const summary = $('div.article-header__subhead > ul');
+
+                    // Metadata (categories & updatedAt)
+                    const updatedAt = $('meta[itemprop="dateModified"]').attr('content');
+                    const publishedAt = $('meta[itemprop="datePublished"]').attr('content');
+
+                    const categories = $('meta[name="keywords"]')
+                        .attr('content')
+                        .split(',')
+                        .map((c) => c.trim());
+
+                    // Images
+                    content.find('amp-img').each((i, e) => {
+                        const img = $(`<img width="${e.attribs.width}" height="${e.attribs.height}" src="${e.attribs.src}" alt="${e.attribs.alt}">`);
+
+                        // Caption follows, no need to handle caption
+                        $(img).insertBefore(e);
+                        $(e).remove();
+                    });
+
+                    // iframes (youtube videos and interactive elements)
+                    content.find('amp-iframe').each((i, e) => {
+                        if ($(e).find('iframe').length > 0) {
+                            const iframe = $(e).find('iframe')[0];
+                            $(iframe).insertBefore(e);
+                            $(e).remove();
+                        }
+                    });
+
+                    content.find('div.video-wrapper > amp-iframe').each((i, e) => {
+                        const iframe = $(`<iframe width="${e.attribs.width}" height="${e.attribs.height}" src="${e.attribs.src}">`);
+                        $(iframe).insertBefore(e);
+                        $(e).remove();
+                    });
+
+                    // Remove unwanted DOMs
+                    const unwanted_element_selectors = [
+                        '[class*="-advert"]',
+                        '.social-share',
+                        '.article-body-after',
+                        'scmp-chinaR2-early-text',
+                        '.newsletter-widget-wrapper',
+                        '[id*="-tracker"]',
+                        '[class^="advert-"]',
+                        'amp-list',
+                        '.more-on-this',
+                    ];
+                    unwanted_element_selectors.forEach((selector) => {
+                        content.find(selector).each((i, e) => {
+                            $(e).remove();
+                        });
+                    });
+
+                    return {
+                        title: item.title,
+                        id: item.guid,
+                        pubDate: new Date(publishedAt).toUTCString(),
+                        updated: new Date(updatedAt).toUTCString(),
+                        author: item.creator,
+                        link: item.link,
+                        summary: summary.html(),
+                        description: content.html(),
+                        category: categories,
+                        icon: 'https://assets.i-scmp.com/static/img/icons/scmp-icon-256x256.png',
+                        logo: 'https://customerservice.scmp.com/img/logo_scmp@2x.png',
+                    };
+                })
+        )
+    );
+
+    ctx.state.data = {
+        title: feed.title,
+        link: feed.link,
+        description: feed.description,
+        item: items,
+        language: 'en-hk',
+        icon: 'https://assets.i-scmp.com/static/img/icons/scmp-icon-256x256.png',
+        logo: 'https://customerservice.scmp.com/img/logo_scmp@2x.png',
+    };
+};


### PR DESCRIPTION
Scmp dynamically loads articles. Article content is stored in the HTML from the very beginning as Apollo state. But I don't figure out a convinient way to restore that back to HTML. So it has to use puppeteer.

To optimize performance, the followings are applied:
* Loads mobile page instead of the desktop version
* Prohibits images and webfonts from loading
* Introduces PuppeteerBlocker to block ads
* Switches to offline mode as long as the Apollo state is loaded

