### PR TITLE
feat: facebook html content

### DIFF
--- a/lib/routes/facebook/page.js
+++ b/lib/routes/facebook/page.js
@@ -33,18 +33,7 @@ const parseStoryPage = async (linkPath, cache) => {
     const isAttachAreImageSet = attachLinkList.filter((link) => new RegExp('/photos/').test(link)).length === attachLinkList.length;
     const title = $header.find('h3').text();
 
-    let content = '';
-    if ($content.find('p').length === 0) {
-        $content.find('br').replaceWith('\n');
-        content = $content.text();
-    } else {
-        const $ps = $content.find('p');
-        $ps.find('br').replaceWith('\n');
-        content = $ps
-            .toArray()
-            .map((p) => $(p).text())
-            .join('\n');
-    }
+    const content = $content.html();
 
     let images = [];
     if (isAttachAreImageSet) {
@@ -69,8 +58,7 @@ const parsePhotoPage = async (linkPath, cache) => {
     const title = $('#MPhotoContent div.msg > a > strong').first().text();
     const url = `https://www.facebook.com${pathname}`;
     const $content = $('#MPhotoContent div.msg > div');
-    $content.find('br').replaceWith('\n');
-    const content = $content.text();
+    const content = $content.html();
     const image = $('#MPhotoContent div.desc.attachment > span > div > span > a[target=_blank].sec').attr('href');
 
     return {
@@ -100,7 +88,7 @@ module.exports = async (ctx) => {
                 return {
                     title: data.title,
                     link: data.url,
-                    description: `<img src="${data.image}"><br>${data.content.replace(/\n/g, '<br>')}`,
+                    description: `<img src="${data.image}"><br>${data.content}`,
                 };
             }
             if (new RegExp(`^/story.php`).test(itemLink)) {
@@ -109,10 +97,10 @@ module.exports = async (ctx) => {
                 const isEmptyImageList = data.images.length === 0;
 
                 let desc = '';
-                desc += data.images.map((image) => `<img src="${image.image}"><br>${image.content.replace(/\n/g, '<br>')}`).join('<br>');
+                desc += data.images.map((image) => `<img src="${image.image}"><br>${image.content}`).join('<br>');
                 if (!isSingleImageStory) {
                     !isEmptyImageList && (desc += '<br>');
-                    desc += data.content.replace(/\n/g, '<br>');
+                    desc += data.content;
                 }
 
                 return {


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue
無

## 完整路由地址 / Example for the proposed route(s)
`/facebook/page/FGOwarehouse`
`/facebook/page/ykohmk`

## 說明
原先使用 `content.text()` 的方法，只顯示需要的 html，但裡面連結時就不好做 parse，索性把全部 html 結構放出