### PR TITLE
feat: 支持在 Safari 中直接浏览 XML 格式的 RSS

### DIFF
--- a/lib/middleware/header.js
+++ b/lib/middleware/header.js
@@ -5,6 +5,7 @@ const headers = {
     'Access-Control-Allow-Methods': 'GET',
     'Content-Type': 'application/xml; charset=utf-8',
     'Cache-Control': `public, max-age=${config.cache.routeExpire}`,
+    'X-Content-Type-Options': 'nosniff',
 };
 if (config.nodeName) {
     headers['RSSHub-Node'] = config.nodeName;


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

使用 Safari 打开任意地址，如https://rsshub.app/github/repos/DIYgod ，原本 RSS 连接会被提示跳转到 Apple News，现在与 Chrome 保持一致，直接可以浏览 XML

https://discussions.apple.com/thread/251925510