### PR TITLE
fix: change adnmb domain to adnmb3.com

### DIFF
--- a/lib/routes/adnmb/index.js
+++ b/lib/routes/adnmb/index.js
@@ -1,12 +1,15 @@
 const got = require('@/utils/got');
 
+const adnmbBaseUrl = 'https://adnmb3.com';
+const cdnBaseUrl = 'https://nmbimg.fastmirror.org/image/';
+
 async function getForumInfo(pid, ctx) {
     const cache_key = `adnmb::forum::${pid}`;
     const cache = await ctx.cache.get(cache_key);
     if (cache) {
         return JSON.parse(cache);
     }
-    const forumListResponse = await got('https://adnmb2.com/Api/getForumList');
+    const forumListResponse = await got(`${adnmbBaseUrl}/Api/getForumList`);
     const matchedForum = forumListResponse.data
         .map((a) => a.forums)
         .flat()
@@ -24,7 +27,7 @@ module.exports = async (ctx) => {
 
     const forumInfo = await getForumInfo(pid, ctx);
 
-    const url = forumInfo.name === '时间线' ? `https://adnmb2.com/Api/timeline?page=1` : `https://adnmb2.com/Api/showf?id=${forumInfo.id}&page=1`;
+    const url = forumInfo.name === '时间线' ? `${adnmbBaseUrl}/Api/timeline?page=1` : `${adnmbBaseUrl}/Api/showf?id=${forumInfo.id}&page=1`;
     const response = await got({
         method: 'get',
         url: url,
@@ -36,12 +39,12 @@ module.exports = async (ctx) => {
         const newItems = {
             title: item.content,
             pubDate: new Date(item.now.replace(/\(.*?\)/g, ' ') + ' +0800').toUTCString(),
-            link: `https://adnmb2.com/t/${item.id}`,
+            link: `${adnmbBaseUrl}/t/${item.id}`,
         };
-        const img = item.img !== '' ? '<img style="max-width: 100%" src="https://nmbimg.fastmirror.org/image/' + item.img + item.ext + '"/>' : '';
+        const img = item.img !== '' ? '<img style="max-width: 100%" src="' + cdnBaseUrl + item.img + item.ext + '"/>' : '';
         let replys = '';
         item.replys.forEach((reply) => {
-            const replyImg = reply.img !== '' ? '<img style="max-width: 100%" src="https://nmbimg.fastmirror.org/image/' + reply.img + reply.ext + '"/>' : '';
+            const replyImg = reply.img !== '' ? '<img style="max-width: 100%" src="' + cdnBaseUrl + reply.img + reply.ext + '"/>' : '';
             replys += `<h4>${reply.title} ${reply.name}  ${reply.now} ID:${reply.userid} No.${reply.id}</h4> </br>
                           ${reply.content}
                           ${replyImg}
@@ -58,8 +61,8 @@ module.exports = async (ctx) => {
     });
 
     ctx.state.data = {
-        title: `${forumInfo.showName ? forumInfo.showName : forumInfo.name} - a岛匿名版`,
-        link: `https://adnmb2.com/f/${forumInfo.name}`,
+        title: `${forumInfo.showName ? forumInfo.showName : forumInfo.name} - A岛匿名版`,
+        link: `${adnmbBaseUrl}/f/${forumInfo.name}`,
         description: forumInfo.msg,
         item: items,
     };


### PR DESCRIPTION
https://adnmb2.com has been DNS poisoned [since August 2020](https://en.greatfire.org/https/adnmb2.com).

## 完整路由地址 / Example for the proposed route(s)

- `/adnmb/:pid`
  - `/adnmb/-1`
  - `/adnmb/欢乐恶搞`
