### PR TITLE
lower the barrier to contributions via automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,19 @@
+tasks:
+  - name: Start
+    init: |
+        yarn install
+        gp sync-done install
+    command: yarn dev
+
+  - name: Docs
+    init: |
+        gp sync-await install
+    command:
+        yarn docs:dev
+
+ports:
+  - port: 1200
+    onOpen: open-preview
+  - port: 8080
+    onOpen: open-preview
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![telegram](https://img.shields.io/badge/chat-telegram-brightgreen.svg?style=flat-square)](https://t.me/rsshub)
 [![build status](https://img.shields.io/travis/DIYgod/RSSHub/master.svg?style=flat-square)](https://travis-ci.org/DIYgod/RSSHub)
 [![Test coverage](https://img.shields.io/codecov/c/github/DIYgod/RSSHub.svg?style=flat-square)](https://codecov.io/github/DIYgod/RSSHub?branch=master)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 ## Introduction
 
@@ -26,6 +27,10 @@ RSSHub 是一个开源、简单易用、易于扩展的 RSS 生成器，可以�
 可以配合浏览器扩展 [RSSHub Radar](https://github.com/DIYgod/RSSHub-Radar) 和 iOS 辅助 App [RSSBud](https://github.com/Cay-Zhang/RSSBud) 食用
 
 [中文文档](https://docs.rsshub.app) | [Telegram 群](https://t.me/rsshub) | [Telegram 频道](https://t.me/awesomeRSSHub)
+
+## Online one-click setup
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Special Thanks
 


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue


Hi. I work for Gitpod. The Prs lowers the barrier to entry for beginners who are willing to contribute code this project via automating the dev setup with Gitpod. With this config in place anyone would be able to start a workspace where it will automatically:

- clone the `RSSHub` repo.
- install all the dependencies via `yarn install`.
- run `yarn dev` and `yarn docs:dev` in separate Linux terminals.

This way any newcomer would be able to start contributing with just a single click with taking care of the setup.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/rsshub

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/96211562-1bbbd780-0f8e-11eb-8b5f-1ab091c7ceed.png)

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->
