### PR TITLE
feat(route): add xhu

### DIFF
--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -656,6 +656,20 @@ Tiny Tiny RSS 会给所有 iframe 元素添加 `sandbox="allow-scripts"` 属性�
 
 <Route author="kt286" example="/vuevideo/971924215514" path="/vuevideo/:userid" :paramsDesc="['用户ID, 可在对应页面的 URL 中找到']"/>
 
+## xhu
+
+### 收藏夹
+
+<Route author="hellodword" example="/xhu/collection/26444956" path="/xhu/collection/:id" :paramsDesc="['收藏夹 id, 可在收藏夹页面 URL 中找到']" />
+
+### 专栏
+
+<Route author="hellodword" example="/xhu/zhuanlan/googledevelopers" path="/xhu/zhuanlan/:id" :paramsDesc="['专栏 id, 可在专栏主页 URL 中找到']" />
+
+### 话题
+
+<Route author="hellodword" example="/xhu/topic/19828946" path="/xhu/topic/:topicId" :paramsDesc="['话题 id']" />
+
 ## YouTube
 
 ::: tip Tiny Tiny RSS 用户请注意

--- a/lib/router.js
+++ b/lib/router.js
@@ -161,6 +161,11 @@ router.get('/zhihu/weekly', require('./routes/zhihu/weekly'));
 router.get('/zhihu/timeline', require('./routes/zhihu/timeline'));
 router.get('/zhihu/hot/:category?', require('./routes/zhihu/hot'));
 
+// xhu
+router.get('/xhu/collection/:id', require('./routes/xhu/collection'));
+router.get('/xhu/topic/:topicId', require('./routes/xhu/topic'));
+router.get('/xhu/zhuanlan/:id', require('./routes/xhu/zhuanlan'));
+
 // 妹子图
 router.get('/mzitu/home/:type?', require('./routes/mzitu/home'));
 router.get('/mzitu/tags', require('./routes/mzitu/tags'));

--- a/lib/routes/xhu/auth.js
+++ b/lib/routes/xhu/auth.js
@@ -1,0 +1,36 @@
+const got = require('@/utils/got');
+const config = require('@/config').value;
+
+function reset() {
+    config.xhu = {
+        access_token: '',
+        count: 0,
+    };
+}
+
+module.exports = {
+    Reset: () => {
+        reset();
+    },
+    Get: async () => {
+        if (!config.xhu) {
+            reset();
+        }
+
+        if (config.xhu.count++ > 512) {
+            reset();
+        }
+
+        if (config.xhu.access_token === '') {
+            const res = await got.get('https://xhu.privacyhide.com/regToken');
+            config.xhu.access_token = res.data.access_token || '';
+            config.xhu.headers = res.data.headers;
+        }
+
+        if (config.xhu.access_token === '') {
+            throw 'get access_token failed';
+        }
+
+        return config.xhu;
+    },
+};

--- a/lib/routes/xhu/collection.js
+++ b/lib/routes/xhu/collection.js
@@ -1,0 +1,45 @@
+const got = require('@/utils/got');
+const auth = require('./auth');
+const { generateData } = require('./pin/utils');
+
+module.exports = async (ctx) => {
+    const xhu = await auth.Get();
+
+    const id = ctx.params.id;
+
+    const response = await got({
+        method: 'get',
+        url: `https://api.zhihu.com/collections/${id}/items?limit=20&offset=0`,
+        headers: xhu.headers,
+    });
+
+    const list = response.data.data;
+
+    const info = await got({
+        method: 'get',
+        url: `https://api.zhihu.com/collections/${id}`,
+        headers: xhu.headers,
+    });
+
+    const collection_title = (info.data.collection ? info.data.collection.title : info.data.title) + ' - 知乎收藏夹';
+    const collection_description = info.data.collection ? info.data.collection.description : info.data.description;
+
+    const generateDataPin = (item) => generateData([item.content])[0];
+    ctx.state.data = {
+        title: `${collection_title}`,
+        link: `https://www.zhihu.com/collection/${id}`,
+        description: `${collection_description}`,
+        item:
+            list &&
+            list.map((item) =>
+                item.content.type === 'pin'
+                    ? generateDataPin(item)
+                    : {
+                          title: `${item.content.type === 'article' ? item.content.title : item.content.question.title}`,
+                          link: `${item.content.url}`,
+                          description: `${item.content.content}`,
+                          pubDate: new Date((item.content.type === 'article' ? item.content.updated : item.content.updated_time) * 1000).toUTCString(),
+                      }
+            ),
+    };
+};

