### PR TITLE
feat: added DailyArt & fix: error occurred when without user-agent

### DIFF
--- a/docs/en/picture.md
+++ b/docs/en/picture.md
@@ -42,6 +42,10 @@ pageClass: routes
 
 <RouteEn author="FHYunCai" example="/bing" path="/bing" radar="1" rssbud="1"/>
 
+## DailyArt
+
+<RouteEn author="zphw" example="/dailyart/en" path="/dailyart/:language?" :paramsDesc="['Support en, es, fr, de, it, zh, jp, etc. English by default.']" />
+
 ## Dilbert Comic Strip
 
 <RouteEn name="Daily Strip" author="Maecenas" example="/dilbert/strip" path="/dilbert/strip"/>

--- a/docs/picture.md
+++ b/docs/picture.md
@@ -66,6 +66,10 @@ pageClass: routes
 | ---- | --------- | ------ |
 | hot  | recommend | recent |
 
+## DailyArt 每日艺术
+
+<Route author="zphw" example="/dailyart/zh" path="/dailyart/:language?" :paramsDesc="['语言，支持 en, zh, jp 等，默认为 en']" />
+
 ## Dilbert Comic Strip
 
 <Route name="Daily Strip" author="Maecenas" example="/dilbert/strip" path="/dilbert/strip">

--- a/lib/middleware/template.js
+++ b/lib/middleware/template.js
@@ -9,7 +9,7 @@ module.exports = async (ctx, next) => {
         throw Error('<b>JSON output had been removed, see: <a href="https://github.com/DIYgod/RSSHub/issues/1114">https://github.com/DIYgod/RSSHub/issues/1114</a></b>');
     }
 
-    if (ctx.headers['user-agent'].includes('Reeder')) {
+    if (ctx.headers['user-agent'] && ctx.headers['user-agent'].includes('Reeder')) {
         ctx.request.path = ctx.request.path.replace(/.com$/, '');
     }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -3742,4 +3742,7 @@ router.get('/idaily/today', require('./routes/idaily/index'));
 // 北屋
 router.get('/northhouse/:category?', require('./routes/northhouse/index'));
 
+// DailyArt
+router.get('/dailyart/:language?', require('./routes/dailyart/index'));
+
 module.exports = router;

--- a/lib/routes/dailyart/index.js
+++ b/lib/routes/dailyart/index.js
@@ -1,0 +1,33 @@
+const got = require('@/utils/got');
+
+module.exports = async (ctx) => {
+    const { body } = await got.post('https://panel.getdailyart.com/APIMobile/artworks/query', {
+        headers: {
+            Language: ctx.params.language || 'en',
+            AuthSalt: 'ZG9jY29tcGFuaW9uc2FsdA==',
+        },
+        json: {
+            take: 10,
+            skip: 0,
+            local_date: new Date().toISOString().split('T')[0],
+        },
+        responseType: 'json',
+    });
+
+    const data = body.entities;
+
+    ctx.state.data = {
+        title: `DailyArt`,
+        link: 'https://www.getdailyart.com/',
+        item: data.map((item) => ({
+            title: item.title,
+            description: `<img src='${item.photo_ipad}'><br>
+${item.info}<br>
+${item.size || ''}<br>
+${item.genre && item.genre.name ? item.genre.name : ''}<br>
+${item.museum && item.museum.name ? item.museum.name : ''}`,
+            pubDate: new Date(item.publish_date).toUTCString(),
+            link: item.photo_retina,
+        })),
+    };
+};


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

route: /dailyart/:language?
example: /dailyart/zh

- language: optional, indicating the text language. Languages supported include en, es, fr, de, it, zh, jp, etc. English by default.
