### PR TITLE
fix: 福建新闻路由参数

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -3108,6 +3108,8 @@ router.get('/justrun', require('./routes/justrun/index'));
 router.get('/shiep/:type', require('./routes/universities/shiep/index'));
 
 // 福建新闻
+router.get('/fjnews/:city/:limit', require('./routes/fjnews/fznews'));
+
 router.get('/fjnews/fj/30', require('./routes/fjnews/fznews'));
 
 // 福州新闻


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #


## 完整路由地址 / Example for the proposed route(s)

<!--

router.get('/fjnews/:city/:limit', require('./routes/fjnews/fznews'));

-->
