### PR TITLE
fix: facebook page attach cover image

### DIFF
--- a/lib/routes/facebook/page.js
+++ b/lib/routes/facebook/page.js
@@ -20,11 +20,11 @@ const parseStoryPage = async (linkPath, cache) => {
     const $ = cheerio.load(html);
 
     const url = `https://www.facebook.com/story.php?story_fbid=${storyFbId}&id=${storyId}`;
-    const $story = $('#m_story_permalink_view').first();
+    const $story = $('#m_story_permalink_view').eq(0);
     const $box = $story.find('div > div > div > div').eq(0);
     const $header = $box.find('header').eq(0);
     const $content = $box.find('div > div').eq(0);
-    const $attach = $box.find('div > div').eq(1);
+    const $attach = $story.find('div > div > div > div:nth-child(3)').eq(0);
 
     const attachLinkList = $attach
         .find('a')


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue
無

## 完整路由地址 / Example for the proposed route(s)
`facebook/page/ykohmk` (p.s 幾乎每個貼文都有圖片，debug 起來比較方便)

## 範例
修復前
![修復前](https://user-images.githubusercontent.com/1111538/99162723-c9600900-273b-11eb-881a-b4e87e3c6796.png)

修復後
![修復後](https://user-images.githubusercontent.com/1111538/99162726-ccf39000-273b-11eb-8cd6-5a39e3345d93.png)