### PR TITLE
fix:  update url of guanchazhe api

### DIFF
--- a/lib/routes/guanchazhe/index.js
+++ b/lib/routes/guanchazhe/index.js
@@ -7,7 +7,7 @@ module.exports = async (ctx) => {
         all: { name: '首页Feeds', url: 'https://www.guancha.cn/' },
         redian: { name: '热点新闻', url: 'https://www.guancha.cn/api/redian.htm' },
         member: { name: '观察者', url: 'https://www.guancha.cn/api/member.htm' },
-        gundong: { name: '滚动新闻', url: 'https://www.guancha.cn/api/new_gundong.htm' },
+        gundong: { name: '滚动新闻', url: 'https://www.guancha.cn/api/gundong.htm' },
     };
     // 定义list存放请求数据,htmlarr暂存html数据组,outList存放输出的数据组
     const list = [],


### PR DESCRIPTION
Trying to fix 'gundong' api.本pull request 尝试解决观察者网的api错误. (NOTE 本人不会js,目前的分析对代码本身的分析较少,不过我发现了api网址错误是明显且严重的,因此提交此pr修正)

## 该 PR 相关 Issue / Involved issue

Open #5969 

## 完整路由地址 / Example for the proposed route(s)

https://rsshub.app/guanchazhe/index/all

