### PR TITLE
refactor: mastodon

### DIFF
--- a/lib/routes/mastodon/account_id.js
+++ b/lib/routes/mastodon/account_id.js
@@ -1,39 +1,17 @@
-const got = require('@/utils/got');
 const utils = require('./utils');
 
 module.exports = async (ctx) => {
     const site = ctx.params.site;
     const account_id = ctx.params.account_id;
-    const only_media = ctx.params.only_media ? true : false;
+    const only_media = ctx.params.only_media ? 'true' : 'false';
 
-    const statuses_url = `http://${site}/api/v1/accounts/${account_id}/statuses`;
-    const statuses_response = await got({
-        method: 'get',
-        url: statuses_url,
-    });
-    let data = statuses_response.data;
-
-    let account_data;
-    if (data.length !== 0 && data[0].account !== null) {
-        account_data = data[0].account;
-    } else {
-        const account_url = `http://${site}/api/v1/accounts/${account_id}`;
-        const account_response = await got({
-            method: 'get',
-            url: account_url,
-        });
-        account_data = account_response.data;
-    }
-
-    if (only_media === true) {
-        data = data.filter((item) => item.media_attachments.length !== 0);
-    }
+    const { account_data, data } = await utils.getAccountStatuses(site, account_id, only_media);
 
     ctx.state.data = {
         title: `${account_data.display_name} (@${account_data.acct})`,
         link: `${account_data.url}`,
         description: `${account_data.note}`,
-        item: utils.ProcessFeed(data),
+        item: utils.parseStatuses(data),
         allowEmpty: true,
     };
 };

--- a/lib/routes/mastodon/acct.js
+++ b/lib/routes/mastodon/acct.js
@@ -1,87 +1,18 @@
-const got = require('@/utils/got');
 const utils = require('./utils');
-const config = require('@/config').value;
-const mastodonConfig = config.mastodon;
 
 module.exports = async (ctx) => {
-    const getAccountIdByAcct = async (acct) => {
-        if (!(mastodonConfig.apiHost && mastodonConfig.accessToken && mastodonConfig.acctDomain)) {
-            throw 'this route require api configuration, please check <a href="https://docs.rsshub.app/en/install/#configuration">documentation</a>';
-        }
-
-        const site = mastodonConfig.apiHost;
-
-        const search_url = `http://${site}/api/v2/search`;
-        const cacheUid = `mastodon_acct_id/${site}/${acct}`;
-
-        return await ctx.cache.tryGet(cacheUid, async () => {
-            const search_response = await got({
-                method: 'get',
-                url: search_url,
-                headers: {
-                    Authorization: `Bearer ${mastodonConfig.accessToken}`,
-                },
-                searchParams: {
-                    q: acct,
-                    type: 'accounts',
-                },
-            });
-            const [acctUser, acctHost] = acct.split('@').filter((e) => e);
-            let acctOnServer;
-
-            if (acctHost) {
-                if (acctHost === mastodonConfig.acctDomain) {
-                    acctOnServer = acctUser;
-                } else {
-                    acctOnServer = acctUser + '@' + acctHost;
-                }
-            } else {
-                acctOnServer = acctUser;
-            }
-
-            const accountData = search_response.data.accounts.filter((item) => item.acct === acctOnServer);
-
-            if (accountData.length === 0) {
-                throw `acct ${acct} not found`;
-            }
-            return accountData[0].id;
-        });
-    };
-
     const acct = ctx.params.acct;
-    const only_media = ctx.params.only_media ? true : false;
+    const only_media = ctx.params.only_media ? 'true' : 'false';
 
-    const site = mastodonConfig.apiHost;
-    const account_id = await getAccountIdByAcct(acct);
+    const { site, account_id } = await utils.getAccountIdByAcct(acct, ctx);
 
-    const statuses_url = `http://${site}/api/v1/accounts/${account_id}/statuses`;
-    const statuses_response = await got({
-        method: 'get',
-        url: statuses_url,
-    });
-    let data = statuses_response.data;
-
-    let account_data;
-    if (data.length !== 0 && data[0].account !== null) {
-        account_data = data[0].account;
-    } else {
-        const account_url = `http://${site}/api/v1/accounts/${account_id}`;
-        const account_response = await got({
-            method: 'get',
-            url: account_url,
-        });
-        account_data = account_response.data;
-    }
-
-    if (only_media === true) {
-        data = data.filter((item) => item.media_attachments.length !== 0);
-    }
+    const { account_data, data } = await utils.getAccountStatuses(site, account_id, only_media);
 
     ctx.state.data = {
         title: `${account_data.display_name} (@${account_data.acct})`,
         link: `${account_data.url}`,
         description: `${account_data.note}`,
-        item: utils.ProcessFeed(data),
+        item: utils.parseStatuses(data),
         allowEmpty: true,
     };
 };

