### PR TITLE
fix: weibo keyword: add author metainfo

### DIFF
--- a/lib/routes/weibo/keyword.js
+++ b/lib/routes/weibo/keyword.js
@@ -36,6 +36,7 @@ module.exports = async (ctx) => {
                 title: title,
                 description: description,
                 pubDate: date(item.mblog.created_at, 8),
+                author: item.mblog.user.screen_name,
                 link: `https://weibo.com/${item.mblog.user.id}/${item.mblog.bid}`,
             };
         }),


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

解决了[该 PR 下的评论](https://github.com/DIYgod/RSSHub/commit/e44064d40db32468415cda9bf2e535b99028ab90#commitcomment-43772031)提出的问题，添加了 `/weibo/keyword` 路由下的作者信息

## 完整路由地址 / Example for the proposed route(s)

`/weibo/keyword/%E8%BD%AC%E5%8F%91`