### PR TITLE
feat(route): 公众号（Telegram 频道来源）增加筛选

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -2760,7 +2760,7 @@ column 为 third 时可选的 category:
 
 ### 公众号（Telegram 频道来源）
 
-<Route author="LogicJake" example="/wechat/tgchannel/lifeweek" path="/wechat/tgchannel/:id" :paramsDesc="['公众号绑定频道 id']">
+<Route author="LogicJake" example="/wechat/tgchannel/lifeweek" path="/wechat/tgchannel/:id/:mpName?" :paramsDesc="['公众号绑定频道 id', '欲筛选的公众号全名（精确匹配），在频道订阅了多个公众号时可选用']">
 
 ::: warning 注意
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -511,7 +511,7 @@ router.get('/wechat/csm/:id', lazyloadRouteHandler('./routes/tencent/wechat/csm'
 router.get('/wechat/ce/:id', lazyloadRouteHandler('./routes/tencent/wechat/ce'));
 router.get('/wechat/announce', lazyloadRouteHandler('./routes/tencent/wechat/announce'));
 router.get('/wechat/miniprogram/plugins', lazyloadRouteHandler('./routes/tencent/wechat/miniprogram/plugins'));
-router.get('/wechat/tgchannel/:id', lazyloadRouteHandler('./routes/tencent/wechat/tgchannel'));
+router.get('/wechat/tgchannel/:id/:mpName?', lazyloadRouteHandler('./routes/tencent/wechat/tgchannel'));
 router.get('/wechat/uread/:userid', lazyloadRouteHandler('./routes/tencent/wechat/uread'));
 router.get('/wechat/ershicimi/:id', lazyloadRouteHandler('./routes/tencent/wechat/ershcimi'));
 router.get('/wechat/wjdn/:id', lazyloadRouteHandler('./routes/tencent/wechat/wjdn'));

--- a/lib/routes/tencent/wechat/tgchannel.js
+++ b/lib/routes/tencent/wechat/tgchannel.js
@@ -3,26 +3,62 @@ const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
     const id = ctx.params.id;
+    const mpName = ctx.params.mpName ?? '';
 
     const { data } = await got.get(`https://t.me/s/${id}`);
     const $ = cheerio.load(data);
-    const list = $('.tgme_widget_message_wrap').slice(-10);
+    const list = $('.tgme_widget_message_wrap').slice(-20);
 
     const out = await Promise.all(
         list
             .map(async (index, item) => {
                 item = $(item);
 
-                let author;
-                let title = item.find('.tgme_widget_message_text > a:nth-child(5)').text() || item.find('.tgme_widget_message_text > a:nth-child(2)').text();
+                // [ div.tgme_widget_message_text 格式简略说明 ]
+                // 若频道只订阅一个公众号：
+                // 第 1 个元素: <a href="${用于 link priview 的预览图 url}"><i><b>${emoji(链接)}</b></i></a>
+                // 第 2 个元素: <a href="${文章 url}">${文章标题}</a>
+                // (余下是文章简介，一般是裸文本，这里用不到)
+                //
+                // 若频道订阅多于一个公众号：
+                // 第 1 个元素: <i><b>${emoji(标注消息来源于什么 slave，这里是表示微信的对话气泡)}</b></i>
+                // 第 2 个元素: <i><b>${emoji(标注对话类型，这里是表示私聊的半身人像)</b></i>
+                // 裸文本: (半角空格)${公众号名}(半角冒号)
+                // 第 3 个元素: <br />
+                // 第 4 个元素: <a href="${用于 link priview 的预览图 url}"><i><b>${emoji(链接)}</b></i></a>
+                // 第 5 个元素: <a href="${文章 url}">${文章标题}</a>
+                // (余下是文章简介，一般是裸文本，这里用不到)
 
-                const all_text = item.find('.tgme_widget_message_text').text();
-                if (all_text.indexOf(':') !== -1) {
-                    author = all_text.split(':')[0].split(' ')[1];
-                    title = author + ': ' + title;
+                const title_elem = item.find('.tgme_widget_message_text > a:nth-of-type(2)'); // 第二个 a 元素会是文章链接
+
+                if (title_elem.length === 0) {
+                    // 获取不到第二个 a 元素，这可能是公众号发的服务消息，丢弃它
+                    return;
                 }
 
-                const link = item.find('.tgme_widget_message_text > a:nth-child(5)').attr('href') || item.find('.tgme_widget_message_text > a:nth-child(2)').attr('href');
+                let author;
+                let title = title_elem.text();
+                const link = title_elem.attr('href');
+
+                const br_node = item.find('.tgme_widget_message_text > br:nth-of-type(1)').get(0); // 获取第一个换行
+                const author_node = br_node && br_node.prev; // br_node 不为 undefined 时获取它的前一个节点
+                if (author_node && author_node.type === 'text') {
+                    // 只有这个节点是一个裸文本时它才可能是公众号名
+                    const spaceIndex = author_node.data.indexOf(' ');
+                    const colonIndex = author_node.data.indexOf(':');
+                    if (spaceIndex !== -1 && colonIndex !== -1) {
+                        // 找到了公众号名，说明这个频道订阅了多个公众号
+                        author = author_node.data.slice(spaceIndex + 1, colonIndex); // 提取作者
+                        if (mpName && author !== mpName) {
+                            // 指定了要筛选的公众号名，且该文章不是该公众号发的
+                            return; // 丢弃
+                        } else if (!mpName) {
+                            // 没有指定要筛选的公众号名
+                            title = author + ': ' + title; // 给标题里加上获取到的作者
+                        }
+                    }
+                }
+
                 const pubDate = new Date(item.find('.tgme_widget_message_date time').attr('datetime')).toUTCString();
 
                 const single = {
@@ -51,15 +87,16 @@ module.exports = async (ctx) => {
                     }
                 }
 
-                return Promise.resolve(single);
+                return single;
             })
             .get()
     );
 
     out.reverse();
     ctx.state.data = {
-        title: $('.tgme_channel_info_header_title').text(),
+        title: mpName ?? $('.tgme_channel_info_header_title').text(),
         link: `https://t.me/s/${id}`,
-        item: out,
+        item: out.filter((item) => item),
+        allowEmpty: !!mpName,
     };
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/wechat/tgchannel/lifeweek
/wechat/tgchannel/rsswiki
/wechat/tgchannel/rsswiki/大洋网
/wechat/tgchannel/rsswiki/盖世汽车每日速递
```

## 新RSS检查列表 / New RSS Script Checklist

- [ ] 这个PR中包含了新的路由吗? Does this PR add new route?
  - 如果有, 请完成检查列表. If yes, please finish the check list
  - **如果你的PR符合下方某个事项, 也请注明. If any of the checklist item meets your PR, please fill it out.**
  - [x] <- 这样打勾
- [x] 是否提供了文档? Documentation provided?
  - [ ] 是否提供了英文文档? EN Documentation provided?
- [x] 是否支持全文获取? Is this RSS Script support fulltext?
  - [x] 如果全文获取中需要访问文章链接, 是否使用了缓存? If fulltext requires to fetch detail pages, is cache used in the process?
  - [缓存说明](https://docs.rsshub.app/joinus/quick-start.html#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun) | [How to use cache](https://docs.rsshub.app/joinus/quick-start.html#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun)
- [ ] 目标是否有明显的反爬/频率限制? Is there any sign of anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? (延长缓存时间, 写文档说明, etc.) If yes, do your code reflect this sign? (e.g. write documentations, use long cache time)
- [x] 目标是否有提供日期？ Is there a date in the source?
  - [x] 如果有，包是否正确解析？ If there is, can this script provide this info?
  - [x] 如果有提供解析能力，时区是否正确调整？ Is the timezone correctly provided?
  - 如果有提供日期，但是没有提供解析，请说明原因 If there is a date but this script does not parse, please provide your reason.
- [ ] 是否引入的新的包? Any new package introduced?
  - 如果有, 请说明原因. If yes, please state your reason
- [ ] 是否使用了`Puppeteer`? Make use of `Puppeteer`?
  - 如果有, 请说明原因. If yes, please state your reason
  

## 说明 / Note

公众号（Telegram 频道来源）原先需要筛选公众号时只能通过 RSSHub 通用参数筛选作者实现，这主要带来了两个问题：
* feed title 永远是频道名
* post title 永远含有公众号名

这在只需要筛选一个公众号时，将会带来并不美观的结果。然而，考虑到 Telegram 的公开频道/群组配额是高度有限的，将多个公众号绑定到同一个频道，是常见的做法；在订阅时，希望各公众号能分开订阅，也是常见的需求。

基于此，这个 PR 的主要改进有：
* 增加可选参数 mpName 用于筛选，解决以上问题
* 顺手修复公众号名带空格时会被截断的 bug（暂无示例路由提供）
* 增大了对消息列表的切片大小（因许多公众号推送的时间都固定在某几个整点，切片太小很可能遗漏）