--- a/lib/routes/mastodon/timeline.js
+++ b/lib/routes/mastodon/timeline.js
@@ -13,6 +13,6 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `Local Public${ctx.params.only_media ? ' Media' : ''} Timeline on ${site}`,
         link: `http://${site}`,
-        item: utils.ProcessFeed(list),
+        item: utils.parseStatuses(list),
     };
 };

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -2,36 +2,39 @@ const ProcessFeed = (data) =>
     data.map((item) => {
         const content = item.content
             ? item.content
-                  .replace(/<span.*?>|<\/span.*?>/gm, '')
-                  .replace(/<(?:.|\n)*?>/gm, '\n')
-                  .split('\n')
-                  .filter((s) => s !== '')[0]
+                .replace(/<span.*?>|<\/span.*?>/gm, '')
+                .replace(/<(?:.|\n)*?>/gm, '\n')
+                .split('\n')
+                .filter((s) => s !== '')[0]
             : '';
 
-        const media = item.media_attachments
-            .map((item) => {
-                switch (item.type) {
-                    case 'gifv':
-                        return `<br><video src="${item.url}" autoplay loop>GIF</video>`;
-                    case 'video':
-                        return `<br><video src="${item.url}" controls loop>Video</video>`;
-                    case 'image':
-                        return `<br><img src="${item.url}">`;
-                    default:
-                        return '';
-                }
-            })
-            .join('');
+        const mediaParse = (media_attachments) =>
+            media_attachments
+                .map((item) => {
+                    switch (item.type) {
+                        case 'gifv':
+                            return `<br><video src="${item.url}" autoplay loop>GIF</video>`;
+                        case 'video':
+                            return `<br><video src="${item.url}" controls loop>Video</video>`;
+                        case 'image':
+                            return `<br><img src="${item.url}">`;
+                        default:
+                            return '';
+                    }
+                })
+                .join('');
 
-        let author, link, titleAuthor;
+        let author, link, titleAuthor, media;
         if (item.reblog !== null) {
             author = `${item.reblog.account.display_name} (@${item.reblog.account.acct})`;
             link = item.reblog.url;
             titleAuthor = `Re @${item.reblog.account.username}`;
+            media = mediaParse(item.reblog.media_attachments);
         } else {
             author = `${item.account.display_name} (@${item.account.acct})`;
             link = item.url;
             titleAuthor = `@${item.account.username}`;
+            media = mediaParse(item.media_attachments);
         }
         const titleText = item.sentitive === true ? `(CW) ${item.spoiler_text}` : content;
 

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -3,6 +3,7 @@ const got = require('@/utils/got');
 const parseStatuses = (data) =>
     data.map((item) => {
         const content = item.content ? item.content.replace(/<span.*?>|<\/span.*?>/gm, '') : '';
+        const contentRemovedHtml = content.replace(/<(?:.|\n)*?>/gm, '\n');
 
         const mediaParse = (media_attachments) =>
             media_attachments
@@ -32,7 +33,7 @@ const parseStatuses = (data) =>
             titleAuthor = `@${item.account.username}`;
             media = mediaParse(item.media_attachments);
         }
-        const titleText = item.sentitive === true ? `(CW) ${item.spoiler_text}` : content;
+        const titleText = item.sentitive === true ? `(CW) ${item.spoiler_text}` : contentRemovedHtml;
 
         return {
             title: `${titleAuthor}: "${titleText}"`,

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -1,4 +1,6 @@
-const ProcessFeed = (data) =>
+const got = require('@/utils/got');
+
+const parseStatuses = (data) =>
     data.map((item) => {
         const content = item.content ? item.content.replace(/<span.*?>|<\/span.*?>/gm, '') : '';
 
@@ -42,6 +44,82 @@ const ProcessFeed = (data) =>
         };
     });
 
+async function getAccountStatuses(site, account_id, only_media) {
+    const statuses_url = `http://${site}/api/v1/accounts/${account_id}/statuses?only_media=${only_media}`;
+    const statuses_response = await got({
+        method: 'get',
+        url: statuses_url,
+    });
+    let data = statuses_response.data;
+
+    let account_data;
+    if (data.length !== 0 && data[0].account !== null) {
+        account_data = data[0].account;
+    } else {
+        const account_url = `http://${site}/api/v1/accounts/${account_id}`;
+        const account_response = await got({
+            method: 'get',
+            url: account_url,
+        });
+        account_data = account_response.data;
+    }
+
+    if (only_media === true) {
+        data = data.filter((item) => item.media_attachments.length !== 0);
+    }
+    return { account_data, data };
+}
+
+async function getAccountIdByAcct(acct, ctx) {
+    const config = require('@/config').value;
+    const mastodonConfig = config.mastodon;
+
+    if (!(mastodonConfig.apiHost && mastodonConfig.accessToken && mastodonConfig.acctDomain)) {
+        throw 'this route require api configuration, please check <a href="https://docs.rsshub.app/en/install/#configuration">documentation</a>';
+    }
+
+    const site = mastodonConfig.apiHost;
+
+    const search_url = `http://${site}/api/v2/search`;
+    const cacheUid = `mastodon_acct_id/${site}/${acct}`;
+
+    const account_id = await ctx.cache.tryGet(cacheUid, async () => {
+        const search_response = await got({
+            method: 'get',
+            url: search_url,
+            headers: {
+                Authorization: `Bearer ${mastodonConfig.accessToken}`,
+            },
+            searchParams: {
+                q: acct,
+                type: 'accounts',
+            },
+        });
+        const [acctUser, acctHost] = acct.split('@').filter((e) => e);
+        let acctOnServer;
+
+        if (acctHost) {
+            if (acctHost === mastodonConfig.acctDomain) {
+                acctOnServer = acctUser;
+            } else {
+                acctOnServer = acctUser + '@' + acctHost;
+            }
+        } else {
+            acctOnServer = acctUser;
+        }
+
+        const accountData = search_response.data.accounts.filter((item) => item.acct === acctOnServer);
+
+        if (accountData.length === 0) {
+            throw `acct ${acct} not found`;
+        }
+        return accountData[0].id;
+    });
+    return { site, account_id };
+}
+
 module.exports = {
-    ProcessFeed: ProcessFeed,
+    parseStatuses: parseStatuses,
+    getAccountStatuses: getAccountStatuses,
+    getAccountIdByAcct: getAccountIdByAcct,
 };

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -38,7 +38,7 @@ const parseStatuses = (data) =>
         return {
             title: `${titleAuthor}: "${titleText}"`,
             author: author,
-            description: content + media,
+            description: item.spoiler_text + '<br><br>' + content + media,
             pubDate: new Date(item.created_at).toUTCString(),
             link: link,
             guid: item.uri,

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -38,7 +38,7 @@ const parseStatuses = (data) =>
         return {
             title: `${titleAuthor}: "${titleText}"`,
             author: author,
-            description: item.spoiler_text + '<br><br>' + content + media,
+            description: item.spoiler_text + '<hr />' + content + media,
             pubDate: new Date(item.created_at).toUTCString(),
             link: link,
             guid: item.uri,

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -51,7 +51,7 @@ async function getAccountStatuses(site, account_id, only_media) {
         method: 'get',
         url: statuses_url,
     });
-    let data = statuses_response.data;
+    const data = statuses_response.data;
 
     let account_data;
     if (data.length !== 0 && data[0].account !== null) {
@@ -65,9 +65,6 @@ async function getAccountStatuses(site, account_id, only_media) {
         account_data = account_response.data;
     }
 
-    if (only_media === true) {
-        data = data.filter((item) => item.media_attachments.length !== 0);
-    }
     return { account_data, data };
 }
 

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -1,12 +1,6 @@
 const ProcessFeed = (data) =>
     data.map((item) => {
-        const content = item.content
-            ? item.content
-                .replace(/<span.*?>|<\/span.*?>/gm, '')
-                .replace(/<(?:.|\n)*?>/gm, '\n')
-                .split('\n')
-                .filter((s) => s !== '')[0]
-            : '';
+        const content = item.content ? item.content.replace(/<span.*?>|<\/span.*?>/gm, '') : '';
 
         const mediaParse = (media_attachments) =>
             media_attachments


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

涉及到的路由及测试地址：
 - `/mastodon/acct/:acct/statuses/:only_media?` （此路由需配置 API）
   - ([profile(toots)](https://mastodon.social/@meina)) `/mastodon/acct/meina@mastodon.social/statuses`
   - ([profile(media)](https://mastodon.social/@meina/media)) `/mastodon/acct/meina@mastodon.social/statuses/only_media`
 - `/mastodon/account_id/:site/:account_id/statuses/:only_media?`
   - ([profile(toots)](https://mastodon.social/@meina)) https://rsshub-git-fork-notofoe-mastodon-format.diy.vercel.app/mastodon/account_id/mastodon.online/10037/statuses 
   - ([profile(media)](https://mastodon.social/@meina/media)) https://rsshub-git-fork-notofoe-mastodon-format.diy.vercel.app/mastodon/account_id/mastodon.online/10037/statuses/only_media
-----
 - `/mastodon/timeline/:site/:only_media?`
   - https://rsshub-git-fork-notofoe-mastodon-format.diy.vercel.app/mastodon/timeline/mastodon.social
   - https://rsshub-git-fork-notofoe-mastodon-format.diy.vercel.app/mastodon/timeline/mastodon.social/only_media