### PR TITLE
fix: (tencent/wechat/csm)图片路径

### DIFF
--- a/lib/routes/tencent/wechat/csm.js
+++ b/lib/routes/tencent/wechat/csm.js
@@ -13,7 +13,7 @@ module.exports = async (ctx) => {
 
     const items = await Promise.all(
         $('.feed_item')
-            .slice(0, 5)
+            .slice(0, 10)
             .get()
             .map(async (e) => {
                 const pubDate = date(`${$(e).find('.timestamp').text().trim()}`, 8);
@@ -31,9 +31,9 @@ module.exports = async (ctx) => {
                 article('#js_content img').each((index, elem) => {
                     const $elem = article(elem);
 
-                    const imgSrc = $elem.attr('data-original');
+                    const imgSrc = $elem.attr('data-original') || $elem.attr('src');
                     if (imgSrc) {
-                        const realSrc = imgSrc.replace(/^https:\/\/img.chuansongme.com\//, 'https://mmbiz.qpic.cn/');
+                        const realSrc = imgSrc.replace(/^https:\/\/img.chuansongme.com\//, 'https://mmbiz.qpic.cn/').replace(/^http.?\/\/img\d+.store.sogou.com.*url=(.*)$/, '$1');
                         $elem.attr('src', realSrc);
                     }
                 });


### PR DESCRIPTION
修正搜狗搜索图片路径为真实的微信公众号路径

## 该 PR 相关 Issue / Involved issue

无

## 完整路由地址 / Example for the proposed route(s)
https://rsshub.app/wechat/csm/FeZaoDuKe
<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->
