### PR TITLE
fix: RSS Language Tag for Engadget

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -2058,7 +2058,7 @@ router.get('/pintu360/:type?', require('./routes/pintu360/index'));
 router.get('/engadget-cn', require('./routes/engadget/home'));
 
 // engadget
-router.get('/engadget/:lang', require('./routes/engadget/home'));
+router.get('/engadget/:lang?', require('./routes/engadget/home'));
 
 // 吹牛部落
 router.get('/chuiniu/column/:id', require('./routes/chuiniu/column'));

--- a/lib/routes/engadget/home.js
+++ b/lib/routes/engadget/home.js
@@ -57,6 +57,7 @@ module.exports = async (ctx) => {
         title: feed.title,
         link: feed.link,
         description: feed.description,
+        language: feed.language,
         item: items,
     };
 };


### PR DESCRIPTION
## Desc.

- Add RSS Language Tag for Engadget;
- Allow empty language argument in Engadget path, which is handled in `lib/routes/engadget/home.js` at line 6 but is not allowed in libs/router.js
  - At line 6 in `lib/routes/engadget/home.js`, empty `ctx.params.lang` is accepted and deemed as `cn`. 

    ```javascript
    const lang = ctx.params.lang === 'us' ? 'www' : ctx.params.lang || 'cn';
    ```

  - However, in `lib/router.js`, we do not have a corresponding rule to handle empty language argument.  At line 2061:

    ```javascript
    // engadget中国版
    router.get('/engadget-cn', require('./routes/engadget/home'));

    // engadget
    router.get('/engadget/:lang', require('./routes/engadget/home'));
    ```

## 该 PR 相关 Issue / Involved issue

None

## 完整路由地址 / Example for the proposed route(s)

`/engadget/:language` -> `/engadget/:language?`

<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->