### PR TITLE
fix: add custom certificate validation to pixiv-got

### DIFF
--- a/lib/routes/pixiv/pixiv-got.js
+++ b/lib/routes/pixiv/pixiv-got.js
@@ -1,3 +1,4 @@
+const tls = require('tls');
 const ipRegex = require('ip-regex');
 const got = require('@/utils/got');
 const logger = require('@/utils/logger');
@@ -20,7 +21,7 @@ async function dohResolve(name, jsonDohEndpoint) {
             return response.data.Answer.map((item) => item.data);
         }
     } catch (e) {
-        logger.error(`Failed to resolve ${pixivConfig.bypassCdnHostname}`);
+        logger.error(`Failed to resolve ${name}`);
         logger.debug(e);
     }
     return [];
@@ -46,11 +47,15 @@ const pixivGot = got.extend({
                     }
                 }
                 if (hostname) {
+                    const actualHost = options.url.host;
                     options.headers = {
                         ...options.headers,
-                        host: options.url.host,
+                        host: actualHost,
                     };
                     options.url.hostname = hostname;
+                    options.checkServerIdentity = function (host, certificate) {
+                        return tls.checkServerIdentity(actualHost, certificate);
+                    };
                 }
             },
         ],


### PR DESCRIPTION
<!-- 

请不要删除, 自行修改已有结构/注释, 这会导致自动检测失败；不符合要求的部分留空即可

Do not remove existing titles or structures: it breaks CI

-->

## 该 PR 相关 Issue / Involved issue

Close #6584

## 完整路由地址 / Example for the proposed route(s)

<!--
为方便测试，请附上完整路由地址，包括所有必选与可选参数，否则将导致 PR 被关闭。
To simplify the testing workflow, please include the complete route, with all required and optional parameters, otherwise your pull request will be closed.

请按照如下格式填写`routes`区域: 我们将会根据你的参数展开自动测试. 一行一个路由
Please fill the `routes` block follow the format below, as we will perform automatic test based on this information. one route per line.

```
/some/route
/some/other/route
```

如果与路由无关, 请写`NOROUTE`
-->

<!-- 在下方填写, 请不要删除`routes`标识: CI验证需要. FILL BELOW and keep `routes` keyword -->
```routes
NOROUTE
```


## 新RSS检查列表 / New RSS Script Checklist

<!-- 

Please go over the checklist below before PR: this improve your PR pass rate.

Reference: https://docs.rsshub.app/en/joinus/

请在提交PR前检查以下事项: 这可以大大提升通过率

这些就是我们在审核时主要关注的事项, 敬请留意

参考: https://docs.rsshub.app/joinus

-->

- [ ] 这个PR中包含了新的路由吗? Does this PR add new route?
  - 如果有, 请完成检查列表. If yes, please finish the check list
  - **如果你的PR符合下方某个事项, 也请注明. If any of the checklist item meets your PR, please fill it out.**
  - [x] <- 这样打勾
- [ ] 是否提供了文档? Documentation provided?
  - [ ] 是否提供了英文文档? EN Documentation provided?
- [ ] 是否支持全文获取? Is this RSS Script support fulltext?
  - [ ] 如果全文获取中需要访问文章链接, 是否使用了缓存? If fulltext requires to fetch detail pages, is cache used in the process?
  - [缓存说明](https://docs.rsshub.app/joinus/#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun) | [How to use cache](https://docs.rsshub.app/joinus/#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun)
- [ ] 目标是否有明显的反爬/频率限制? Is there any sign of anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? (延长缓存时间, 写文档说明, etc.) If yes, do your code reflect this sign? (e.g. write documentations, use long cache time)
- [ ] 是否引入的新的包? Any new package introduced?
  - 如果有, 请说明原因. If yes, please state your reason
- [ ] 是否使用了`Puppeteer`? Make use of `Puppeteer`?
  - 如果有, 请说明原因. If yes, please state your reason
  

## 说明 / Note

<!-- 

Please state your reason/note here 

请在这里描述你的原因或留下其他相关的说明

-->

修复了同时使用`PROXY_URI`和`PIXIV_BYPASS_CDN`导致#6141, #6584中的问题，

#6141中的
>(node:7356) [DEP0123] DeprecationWarning: Setting the TLS ServerName to an IP address is not permitted by RFC 6066. 

警告是由于使用socks代理时， socks-proxy-agent 会将 `tls.connect(options)` 的 `options.servername` 设为host即解析得到的IP，内部逻辑使外部无法将此值设为空或真实SNI。由于此DEP0123还没被真正弃用，暂时没有影响。
https://github.com/TooTallNate/node-socks-proxy-agent/blob/8ed8efa99c8a17a8ee52872728f13a94497ddc13/src/agent.ts#L169-L177