### PR TITLE
Add ansible deployment

### DIFF
--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -106,19 +106,20 @@ To configure more options please refer to [Configuration](#configuration).
 
 # Ansible Deployment
 
-[This Ansible playbook](https://github.com/k-t-corp/RSSHub-ansible) includes RSSHub, Redis, browserless and Caddy 2
+This Ansible playbook includes RSSHub, Redis, browserless and Caddy 2
 
-This Ansible playbook currently only support Ubuntu 20.04
+Currently only support Ubuntu 20.04
+
+Requires sudo privilege
 
 ### Install
 
 ```bash
 sudo apt update
 sudo apt install ansible
-cd ~
-git clone https://github.com/k-t-corp/RSSHub-ansible.git
-cd RSSHub-ansible
-ansible-playbook rsshub.yaml
+git clone https://github.com/DIYgod/RSSHub.git ~/RSSHub
+cd ~/RSSHub/scripts/ansible
+sudo ansible-playbook rsshub.yaml
 # When prompt to enter a domain name, enter the domain name that this machine/VM will use
 # For example, if your users use https://rsshub.exmaple.com to access your RSSHub instance, enter rsshub.exmaple.com (remove the https://)
 ```
@@ -126,10 +127,8 @@ ansible-playbook rsshub.yaml
 ### Update
 
 ```bash
-cd ~
-git clone https://github.com/k-t-corp/RSSHub-ansible.git
-cd RSSHub-ansible
-ansible-playbook rsshub.yaml
+cd ~/RSSHub/scripts/ansible
+sudo ansible-playbook rsshub.yaml
 # When prompt to enter a domain name, enter the domain name that this machine/VM will use
 # For example, if your users use https://rsshub.exmaple.com to access your RSSHub instance, enter rsshub.exmaple.com (remove the https://)
 ```

--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -106,7 +106,7 @@ To configure more options please refer to [Configuration](#configuration).
 
 # Ansible Deployment
 
-[This Ansible playbook](https://github.com/k-t-corp/RSSHub-ansible) includes RSSHub, Redis, browserless and Caddy
+[This Ansible playbook](https://github.com/k-t-corp/RSSHub-ansible) includes RSSHub, Redis, browserless and Caddy 2
 
 This Ansible playbook currently only support Ubuntu 20.04
 

--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -104,6 +104,36 @@ $ docker run -d --name rsshub -p 1200:1200 -e CACHE_EXPIRE=3600 -e GITHUB_ACCESS
 
 To configure more options please refer to [Configuration](#configuration).
 
+# Ansible Deployment
+
+[This Ansible playbook](https://github.com/k-t-corp/RSSHub-ansible) includes RSSHub, Redis, browserless and Caddy
+
+This Ansible playbook currently only support Ubuntu 20.04
+
+### Install
+
+```bash
+sudo apt update
+sudo apt install ansible
+cd ~
+git clone https://github.com/k-t-corp/RSSHub-ansible.git
+cd RSSHub-ansible
+ansible-playbook rsshub.yaml
+# When prompt to enter a domain name, enter the domain name that this machine/VM will use
+# For example, if your users use https://rsshub.exmaple.com to access your RSSHub instance, enter rsshub.exmaple.com (remove the https://)
+```
+
+### Update
+
+```bash
+cd ~
+git clone https://github.com/k-t-corp/RSSHub-ansible.git
+cd RSSHub-ansible
+ansible-playbook rsshub.yaml
+# When prompt to enter a domain name, enter the domain name that this machine/VM will use
+# For example, if your users use https://rsshub.exmaple.com to access your RSSHub instance, enter rsshub.exmaple.com (remove the https://)
+```
+
 ## Manual Deployment
 
 The most direct way to deploy `RSSHub`, you can follow the steps below to deploy`RSSHub` on your computer, server or anywhere.

--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -110,7 +110,7 @@ This Ansible playbook includes RSSHub, Redis, browserless (uses Docker) and Cadd
 
 Currently only support Ubuntu 20.04
 
-Requires sudo privilege
+Requires sudo privilege and virtualization capability (Docker will be automatically installed)
 
 ### Install
 

--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -106,7 +106,7 @@ To configure more options please refer to [Configuration](#configuration).
 
 # Ansible Deployment
 
-This Ansible playbook includes RSSHub, Redis, browserless and Caddy 2
+This Ansible playbook includes RSSHub, Redis, browserless (uses Docker) and Caddy 2
 
 Currently only support Ubuntu 20.04
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -108,19 +108,20 @@ $ docker run -d --name rsshub -p 1200:1200 -e CACHE_EXPIRE=3600 -e GITHUB_ACCESS
 
 ## Ansible 部署
 
-[该 Ansible playbook](https://github.com/k-t-corp/RSSHub-ansible) 包括了 RSSHub, Redis, browserless 以及 Caddy 2
+这个 Ansible playbook 包括了 RSSHub, Redis, browserless 以及 Caddy 2
 
-该 Ansible playbook 目前只支持 Ubuntu 20.04
+目前只支持 Ubuntu 20.04
+
+需要 sudo 权限
 
 ### 安装
 
 ```bash
 sudo apt update
 sudo apt install ansible
-cd ~
-git clone https://github.com/k-t-corp/RSSHub-ansible.git
-cd RSSHub-ansible
-ansible-playbook rsshub.yaml
+git clone https://github.com/DIYgod/RSSHub.git ~/RSSHub
+cd ~/RSSHub/scripts/ansible
+sudo ansible-playbook rsshub.yaml
 # 当提示输入 domain name 的时候，输入该主机所使用的域名
 # 举例：如果您的 RSSHub 用户使用 https://rsshub.exmaple.com 访问您的 RSSHub 实例，输入 rsshub.exmaple.com（去掉 https://）
 ```
@@ -128,10 +129,8 @@ ansible-playbook rsshub.yaml
 ### 更新
 
 ```bash
-cd ~
-git clone https://github.com/k-t-corp/RSSHub-ansible.git
-cd RSSHub-ansible
-ansible-playbook rsshub.yaml
+cd ~/RSSHub/scripts/ansible
+sudo ansible-playbook rsshub.yaml
 # 当提示输入 domain name 的时候，输入该主机所使用的域名
 # 举例：如果您的 RSSHub 用户使用 https://rsshub.exmaple.com 访问您的 RSSHub 实例，输入 rsshub.exmaple.com（去掉 https://）
 ```

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -112,7 +112,7 @@ $ docker run -d --name rsshub -p 1200:1200 -e CACHE_EXPIRE=3600 -e GITHUB_ACCESS
 
 目前只支持 Ubuntu 20.04
 
-需要 sudo 权限
+需要 sudo 权限和虚拟化能力（Docker 将会被自动安装）
 
 ### 安装
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -108,7 +108,7 @@ $ docker run -d --name rsshub -p 1200:1200 -e CACHE_EXPIRE=3600 -e GITHUB_ACCESS
 
 ## Ansible 部署
 
-[该 Ansible playbook](https://github.com/k-t-corp/RSSHub-ansible) 包括了 RSSHub, Redis, browserless 以及 Caddy 的安装
+[该 Ansible playbook](https://github.com/k-t-corp/RSSHub-ansible) 包括了 RSSHub, Redis, browserless 以及 Caddy 2
 
 该 Ansible playbook 目前只支持 Ubuntu 20.04
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -106,6 +106,36 @@ $ docker run -d --name rsshub -p 1200:1200 -e CACHE_EXPIRE=3600 -e GITHUB_ACCESS
 
 更多配置项请看 [#配置](#pei-zhi)
 
+## Ansible 部署
+
+[该 Ansible playbook](https://github.com/k-t-corp/RSSHub-ansible) 包括了 RSSHub, Redis, browserless 以及 Caddy 的安装
+
+该 Ansible playbook 目前只支持 Ubuntu 20.04
+
+### 安装
+
+```bash
+sudo apt update
+sudo apt install ansible
+cd ~
+git clone https://github.com/k-t-corp/RSSHub-ansible.git
+cd RSSHub-ansible
+ansible-playbook rsshub.yaml
+# 当提示输入 domain name 的时候，输入该主机所使用的域名
+# 举例：如果您的 RSSHub 用户使用 https://rsshub.exmaple.com 访问您的 RSSHub 实例，输入 rsshub.exmaple.com（去掉 https://）
+```
+
+### 更新
+
+```bash
+cd ~
+git clone https://github.com/k-t-corp/RSSHub-ansible.git
+cd RSSHub-ansible
+ansible-playbook rsshub.yaml
+# 当提示输入 domain name 的时候，输入该主机所使用的域名
+# 举例：如果您的 RSSHub 用户使用 https://rsshub.exmaple.com 访问您的 RSSHub 实例，输入 rsshub.exmaple.com（去掉 https://）
+```
+
 ## 手动部署
 
 部署 `RSSHub` 最直接的方式，您可以按照以下步骤将 `RSSHub` 部署在您的电脑、服务器或者其他任何地方

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -108,7 +108,7 @@ $ docker run -d --name rsshub -p 1200:1200 -e CACHE_EXPIRE=3600 -e GITHUB_ACCESS
 
 ## Ansible 部署
 
-这个 Ansible playbook 包括了 RSSHub, Redis, browserless 以及 Caddy 2
+这个 Ansible playbook 包括了 RSSHub, Redis, browserless (依赖 Docker) 以及 Caddy 2
 
 目前只支持 Ubuntu 20.04
 

--- a/scripts/ansible/.gitignore
+++ b/scripts/ansible/.gitignore
@@ -1,0 +1,90 @@
+# Created by https://www.toptal.com/developers/gitignore/api/windows,linux,macos,ansible,vagrant
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows,linux,macos,ansible,vagrant
+
+### Ansible ###
+*.retry
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vagrant ###
+# General
+.vagrant/
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.log
+
+### Vagrant Patch ###
+*.box
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows,linux,macos,ansible,vagrant
+
+# vagrant logs
+*.log

--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -1,0 +1,20 @@
+# Readme
+
+Ansible playbook to deploy [RSSHub](https://github.com/DIYgod/RSSHub) on bare-metal with Redis, browserless and Caddy 2
+
+Requires sudo permission
+
+## Usage
+On `Ubuntu 20.04`, [install ansible](https://www.digitalocean.com/community/tutorials/how-to-install-and-configure-ansible-on-ubuntu-20-04), then
+
+```bash
+sudo ansible-playbook rsshub.yaml
+```
+
+## Development
+Install `vagrant`, then
+
+```bash
+./try.sh
+ansible-playbook rsshub.yaml
+```

--- a/scripts/ansible/Vagrantfile
+++ b/scripts/ansible/Vagrantfile
@@ -1,0 +1,5 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2004"
+  config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: ".git/"
+  config.ssh.extra_args = ["-t", "cd /vagrant; bash --login"]
+end

--- a/scripts/ansible/rsshub.Caddyfile
+++ b/scripts/ansible/rsshub.Caddyfile
@@ -1,0 +1,3 @@
+{{ domain_name }}
+
+reverse_proxy localhost:1200

--- a/scripts/ansible/rsshub.env
+++ b/scripts/ansible/rsshub.env
@@ -1,0 +1,3 @@
+NODE_ENV=production
+CACHE_TYPE=redis
+PUPPETEER_WS_ENDPOINT=ws://localhost:3000

--- a/scripts/ansible/rsshub.service
+++ b/scripts/ansible/rsshub.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=RSSHub is an open source, easy to use, and extensible RSS feed aggregator
+
+[Service]
+User=rsshub
+WorkingDirectory=/home/rsshub/app
+ExecStart=yarn start
+EnvironmentFile=/home/rsshub/app/.env
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ansible/rsshub.yaml
+++ b/scripts/ansible/rsshub.yaml
@@ -1,0 +1,130 @@
+-
+  name: Install RSSHub
+  hosts: localhost
+  become: true
+  vars_prompt:
+    -
+      name: domain_name
+      prompt: What is the domain name (without www, e.g. rsshub.example.com)? Use "http://localhost" for development in Vagrant VM.
+      private: no
+  tasks:
+    -
+      name: Check OS
+      fail:
+        msg: This playbook can only be run on Ubuntu 20.04 at this moment
+      when: ansible_distribution != 'Ubuntu' or ansible_distribution_version !='20.04'
+    -
+      name: Install GPG keys for repos
+      apt_key:
+        url: '{{ item }}'
+        state: present
+      with_items:
+        - https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+        - https://dl.yarnpkg.com/debian/pubkey.gpg
+        - https://download.docker.com/linux/ubuntu/gpg
+        - https://dl.cloudsmith.io/public/caddy/stable/cfg/gpg/gpg.155B6D79CA56EA34.key
+    -
+      name: Install repos
+      apt_repository:
+        repo: '{{ item }}'
+        state: present
+        update_cache: yes
+      with_items:
+        - deb https://deb.nodesource.com/node_12.x focal main
+        - deb https://dl.yarnpkg.com/debian/ stable main
+        - deb https://download.docker.com/linux/ubuntu focal stable
+        - deb https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main
+    -
+      name: Install prerequisites
+      apt:
+        name:
+          - nodejs
+          - yarn
+          - build-essential
+          - python-is-python2
+          - redis-server
+          - docker-ce
+          - python3-pip
+          - virtualenv
+          - python3-setuptools
+          - caddy
+        state: present
+        update_cache: yes
+    -
+      name: Install python module for docker
+      pip:
+        name: docker
+    -
+      name: Pull docker image for browserless
+      docker_image:
+        name: browserless/chrome
+        source: pull
+    -
+      name: Start redis
+      systemd:
+        state: restarted
+        enabled: yes
+        name: redis
+        daemon_reload: yes
+    -
+      name: Copy caddy configuration
+      template:
+        src: rsshub.Caddyfile
+        dest: /etc/caddy/Caddyfile
+    -
+      name: Start caddy
+      systemd:
+        state: restarted
+        enabled: yes
+        name: caddy
+        daemon_reload: yes
+    -
+      name: Create and start browserless container
+      docker_container:
+        name: browserless
+        image: browserless/chrome
+        state: started
+        restart_policy: always
+        published_ports:
+          - "3000:3000"
+    -
+      name: Create the user
+      user:
+        name: rsshub
+        create_home: true
+        shell: /bin/bash
+    -
+      name: Clone the repo
+      git:
+        repo: https://github.com/DIYgod/RSSHub.git
+        dest: /home/rsshub/app
+        update: yes
+    -
+      name: Install repo dependencies
+      command: yarn install --production
+      args:
+        chdir: /home/rsshub/app
+    -
+      name: Copy configuration
+      copy:
+        src: rsshub.env
+        dest: /home/rsshub/app/.env
+    -
+      name: Own repo to the user
+      file:
+        path: /home/rsshub/app
+        owner: rsshub
+        group: rsshub
+        recurse: yes
+    -
+      name: Install the systemd unit
+      copy:
+        src: rsshub.service
+        dest: /etc/systemd/system/rsshub.service
+    -
+      name: Start the systemd service
+      systemd:
+        state: restarted
+        enabled: yes
+        name: rsshub
+        daemon_reload: yes

--- a/scripts/ansible/try.sh
+++ b/scripts/ansible/try.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+vagrant rsync
+vagrant ssh


### PR DESCRIPTION
This PR adds instructions on how to use [an Ansible playbook](https://github.com/k-t-corp/RSSHub-ansible) that I wrote to deploy RSSHub on bare-metal with Redis, browserless and Caddy 2

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--

为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。

To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

-->
