### PR TITLE
feat: linkify GitHub markdown

### DIFF
--- a/lib/routes/github/issue.js
+++ b/lib/routes/github/issue.js
@@ -2,6 +2,7 @@ const got = require('@/utils/got');
 const config = require('@/config').value;
 const md = require('markdown-it')({
     html: true,
+    linkify: true,
 });
 const queryString = require('query-string');
 

--- a/lib/routes/github/pulls.js
+++ b/lib/routes/github/pulls.js
@@ -2,6 +2,7 @@ const got = require('@/utils/got');
 const config = require('@/config').value;
 const md = require('markdown-it')({
     html: true,
+    linkify: true,
 });
 const queryString = require('query-string');
 


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

(no issue)

## 完整路由地址 / Example for the proposed route(s)

I subscribe to this feed: https://rsshub.app/github/issue/Microsoft/TypeScript/all/Design%20Notes

The URLs for related issues come out looking like this:

![image](https://user-images.githubusercontent.com/98301/98391159-485e8e80-2024-11eb-8469-9a64b5247e3e.png)

This change will turn them into clickable links (as they are on GitHub).

After: (https://rsshub-git-linkify-github.diy.vercel.app/github/issue/Microsoft/TypeScript/all/Design%20Notes)

![image](https://user-images.githubusercontent.com/98301/98392665-47c6f780-2026-11eb-9163-c3af2fb5623c.png)
