### PR TITLE
[Instagram] 修复使用path.join导致的URL不正确的BUG

### DIFF
--- a/lib/routes/instagram/index.js
+++ b/lib/routes/instagram/index.js
@@ -1,5 +1,4 @@
 const cheerio = require('cheerio');
-const path = require('path');
 const { IgLoginRequiredError } = require('instagram-private-api');
 const { ig, login } = require('./utils');
 

--- a/lib/routes/instagram/index.js
+++ b/lib/routes/instagram/index.js
@@ -55,7 +55,7 @@ module.exports = async (ctx) => {
             logo = userInfo.hd_profile_pic_url_info.url;
             const fullName = userInfo.full_name;
             title = `${fullName} (@${username}) - Instagram`;
-            link = path.join('https://www.instagram.com', username);
+            link = `https://www.instagram.com/${username}`;
 
             itemsRaw = await ig.feed.user(id).items();
             break;
@@ -64,7 +64,7 @@ module.exports = async (ctx) => {
             const tag = nameOrId;
 
             title = `#${tag}) - Instagram`;
-            link = path.join('https://www.instagram.com', 'explore', 'tags', tag);
+            link = `https://www.instagram.com/explore/tags/${tag}`;
 
             itemsRaw = await (await ig.feed.tags(tag).items()).slice(1); // the 0 item is undefined for unknown reason
             break;
@@ -89,7 +89,7 @@ module.exports = async (ctx) => {
             }
 
             // Metadata
-            const url = path.join('https://www.instagram.com', 'p', item.code);
+            const url = `https://www.instagram.com/p/${item.code}`;
             const pubDate = new Date(item.taken_at * 1000).toUTCString();
             const title = summary.split('\n')[0];
 


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue


## 完整路由地址 / Example for the proposed route(s)
```
NOROUTE
```
## 新RSS检查列表 / New RSS Script Checklist

- [ ] 这个PR中包含了新的路由吗? Does this PR add new route?
- [ ] 是否提供了文档? Documentation provided?
  - [ ] 是否提供了英文文档? EN Documentation provided?
- [ ] 是否支持全文获取? Is this RSS Script support fulltext?
  - [ ] 如果全文获取中需要访问文章链接, 是否使用了缓存? If fulltext requires to fetch detail pages, is cache used in the process?
  - [缓存说明](https://docs.rsshub.app/joinus/#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun) | [How to use cache](https://docs.rsshub.app/joinus/#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun)
- [ ] 目标是否有明显的反爬/频率限制? Is there any sign of anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? (延长缓存时间, 写文档说明, etc.) If yes, do your code reflect this sign? (e.g. write documentations, use long cache time)
- [ ] 是否引入的新的包? Any new package introduced?
  - 如果有, 请说明原因. If yes, please state your reason
- [ ] 是否使用了`Puppeteer`? Make use of `Puppeteer`?
  - 如果有, 请说明原因. If yes, please state your reason
  

## 说明 / Note
修复使用`path.join`导致的BUG
`path.join`会将`://`替换为`:\`，从而导致生成的URL不是有效的URL。
