### PR TITLE
feat: 端传媒 iOS IAP 内购凭证

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -535,8 +535,10 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 -   端传媒设置，用于获取付费内容全文：
 
     -   `INITIUM_BEARER_TOKEN`: 端传媒 Web 版认证 token。获取方式：登陆后打开端传媒站内任意页面，打开浏览器开发者工具中 “网络”(Network) 选项卡，筛选 URL 找到任一个地址为`api.initium.com`开头的请求，点击检查其 “消息头”，在 “请求头” 中找到`Authorization`字段，将其值复制填入配置即可。你的配置应该形如`INITIUM_BEARER_TOKEN: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6JiE1NTYzNDgxNDVAcXEuY29tIiwidXNlcl9pZCI6MTM0NDIwLCJlbWFpbCI6IjE1NTYzNDgxNDVAcXEuY29tIiwiZXhwIjoxNTk0MTk5NjQ3fQ.Tqui-ORNR7d4Bh240nKy_Ldi6crfq0A78Yj2iwy2_U8'`。
+    
+    -   `INITIUM_IAP_RECEIPT`: 端传媒 iOS 版内购回执认证 token。获取方式：登陆后打开端传媒 iOS app 内任意页面，打开抓包工具，筛选 URL 找到任一个地址为`api.initium.com`开头的请求，点击检查其 “消息头”，在 “请求头” 中找到`X-IAP-Receipt`字段，将其值复制填入配置即可。你的配置应该形如`INITIUM_IAP_RECEIPT: 'ef81dee9e4e2fe084a0af1ea82da2f7b16e75f756db321618a119fa62b52550e'`。
 
-    如果你在进行上述操作时遇到困难，亦可选择在环境设置中填写明文的用户名和密码：
+    Web 版认证 token 和 iOS 内购回执认证 token 只需选择其一填入即可。如果你在进行上述操作时遇到困难，亦可选择在环境设置中填写明文的用户名和密码：
 
     -   `INITIUM_USERNAME`: 端传媒用户名 (邮箱)
     -   `INITIUM_PASSWORD`: 端传媒密码

--- a/lib/config.js
+++ b/lib/config.js
@@ -142,6 +142,7 @@ const calculateValue = () => {
             username: envs.INITIUM_USERNAME,
             password: envs.INITIUM_PASSWORD,
             bearertoken: envs.INITIUM_BEARER_TOKEN,
+            iap_receipt: envs.INITIUM_IAP_RECEIPT,
         },
         btbyr: {
             host: envs.BTBYR_HOST,

--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -32,6 +32,7 @@ module.exports = async (ctx) => {
     const key = {
         email: config.initium.username,
         password: config.initium.password,
+        iapReceipt: config.initium.iap_receipt,
     };
     const body = JSON.stringify(key);
 
@@ -74,18 +75,18 @@ module.exports = async (ctx) => {
         token = 'Bearer ' + login.data.token;
         ctx.cache.set('INITIUM_TOKEN', token);
     }
+    
+    let headers = {
+        Accept: '*/*',
+        Connection: 'keep-alive',
+        Authorization: token,
+        'X-IAP-Receipt': key.iapReceipt || '',
+    };
 
     const response = await got({
         method: 'get',
         url: listurl,
-        headers: {
-            'X-Client-Name': 'Web',
-            Accept: '*/*',
-            Connection: 'keep-alive',
-            Authorization: token,
-            Origin: `https://theinitium.com/`,
-            Referer: `https://theinitium.com/`,
-        },
+        headers: headers,
     });
 
     const name = response.data.name || (response.data[model] && response.data[model].name) || '追踪';
@@ -105,14 +106,7 @@ module.exports = async (ctx) => {
         const response = await got({
             method: 'get',
             url: `https://api.theinitium.com/api/v2/article/detail/?language=${language}&slug=${slug}`,
-            headers: {
-                'X-Client-Name': 'web',
-                Accept: '*/*',
-                Connection: 'keep-alive',
-                Authorization: token,
-                Origin: `https://theinitium.com/`,
-                Referer: `https://theinitium.com/article/${slug}`,
-            },
+            headers: headers,
         });
 
         const data = response.data;
@@ -163,7 +157,7 @@ module.exports = async (ctx) => {
     };
 
     const items = await Promise.all(
-        articles.slice(0, token === 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=' ? 10 : articles.length).map(async (item) => ({
+        articles.slice(0, token === 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=' && key.iapReceipt === undefined ? 10 : articles.length).map(async (item) => ({
             title: item.article.headline,
             author: item.article.authors.length > 0 ? item.article.authors.map((x) => x.name).toString() : item.article.byline,
             category: item.article.channels.filter((x) => !x.homepage).map((x) => x.name),


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

/initium/*

说明：新增一个新的环境变量 `INITIUM_IAP_RECEIPT` 用于 iOS 内购付费情况。测试通过可用并更新了说明文档。

<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->
