### PR TITLE
fix: 端传媒网站接口升级

### DIFF
--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -243,19 +243,21 @@ Category 列表:
 
 ### 端传媒
 
-<Route author="prnake" example="/initium/feature/zh-hans" path="/initium/:type?/:language?" :paramsDesc="['栏目，缺省为深度', '语言，简体`zh-hans`，繁体`zh-hant`，缺省为简体']"/>
+<Route author="prnake" example="/initium/latest/zh-hans" path="/initium/:type?/:language?" :paramsDesc="['栏目，缺省为最新', '语言，简体`zh-hans`，繁体`zh-hant`，缺省为简体']"/>
 
 ::: warning 注意
 
-付费内容全文需要登陆获取，详情见部署页面的配置模块。
+付费内容全文可能需要登陆获取，详情见部署页面的配置模块。
 
 :::
 
 Type 栏目:
 
-| 深度    | What’s New | 广场              | Pick-Up |
-| ------- | ---------- | ----------------- | ------- |
-| feature | news-brief | notes-and-letters | pick_up |
+| 最新   | 深度    | What’s New | 广场              | Pick-Up | 科技       | 风物    | ... |
+| ------ | ------- | ---------- | ----------------- | ------- | ---------- | ------- | --- |
+| latest | feature | news-brief | notes-and-letters | pick_up | technology | culture | ... |
+
+更多栏目名称可通过 <https://theinitium.com/section/special/> 及 <https://theinitium.com/section/hot_channel/> 获取。
 
 通过提取文章全文，以提供比官方源更佳的阅读体验.
 

--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -241,9 +241,7 @@ Category 列表:
 
 ## 端传媒
 
-### 端传媒
-
-<Route author="prnake" example="/initium/latest/zh-hans" path="/initium/:type?/:language?" :paramsDesc="['栏目，缺省为最新', '语言，简体`zh-hans`，繁体`zh-hant`，缺省为简体']"/>
+通过提取文章全文，以提供比官方源更佳的阅读体验。
 
 ::: warning 注意
 
@@ -251,17 +249,23 @@ Category 列表:
 
 :::
 
+### 专题・栏目
+
+<Route author="prnake" example="/initium/latest/zh-hans" path="/initium/:type?/:language?" :paramsDesc="['栏目，缺省为最新', '语言，简体`zh-hans`，繁体`zh-hant`，缺省为简体']"/>
+
 Type 栏目:
 
-| 最新   | 深度    | What’s New | 广场              | Pick-Up | 科技       | 风物    | ... |
-| ------ | ------- | ---------- | ----------------- | ------- | ---------- | ------- | --- |
-| latest | feature | news-brief | notes-and-letters | pick_up | technology | culture | ... |
+| 最新   | 深度    | What’s New | 广场              | 科技       | 风物    | 特约    | ... |
+| ------ | ------- | ---------- | ----------------- | ---------- | ------- | ------- | --- |
+| latest | feature | news-brief | notes-and-letters | technology | culture | pick_up | ... |
 
 更多栏目名称可通过 <https://theinitium.com/section/special/> 及 <https://theinitium.com/section/hot_channel/> 获取。
 
-通过提取文章全文，以提供比官方源更佳的阅读体验.
-
 </Route>
