### PR TITLE
fix: 修复「小宇宙 - 发现」缓存

### DIFF
--- a/lib/routes/xiaoyuzhou/pickup.js
+++ b/lib/routes/xiaoyuzhou/pickup.js
@@ -1,6 +1,13 @@
 const got = require('@/utils/got');
 const config = require('@/config').value;
 
+const XIAOYUZHOU_ITEMS = 'xiaoyuzhou_items';
+
+const isToday = (date) => {
+    const today = new Date();
+    return date.getDate() === today.getDate() && date.getMonth() === today.getMonth() && date.getFullYear() === today.getFullYear();
+};
+
 const ProcessFeed = async (ctx) => {
     const device_id = config.xiaoyuzhou.device_id || 'f5d56d9a-8530-49a4-a6d2-cfb4b7a31240';
     const refresh_token =
@@ -73,7 +80,12 @@ const ProcessFeed = async (ctx) => {
 };
 
 module.exports = async (ctx) => {
-    const resultItems = await ctx.cache.tryGet('xiaoyuzhou_items', async () => await ProcessFeed(ctx));
+    let resultItems = await ctx.cache.tryGet(XIAOYUZHOU_ITEMS, async () => await ProcessFeed(ctx));
+    if (!isToday(resultItems[0].pubDate)) {
+        // force refresh cache
+        resultItems = await ProcessFeed(ctx);
+        ctx.cache.set(XIAOYUZHOU_ITEMS, resultItems);
+    }
     ctx.state.data = {
         title: '小宇宙 - 发现',
         link: 'https://www.xiaoyuzhoufm.com/',

--- a/lib/routes/xiaoyuzhou/pickup.js
+++ b/lib/routes/xiaoyuzhou/pickup.js
@@ -4,6 +4,7 @@ const config = require('@/config').value;
 const XIAOYUZHOU_ITEMS = 'xiaoyuzhou_items';
 
 const isToday = (date) => {
+    date = new Date(date);
     const today = new Date();
     return date.getDate() === today.getDate() && date.getMonth() === today.getMonth() && date.getFullYear() === today.getFullYear();
 };
@@ -60,7 +61,7 @@ const ProcessFeed = async (ctx) => {
             const pubDate = item.pubDate;
             const enclosure_length = item.episode.duration;
             const enclosure_url = item.episode.enclosure.url;
-            const desc = item.episode.shownotes;
+            const desc = `<p><strong>${item.comment.author.nickname}：</strong>${item.comment.text}</p><hr>` + item.episode.shownotes;
             const author = item.episode.podcast.author;
 
             const resultItem = {

--- a/lib/routes/xiaoyuzhou/pickup.js
+++ b/lib/routes/xiaoyuzhou/pickup.js
@@ -1,76 +1,78 @@
 const got = require('@/utils/got');
 const config = require('@/config').value;
 
-module.exports = async (ctx) => {
-    const resultItems = await ctx.cache.tryGet('xiaoyuzhou_items', async () => {
-        const device_id = config.xiaoyuzhou.device_id || 'f5d56d9a-8530-49a4-a6d2-cfb4b7a31240';
-        const refresh_token =
-            (await ctx.cache.get('XIAOYUZHOU_TOKEN')) ||
-            config.xiaoyuzhou.refresh_token ||
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjoiVzhieXB2dTJtT24xZWNqcEppN2p6R2xhMDBhMHYxellLaHFcL0ZXVWVkdDcxNlh3bnJnOFE0cFpGbVJmVFJQQ29ESWsxMmVuY3RcLzNqQWNjeFU3aTZNbkM4MUtWcUlmWWJJbVBKdXJDTXVYc1dHa2x0SE5TK3llNnJvTldLSWN1M1ZFTGY5WFE0cGhnK2crQld6bFloM2g0VUtONlNKWWlUSGtkaHowd0RJYXIrdTlzOE5PaEJPYXdJXC80NEFZcW41RjJqUXNnU3o1TExDSGtuTENuUFppRXllaTNwcVFwRkgweWFWbk03bmQ2RFhrUmVmUExVMTVpMXcwRnpkXC9wWDEiLCJ2IjozLCJpdiI6IkJiVGFjXC9KTG9BU1NYY0tPMkk3M0JBPT0iLCJpYXQiOjE1OTQ1NzIyOTEuODE2fQ.aQm7A6A1R3P94s88vWBWTbIeek9nJ-q9ztfCB7o1uK0';
+const ProcessFeed = async (ctx) => {
+    const device_id = config.xiaoyuzhou.device_id || 'f5d56d9a-8530-49a4-a6d2-cfb4b7a31240';
+    const refresh_token =
+        (await ctx.cache.get('XIAOYUZHOU_TOKEN')) ||
+        config.xiaoyuzhou.refresh_token ||
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjoiVzhieXB2dTJtT24xZWNqcEppN2p6R2xhMDBhMHYxellLaHFcL0ZXVWVkdDcxNlh3bnJnOFE0cFpGbVJmVFJQQ29ESWsxMmVuY3RcLzNqQWNjeFU3aTZNbkM4MUtWcUlmWWJJbVBKdXJDTXVYc1dHa2x0SE5TK3llNnJvTldLSWN1M1ZFTGY5WFE0cGhnK2crQld6bFloM2g0VUtONlNKWWlUSGtkaHowd0RJYXIrdTlzOE5PaEJPYXdJXC80NEFZcW41RjJqUXNnU3o1TExDSGtuTENuUFppRXllaTNwcVFwRkgweWFWbk03bmQ2RFhrUmVmUExVMTVpMXcwRnpkXC9wWDEiLCJ2IjozLCJpdiI6IkJiVGFjXC9KTG9BU1NYY0tPMkk3M0JBPT0iLCJpYXQiOjE1OTQ1NzIyOTEuODE2fQ.aQm7A6A1R3P94s88vWBWTbIeek9nJ-q9ztfCB7o1uK0';
 
-        const headers = {
-            applicationid: 'app.podcast.cosmos',
-            'app-version': '1.6.0',
-            'x-jike-device-id': device_id,
-            'user-agent': 'okhttp/4.7.2',
-        };
+    const headers = {
+        applicationid: 'app.podcast.cosmos',
+        'app-version': '1.6.0',
+        'x-jike-device-id': device_id,
+        'user-agent': 'okhttp/4.7.2',
+    };
 
-        const token_updated = await got({
-            method: 'post',
-            url: 'https://api.xiaoyuzhoufm.com/app_auth_tokens.refresh',
-            headers: {
-                ...headers,
-                'x-jike-refresh-token': refresh_token,
-            },
-        });
-        ctx.cache.set('XIAOYUZHOU_TOKEN', token_updated.data['x-jike-refresh-token']);
-
-        const response = await got({
-            method: 'post',
-            url: 'https://api.xiaoyuzhoufm.com/v1/editor-pick/list',
-            headers: {
-                ...headers,
-                'x-jike-access-token': token_updated.data['x-jike-access-token'],
-            },
-        });
-
-        const data = response.data.data;
-        const playList = [];
-        for (let i = 0; i < data.length; i++) {
-            for (let j = 0; j < data[i].picks.length; j++) {
-                data[i].picks[j].episode.pubDate = data[i].date;
-                playList.push(data[i].picks[j]);
-            }
-        }
-
-        return await Promise.all(
-            playList.map(async (item) => {
-                const title = item.episode.title + ' - ' + item.episode.podcast.title;
-                const eid = item.episode.eid;
-                const itunes_item_image = item.episode.image ? item.episode.image.picUrl : item.episode.podcast.image ? item.episode.podcast.image.picUrl : '';
-                const link = `https://www.xiaoyuzhoufm.com/episode/${eid}`;
-                const pubDate = new Date(item.episode.pubDate).toUTCString();
-                const enclosure_length = item.episode.duration;
-                const enclosure_url = item.episode.enclosure.url;
-                const desc = item.episode.shownotes;
-                const author = item.episode.podcast.author;
-
-                const resultItem = {
-                    title: title,
-                    description: desc,
-                    link: link,
-                    author: author,
-                    pubDate: pubDate,
-                    enclosure_url: enclosure_url,
-                    enclosure_length: enclosure_length,
-                    itunes_item_image: itunes_item_image,
-                    enclosure_type: 'audio/mpeg',
-                };
-                return Promise.resolve(resultItem);
-            })
-        );
+    const token_updated = await got({
+        method: 'post',
+        url: 'https://api.xiaoyuzhoufm.com/app_auth_tokens.refresh',
+        headers: {
+            ...headers,
+            'x-jike-refresh-token': refresh_token,
+        },
     });
+    ctx.cache.set('XIAOYUZHOU_TOKEN', token_updated.data['x-jike-refresh-token']);
+
+    const response = await got({
+        method: 'post',
+        url: 'https://api.xiaoyuzhoufm.com/v1/editor-pick/list',
+        headers: {
+            ...headers,
+            'x-jike-access-token': token_updated.data['x-jike-access-token'],
+        },
+    });
+
+    const data = response.data.data;
+    const playList = [];
+    for (let i = 0; i < data.length; i++) {
+        for (let j = 0; j < data[i].picks.length; j++) {
+            data[i].picks[j].episode.pubDate = data[i].date;
+            playList.push(data[i].picks[j]);
+        }
+    }
+
+    return await Promise.all(
+        playList.map(async (item) => {
+            const title = item.episode.title + ' - ' + item.episode.podcast.title;
+            const eid = item.episode.eid;
+            const itunes_item_image = item.episode.image ? item.episode.image.picUrl : item.episode.podcast.image ? item.episode.podcast.image.picUrl : '';
+            const link = `https://www.xiaoyuzhoufm.com/episode/${eid}`;
+            const pubDate = new Date(item.episode.pubDate).toUTCString();
+            const enclosure_length = item.episode.duration;
+            const enclosure_url = item.episode.enclosure.url;
+            const desc = item.episode.shownotes;
+            const author = item.episode.podcast.author;
+
+            const resultItem = {
+                title: title,
+                description: desc,
+                link: link,
+                author: author,
+                pubDate: pubDate,
+                enclosure_url: enclosure_url,
+                enclosure_length: enclosure_length,
+                itunes_item_image: itunes_item_image,
+                enclosure_type: 'audio/mpeg',
+            };
+            return Promise.resolve(resultItem);
+        })
+    );
+};
+
+module.exports = async (ctx) => {
+    const resultItems = await ctx.cache.tryGet('xiaoyuzhou_items', async () => await ProcessFeed(ctx));
     ctx.state.data = {
         title: '小宇宙 - 发现',
         link: 'https://www.xiaoyuzhoufm.com/',

--- a/lib/routes/xiaoyuzhou/pickup.js
+++ b/lib/routes/xiaoyuzhou/pickup.js
@@ -36,10 +36,11 @@ const ProcessFeed = async (ctx) => {
 
     const data = response.data.data;
     const playList = [];
-    for (let i = 0; i < data.length; i++) {
-        for (let j = 0; j < data[i].picks.length; j++) {
-            data[i].picks[j].episode.pubDate = data[i].date;
-            playList.push(data[i].picks[j]);
+    for (const dailyPicks of data) {
+        const pubDate = new Date(dailyPicks.date + ' 00:00:00 +0800').toUTCString();
+        for (const pick of dailyPicks.picks) {
+            pick.pubDate = pubDate;
+            playList.push(pick);
         }
     }
 
@@ -49,7 +50,7 @@ const ProcessFeed = async (ctx) => {
             const eid = item.episode.eid;
             const itunes_item_image = item.episode.image ? item.episode.image.picUrl : item.episode.podcast.image ? item.episode.podcast.image.picUrl : '';
             const link = `https://www.xiaoyuzhoufm.com/episode/${eid}`;
-            const pubDate = new Date(item.episode.pubDate).toUTCString();
+            const pubDate = item.pubDate;
             const enclosure_length = item.episode.duration;
             const enclosure_url = item.episode.enclosure.url;
             const desc = item.episode.shownotes;


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Fixes #6356.

## 完整路由地址 / Example for the proposed route(s)

`/xiaoyuzhou`

想明白了为什么这个路由会有缓存问题。一般来说用于缓存的 `(Key, Value)` 应该是固定的，但是目前的设计是使用固定的 Key，Value 会固定在每天零点更新。其他类似的路由一般都储存的是 `(item_link, content)`，不会有 stale cache 的问题。

有两种设计思路：
1. 每天使用不同的 Key，如`xiaoyuzhou_items_20201215`
2. 使用固定的 Key，取回 Value 时如果发现过期则手动刷新缓存。

二者的时间复杂度和实现难度、可读性都差不多，这次 PR 采用的是第二种。同时修复了输出的时区不正确的问题，增加了编辑推荐的评论。