### PR TITLE
feat: add fulltext to the article route of caixin

### DIFF
--- a/lib/routes/caixin/article.js
+++ b/lib/routes/caixin/article.js
@@ -1,4 +1,5 @@
 const got = require('@/utils/got');
+const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
     const response = await got({
@@ -12,15 +13,33 @@ module.exports = async (ctx) => {
 
     const data = response.data.data.list;
 
+    const items = await Promise.all(
+        data.map(async (item) => {
+            const link = item.web_url;
+            const summary = `<p><strong>摘要:</strong>${item.summary}</p><img src="${item.pics}">`;
+
+            const fullText = await ctx.cache.tryGet(link, async () => {
+                const result = await got.get(link);
+
+                const $ = cheerio.load(result.data);
+
+                return $('#Main_Content_Val').html();
+            });
+
+            return {
+                title: item.title,
+                description: summary + fullText,
+                link: link,
+                pubDate: new Date(item.time * 1000),
+                author: item.author_name,
+            };
+        })
+    );
+
     ctx.state.data = {
         title: `财新网 - 首页`,
         link: `http://www.caixin.com/`,
         description: '财新网 - 首页',
-        item: data.map((item) => ({
-            title: item.title,
-            description: `<p>${item.summary}</p><img src="${item.pics}">`,
-            link: item.web_url,
-            pubDate: new Date(item.time * 1000),
-        })),
+        item: items,
     };
 };

--- a/lib/routes/caixin/article.js
+++ b/lib/routes/caixin/article.js
@@ -28,7 +28,7 @@ module.exports = async (ctx) => {
 
             return {
                 title: item.title,
-                description: summary + fullText,
+                description: fullText ? summary + fullText : summary,
                 link: link,
                 pubDate: new Date(item.time * 1000),
                 author: item.author_name,

--- a/lib/routes/caixin/article.js
+++ b/lib/routes/caixin/article.js
@@ -16,7 +16,7 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         data.map(async (item) => {
             const link = item.web_url;
-            const summary = `<p><strong>摘要:</strong>${item.summary}</p><img src="${item.pics}">`;
+            const summary = `<blockquote><p>${item.summary}</p></blockquote><img src="${item.pics}">`;
 
             const fullText = await ctx.cache.tryGet(link, async () => {
                 const result = await got.get(link);


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

None

## 完整路由地址 / Example for the proposed route(s)

/caixin/article

Although most of the articles are not free, the free part of each article is still informative. I'd like to have it in the RSS. If people don't like it, I can add a switch and return without the text by default.
