### PR TITLE
fix: mastodon broken local image

### DIFF
--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -21,7 +21,7 @@ const parseStatuses = (data) =>
                             return `<br><audio controls src="${selectedUrl}">audio ${description}</audio>`;
                         case 'unknown':
                         default:
-                            return `<br><a href=${selectedUrl}">media ${description}</a>`;
+                            return `<br><a href="${selectedUrl}">media ${description}</a>`;
                     }
                 })
                 .join('');

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -15,7 +15,7 @@ const parseStatuses = (data) =>
                         case 'video':
                             return `<br><video src="${selectedUrl}" controls loop>video ${item.description}</video>`;
                         case 'image':
-                            return `<br><img src="${selectedUrl} alt="${item.description}">`;
+                            return `<br><img src="${selectedUrl}" alt="${item.description}">`;
                         case 'audio':
                             return `<br><audio controls src="${selectedUrl}">audio ${item.description}</audio>`;
                         case 'unknown':

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -8,18 +8,19 @@ const parseStatuses = (data) =>
         const mediaParse = (media_attachments) =>
             media_attachments
                 .map((item) => {
+                    const selectedUrl = item.remote_url ? item.remote_url : item.url;
                     switch (item.type) {
                         case 'gifv':
-                            return `<br><video src="${item.remote_url}" autoplay loop>GIF</video>`;
+                            return `<br><video src="${selectedUrl}" autoplay loop>gif ${item.description}</video>`;
                         case 'video':
-                            return `<br><video src="${item.remote_url}" controls loop>Video</video>`;
+                            return `<br><video src="${selectedUrl}" controls loop>video ${item.description}</video>`;
                         case 'image':
-                            return `<br><img src="${item.remote_url}">`;
+                            return `<br><img src="${selectedUrl} alt="${item.description}">`;
                         case 'audio':
-                            return `<br><audio controls src="${item.remote_url}"/>`;
+                            return `<br><audio controls src="${selectedUrl}">audio ${item.description}</audio>`;
                         case 'unknown':
                         default:
-                            return `<br><a href=${item.remote_url}>${item.remote_url}</a>`;
+                            return `<br><a href=${selectedUrl}media ${item.description}</a>`;
                     }
                 })
                 .join('');

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -9,18 +9,19 @@ const parseStatuses = (data) =>
             media_attachments
                 .map((item) => {
                     const selectedUrl = item.remote_url ? item.remote_url : item.url;
+                    const description = item.description ? item.description : '';
                     switch (item.type) {
                         case 'gifv':
-                            return `<br><video src="${selectedUrl}" autoplay loop>gif ${item.description}</video>`;
+                            return `<br><video src="${selectedUrl}" autoplay loop>gif ${description}</video>`;
                         case 'video':
-                            return `<br><video src="${selectedUrl}" controls loop>video ${item.description}</video>`;
+                            return `<br><video src="${selectedUrl}" controls loop>video ${description}</video>`;
                         case 'image':
-                            return `<br><img src="${selectedUrl}" alt="${item.description}">`;
+                            return `<br><img src="${selectedUrl}" alt="image ${description}">`;
                         case 'audio':
-                            return `<br><audio controls src="${selectedUrl}">audio ${item.description}</audio>`;
+                            return `<br><audio controls src="${selectedUrl}">audio ${description}</audio>`;
                         case 'unknown':
                         default:
-                            return `<br><a href=${selectedUrl}media ${item.description}</a>`;
+                            return `<br><a href=${selectedUrl}">media ${description}</a>`;
                     }
                 })
                 .join('');


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

N/A

## 完整路由地址 / Example for the proposed route(s)

涉及到的路由及测试地址：

 - `/mastodon/acct/:acct/statuses/:only_media?`
 - `/mastodon/account_id/:site/:account_id/statuses/:only_media?`
   - \[[profile 1(media)](https://mastodon.online/@Akillusion/media)\] `/mastodon/account_id/mastodon.online/62270/statuses/only_media`
   - \[[profile 2(media)](https://pawoo.net/@torot/media)\] `/mastodon/account_id/mastodon.online/33105/statuses/only_media`
 - `/mastodon/timeline/:site/:only_media?`
   - `/mastodon/timeline/pawoo.net/only_media`
 - `/mastodon/remote/:site/:only_media?`
   - `/mastodon/remote/pawoo.net/only_media`

## Checklist
 - [x] 本站图片的正常显示 (check profile 1)
 - [x] 跨站图片的正常显示 (check profile 2)
