### PR TITLE
Update router.js

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -3108,10 +3108,8 @@ router.get('/justrun', require('./routes/justrun/index'));
 router.get('/shiep/:type', require('./routes/universities/shiep/index'));
 
 // 福建新闻
-router.get('/fjnews/fj/30', require('./routes/fjnews/fznews'));
-
-// 福州新闻
-router.get('/fjnews/fz/30', require('./routes/fjnews/fznews'));
+// city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
+router.get('/fjnews/:city/:limit', require('./routes/fjnews/fznews'));
 
 // 九江新闻jjnews
 router.get('/fjnews/jjnews', require('./routes/fjnews/jjnews'));

--- a/lib/router.js
+++ b/lib/router.js
@@ -3108,7 +3108,6 @@ router.get('/justrun', require('./routes/justrun/index'));
 router.get('/shiep/:type', require('./routes/universities/shiep/index'));
 
 // 福建新闻
-// city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
 router.get('/fjnews/:city/:limit', require('./routes/fjnews/fznews'));
 
 // 九江新闻jjnews


### PR DESCRIPTION
fix 福建新闻路由参数

// 福建新闻
// city=fj,福建新闻,city=fz，福州新闻;limit-限制条数,建议30
router.get('/fjnews/:city/:limit', require('./routes/fjnews/fznews'));

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->
