### PR TITLE
feat: telegram channel audio & podcast support

### DIFF
--- a/lib/routes/telegram/channel.js
+++ b/lib/routes/telegram/channel.js
@@ -21,6 +21,10 @@ module.exports = async (ctx) => {
         description: $('.tgme_channel_info_description').text(),
         link: resourceUrl,
         allowEmpty: true,
+
+        itunes_author: $('.tgme_channel_info_header_title').text(),
+        image: $('.tgme_page_photo_image > img').attr('src'),
+
         item:
             list &&
             list
@@ -136,6 +140,26 @@ module.exports = async (ctx) => {
                         return messageVideos;
                     };
 
+                    /* audio */
+                    const messageAudioUrl = item.find('audio.tgme_widget_message_voice').length ? item.find('audio.tgme_widget_message_voice').attr('src') : '';
+                    const messageAudioText = item.find('audio.tgme_widget_message_voice').length ? `<audio src="${item.find('audio.tgme_widget_message_voice').attr('src')}"></audio>` : '';
+                    const messageAudioDuration = () => {
+                        if (item.find('.tgme_widget_message_voice_duration').length) {
+                            const durationInMmss = item.find('.tgme_widget_message_voice_duration').text();
+                            const p = durationInMmss.split(':');
+
+                            let second = 0,
+                                minute = 1;
+                            while (p.length > 0) {
+                                second += minute * parseInt(p.pop(), 10);
+                                minute *= 60;
+                            }
+                            return second.toString();
+                        } else {
+                            return '';
+                        }
+                    };
+
                     /* link preview */
                     const linkPreview = () => {
                         const linkPreviewSite = item.find('.link_preview_site_name').length ? `<b>${item.find('.link_preview_site_name').text()}</b><br>` : '';
@@ -162,6 +186,9 @@ module.exports = async (ctx) => {
                     /* attachment */
                     const attachmentTitle = item.find('.tgme_widget_message_document_title').length ? item.find('.tgme_widget_message_document_title').text() + ' / ' + item.find('.tgme_widget_message_document_extra').text() : '';
 
+                    /* pubDate */
+                    const pubDate = new Date(item.find('.tgme_widget_message_date time').attr('datetime')).toUTCString();
+
                     /* message text & title */
                     const messageTextObject = item.find('.tgme_widget_message_bubble > .tgme_widget_message_text');
                     let messageText = '',
@@ -175,16 +202,20 @@ module.exports = async (ctx) => {
                         } else if (attachmentTitle !== '') {
                             messageTitle = attachmentTitle;
                         } else {
-                            messageTitle = '无题';
+                            messageTitle = pubDate;
                         }
                     }
 
                     return {
                         title: mediaTag() + messageTitle,
-                        description: fwdFrom() + replyContent() + messageText + linkPreview() + messageImgs + messageVideos(),
-                        pubDate: new Date(item.find('.tgme_widget_message_date time').attr('datetime')).toUTCString(),
+                        description: fwdFrom() + replyContent() + messageAudioText + messageText + linkPreview() + messageImgs + messageVideos(),
+                        pubDate: pubDate,
                         link: item.find('.tgme_widget_message_date').attr('href'),
                         author: item.find('.tgme_widget_message_from_author').text(),
+
+                        enclosure_url: messageAudioUrl,
+                        enclosure_length: messageAudioDuration(),
+                        enclosure_type: 'audio/ogg',
                     };
                 })
                 .get()


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

`/telegram/channel/:username`

试用泛用型播客客户端订阅路由：
 - `/telegram/channel/notobjective`