+
+### 话题・标签
+
+<Route author="AgFlore" example="/theinitium/tags/2019_10/zh-hans" path="/theinitium/tags/:type/:language?" :paramsDesc="['话题ID，可从话题页URL中获取，如<https://theinitium.com/tags/2019_10/>', '语言，简体`zh-hans`，繁体`zh-hant`，缺省为简体']"/>
 
 ## 多维新闻网
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -2845,6 +2845,7 @@ router.get('/netease/news/special/:type?', require('./routes/netease/news/specia
 
 // 端传媒
 router.get('/initium/:type?/:language?', require('./routes/initium/full'));
+router.get('/theinitium/:model/:type?/:language?', require('./routes/initium/full'));
 
 // Grub Street
 router.get('/grubstreet', require('./routes/grubstreet/index'));

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -25,7 +25,7 @@ module.exports = async (ctx) => {
     } else {
         const login = await got({
             method: 'post',
-            url: `https://api.theinitium.com/api/v1/auth/login/?language=${language}`,
+            url: `https://api.theinitium.com/api/v2/auth/login/?language=${language}`,
             headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -55,7 +55,7 @@ module.exports = async (ctx) => {
 
     const response = await got({
         method: 'get',
-        url: `https://api.theinitium.com/api/v1/channel/articles/?language=${language}&slug=${type}`,
+        url: `https://api.theinitium.com/api/v2/channel/articles/?language=${language}&slug=${type}`,
         headers: {
             'X-Client-Name': 'Web',
             Accept: '*/*',
@@ -68,6 +68,7 @@ module.exports = async (ctx) => {
 
     const name = response.data.name;
     const articles = response.data.digests;
+    // const image =
 
     const getFullText = async (slug) => {
         let content = await ctx.cache.get(slug + language);
@@ -79,14 +80,14 @@ module.exports = async (ctx) => {
 
         const response = await got({
             method: 'get',
-            url: `https://api.theinitium.com/api/v1/article/detail/?language=${language}&slug=${slug}`,
+            url: `https://api.theinitium.com/api/v2/article/detail/?language=${language}&slug=${slug}`,
             headers: {
                 'X-Client-Name': 'web',
                 Accept: '*/*',
                 Connection: 'keep-alive',
                 Authorization: token,
                 Origin: `https://theinitium.com/`,
-                Referer: `https://theinitium.com/`,
+                Referer: `https://theinitium.com/article/${slug}`,
             },
         });
 
@@ -128,15 +129,18 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         articles.slice(0, 10).map(async (item) => ({
             title: item.article.headline,
+            author: item.article.authors.map((x) => x.name).toString(),
+            // category: ,
             description: await getFullText(item.article.slug),
             link: resolve_url('https://theinitium.com', item.article.url),
             pubDate: item.article.date,
+            guid: item.article.uuid,
         }))
     );
 
     ctx.state.data = {
         title: `端传媒 - ${name}`,
-        link: `https://theinitium.com`,
+        link: `https://theinitium.com/channel/${type}`,
         item: items,
     };
 };

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -4,7 +4,7 @@ const cheerio = require('cheerio');
 const resolve_url = require('url').resolve;
 
 module.exports = async (ctx) => {
-    const type = ctx.params.type || 'feature';
+    const type = ctx.params.type || 'latest';
     const language = ctx.params.language || 'zh-hans';
 
     const key = {
@@ -129,7 +129,8 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         articles.slice(0, token === 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=' ? 10 : articles.length).map(async (item) => ({
             title: item.article.headline,
-            author: item.article.authors.map((x) => x.name).toString(),
+            author: item.article.byline,
+            //author: item.article.authors === [] ? item.article.byline : item.article.authors.map((x) => x.name).toString(),
             category: item.article.tags,
             description: await getFullText(item.article.slug),
             link: resolve_url('https://theinitium.com', item.article.url),

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -130,7 +130,7 @@ module.exports = async (ctx) => {
         articles.slice(0, token === 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=' ? 10 : articles.length).map(async (item) => ({
             title: item.article.headline,
             author: item.article.byline,
-            //author: item.article.authors === [] ? item.article.byline : item.article.authors.map((x) => x.name).toString(),
+            // author: item.article.authors === [] ? item.article.byline : item.article.authors.map((x) => x.name).toString(),
             category: item.article.tags,
             description: await getFullText(item.article.slug),
             link: resolve_url('https://theinitium.com', item.article.url),

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -68,7 +68,7 @@ module.exports = async (ctx) => {
 
     const name = response.data.name;
     const articles = response.data.digests;
-    // const image =
+    const image = 'https://d32kak7w9u5ewj.cloudfront.net/static/bundles/0b9cf7fe9c518887768e6c485764cd12.ico';
 
     const getFullText = async (slug) => {
         let content = await ctx.cache.get(slug + language);
@@ -127,10 +127,10 @@ module.exports = async (ctx) => {
     };
 
     const items = await Promise.all(
-        articles.slice(0, 10).map(async (item) => ({
+        articles.slice(0, token === 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=' ? 10 : articles.length).map(async (item) => ({
             title: item.article.headline,
             author: item.article.authors.map((x) => x.name).toString(),
-            // category: ,
+            category: item.article.tags,
             description: await getFullText(item.article.slug),
             link: resolve_url('https://theinitium.com', item.article.url),
             pubDate: item.article.date,
@@ -142,5 +142,6 @@ module.exports = async (ctx) => {
         title: `端传媒 - ${name}`,
         link: `https://theinitium.com/channel/${type}`,
         item: items,
+        image: image,
     };
 };

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -11,6 +11,7 @@ module.exports = async (ctx) => {
     let listurl;
     let listlink;
     switch (model) {
+
         /*
         case 'author':
             listurl = `https://api.theinitium.com/api/v2/author/?language=${language}&slug=${type}`;

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -4,8 +4,32 @@ const cheerio = require('cheerio');
 const resolve_url = require('url').resolve;
 
 module.exports = async (ctx) => {
+    // model是channel/tag/etc.，而type是latest/feature/quest-academy/etc.
+    const model = ctx.params.model || 'channel';
     const type = ctx.params.type || 'latest';
     const language = ctx.params.language || 'zh-hans';
+    let listurl;
+    let listlink;
+    switch (model) {
+        /*
+        case 'author':
+            listurl = `https://api.theinitium.com/api/v2/author/?language=${language}&slug=${type}`;
+            listlink = `https://theinitium.com/author/${type}/`;
+            break;
+        case 'follows':
+            listurl = `https://api.theinitium.com/api/v2/user/follows/?language=${language}&slug=${type}`;
+            listlink = `https://theinitium.com/follow/`;
+            break;
+        */
+        case 'channel':
+            listurl = `https://api.theinitium.com/api/v2/channel/articles/?language=${language}&slug=${type}`;
+            listlink = `https://theinitium.com/channel/${type}/`;
+            break;
+        case 'tags':
+            listurl = `https://api.theinitium.com/api/v2/tag/articles/?language=${language}&slug=${type}`;
+            listlink = `https://theinitium.com/tags/${type}/`;
+            break;
+    }
 
     const key = {
         email: config.initium.username,
@@ -55,7 +79,7 @@ module.exports = async (ctx) => {
 
     const response = await got({
         method: 'get',
-        url: `https://api.theinitium.com/api/v2/channel/articles/?language=${language}&slug=${type}`,
+        url: listurl,
         headers: {
             'X-Client-Name': 'Web',
             Accept: '*/*',
@@ -129,19 +153,19 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         articles.slice(0, token === 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=' ? 10 : articles.length).map(async (item) => ({
             title: item.article.headline,
-            author: item.article.byline,
-            // author: item.article.authors === [] ? item.article.byline : item.article.authors.map((x) => x.name).toString(),
-            category: item.article.tags,
+            author: item.article.authors.length > 0 ? item.article.authors.map((x) => x.name).toString() : item.article.byline,
+            category: item.article.channels.filter((x) => !x.homepage).map((x) => x.name),
             description: await getFullText(item.article.slug),
             link: resolve_url('https://theinitium.com', item.article.url),
             pubDate: item.article.date,
+            updated: item.article.updated,
             guid: item.article.uuid,
         }))
     );
 
     ctx.state.data = {
         title: `端传媒 - ${name}`,
-        link: `https://theinitium.com/channel/${type}`,
+        link: listlink,
         item: items,
         image: image,
     };


### PR DESCRIPTION
9月29日，theinitium.com 网站升级改版，接口相应从v1升级至v2。从这两天开始，~~新的文章似乎已经不再给v1的接口同步推送；因此需要紧急先修一下~~ 啊不，不是旧接口停用，而是似乎今后更新的深度文章都不再使用feature频道了，因此至少要修改一下默认路由使用feature的逻辑。

新的接口有很多新feature，比如增加了作者信息的数据结构，读者可以对自己需要作者自主订阅，在这边也能实现 ~~（然而拖延症+js苦手导致拖到现在还没弄好）~~ 。但是文章不更新了这个比较要命，所以需要赶紧先上再说【