### PR TITLE
chore: remove unnecessary apt-get clean in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1;
 
 RUN ln -sf /bin/bash /bin/sh
 
-RUN apt-get update && apt-get install -yq libgconf-2-4 apt-transport-https git dumb-init python make g++ build-essential --no-install-recommends && apt-get clean \
+RUN apt-get update && apt-get install -yq libgconf-2-4 apt-transport-https git dumb-init python make g++ build-essential --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -29,7 +29,6 @@ RUN if [ "$PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" = 0 ]; then \
   && apt-get update \
   && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
   --no-install-recommends \
-  && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get purge --auto-remove -y wget\
   && rm -rf /src/*.deb \


### PR DESCRIPTION
This image is built from the official Debian image as upstream, so there
is no need to do apt-get clean manually.

Ref:
- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get

> Official Debian and Ubuntu images automatically run apt-get clean, so
> explicit invocation is not required.