--- a/lib/routes/xhu/pin/utils.js
+++ b/lib/routes/xhu/pin/utils.js
@@ -1,0 +1,48 @@
+module.exports = {
+    generateData: (data) =>
+        data.map((item) => {
+            const target = item.target ? item.target : item;
+            const pubDate = new Date(target.created * 1000).toUTCString();
+            const author = target.author.name;
+            const title = `${author}：${target.excerpt_title}`;
+            const link = `https://www.zhihu.com/pin/${target.id}`;
+            const description = target.content.reduce((description, item) => {
+                switch (item.type) {
+                    case 'text':
+                        description += `<div>${item.content}</div>`;
+                        break;
+
+                    case 'image':
+                        description += `<img src="${item.url.replace(/_.+\.jpg/g, '.jpg')}" />`;
+                        break;
+
+                    case 'video':
+                        description += `<video
+                    controls="controls"
+                    width="${item.playlist.hd.width}"
+                    height="${item.playlist.hd.height}"
+                    poster="${item.cover_info.thumbnail}"
+                    src="${item.playlist.hd.play_url}"
+                  >`;
+                        break;
+
+                    case 'link':
+                        description += `<div><a href="${item.url}">${item.title}</a><br><img src="${item.image_url}" /></div>`;
+                        break;
+
+                    default:
+                        description += '未知类型，请点击<a href="https://github.com/DIYgod/RSSHub/issues">链接</a>提交issue';
+                }
+
+                return description;
+            }, `<a href="https://www.zhihu.com${target.author.url}">${author}</a>：`);
+
+            return {
+                title,
+                description,
+                author,
+                pubDate,
+                link,
+            };
+        }),
+};

--- a/lib/routes/xhu/topic.js
+++ b/lib/routes/xhu/topic.js
@@ -1,0 +1,62 @@
+const got = require('@/utils/got');
+const auth = require('./auth');
+
+module.exports = async (ctx) => {
+    const xhu = await auth.Get();
+    const { topicId } = ctx.params;
+
+    const response = await got({
+        method: 'get',
+        url: `https://api.zhihu.com/topics/${topicId}/feeds/timeline_activity?limit=20`,
+        headers: xhu.headers,
+    });
+    const listRes = response.data.data;
+
+    const info = await got({
+        method: 'get',
+        url: `https://api.zhihu.com/topics/${topicId}`,
+        headers: xhu.headers,
+    });
+
+    ctx.state.data = {
+        title: `知乎话题-${info.data.name ? info.data.name : topicId}`,
+        link: `https://www.zhihu.com/topic/${topicId}/newest`,
+        item: listRes.map((item) => {
+            const type = item.type;
+            let title = '';
+            let description = '';
+            let link = '';
+            let pubDate = '';
+            let author = '';
+
+            switch (type) {
+                case 'answer':
+                    title = `${item.question.title}-${item.author.name}的回答：${item.excerpt}`;
+                    description = `<strong>${item.question.title}</strong><br>${item.author.name}的回答<br/>${item.excerpt}`;
+                    link = `https://www.zhihu.com/question/${item.question.id}/answer/${item.id}`; // TODO
+                    pubDate = new Date(item.updated_time * 1000).toUTCString();
+                    author = item.author.name;
+                    break;
+
+                case 'question':
+                    title = item.title;
+                    description = item.title;
+                    link = `https://www.zhihu.com/question/${item.id}`;
+                    pubDate = new Date(item.created * 1000).toUTCString();
+                    break;
+
+                default:
+                    description = `未知类型 ${topicId}.${type}，请点击<a href="https://github.com/DIYgod/RSSHub/issues">链接</a>提交issue`;
+            }
+
+            return {
+                title,
+                description,
+                author,
+                pubDate,
+                guid: item.id.toString(),
+                link,
+            };
+        }),
+    };
+};

--- a/lib/routes/xhu/utils.js
+++ b/lib/routes/xhu/utils.js
@@ -1,0 +1,37 @@
+const cheerio = require('cheerio');
+
+module.exports = {
+    ProcessImage: function (content) {
+        const $ = cheerio.load(content, {
+            xmlMode: true,
+        });
+
+        $('noscript').remove();
+
+        $('a[data-draft-type="mcn-link-card"]').remove();
+
+        $('img.content_image, img.origin_image, img.content-image, img.data-actualsrc, figure>img').each((i, e) => {
+            if (e.attribs['data-actualsrc']) {
+                $(e).attr({
+                    src: e.attribs['data-actualsrc'].replace('_b.jpg', '_1440w.jpg'),
+                    width: null,
+                    height: null,
+                });
+            } else if (e.attribs['data-original']) {
+                $(e).attr({
+                    src: e.attribs['data-original'].replace('_r.jpg', '_1440w.jpg'),
+                    width: null,
+                    height: null,
+                });
+            } else {
+                $(e).attr({
+                    src: e.attribs.src.replace('_b.jpg', '_1440w.jpg'),
+                    width: null,
+                    height: null,
+                });
+            }
+        });
+
+        return $.html();
+    },
+};

