### PR TITLE
fix: 网易云歌单曲目过少 & 歌手专辑更新日期错误

### DIFF
--- a/lib/routes/ncm/artist.js
+++ b/lib/routes/ncm/artist.js
@@ -23,6 +23,10 @@ module.exports = async (ctx) => {
                 title: `${item.name} - ${singer}`,
                 description: `歌手：${singer}<br>专辑：${item.name}<br>日期：${new Date(item.publishTime).toLocaleDateString()}<br><img src="${item.picUrl}">`,
                 link: `https://music.163.com/#/album?id=${item.id}`,
+                pubDate: new Date(item.publishTime),
+                published: new Date(item.publishTime),
+                category: item.subType,
+                author: singer,
             };
         }),
     };

--- a/lib/routes/ncm/playlist.js
+++ b/lib/routes/ncm/playlist.js
@@ -15,15 +15,23 @@ module.exports = async (ctx) => {
     });
 
     const data = response.data.playlist;
+    const songinfo = await got({
+        method: 'get',
+        url: `https://music.163.com/api/song/detail?ids=${data.trackIds.map((item) => item.id)}`,
+        headers: {
+            Referer: 'https://music.163.com',
+        },
+    });
+    const songs = songinfo.data.songs;
 
     ctx.state.data = {
         title: data.name,
         link: `https://music.163.com/#/playlist?id=${id}`,
         description: `网易云音乐歌单 - ${data.name}`,
         item:
-            data.tracks &&
-            data.tracks.map((item) => {
-                const singer = item.ar.length === 1 ? item.ar[0].name : item.ar.reduce((prev, cur) => (prev.name || prev) + '/' + cur.name);
+            // songs &&
+            songs.map((item) => {
+                const singer = item.artists.length === 1 ? item.artists[0].name : item.artists.reduce((prev, cur) => (prev.name || prev) + '/' + cur.name);
                 return {
                     title: `${item.name} - ${singer}`,
                     description: `歌手：${singer}<br>专辑：${item.al.name}<br>日期：${new Date(item.publishTime).toLocaleDateString()}<br><img src="${item.al.picUrl}">`,

--- a/lib/routes/ncm/playlist.js
+++ b/lib/routes/ncm/playlist.js
@@ -17,7 +17,7 @@ module.exports = async (ctx) => {
     const data = response.data.playlist;
     const songinfo = await got({
         method: 'get',
-        url: `https://music.163.com/api/song/detail?ids=${data.trackIds.map((item) => item.id)}`,
+        url: `https://music.163.com/api/song/detail?ids=[${data.trackIds.slice(0, 201).map((item) => item.id)}]`,
         headers: {
             Referer: 'https://music.163.com',
         },
@@ -28,15 +28,16 @@ module.exports = async (ctx) => {
         title: data.name,
         link: `https://music.163.com/#/playlist?id=${id}`,
         description: `网易云音乐歌单 - ${data.name}`,
-        item:
-            // songs &&
-            songs.map((item) => {
-                const singer = item.artists.length === 1 ? item.artists[0].name : item.artists.reduce((prev, cur) => (prev.name || prev) + '/' + cur.name);
-                return {
-                    title: `${item.name} - ${singer}`,
-                    description: `歌手：${singer}<br>专辑：${item.al.name}<br>日期：${new Date(item.publishTime).toLocaleDateString()}<br><img src="${item.al.picUrl}">`,
-                    link: `https://music.163.com/#/song?id=${item.id}`,
-                };
-            }),
+        item: data.trackIds.slice(0, 201).map((item) => {
+            const thissong = songs.find((element) => element.id === item.id);
+            const singer = thissong.artists.length === 1 ? thissong.artists[0].name : thissong.artists.reduce((prev, cur) => (prev.name || prev) + '/' + cur.name);
+            return {
+                title: `${thissong.name} - ${singer}`,
+                description: `歌手：${singer}<br>专辑：${thissong.album.name}<br>发行日期：${new Date(thissong.album.publishTime).toLocaleDateString()}<br><img src="${thissong.album.picUrl}">`,
+                link: `https://music.163.com/#/song?id=${item.id}`,
+                pubDate: new Date(item.at),
+                author: singer,
+            };
+        }),
     };
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

此前网易云歌单只返回前六七首甚至两三首歌曲，现在修复这一问题。

同时修复了歌手专辑路由的pubDate缺失 ~~导致部分RSS Parser不能正常工作~~ 的问题

Close #

## 完整路由地址 / Example for the proposed route(s)

`/ncm/playlist/*` 及 `/ncm/artist/*`

<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->
