### PR TITLE
fix: allow empty in twitter keyword

### DIFF
--- a/lib/routes/twitter/keyword.js
+++ b/lib/routes/twitter/keyword.js
@@ -20,5 +20,6 @@ module.exports = async (ctx) => {
         item: utils.ProcessFeed({
             data: data.statuses,
         }),
+        allowEmpty: true,
     };
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #6023

## 完整路由地址 / Example for the proposed route(s)

缺少 API key 无法测试