### PR TITLE
Add short video support for Bilibili user posts

### DIFF
--- a/lib/routes/bilibili/dynamic.js
+++ b/lib/routes/bilibili/dynamic.js
@@ -125,7 +125,7 @@ module.exports = async (ctx) => {
                 imgHTML += getImgs(origin.item || origin);
             }
             // video小视频
-            videoHTML = '';
+            let videoHTML = '';
             if (data.video_playurl) {
                 videoHTML += `<video width="${data.width}" height="${data.height}" controls><source src="${unescape(data.video_playurl).replace(/^http\:/,'https:')}"><source src="${unescape(data.video_playurl)}"></video>`;
             }

--- a/lib/routes/bilibili/dynamic.js
+++ b/lib/routes/bilibili/dynamic.js
@@ -127,7 +127,7 @@ module.exports = async (ctx) => {
             // video小视频
             let videoHTML = '';
             if (data.video_playurl) {
-                videoHTML += `<video width="${data.width}" height="${data.height}" controls><source src="${unescape(data.video_playurl).replace(/^http\:/,'https:')}"><source src="${unescape(data.video_playurl)}"></video>`;
+                videoHTML += `<video width="${data.width}" height="${data.height}" controls><source src="${unescape(data.video_playurl).replace(/^http:/, 'https:')}"><source src="${unescape(data.video_playurl)}"></video>`;
             }
             // some rss readers disallow http content.
             // 部分 RSS 阅读器要求内容必须使用https传输

--- a/lib/routes/bilibili/dynamic.js
+++ b/lib/routes/bilibili/dynamic.js
@@ -109,7 +109,7 @@ module.exports = async (ctx) => {
                 // 音频/番剧/直播间封面/小视频封面
                 if (data.cover && data.cover.unclipped) {
                     imgs += `<img src="${data.cover.unclipped}">`;
-                }else if(data.cover){
+                } else if (data.cover) {
                     imgs += `<img src="${data.cover}">`;
                 }
                 // 专题页封面
@@ -126,12 +126,12 @@ module.exports = async (ctx) => {
             }
             // video小视频
             videoHTML = '';
-            if (data.video_playurl){
+            if (data.video_playurl) {
                 videoHTML += `<video width="${data.width}" height="${data.height}" controls><source src="${unescape(data.video_playurl).replace(/^http\:/,'https:')}"><source src="${unescape(data.video_playurl)}"></video>`;
             }
             // some rss readers disallow http content.
             // 部分 RSS 阅读器要求内容必须使用https传输
-            // bilibili short video does support https request, but https request may timeout ocassionally. 
+            // bilibili short video does support https request, but https request may timeout ocassionally.
             // to maximize content availability, here add two source tags.
             // bilibili的API中返回的视频地址采用http，然而经验证，短视频地址支持https访问，但偶尔会返回超时错误(可能是网络原因)。
             // 因此保险起见加入两个source标签

--- a/lib/routes/bilibili/dynamic.js
+++ b/lib/routes/bilibili/dynamic.js
@@ -106,8 +106,10 @@ module.exports = async (ctx) => {
                 if (data.pic) {
                     imgs += `<img src="${data.pic}">`;
                 }
-                // 音频/番剧/直播间封面
-                if (data.cover) {
+                // 音频/番剧/直播间封面/小视频封面
+                if (data.cover && data.cover.unclipped) {
+                    imgs += `<img src="${data.cover.unclipped}">`;
+                }else if(data.cover){
                     imgs += `<img src="${data.cover}">`;
                 }
                 // 专题页封面
@@ -122,6 +124,17 @@ module.exports = async (ctx) => {
             if (origin) {
                 imgHTML += getImgs(origin.item || origin);
             }
+            // video小视频
+            videoHTML = '';
+            if (data.video_playurl){
+                videoHTML += `<video width="${data.width}" height="${data.height}" controls><source src="${unescape(data.video_playurl).replace(/^http\:/,'https:')}"><source src="${unescape(data.video_playurl)}"></video>`;
+            }
+            // some rss readers disallow http content.
+            // 部分 RSS 阅读器要求内容必须使用https传输
+            // bilibili short video does support https request, but https request may timeout ocassionally. 
+            // to maximize content availability, here add two source tags.
+            // bilibili的API中返回的视频地址采用http，然而经验证，短视频地址支持https访问，但偶尔会返回超时错误(可能是网络原因)。
+            // 因此保险起见加入两个source标签
             // link
             let link = '';
             if (data.dynamic_id) {
@@ -154,7 +167,7 @@ module.exports = async (ctx) => {
                 title: getTitle(data),
                 description: `${data_content || getDes(data)}${
                     origin && getOriginName(origin) ? `<br><br>//转发自: @${getOriginName(origin)}: ${getOriginTitle(origin.item || origin)}${getDes(origin.item || origin)}` : `${getOriginDes(origin)}`
-                }${getIframe(data)}${getIframe(origin)}${imgHTML ? `<br>${imgHTML}` : ''}`,
+                }${getIframe(data)}${getIframe(origin)}${imgHTML ? `<br>${imgHTML}` : ''}${videoHTML ? `<br>${videoHTML}` : ''}`,
                 pubDate: new Date(item.desc.timestamp * 1000).toUTCString(),
                 link: link,
             };


### PR DESCRIPTION
Fix issue #5306 

`item.cover` could be JSON object after Bilibili add short video support in user's post content. Fix a bug that could result in feed exceptions when user's post contains a short video. RSSHub feed now can display video content if user uploads short video in his post.