### PR TITLE
fix: keep coolapk sharekey in url

### DIFF
--- a/lib/routes/coolapk/utils.js
+++ b/lib/routes/coolapk/utils.js
@@ -83,13 +83,12 @@ const parseDongtai = async (item, ctx) => {
 const parseTuwen = async (item, ctx) => {
     const title = item.title;
     const pubdate = new Date(item.lastupdate * 1000).toUTCString();
-    const itemUrl = item.shareUrl.split('?')[0];
     const author = item.username;
 
-    const description = await ctx.cache.tryGet(itemUrl, async () => {
+    const description = await ctx.cache.tryGet(item.shareUrl, async () => {
         const result = await got({
             method: 'get',
-            url: itemUrl,
+            url: item.shareUrl,
             headers: getHeaders(),
         });
 
@@ -104,7 +103,8 @@ const parseTuwen = async (item, ctx) => {
         title: title,
         description: description,
         pubDate: pubdate,
-        link: itemUrl,
+        link: item.shareUrl,
+        guid: item.shareUrl.split('?')[0],
         author: author,
     };
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #6015

## 完整路由地址 / Example for the proposed route(s)

/coolapk/tuwen
