### PR TITLE
fix: weibo keyword: default showAuthorInTitle & showAuthorInDesc should not override routeParams

### DIFF
--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -906,21 +906,21 @@ rule
 
 对于微博内容，在 `routeParams` 参数中以 query string 格式指定选项，可以控制输出的样式
 
-| 键                         | 含义                                                           | 接受的值       | 默认值 |
-| -------------------------- | -------------------------------------------------------------- | -------------- | ------ |
-| readable                   | 是否开启细节排版可读性优化                                     | 0/1/true/false | false  |
-| authorNameBold             | 是否加粗作者名字                                               | 0/1/true/false | false  |
-| showAuthorInTitle          | 是否在标题处显示作者                                           | 0/1/true/false | false  |
-| showAuthorInDesc           | 是否在正文处显示作者                                           | 0/1/true/false | false  |
-| showAuthorAvatarInDesc     | 是否在正文处显示作者头像（若阅读器会提取正文图片，不建议开启） | 0/1/true/false | false  |
-| showEmojiForRetweet        | 显示 “🔁” 取代 “转发” 两个字                                   | 0/1/true/false | false  |
-| showRetweetTextInTitle     | 在标题出显示转发评论（置为 false 则在标题只显示被转发微博）    | 0/1/true/false | true   |
-| addLinkForPics             | 为图片添加可点击的链接                                         | 0/1/true/false | false  |
-| showTimestampInDescription | 在正文处显示被转发微博的时间戳                                 | 0/1/true/false | false  |
-| widthOfPics                | 微博配图宽（生效取决于阅读器）                                 | 不指定 / 数字  | 不指定 |
-| heightOfPics               | 微博配图高（生效取决于阅读器）                                 | 不指定 / 数字  | 不指定 |
-| sizeOfAuthorAvatar         | 作者头像大小                                                   | 数字           | 48     |
-| displayVideo               | 是否直接显示微博视频，只在博主 RSS 中有效                      | 0/1/true/false | true   |
+| 键                         | 含义                                                           | 接受的值       | 默认值                              |
+| -------------------------- | -------------------------------------------------------------- | -------------- | ----------------------------------- |
+| readable                   | 是否开启细节排版可读性优化                                     | 0/1/true/false | false                               |
+| authorNameBold             | 是否加粗作者名字                                               | 0/1/true/false | false                               |
+| showAuthorInTitle          | 是否在标题处显示作者                                           | 0/1/true/false | false（`/weibo/keyword/`中为 true） |
+| showAuthorInDesc           | 是否在正文处显示作者                                           | 0/1/true/false | false（`/weibo/keyword/`中为 true） |
+| showAuthorAvatarInDesc     | 是否在正文处显示作者头像（若阅读器会提取正文图片，不建议开启） | 0/1/true/false | false                               |
+| showEmojiForRetweet        | 显示 “🔁” 取代 “转发” 两个字                                   | 0/1/true/false | false                               |
+| showRetweetTextInTitle     | 在标题出显示转发评论（置为 false 则在标题只显示被转发微博）    | 0/1/true/false | true                                |
+| addLinkForPics             | 为图片添加可点击的链接                                         | 0/1/true/false | false                               |
+| showTimestampInDescription | 在正文处显示被转发微博的时间戳                                 | 0/1/true/false | false                               |
+| widthOfPics                | 微博配图宽（生效取决于阅读器）                                 | 不指定 / 数字  | 不指定                              |
+| heightOfPics               | 微博配图高（生效取决于阅读器）                                 | 不指定 / 数字  | 不指定                              |
+| sizeOfAuthorAvatar         | 作者头像大小                                                   | 数字           | 48                                  |
+| displayVideo               | 是否直接显示微博视频，只在博主 RSS 中有效                      | 0/1/true/false | true                                |
 
 指定更多与默认值不同的参数选项可以改善 RSS 的可读性，如
 

--- a/lib/routes/weibo/keyword.js
+++ b/lib/routes/weibo/keyword.js
@@ -1,6 +1,8 @@
+const querystring = require('querystring');
 const got = require('@/utils/got');
 const weiboUtils = require('./utils');
 const date = require('@/utils/date');
+const { fallback, queryToBoolean } = require('@/utils/readable-social');
 
 module.exports = async (ctx) => {
     const keyword = ctx.params.keyword;
@@ -17,6 +19,7 @@ module.exports = async (ctx) => {
     });
     const data = response.data.data.cards;
 
+    const routeParams = querystring.parse(ctx.params.routeParams);
     ctx.state.data = {
         title: `又有人在微博提到${keyword}了`,
         link: `http://s.weibo.com/weibo/${encodeURIComponent(keyword)}&b=1&nodup=1`,
@@ -27,8 +30,8 @@ module.exports = async (ctx) => {
                 item.mblog.retweeted_status.created_at = date(item.mblog.retweeted_status.created_at, 8);
             }
             const formatExtended = weiboUtils.formatExtended(ctx, item.mblog, {
-                showAuthorInTitle: true,
-                showAuthorInDesc: true,
+                showAuthorInTitle: fallback(undefined, queryToBoolean(routeParams.showAuthorInTitle), true),
+                showAuthorInDesc: fallback(undefined, queryToBoolean(routeParams.showAuthorInDesc), true),
             });
             const title = formatExtended.title;
             const description = formatExtended.description;


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

解决了[该 PR 下的评论](https://github.com/DIYgod/RSSHub/commit/e44064d40db32468415cda9bf2e535b99028ab90#commitcomment-43772031)提出的问题，用户提供的 `showAuthorInTitle` 和 `showAuthorInDesc` 应能覆盖默认值而非反过来

## 完整路由地址 / Example for the proposed route(s)

`/weibo/keyword/%E8%BD%AC%E5%8F%91/readable=1&authorNameBold=1&showAuthorAvatarInDesc=1&showEmojiForRetweet=1&showRetweetTextInTitle=0&addLinkForPics=1&showTimestampInDescription=1&showTimestampInDescription=1&heightOfPics=150`
`/weibo/keyword/%E8%BD%AC%E5%8F%91/readable=1&authorNameBold=1&showAuthorInTitle=0&showAuthorInDesc=0&showAuthorAvatarInDesc=1&showEmojiForRetweet=1&showRetweetTextInTitle=0&addLinkForPics=1&showTimestampInDescription=1&showTimestampInDescription=1&heightOfPics=150`
`/weibo/keyword/%E8%BD%AC%E5%8F%91/readable=1&authorNameBold=1&showAuthorInTitle=0&showAuthorInDesc=0&showAuthorAvatarInDesc=1&showEmojiForRetweet=1&showRetweetTextInTitle=0&addLinkForPics=1&showTimestampInDescription=1&showTimestampInDescription=1&heightOfPics=150`
`/weibo/keyword/%E8%BD%AC%E5%8F%91`
`/weibo/keyword/%E8%BD%AC%E5%8F%91/showAuthorInDesc=0&showAuthorInTitle=0`