### PR TITLE
fix: remove unnecessary URIEncoding from clickme route

### DIFF
--- a/lib/routes/clickme/index.js
+++ b/lib/routes/clickme/index.js
@@ -17,7 +17,7 @@ module.exports = async (ctx) => {
         form: {
             articleType: site ? 'r18' : 'article',
             subtype: grouping,
-            subtypeSlug: encodeURIComponent(name),
+            subtypeSlug: name,
             device: '',
             limit: 10,
             page: 1,


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

中文参数被误编码
![image](https://user-images.githubusercontent.com/9067094/98694733-ca481200-23ac-11eb-989c-2c0b9b469579.png)


## 完整路由地址 / Example for the proposed route(s)

https://rsshub.app/clickme/default/tag/%E6%AD%A3%E5%A6%B9

https://rsshub-git-fix-clickme-subtype.diy.vercel.app/clickme/default/tag/%E6%AD%A3%E5%A6%B9