### PR TITLE
fix: broken route /douban/book/rank

### DIFF
--- a/lib/routes/douban/book/rank.js
+++ b/lib/routes/douban/book/rank.js
@@ -6,7 +6,7 @@ module.exports = async (ctx) => {
 
     const _ = async (type) => {
         const response = await got({
-            url: `https://m.douban.com/rexxar/api/v2/subject_collection/book_${type}_hot_weekly/items?start=0&count=10`,
+            url: `https://m.douban.com/rexxar/api/v2/subject_collection/book_${type}/items?start=0&count=10`,
             headers: { Referer: referer },
         });
         return response.data.subject_collection_items;


### PR DESCRIPTION
路由 `/douban/book/rank` 接口有变化，导致原路由失效。