--- a/lib/routes/xhu/zhuanlan.js
+++ b/lib/routes/xhu/zhuanlan.js
@@ -1,0 +1,75 @@
+const got = require('@/utils/got');
+const auth = require('./auth');
+const utils = require('./utils');
+
+module.exports = async (ctx) => {
+    const xhu = await auth.Get();
+    const id = String(ctx.params.id);
+
+    const response = await got({
+        method: 'get',
+        url: `https://api.zhihu.com/columns/${id}/items?limit=20`,
+        headers: xhu.headers,
+    });
+    const listRes = response.data.data;
+
+    const info = await got({
+        method: 'get',
+        url: `https://api.zhihu.com/columns/${id}`,
+        headers: xhu.headers,
+    });
+
+    const title = info.data.title;
+    const description = info.data.description || info.data.title;
+
+    const item = listRes.map((item) => {
+        let title = '';
+        let description = '';
+        let link = '';
+        let pubDate = '';
+        let author = '';
+
+        switch (item.type) {
+            case 'article':
+                title = item.title;
+                description = item.content ? utils.ProcessImage(item.content) : item.excerpt;
+                link = item.url ? item.url : `https://zhuanlan.zhihu.com/p/${item.id}`;
+                pubDate = new Date(item.updated * 1000).toUTCString();
+                author = item.author.name;
+                break;
+            case 'answer':
+                title = `${item.question.title}-${item.author.name}的回答：${item.excerpt}`;
+                description = `<strong>${item.question.title}</strong><br>${item.author.name}的回答<br/>${item.content ? utils.ProcessImage(item.content) : item.excerpt}`;
+                link = `https://www.zhihu.com/question/${item.question.id}/answer/${item.id}`; // TODO
+                pubDate = new Date(item.updated_time * 1000).toUTCString();
+                author = item.author.name;
+                break;
+            case 'zvideo':
+                title = item.title;
+                description = item.description;
+                link = `https://www.zhihu.com/zvideo/${item.video.video_id}`;
+                pubDate = new Date(item.published_at * 1000).toUTCString();
+                author = item.author.name;
+                break;
+
+            default:
+                description = `未知类型 ${id}.${item.type}，请点击<a href="https://github.com/DIYgod/RSSHub/issues">链接</a>提交issue`;
+        }
+
+        return {
+            title,
+            description,
+            author,
+            pubDate,
+            guid: item.id.toString(),
+            link,
+        };
+    });
+
+    ctx.state.data = {
+        description,
+        item,
+        title: `知乎专栏-${title}`,
+        link: `https://zhuanlan.zhihu.com/${id}`,
+    };
+};


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #6784

## 完整路由地址 / Example for the proposed route(s)



```
/xhu/collection/26444956
/xhu/zhuanlan/googledevelopers
/xhu/topic/19828946
```


## 新RSS检查列表 / New RSS Script Checklist

- [x] 这个PR中包含了新的路由吗? Does this PR add new route?
  - 如果有, 请完成检查列表. If yes, please finish the check list
  - **如果你的PR符合下方某个事项, 也请注明. If any of the checklist item meets your PR, please fill it out.**
  - [x] <- 这样打勾
- [x] 是否提供了文档? Documentation provided?
  - [ ] 是否提供了英文文档? EN Documentation provided?
- [ ] 是否支持全文获取? Is this RSS Script support fulltext?
  - [ ] 如果全文获取中需要访问文章链接, 是否使用了缓存? If fulltext requires to fetch detail pages, is cache used in the process?
  - [缓存说明](https://docs.rsshub.app/joinus/#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun) | [How to use cache](https://docs.rsshub.app/joinus/#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun)
- [ ] 目标是否有明显的反爬/频率限制? Is there any sign of anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? (延长缓存时间, 写文档说明, etc.) If yes, do your code reflect this sign? (e.g. write documentations, use long cache time)
- [ ] 是否引入的新的包? Any new package introduced?
  - 如果有, 请说明原因. If yes, please state your reason
- [ ] 是否使用了`Puppeteer`? Make use of `Puppeteer`?
  - 如果有, 请说明原因. If yes, please state your reason
  

## 说明 / Note

- 只写了自己经常用到的路由，就是把 `zhihu` 下面的源码改了点 API
- 关于反爬，我自己实在没测出来，简单限制了一下 token 使用次数，超过次数就再生成，对于 IP 的限制怕喝茶也不好测试，有人方便测试的话，可以告诉我一下结果，如果触发反爬我可以分析并更新一下 APP 版本
- 用 `./lib/config` 存储了 token 等数据，不知道有无更规范的方式？
- 为了规避一些众所周知的风险，token 的生成做成了 API，运行于 [workers.dev](https://workers.dev)，源码在 [zhihu-core](https://github.com/hellodword/zhihu-core)
