### PR TITLE
docs: add `NODE_ENV` to the deployment docs

### DIFF
--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -393,6 +393,8 @@ See the relation between access key/code and white/blacklisting.
 
 `DEBUG_INFO`: display route information on homepage for debugging purpose, default to `true`
 
+`NODE_ENV`: display error message on pages for authentication failing, default to `production` (i.e. no display)
+
 `LOGGER_LEVEL`: specifies the maximum [level](https://github.com/winstonjs/winston#logging-levels) of messages to the console and log file, default to `info`
 
 `NODE_NAME`: node name, used for load balancing, identify current node

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -420,6 +420,8 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 
 `DEBUG_INFO`: 是否在首页显示路由信息，默认 `true`
 
+`NODE_ENV`: 是否显示错误输出，默认 `production` （即关闭输出）
+
 `LOGGER_LEVEL`: 指明输出到 console 和日志文件的日志的最大 [等级](https://github.com/winstonjs/winston#logging-levels)，默认 `info`
 
 `NODE_NAME`: 节点名，用于负载均衡，识别当前节点


### PR DESCRIPTION
A `NODE_ENV` configuration is used to control displaying error
messages. #5982

## 该 PR 相关 Issue / Involved issue

Close #5982

## 完整路由地址 / Example for the proposed route(s)

<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->
