### PR TITLE
fix: disable default debug info

### DIFF
--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -394,7 +394,7 @@ See the relation between access key/code and white/blacklisting.
 
 `REQUEST_RETRY`: retries allowed for failed requests, default to `2`
 
-`DEBUG_INFO`: display route information on homepage for debugging purpose, default to `true`
+`DEBUG_INFO`: display route information on homepage for debugging purpose, default to `false`
 
 `NODE_ENV`: display error message on pages for authentication failing, default to `production` (i.e. no display)
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -422,7 +422,7 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 
 `REQUEST_RETRY`: 请求失败重试次数，默认 `2`
 
-`DEBUG_INFO`: 是否在首页显示路由信息，默认 `true`
+`DEBUG_INFO`: 是否在首页显示路由信息，默认 `false`
 
 `NODE_ENV`: 是否显示错误输出，默认 `production` （即关闭输出）
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,7 +40,7 @@ const calculateValue = () => {
         listenInaddrAny: envs.LISTEN_INADDR_ANY || 1, // 是否允许公网连接，取值 0 1
         requestRetry: parseInt(envs.REQUEST_RETRY) || 2, // 请求失败重试次数
         // 是否显示 Debug 信息，取值 boolean 'false' 'key' ，取值为 'false' false 时永远不显示，取值为 'key' 时带上 ?debug=key 显示
-        debugInfo: envs.DEBUG_INFO || true,
+        debugInfo: envs.DEBUG_INFO || false,
         disallowRobot: envs.DISALLOW_ROBOT !== '0' && envs.DISALLOW_ROBOT !== 'false',
         titleLengthLimit: parseInt(envs.TITLE_LENGTH_LIMIT) || 150,
         redis: {


### PR DESCRIPTION
Changed default debugInfo config to false to avoid potential privacy leakage.

RSSHub displays client IP within debug information when debugInfo is set to true, and since all pull request will be automatically deployed with Vercel, anyone, including contributors, who uses the deployment for any purpose would passively disclose their IP addresses to the instance in public. As per the principle of least privilege, therefore, users should not be granted the access to the information by default. Instead, this configuration should be manually changed for debugging purposes where needed.