### PR TITLE
fix: set initium's bearer token manually (#5047)

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -256,6 +256,18 @@ env_variables:
 # [END app_yaml]
 ```
 
+### 安装
+
+在 RSSHub 项目根目录下运行
+
+```bash
+gcloud app deploy
+```
+
+进行项目部署，如果您需要变更 app.yaml 文件名称或者变更部署的项目 ID 或者指定版本号等，请参考 [Deploying a service](https://cloud.google.com/appengine/docs/flexible/nodejs/testing-and-deploying-your-app#deploying_a_service_2)。
+
+部署完成后可访问您的 Google App Engine URL 查看部署情况。
+
 ## Play with Docker
 
 如果想要测试因为反爬规则导致无法访问的路由，您可以点击下方按钮拉起一套免费，临时，专属于您的 RSSHub
@@ -270,18 +282,6 @@ env_variables:
 -   有的时候 PWD 会抽风，如果遇到点击`Start`后空白页面，或者拉起失败，请重试
 
 :::
-
-### 安装
-
-在 RSSHub 项目根目录下运行
-
-```bash
-gcloud app deploy
-```
-
-进行项目部署，如果您需要变更 app.yaml 文件名称或者变更部署的项目 ID 或者指定版本号等，请参考 [Deploying a service](https://cloud.google.com/appengine/docs/flexible/nodejs/testing-and-deploying-your-app#deploying_a_service_2)。
-
-部署完成后可访问您的 Google App Engine URL 查看部署情况。
 
 ## 配置
 
@@ -493,7 +493,11 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 
 -   端传媒设置，用于获取付费内容全文：
 
-    -   `INITIUM_USERNAME`: 端传媒用户名
+    -   `INITIUM_BEARER_TOKEN`: 端传媒 Web 版认证 token。获取方式：登陆后打开端传媒站内任意页面，打开浏览器开发者工具中 “网络”(Network) 选项卡，筛选 URL 找到任一个地址为`api.initium.com`开头的请求，点击检查其 “消息头”，在 “请求头” 中找到`Authorization`字段，将其值复制填入配置即可。你的配置应该形如`INITIUM_BEARER_TOKEN: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6JiE1NTYzNDgxNDVAcXEuY29tIiwidXNlcl9pZCI6MTM0NDIwLCJlbWFpbCI6IjE1NTYzNDgxNDVAcXEuY29tIiwiZXhwIjoxNTk0MTk5NjQ3fQ.Tqui-ORNR7d4Bh240nKy_Ldi6crfq0A78Yj2iwy2_U8'`。
+
+    如果你在进行上述操作时遇到困难，亦可选择在环境设置中填写明文的用户名和密码：
+
+    -   `INITIUM_USERNAME`: 端传媒用户名 (邮箱)
 
     -   `INITIUM_PASSWORD`: 端传媒密码
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -138,6 +138,7 @@ const calculateValue = () => {
         initium: {
             username: envs.INITIUM_USERNAME,
             password: envs.INITIUM_PASSWORD,
+            bearertoken: envs.INITIUM_BEARER_TOKEN,
         },
         btbyr: {
             host: envs.BTBYR_HOST || 'https://bt.byr.cn/',

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -16,6 +16,9 @@ module.exports = async (ctx) => {
     const cache = await ctx.cache.get('INITIUM_TOKEN');
     if (cache) {
         token = cache;
+    } else if (config.initium.bearertoken) {
+        token = config.initium.bearertoken;
+        ctx.cache.set('INITIUM_TOKEN', config.initium.bearertoken);
     } else if (key.email === undefined) {
         token = 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=';
     } else {
@@ -29,6 +32,7 @@ module.exports = async (ctx) => {
                 Authorization: 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=',
                 Origin: `https://theinitium.com/`,
                 Referer: `https://theinitium.com/`,
+                // X-Client-Name: Web,
             },
             body: body,
         });

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -36,7 +36,7 @@ module.exports = async (ctx) => {
             },
             body: body,
         });
-        
+
         /*
         const devices = login.data.access.devices;
 

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -32,11 +32,12 @@ module.exports = async (ctx) => {
                 Authorization: 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=',
                 Origin: `https://theinitium.com/`,
                 Referer: `https://theinitium.com/`,
-                // X-Client-Name: Web,
+                'X-Client-Name': 'Web',
             },
             body: body,
         });
-
+        
+        /*
         const devices = login.data.access.devices;
 
         for (const key in devices) {
@@ -46,6 +47,8 @@ module.exports = async (ctx) => {
                 break;
             }
         }
+        */
+        token = 'Bearer ' + login.data.token;
         ctx.cache.set('INITIUM_TOKEN', token);
     }
 


### PR DESCRIPTION
See #5047 .

暂时以用户手动提供自己的token的方式来解决登陆故障的问题。~~登陆故障我不大会修，所以原issue暂时还关不了~~

其实这样也挺好的，毕竟端有5台的登陆token数限制，因此和本地共用不失为帮助用户节省限额的一个良方。

顺带修正`install/README.md`里的一处段落位置错乱。