### PR TITLE
fix 福建福州新闻路由参数传递错误

### DIFF
--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -748,12 +748,8 @@ category 对应的关键词有
 </Route>
 
 ### 福建新闻
-
-<Route author="jjlzg" example="/fjnews/fj/30" path="/fjnews/fznews"/>
-
-### 福州新闻
-
-<Route author="jjlzg" example="/fjnews/fz/30" path="/fjnews/fznews"/>
+### city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
+<Route author="jjlzg" example="/fjnews/:city/:limit" path="/fjnews/fznews"/>
 
 ### 九江新闻
 

--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -748,16 +748,12 @@ category 对应的关键词有
 </Route>
 
 ### 福建新闻
-### city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
+
+<Route author="jjlzg" example="/fjnews/fj/30" path="/fjnews/fznews"/>
+
+### 福州新闻
+
 <Route author="jjlzg" example="/fjnews/fz/30" path="/fjnews/fznews"/>
-
-城市分类
-| fj     | fz   |
-| ------ |------|
-|福建新闻|福州新闻|
-
-限制条数
-建议30条，抓取太多速度会变慢
 
 ### 九江新闻
 

--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -749,7 +749,15 @@ category 对应的关键词有
 
 ### 福建新闻
 ### city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
-<Route author="jjlzg" example="/fjnews/:city/:limit" path="/fjnews/fznews"/>
+<Route author="jjlzg" example="/fjnews/fz/30" path="/fjnews/fznews"/>
+
+城市分类
+| fj     | fz   |
+| ------ |------|
+|福建新闻|福州新闻|
+
+限制条数
+建议30条，抓取太多速度会变慢
 
 ### 九江新闻
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -3107,11 +3107,9 @@ router.get('/justrun', require('./routes/justrun/index'));
 // 上海电力大学
 router.get('/shiep/:type', require('./routes/universities/shiep/index'));
 
-// 福建新闻
-router.get('/fjnews/fj/30', require('./routes/fjnews/fznews'));
-
-// 福州新闻
-router.get('/fjnews/fz/30', require('./routes/fjnews/fznews'));
+//福建新闻
+//city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
+router.get('/fjnews/:city/:limit', require('./routes/fjnews/fznews'));
 
 // 九江新闻jjnews
 router.get('/fjnews/jjnews', require('./routes/fjnews/jjnews'));

--- a/lib/router.js
+++ b/lib/router.js
@@ -3107,8 +3107,8 @@ router.get('/justrun', require('./routes/justrun/index'));
 // 上海电力大学
 router.get('/shiep/:type', require('./routes/universities/shiep/index'));
 
-//福建新闻
-//city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
+// 福建新闻
+// city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
 router.get('/fjnews/:city/:limit', require('./routes/fjnews/fznews'));
 
 // 九江新闻jjnews


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

### 福建新闻
### city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
<Route author="jjlzg" example="/fjnews/:city/:limit" path="/fjnews/fznews"/>



## 完整路由地址 / Example for the proposed route(s)

<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->
