### PR TITLE
feat: 上海大学相关

### DIFF
--- a/docs/university.md
+++ b/docs/university.md
@@ -1254,9 +1254,19 @@ type 列表：
 
 ## 上海大学
 
+### 上海大学官网信息
+
+<Route author="lonelyion" example="/shu/news" path="/shu/:type?" :paramsDesc="['消息类型,默认为`news`']">
+
+| 综合新闻 | 科研动态 | 通知公告 |
+| -------- | -------- | -------- |
+| news     | research | notice   |
+
+</Route>
+
 ### 上海大学教务处通知公告
 
-<Route author="tuxinghuan" example="/shu/jwc/notice" path="/university/shu/jwc/:type?" :paramsDesc="['消息类型,默认为`notice`']">
+<Route author="tuxinghuan" example="/shu/jwc/notice" path="/shu/jwc/:type?" :paramsDesc="['消息类型,默认为`notice`']">
 
 | 通知通告 | 新闻 |
 | -------- | ---- |

--- a/lib/router.js
+++ b/lib/router.js
@@ -818,6 +818,7 @@ router.get('/zjut/:type', require('./routes/universities/zjut/index'));
 router.get('/zjut/design/:type', require('./routes/universities/zjut/design'));
 
 // 上海大学
+router.get('/shu/:type?', require('./routes/universities/shu/index'));
 router.get('/shu/jwc/:type?', require('./routes/universities/shu/jwc'));
 
 // 北京科技大学天津学院

--- a/lib/routes/universities/shu/index.js
+++ b/lib/routes/universities/shu/index.js
@@ -1,0 +1,77 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const url = require('url');
+
+const host = 'https://www.shu.edu.cn/';
+
+const config = {
+    news: {
+        link: 'https://www.shu.edu.cn/index/zhxw.htm',
+        title: '综合新闻',
+    },
+    research: {
+        link: 'https://www.shu.edu.cn/index/kydt1.htm',
+        title: '科研动态',
+    },
+    notice: {
+        link: 'https://www.shu.edu.cn/index/tzgg.htm',
+        title: '通知公告',
+    },
+};
+
+module.exports = async (ctx) => {
+    const type = ctx.params.type ? ctx.params.type : 'news';
+    const link = type === 'news' ? config.news.link : type === 'research' ? config.research.link : config.notice.link;
+    const title = type === 'news' ? config.news.title : type === 'research' ? config.research.title : config.notice.title;
+    const respond = await got.get(link);
+    const $ = cheerio.load(respond.data);
+    const list = $('.list-con')
+        .find('li')
+        .slice(0, 10)
+        .map(function (index, ele) {
+            return {
+                title: $(ele).find('.list-txt-1').text(),
+                link: $(ele).find('a').attr('href'),
+                date: $(ele).find('.list-date').text(),
+            };
+        })
+        .get();
+
+    const all = await Promise.all(
+        list.map(async (item) => {
+            const itemUrl = url.resolve(host, item.link);
+            const cache = await ctx.cache.get(itemUrl);
+            if (cache) {
+                return Promise.resolve(JSON.parse(cache));
+            }
+            let desc = '';
+            const respond = await got.get(itemUrl);
+            const $ = cheerio.load(respond.data);
+            if (type === 'notice') {
+                desc = $('.content-con').text();
+            } else {
+                desc = $('#vsb_content_2').text();
+                if (desc.length > 256) {
+                    desc = desc.slice(0, 256) + '...';
+                }
+            }
+            const date = new Date(item.date);
+            const time_zone = 8;
+            const server_offset = date.getTimezoneOffset() / 60;
+            const single = {
+                title: item.title,
+                link: itemUrl,
+                pubDate: new Date(date.getTime() - 60 * 60 * 1000 * (time_zone + server_offset)).toUTCString(),
+                description: desc || item.title,
+            };
+            ctx.cache.set(itemUrl, JSON.stringify(single));
+            return Promise.resolve(single);
+        })
+    );
+
+    ctx.state.data = {
+        title: title + ' - 上海大学',
+        link: 'https://www.shu.edu.cn/',
+        item: all,
+    };
+};

--- a/lib/routes/universities/shu/jwc.js
+++ b/lib/routes/universities/shu/jwc.js
@@ -6,12 +6,12 @@ const host = 'http://www.jwc.shu.edu.cn';
 
 const config = {
     notice: {
-        link: 'http://www.jwc.shu.edu.cn/index/tzgg.htm',
+        link: 'http://www.jwc.shu.edu.cn/nry.jsp?urltype=tree.TreeTempUrl&wbtreeid=1015',
         type: 'notice',
         title: '通知通告',
     },
     news: {
-        link: 'http://www.jwc.shu.edu.cn/index/xw.htm',
+        link: 'http://www.jwc.shu.edu.cn/nry.jsp?urltype=tree.TreeTempUrl&wbtreeid=1016',
         type: 'news',
         title: '新闻',
     },
@@ -30,7 +30,7 @@ module.exports = async (ctx) => {
             return {
                 title: $(ele).attr('title'),
                 link: $(ele).attr('href'),
-                date: $('#dnn_ctr43465_ArtDetail_lblDatePosted').text(),
+                date: $('#dnn_ctr43516_ArticleList__ctl0_ArtDataList__ctl1_Label6').text(),
             };
         })
         .get();
@@ -58,7 +58,7 @@ module.exports = async (ctx) => {
     );
     ctx.state.data = {
         title: '上海大学教务处--' + title,
-        link: 'http://www.jwc.shu.edu.cn/index.htm',
+        link: 'http://www.jwc.shu.edu.cn/',
         item: all,
     };
 };


### PR DESCRIPTION
1. 修复了上海大学教务处获取的错误
2. 增加了上海大学官网 (www.shu.edu.cn) 的三个信息栏目
3. 文档路由地址更新

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

`/shu/:type` (新增)
其中`:type`可以为`news`, `research`, `notice`

`/shu/jwc/:type` (修复)
其中`:type`可以为`news`, `notice`