### PR TITLE
fix: 网易号获取缓存出错 & 修复全文 CSS 选择器

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -1406,8 +1406,8 @@ column 为 third 时可选的 category:
 <Route author="HendricksZheng" example="/netease/dy/W4983108759592548559" path="/netease/dy/:id" :paramsDesc="['网易号 ID', '见如下说明']">
 
 1.  在[网易号搜索页面](https://dy.163.com/v2/media/tosearch.html) 搜索想要订阅的网易号。
-2.  打开网易号文章页面。
-3.  通过浏览器控制台执行 `$('#contain').dataset.wemediaid`，返回的即为网易号 ID。
+2.  打开网易号的任意文章。
+3.  查看源代码，搜索 `data-wemediaid`，查看紧随其后的引号内的属性值（类似 `W1966190042455428950`）即为网易号 ID。
 
 </Route>
 

--- a/lib/routes/netease/dy.js
+++ b/lib/routes/netease/dy.js
@@ -19,19 +19,19 @@ module.exports = async (ctx) => {
 
             author = e.source ? e.source : '';
 
-            const response = await ctx.cache.tryGet(
-                e.link,
-                async () =>
+            const html = await ctx.cache.tryGet(e.link, async () =>
+                iconv.decode(
                     (
                         await got.get(e.link, {
                             responseType: 'buffer',
                         })
-                    ).data
+                    ).data,
+                    'gbk'
+                )
             );
-            const html = iconv.decode(response, 'gbk');
             const $ = cheerio.load(html, { decodeEntities: false });
 
-            const article = $('div.article_box > div.content');
+            const article = $('.post_body');
 
             const single = {
                 title: e.title,


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

无

- 相关代码中向 `ctx.cache` 中存了一个 `Buffer`，导致之后取出时出错；此处将其按 GBK 解码为字符串后再存入缓存
- 修复了全文 CSS 选择器
- 更新了文档中网易 ID 的获取办法

## 完整路由地址 / Example for the proposed route(s)

`/netease/dy/W1966190042455428950`
