### PR TITLE
fix: mobile subdomain for ximalaya and zhaishuyuan

### DIFF
--- a/assets/radar-rules.js
+++ b/assets/radar-rules.js
@@ -427,7 +427,7 @@
     },
     'ximalaya.com': {
         _name: '喜马拉雅',
-        www: [
+        '.': [
             {
                 title: '专辑',
                 docs: 'https://docs.rsshub.app/multimedia.html#xi-ma-la-ya',
@@ -1710,7 +1710,7 @@
     },
     'zhaishuyuan.com': {
         _name: '斋书苑',
-        www: [
+        '.': [
             {
                 title: '最新章节',
                 docs: 'https://docs.rsshub.app/reading.html#zhai-shu-yuan',


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

喜马拉雅/斋书苑 `.m` 子域名适配 (RSSBud)