### PR TITLE
fix(route): 修复语雀源无效的问题

### DIFF
--- a/docs/study.md
+++ b/docs/study.md
@@ -454,11 +454,12 @@ pageClass: routes
 
 ### 知识库
 
-<Route author="aha2mao" example="/yuque/doc/75258" path="/yuque/doc/:repo_id" :paramsDesc="['仓库id，可在对应知识库主页的`/api/books/${repo_id}/docs`请求里找到']">
+<Route author="aha2mao" example="/yuque/ruanyf/weekly" path="/yuque/:name/:book" :paramsDesc="['语雀知识库路径，如 https://www.yuque.com/ruanyf/weekly，ruanyf 为 name，weekly 为 book']">
+
 
 | Node.js 专栏 | 阮一峰每周分享 | 语雀使用手册 |
 | ------------ | -------------- | ------------ |
-| 75258        | 102804         | 75257        |
+| egg/nodejs   | ruanyf/weekly  | yuque/help   |
 
 </Route>
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -82,9 +82,6 @@ const calculateValue = () => {
         bilibili: {
             cookies: bilibili_cookies,
         },
-        yuque: {
-            token: envs.YUQUE_TOKEN,
-        },
         zhihu: {
             cookies: envs.ZHIHU_COOKIES,
         },

--- a/lib/router.js
+++ b/lib/router.js
@@ -1784,6 +1784,7 @@ router.get('/wired/tag/:tag', require('./routes/wired/tag'));
 
 // 语雀文档
 router.get('/yuque/doc/:repo_id', require('./routes/yuque/doc'));
+router.get('/yuque/:name/:book', require('./routes/yuque/name/book'));
 
 // 飞地
 router.get('/enclavebooks/category/:id?', require('./routes/enclavebooks/category'));

--- a/lib/routes/yuque/doc.js
+++ b/lib/routes/yuque/doc.js
@@ -1,60 +1,17 @@
-const got = require('@/utils/got');
-const config = require('@/config').value;
-// token通过process.env.YUQUE_TOKEN或者在config.js 配置
-const { token = '' } = config.yuque;
+const { parseDate } = require('@/utils/parse-date');
 
 module.exports = async (ctx) => {
-    const { repo_id } = ctx.params;
-    const baseUrl = 'https://www.yuque.com';
-    const repoUrl = `${baseUrl}/api/v2/repos/${repo_id}`;
-    const docsUrl = `${repoUrl}/docs`;
-
-    const fetchData = (url) =>
-        got({
-            url,
-            method: 'get',
-            headers: {
-                'X-Auth-Token': token,
-            },
-        });
-
-    const repoDetail = await fetchData(repoUrl);
-    const {
-        name: repo,
-        user: { name },
-        description,
-        namespace,
-    } = repoDetail.data.data;
-    const docsDetail = await fetchData(docsUrl);
-    const docs = docsDetail.data.data;
-
-    // 过滤掉草稿类型
-    const publicDocs = docs.filter(({ status }) => status === 1);
     ctx.state.data = {
-        title: `${name} / ${repo}`,
-        link: repoUrl,
-        description,
-        item: await Promise.all(
-            publicDocs.map(async (doc) => {
-                const item = {
-                    title: doc.title,
-                    description: doc.description,
-                    pubDate: doc.published_at,
-                    link: `${baseUrl}/${namespace}/${doc.id}`,
-                };
-                const key = `yuque${doc.id}`;
-                const value = await ctx.cache.get(key);
-
-                if (value) {
-                    item.description = value;
-                } else if (token) {
-                    const docDetail = await fetchData(`${docsUrl}/${doc.id}`);
-                    const { body_html } = docDetail.data.data;
-                    item.description = body_html;
-                    ctx.cache.set(key, item.description);
-                }
-                return Promise.resolve(item);
-            })
-        ),
+        title: '该语雀 RSS 源已废弃',
+        link: 'https://docs.rsshub.app/study.html#yu-que',
+        description: '请参考最新配置方式重新配置',
+        item: [
+            {
+                title: '该配置方式已废弃',
+                description: '请参考语雀最新配置方式重新配置',
+                pubDate: parseDate('2021/07/10', 'YYYY/MM/DD'),
+                link: 'https://docs.rsshub.app/study.html#yu-que',
+            },
+        ],
     };
 };

--- a/lib/routes/yuque/name/book.js
+++ b/lib/routes/yuque/name/book.js
@@ -1,0 +1,53 @@
+const { parseDate } = require('@/utils/parse-date');
+const got = require('@/utils/got');
+
+const GLOBAL_DATA_REGEXP = /window\.appData = JSON\.parse\(decodeURIComponent\("(.+)"\)\);/;
+const PUBLISHED_ARTICLE_STATUS = 1;
+
+const fetchData = (url) => got({ url, method: 'get' });
+
+module.exports = async (ctx) => {
+    const { name, book } = ctx.params;
+    const baseUrl = 'https://www.yuque.com';
+    const bookUrl = `${baseUrl}/${name}/${book}`;
+    const articleUrl = (articleSlug, bookId) => `${baseUrl}/api/docs/${articleSlug}?book_id=${bookId}`;
+    const result = {
+        title: bookUrl,
+        link: bookUrl,
+        description: '',
+        item: [],
+    };
+
+    const { data: bookHtml } = await fetchData(bookUrl);
+    const bookResult = bookHtml.match(GLOBAL_DATA_REGEXP);
+    const globalData = JSON.parse(decodeURIComponent(bookResult[1]));
+    const { group: { name: author }, book: { id: bookId, name: bookName, namespace, description, docs } } = globalData;
+
+    result.title = `${author}/${bookName} · 语雀`;
+    result.description = description;
+
+    const publicDocs = docs.filter(({ status }) => status === PUBLISHED_ARTICLE_STATUS);
+    result.item = await Promise.all(
+        publicDocs.map(async (doc) => {
+            const item = {
+                title: doc.title,
+                description: doc.description,
+                pubDate: parseDate(doc.published_at, 'YYYY/MM/DD'),
+                link: `${baseUrl}/${namespace}/${doc.slug}`,
+                author,
+            };
+            const docKey = `yuque${doc.id}`;
+            const cachedDocDescription = await ctx.cache.get(docKey);
+            if (cachedDocDescription) {
+                item.description = cachedDocDescription;
+                return item;
+            }
+            const { data: { data: docDetail } } = await fetchData(articleUrl(doc.slug, bookId));
+            item.description = docDetail.content;
+            item.author = docDetail.user.name;
+            ctx.cache.set(docKey, item.description);
+            return item;
+        })
+    );
+    return ctx.state.data = result;
+};


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)


