### PR TITLE
fix: add missing author field in github and gitlab routes.

### DIFF
--- a/lib/routes/github/follower.js
+++ b/lib/routes/github/follower.js
@@ -42,6 +42,7 @@ module.exports = async (ctx) => {
         link: host,
         item: data.map((follower) => ({
             title: `${follower.node.login} started following ${user}`,
+            author: follower.node.login,
             description: `<a href="https://github.com/${follower.node.login}">${follower.node.login}</a> <br> <img sytle="width:50px;" src='${follower.node.avatarUrl}'>`,
             link: `https://github.com/${follower.node.login}`,
         })),

--- a/lib/routes/github/pulls.js
+++ b/lib/routes/github/pulls.js
@@ -33,6 +33,7 @@ module.exports = async (ctx) => {
         link: host,
         item: data.map((item) => ({
             title: item.title,
+            author: item.user.login,
             description: item.body ? md.render(item.body) : 'No description',
             pubDate: new Date(item.created_at).toUTCString(),
             link: `${link}/${item.number}`,

--- a/lib/routes/github/search.js
+++ b/lib/routes/github/search.js
@@ -24,6 +24,7 @@ module.exports = async (ctx) => {
             const a = $(this).find('.f4.text-normal > a');
             const single = {
                 title: a.text(),
+                author: a.text().split('/')[0].trim(),
                 link: host.concat(a.attr('href')),
                 description: $(this).find('div p').text().trim(),
             };

--- a/lib/routes/github/star.js
+++ b/lib/routes/github/star.js
@@ -43,6 +43,7 @@ module.exports = async (ctx) => {
         link: host,
         item: data.map((follower) => ({
             title: `${follower.node.login} starred ${user}/${repo}`,
+            author: follower.node.login,
             description: `<a href="https://github.com/${follower.node.login}">${follower.node.login}</a> <br> <img sytle="width:50px;" src='${follower.node.avatarUrl}'>`,
             link: `https://github.com/${follower.node.login}`,
         })),

--- a/lib/routes/github/starred_repos.js
+++ b/lib/routes/github/starred_repos.js
@@ -52,6 +52,7 @@ module.exports = async (ctx) => {
         description: `${user}’s starred repositories`,
         item: data.map((repo) => ({
             title: `${user} starred ${repo.node.name}`,
+            author: user,
             description: `${repo.node.description === null ? 'no description' : repo.node.description} <br> primary language: ${
                 repo.node.primaryLanguage === null ? 'no primary language' : repo.node.primaryLanguage.name
             } <br> stargazers: ${repo.node.stargazers.totalCount} <br> <img sytle="width:50px;" src='${repo.node.openGraphImageUrl}'>`,

--- a/lib/routes/github/trending.js
+++ b/lib/routes/github/trending.js
@@ -29,6 +29,7 @@ module.exports = async (ctx) => {
                     item = $(item);
                     return {
                         title: item.find('h1').text(),
+                        author: item.find('h1').text().split('/')[0].trim(),
                         description: `${item.find('.pr-4').text()}<br>
                             <br>Language: ${item.find('span[itemprop="programmingLanguage"]').text() || 'unknown'}
                             <br>Star: ${item.find('.muted-link').eq(0).text()}

--- a/lib/routes/gitlab/explore.js
+++ b/lib/routes/gitlab/explore.js
@@ -26,6 +26,7 @@ module.exports = async (ctx) => {
                     item = $(item);
                     return {
                         title: item.find('.project-full-name').text(),
+                        author: item.find('.namespace-name').text().slice(0, -1).split('\n').join('').trim(),
                         description: item.find('.description').text(),
                         link: `https://gitlab.com${item.find('a.text-plain').attr('href')}`,
                     };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue
Missing author field in few github routes and gitlab explore route. For stars and followers, I figure adding interactor as the author would be suitable. Let me know if there is any problem.

Changed Routes: 
https://rsshub.app/github/search/RSSHub/bestmatch/desc
https://rsshub.app/github/starred_repos/DIYgod
https://rsshub.app/github/pull/DIYgod/RSSHub
https://rsshub.app/github/user/followers/HenryQW
https://rsshub.app/github/stars/DIYGod/RSSHub
https://rsshub.app/gitlab/explore/trending

