### PR TITLE
Fix? #5385. Force allow `solidot` cert, while `WoTrust` is unclear.

### DIFF
--- a/lib/routes/solidot/_article.js
+++ b/lib/routes/solidot/_article.js
@@ -11,6 +11,9 @@ module.exports = async function get_article(url) {
         method: 'get',
         url: url,
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',
+        https: {
+            rejectUnauthorized: false,
+        },
     });
     const data = response.data;
     const $ = cheerio.load(data);

--- a/lib/routes/solidot/main.js
+++ b/lib/routes/solidot/main.js
@@ -16,6 +16,9 @@ module.exports = async (ctx) => {
         method: 'get',
         url: list_url,
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',
+        https: {
+            rejectUnauthorized: false,
+        },
     });
     const data = response.data; // content is html format
     const $ = cheerio.load(data);


### PR DESCRIPTION
It may be a dangerous choice.
Should we only use this locally?