```routes
/yuque/ruanyf/weekly
/yuque/ruanyf/weekly?content=1
```

## 新RSS检查列表 / New RSS Script Checklist

<!-- 
Please go over the checklist below before PR: this improve your PR pass rate.
Reference: https://docs.rsshub.app/en/joinus/quick-start.html
请在提交PR前检查以下事项: 这可以大大提升通过率
这些就是我们在审核时主要关注的事项, 敬请留意
参考: https://docs.rsshub.app/joinus/quick-start.html
-->

- [x] 这个PR中包含了新的路由吗? Does this PR add new route?
  - 如果有, 请完成检查列表. If yes, please finish the check list
  - **如果你的PR符合下方某个事项, 也请注明. If any of the checklist item meets your PR, please fill it out.**
- [x] 是否提供了文档? Documentation provided?
  - [ ] 是否提供了英文文档? EN Documentation provided?
- [x] 是否支持全文获取? Is this RSS Script support fulltext?
  - [x] 如果全文获取中需要访问文章链接, 是否使用了缓存? If fulltext requires to fetch detail pages, is cache used in the process?
  - [缓存说明](https://docs.rsshub.app/joinus/quick-start.html#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun) | [How to use cache](https://docs.rsshub.app/joinus/quick-start.html#ti-jiao-xin-de-rsshub-gui-ze-bian-xie-jiao-ben-shi-yong-huan-cun)
- [ ] 目标是否有明显的反爬/频率限制? Is there any sign of anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? (延长缓存时间, 写文档说明, etc.) If yes, do your code reflect this sign? (e.g. write documentations, use long cache time)
- [x] 目标是否有提供日期？ Is there a date in the source?
  - [x] 如果有，包是否正确解析？ If there is, can this script provide this info?
  - [ ] 如果有提供解析能力，时区是否正确调整？ Is the timezone correctly provided?
  - 如果有提供日期，但是没有提供解析，请说明原因 If there is a date but this script does not parse, please provide your reason.
- [ ] 是否引入的新的包? Any new package introduced?
  - 如果有, 请说明原因. If yes, please state your reason
- [ ] 是否使用了`Puppeteer`? Make use of `Puppeteer`?
  - 如果有, 请说明原因. If yes, please state your reason
  

## 说明 / Note

发现 `yuque` 现在的配置方式无法抓取页面了，即使提供了 `TOKEN` 仍提示 `401`，猜测之前语雀是客户端渲染所以暴露了接口，现在是将页面数据渲染到 `window.appData` 上，之前的接口都不再对外使用。

所以改为了获取页面内的 `window.appData` 的方式。

在文档中没看到怎么对之前的路由做废弃标志的方式，直接删除还是保留不变，还是做已废弃说明，引导使用新的配置方式？
这里的做法是引导使用新的配置方式了。


