### PR TITLE
feat: add nppa

### DIFF
--- a/docs/government.md
+++ b/docs/government.md
@@ -34,7 +34,7 @@ pageClass: routes
 
 <Route author="nczitzk" example="/gov/chinatax/latest" path="/gov/chinatax/latest"/>
 
-## 国家新闻出版广电总局
+## 国家新闻出版广电总局（弃用）
 
 ### 游戏审批结果
 
@@ -54,6 +54,16 @@ pageClass: routes
 | 某个文章标题的一部分，返回这篇文章内容 | 例：2020 年 1 月 |
 
 </Route>
+
+## 国家新闻出版署
+
+### 列表
+
+<Route author="y2361547758" example="/gov/nppa/317" path="/gov/nppa/:channel" :paramsDesc="['栏目名id']" />
+
+### 详情
+
+<Route author="y2361547758" example="/gov/nppa/318/45948" path="/gov/nppa/:channel/:content" :paramsDesc="['栏目名id', '文章id']" />
 
 ## 联合国
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -1214,6 +1214,10 @@ router.get('/gov/mohurd/policy', require('./routes/gov/mohurd/policy'));
 // 国家新闻出版广电总局
 router.get('/gov/sapprft/approval/:channel/:detail?', require('./routes/gov/sapprft/7026'));
 
+// 国家新闻出版署
+router.get('/gov/nppa/:channel', require('./routes/gov/nppa/channels'));
+router.get('/gov/nppa/:channel/:content', require('./routes/gov/nppa/contents'));
+
 // 北京卫生健康委员会
 router.get('/gov/beijing/mhc/:caty', require('./routes/gov/beijing/mhc'));
 

--- a/lib/routes/gov/nppa/channels.js
+++ b/lib/routes/gov/nppa/channels.js
@@ -1,0 +1,57 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const date = require('@/utils/date');
+
+module.exports = async (ctx) => {
+    const { channel } = ctx.params;
+    const host = `http://www.nppa.gov.cn`;
+    const link = host + `/nppa/channels/${channel}.shtml`;
+    const fullpage = await got.get(link + '?' + new Date().getTime()); // 避免CDN缓存
+    if (~fullpage.data.indexOf('-404</title>')) {
+        ctx.throw(404);
+    }
+    const $ = cheerio.load(fullpage.data);
+    const target = $('ul.m2c2ul li, ul.m2nrul li');
+    ctx.state.data = {
+        title: '国家新闻出版署 - ' + $('.m2nRt, .m2Top_em').text().trim(),
+        link: link,
+        item: await Promise.all(
+            target
+                .map(async (index, item) => {
+                    item = $(item);
+                    const href = item.find('a').attr('href');
+                    let contenlUrl,
+                        description = '';
+                    if (/^https?:\/\//.test(href)) {
+                        contenlUrl = href;
+                    } else {
+                        contenlUrl = host + href;
+                        description = await ctx.cache.tryGet(contenlUrl, async () => {
+                            const fullText = await got.get(contenlUrl);
+                            const $$ = cheerio.load(fullText.data);
+                            if (~$$('.m2pos').text().indexOf('游戏审批结果')) {
+                                let fullTextData = '';
+                                $$('.m3pageCon table.trStyle tbody tr')
+                                    .slice(1)
+                                    .each((index, item) => {
+                                        item = $$(item).find('td');
+                                        fullTextData += $$(item[1]).text().trim() + ' | ';
+                                    });
+                                return fullTextData.slice(0, -3);
+                            } else {
+                                $$('.m3pageCon style, .m3pageCon script').remove();
+                                return $$('.m3pageCon').text().trim().substr(0, 1024);
+                            }
+                        });
+                    }
+                    return {
+                        title: item.find('a').text().trim(),
+                        description: description,
+                        pubDate: date(item.find('span').text(), -8),
+                        link: contenlUrl,
+                    };
+                })
+                .get()
+        ),
+    };
+};

--- a/lib/routes/gov/nppa/contents.js
+++ b/lib/routes/gov/nppa/contents.js
@@ -1,0 +1,37 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const date = require('@/utils/date');
+
+module.exports = async (ctx) => {
+    const { channel, content } = ctx.params;
+    const host = `http://www.nppa.gov.cn`;
+    const link = host + `/nppa/contents/${channel}/${content}.shtml`;
+    const fullpage = await got.get(link + '?' + new Date().getTime()); // 避免CDN缓存
+    if (~fullpage.data.indexOf('-404</title>')) {
+        ctx.throw(404);
+    }
+    const $ = cheerio.load(fullpage.data);
+    const list = $('.m3pageCon table.trStyle tbody tr');
+
+    ctx.state.data = {
+        title: '国家新闻出版署 - ' + $('.m3page_t').text().trim(),
+        link: link,
+        item: await Promise.all(
+            list
+                .slice(1)
+                .map(async (index, item) => {
+                    item = $(item).find('td');
+                    return {
+                        title: $(item[1]).text().trim(),
+                        category: $(item[2]).text().trim(),
+                        description: $(item[5]).text().trim(),
+                        author: $(item[3]).text().trim() + ' | ' + $(item[4]).text().trim(),
+                        pubDate: date($(item[7]).text().trim(), -8),
+                        guid: $(item[6]).text().trim(),
+                        link: link,
+                    };
+                })
+                .get()
+        ),
+    };
+};

--- a/lib/routes/gov/sapprft/7026.js
+++ b/lib/routes/gov/sapprft/7026.js
@@ -60,7 +60,7 @@ module.exports = async (ctx) => {
                         return {
                             title: item.find('a').text(),
                             description: description,
-                            pubDate: date(item.find('span').text()),
+                            pubDate: date(item.find('span').text(), -8),
                             link: contenlUrl,
                         };
                     })
@@ -85,7 +85,7 @@ module.exports = async (ctx) => {
                             category: $$(item[1]).text().trim(),
                             description: $$(item[4]).text().trim(),
                             author: $$(item[2]).text().trim() + ' | ' + $$(item[3]).text().trim(),
-                            pubDate: date($$(item[6]).text().trim()),
+                            pubDate: date($$(item[6]).text().trim(), -8),
                             guid: $$(item[5]).text().trim(),
                             link: url,
                         };


### PR DESCRIPTION
添加国家新闻出版署

原国家新闻出版广电总局(www.sapprft.gov.cn)停用并预备下线