### PR TITLE
feat: better Reeder support

### DIFF
--- a/lib/middleware/template.js
+++ b/lib/middleware/template.js
@@ -1,16 +1,20 @@
 const art = require('art-template');
 const path = require('path');
 const config = require('@/config').value;
-const typeRegrx = /\.(atom|rss)$/;
-const unsupportedRegrx = /\.json$/;
+const typeRegex = /\.(atom|rss)$/;
+const unsupportedRegex = /\.json$/;
 
 module.exports = async (ctx, next) => {
-    if (ctx.request.path.match(unsupportedRegrx)) {
+    if (ctx.request.path.match(unsupportedRegex)) {
         throw Error('<b>JSON output had been removed, see: <a href="https://github.com/DIYgod/RSSHub/issues/1114">https://github.com/DIYgod/RSSHub/issues/1114</a></b>');
     }
 
-    ctx.state.type = ctx.request.path.match(typeRegrx) || ['', ''];
-    ctx.request.path = ctx.request.path.replace(typeRegrx, '');
+    if (ctx.headers['user-agent'].includes('Reeder')) {
+        ctx.request.path = ctx.request.path.replace(/.com$/, '');
+    }
+
+    ctx.state.type = ctx.request.path.match(typeRegex) || ['', ''];
+    ctx.request.path = ctx.request.path.replace(typeRegex, '');
 
     await next();
 


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

使用 Reeder for mac 时，输入**本地订阅地址** http://localhost:1200/amazon/ku/next 时不添加协议结尾，Reeder 会自动添加 `.com`，导致无法订阅。