### PR TITLE
feat: support department location selector in leboncoin

### DIFF
--- a/lib/routes/leboncoin/ad.js
+++ b/lib/routes/leboncoin/ad.js
@@ -31,6 +31,10 @@ const convertQueryToFilters = (query) => {
                         return { locationType: 'department_near', department_id: l.slice(3) };
                     }
 
+                    if (l.startsWith('d_')) {
+                        return { locationType: 'department', department_id: l.slice(2) };
+                    }
+
                     {
                         if (l.match(/.+_.+/)) {
                             const [city, zipcode] = l.split('_');


### PR DESCRIPTION
Previously only "department and near" [1] search location selector was supported.
This PR introduces support of "department" [2] selector.


[1] https://www.leboncoin.fr/recherche/?category=19&text=table&locations=dn_83
RSSHub route : `/leboncoin/ad/category=19&text=table&locations=dn_83`

[2] https://www.leboncoin.fr/recherche/?category=19&text=table&locations=d_83
RSSHub route : `/leboncoin/ad/category=19&text=table&locations=d_83`