### PR TITLE
fix: use the new version of pixiv link

### DIFF
--- a/lib/routes/pixiv/bookmarks.js
+++ b/lib/routes/pixiv/bookmarks.js
@@ -21,7 +21,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `${username} 的收藏`,
-        link: `https://www.pixiv.net/bookmark.php?id=${id}`,
+        link: `https://www.pixiv.net/users/${id}/bookmarks/artworks`,
         description: `${username} 的 pixiv 最新收藏`,
         item: illusts.map((illust) => {
             const images = [];
@@ -37,7 +37,7 @@ module.exports = async (ctx) => {
                 author: illust.user.name,
                 pubDate: new Date(illust.create_date).toUTCString(),
                 description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p>${images.join('')}`,
-                link: `https://www.pixiv.net/member_illust.php?mode=medium&illust_id=${illust.id}`,
+                link: `https://www.pixiv.net/artworks/${illust.id}`,
             };
         }),
     };

--- a/lib/routes/pixiv/illustfollow.js
+++ b/lib/routes/pixiv/illustfollow.js
@@ -28,7 +28,7 @@ module.exports = async (ctx) => {
                 author: illust.user.name,
                 pubDate: new Date(illust.create_date).toUTCString(),
                 description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p>${images.join('')}`,
-                link: `https://www.pixiv.net/member_illust.php?mode=medium&illust_id=${illust.id}`,
+                link: `https://www.pixiv.net/artworks/${illust.id}`,
             };
         }),
     };

--- a/lib/routes/pixiv/ranking.js
+++ b/lib/routes/pixiv/ranking.js
@@ -67,7 +67,7 @@ module.exports = async (ctx) => {
                 title: `#${index + 1} ${illust.title}`,
                 pubDate: new Date(illust.create_date).toUTCString(),
                 description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p><br>${images.join('')}`,
-                link: `https://www.pixiv.net/member_illust.php?mode=medium&illust_id=${illust.id}`,
+                link: `https://www.pixiv.net/artworks/${illust.id}`,
                 author: `${illust.user.name}`,
             };
         }),

--- a/lib/routes/pixiv/search.js
+++ b/lib/routes/pixiv/search.js
@@ -32,7 +32,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `${keyword} 的 pixiv ${order === 'popular' ? '热门' : ''}内容`,
-        link: `https://www.pixiv.net/search.php?word=${keyword}`,
+        link: `https://www.pixiv.net/tags/${keyword}/artworks`,
         item: illusts.map((illust) => {
             const images = [];
             if (illust.page_count === 1) {
@@ -47,7 +47,7 @@ module.exports = async (ctx) => {
                 author: illust.user.name,
                 pubDate: new Date(illust.create_date).toUTCString(),
                 description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p>${images.join('')}`,
-                link: `https://www.pixiv.net/member_illust.php?mode=medium&illust_id=${illust.id}`,
+                link: `https://www.pixiv.net/artworks/${illust.id}`,
             };
         }),
         allowEmpty: true,

--- a/lib/routes/pixiv/user.js
+++ b/lib/routes/pixiv/user.js
@@ -20,7 +20,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `${username} 的 pixiv 动态`,
-        link: `https://www.pixiv.net/member.php?id=${id}`,
+        link: `https://www.pixiv.net/users/${id}`,
         description: `${username} 的 pixiv 最新动态`,
         item: illusts.map((illust) => {
             const images = [];
@@ -36,7 +36,7 @@ module.exports = async (ctx) => {
                 author: username,
                 pubDate: new Date(illust.create_date).toUTCString(),
                 description: `<p>画师：${username} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p>${images.join('')}`,
-                link: `https://www.pixiv.net/member_illust.php?mode=medium&illust_id=${illust.id}`,
+                link: `https://www.pixiv.net/artworks/${illust.id}`,
             };
         }),
     };


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

[https://rsshub-qf259m6en.vercel.app/pixiv/user/bookmarks/15288095](https://rsshub-qf259m6en.vercel.app/pixiv/user/bookmarks/15288095)

[https://rsshub-qf259m6en.vercel.app/pixiv/user/11](https://rsshub-qf259m6en.vercel.app/pixiv/user/11)

[https://rsshub-qf259m6en.vercel.app/pixiv/ranking/week](https://rsshub-qf259m6en.vercel.app/pixiv/ranking/week)

[https://rsshub-qf259m6en.vercel.app/pixiv/search/麻衣/popular/2](https://rsshub-qf259m6en.vercel.app/pixiv/search/麻衣/popular/2)

[https://rsshub-qf259m6en.vercel.app/pixiv/user/illustfollows](https://rsshub-qf259m6en.vercel.app/pixiv/user/illustfollows)
<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->
