### PR TITLE
修正 文档:live.md

### DIFF
--- a/docs/live.md
+++ b/docs/live.md
@@ -22,7 +22,7 @@ pageClass: routes
 
 ### 直播分区
 
-<Route author="Qixingchen" example="/bilibili/live/area/143/online" path="/bilibili/live/area/:areaID/:order" :paramsDesc="['分区 ID 分区增删较多, 可通过 [分区列表](https://api.live.bilibili.com/room/v1/Area/getList) 查询', '排序方式, live_time 开播时间, online 人气']">
+<Route author="Qixingchen" example="/bilibili/live/area/207/online" path="/bilibili/live/area/:areaID/:order" :paramsDesc="['分区 ID 分区增删较多, 可通过 [分区列表](https://api.live.bilibili.com/room/v1/Area/getList) 查询', '排序方式, live_time 开播时间, online 人气']">
 
 ::: warning 注意
 


### PR DESCRIPTION
修正 哔哩哔哩直播分区不存在导致的文档示例api不可用的问题

## 完整路由地址 / Example for the proposed route(s)

/bilibili/live/area/:areaID/:order

/bilibili/live/area/207/online