### PR TITLE
feat:add 中华人民共和国农业农村部-数据-最新发布

### DIFF
--- a/docs/government.md
+++ b/docs/government.md
@@ -417,7 +417,7 @@ pageClass: routes
 
 ### 数据 - 最新发布
 
-<Route author="MisteryMonster" example="/gov/moasj/zxfb" path="/gov/moasj/zxfb"/>
+<Route author="MisteryMonster" example="/gov/moa/sjzxfb" path="/gov/moa/sjzxfb"/>
 
 ## 中华人民共和国商务部
 

--- a/docs/government.md
+++ b/docs/government.md
@@ -413,7 +413,9 @@ pageClass: routes
 -   像[政策法规](http://www.moa.gov.cn/gk/zcfg/)这种页面 (`http://www.moa.gov.cn/gk/zcfg/`), 它**不是**一个合法的分类目录，它是`法律`, `行政法规`, `部门规章`等一堆栏目的集合，这时候请点开对应栏目的`更多 >>`进入栏目的目录，再根据上面的规则提取`suburl`
 -   特别地，`图片新闻`对应的`suburl`为`xw/tpxw/`, `最新公开`对应的`suburl`为`govpublic`
 
-</Route>
+### 数据 - 最新发布
+
+<Route author="MisteryMonster" example="/gov/moasj/zxfb" path="/gov/moasj/zxfb"/>
 
 ## 中华人民共和国商务部
 

--- a/docs/government.md
+++ b/docs/government.md
@@ -413,6 +413,8 @@ pageClass: routes
 -   像[政策法规](http://www.moa.gov.cn/gk/zcfg/)这种页面 (`http://www.moa.gov.cn/gk/zcfg/`), 它**不是**一个合法的分类目录，它是`法律`, `行政法规`, `部门规章`等一堆栏目的集合，这时候请点开对应栏目的`更多 >>`进入栏目的目录，再根据上面的规则提取`suburl`
 -   特别地，`图片新闻`对应的`suburl`为`xw/tpxw/`, `最新公开`对应的`suburl`为`govpublic`
 
+</Route>
+
 ### 数据 - 最新发布
 
 <Route author="MisteryMonster" example="/gov/moasj/zxfb" path="/gov/moasj/zxfb"/>

--- a/lib/router.js
+++ b/lib/router.js
@@ -1809,6 +1809,7 @@ router.get('/ccdi/scdc', require('./routes/ccdi/scdc'));
 
 // 中华人民共和国农业农村部
 router.get('/gov/moa/:suburl(.*)', require('./routes/gov/moa/moa'));
+router.get('/gov/moasj/zxfb', require('./routes/gov/moa/sjzxfb'));
 
 // 香水时代
 router.get('/nosetime/:id/:type/:sort?', require('./routes/nosetime/comment'));

--- a/lib/router.js
+++ b/lib/router.js
@@ -1808,8 +1808,8 @@ router.get('/cninfo/fund_announcement/:code?/:searchkey?', require('./routes/cni
 router.get('/ccdi/scdc', require('./routes/ccdi/scdc'));
 
 // 中华人民共和国农业农村部
+router.get('/gov/moa/sjzxfb', require('./routes/gov/moa/sjzxfb'));
 router.get('/gov/moa/:suburl(.*)', require('./routes/gov/moa/moa'));
-router.get('/gov/moasj/zxfb', require('./routes/gov/moa/sjzxfb'));
 
 // 香水时代
 router.get('/nosetime/:id/:type/:sort?', require('./routes/nosetime/comment'));

--- a/lib/routes/gov/moa/sjzxfb.js
+++ b/lib/routes/gov/moa/sjzxfb.js
@@ -1,0 +1,20 @@
+const got = require('@/utils/got');
+
+module.exports = async (ctx) => {
+    const response = await got({
+        method: 'get',
+        url: `http://zdscxx.moa.gov.cn:8080/misportal/echartReport/webData/%E6%9C%80%E6%96%B0%E5%8F%91%E5%B8%83/page1.json`,
+    });
+    const data = response.data;
+
+    ctx.state.data = {
+        title: '中华人民共和国农业农村部 - 数据 - 最新发布',
+        link: `http://zdscxx.moa.gov.cn:8080/nyb/pc/index.jsp`,
+        item: data.map((item) => ({
+            title: `${item.title}`,
+            description: `${item.content}`,
+            link: `http://zdscxx.moa.gov.cn:8080/misportal/public/agricultureMessageViewDC.jsp?page=1&channel=%E6%9C%80%E6%96%B0%E5%8F%91%E5%B8%83&id=${item._id}`,
+            pubDate: `${item.publishTime}`,
+        })),
+    };
+};


### PR DESCRIPTION
#5260
没办法把路由放在在同一 `/moa` 下，因为原本的` 新闻` 路由覆盖掉了所有的子目录，因为不会搞所以另开了路由……等一个有缘人看看能不能帮忙改到同一路由下。