### PR TITLE
fix: 掘金

### DIFF
--- a/lib/routes/juejin/pins.js
+++ b/lib/routes/juejin/pins.js
@@ -4,8 +4,7 @@ module.exports = async (ctx) => {
     const response = await got({
         method: 'post',
         url: 'https://apinew.juejin.im/recommend_api/v1/short_msg/recommend',
-        json: true,
-        data: { id_type: 4, sort_type: 300, cursor: '0', limit: 20 },
+        json: { id_type: 4, sort_type: 300, cursor: '0', limit: 20 },
     });
 
     const items = response.data.data.map((item) => {

--- a/lib/routes/juejin/trending.js
+++ b/lib/routes/juejin/trending.js
@@ -1,56 +1,71 @@
 const got = require('@/utils/got');
-const querystring = require('querystring');
-
-const got_ins = got.extend({
-    responseType: 'json',
-    headers: { 'X-Juejin-Src': 'web' },
-});
+const util = require('./utils');
 
 module.exports = async (ctx) => {
     const { category, type } = ctx.params;
 
-    let id = 'all';
+    let id = '';
     let name = '';
-    await got_ins.get('https://gold-tag-ms.juejin.im/v1/categories').then(function (response) {
-        const [item] = response.data.d.categoryList.filter((item) => category.localeCompare(item.title) === 0);
-        if (item !== undefined) {
-            id = item.id;
-            name = item.name;
-        }
+    let url = 'recommended';
+    const idResponse = await got({
+        method: 'get',
+        url: 'https://apinew.juejin.im/tag_api/v1/query_category_briefs',
     });
+    const cat = idResponse.data.data.find((item) => item.category_url === category);
+    if (cat) {
+        id = cat.category_id;
+        name = cat.category_name;
+        url = cat.category_url;
+    }
 
     const params = {
-        monthly: { period: 'month', title: '本月', link: 'monthlyHottest', url: 'get_entry_by_period' },
-        weekly: { period: 'week', title: '本周', link: 'weeklyHottest', url: 'get_entry_by_period' },
-        historical: { period: '', title: '历史', link: 'hottest', url: 'get_entry_by_hot' },
+        monthly: {
+            period: 'month',
+            title: '本月',
+            link: 'monthly_hottest',
+            sort_type: 30,
+        },
+        weekly: {
+            period: 'week',
+            title: '本周',
+            link: 'weekly_hottest',
+            url: 'get_entry_by_period',
+            sort_type: 7,
+        },
+        historical: {
+            period: '',
+            title: '历史',
+            link: 'hottest',
+            sort_type: 0,
+        },
     };
 
     const p = params[type];
-    const qs = querystring.stringify({
-        src: 'web',
-        limit: 20,
-        period: p.period,
-        category: id,
-    });
 
     const title = `掘金${name}${p.title}最热`;
-    const url = `https://timeline-merger-ms.juejin.im/v1/${p.url}?${qs}`;
-    const link = `https://juejin.im/timeline/${id}?sort=${p.link}`;
+    const link = `https://juejin.im/${url}?sort=${p.link}`;
 
-    const trendingResponse = await got_ins.get(url);
-    const entrylist = trendingResponse.data.d.entrylist;
+    let getUrl = 'https://apinew.juejin.im/recommend_api/v1/article/recommend_all_feed';
+    const getJson = {
+        cursor: '0',
+        id_type: 2,
+        limit: 20,
+        sort_type: p.sort_type,
+    };
 
-    const resultItems = await Promise.all(
-        entrylist.map(async (item) => {
-            const resultItem = {
-                title: item.title,
-                link: item.originalUrl,
-                description: item.summaryInfo,
-                pubDate: item.createdAt,
-            };
-            return Promise.resolve(resultItem);
-        })
-    );
+    if (url !== 'recommended') {
+        getUrl = 'https://apinew.juejin.im/recommend_api/v1/article/recommend_cate_feed';
+        getJson.cate_id = id;
+    }
+
+    const trendingResponse = await got({
+        method: 'post',
+        url: getUrl,
+        json: getJson,
+    });
+    const entrylist = trendingResponse.data.data;
+
+    const resultItems = await util.ProcessFeed(entrylist, ctx.cache);
 
     ctx.state.data = {
         title: title,


### PR DESCRIPTION
掘金最近更改了 API，导致很多路由都失效了
当前已修复：分类，标签，热门，小册，沸点，专栏（文章），收藏集，单个收藏夹
由于【分享】和【专栏】合并，所以【分享】目前未修复

Closes #5332