### PR TITLE
feat(route): load route handler on the first request

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -19,8 +19,21 @@ for (const project in RouterPath) {
     }
 }
 
+const RouterHandlerMap = new Map();
+
+// 懒加载 Route Handler，Route 首次被请求时才会 require 相关文件
+const lazyloadRouteHandler = (routeHandlerPath) => (ctx) => {
+    if (RouterHandlerMap.has(routeHandlerPath)) {
+        return RouterHandlerMap.get(routeHandlerPath)(ctx);
+    }
+
+    const handler = require(routeHandlerPath);
+    RouterHandlerMap.set(routeHandlerPath, handler);
+    return handler(ctx);
+};
+
 // index
-router.get('/', require('./routes/index'));
+router.get('/', lazyloadRouteHandler('./routes/index'));
 
 router.get('/robots.txt', async (ctx) => {
     if (config.disallowRobot) {
@@ -32,4190 +45,4190 @@ router.get('/robots.txt', async (ctx) => {
 });
 
 // test
-router.get('/test/:id', require('./routes/test'));
+router.get('/test/:id', lazyloadRouteHandler('./routes/test'));
 
 // RSSHub
-router.get('/rsshub/rss', require('./routes/rsshub/routes')); // 弃用
-router.get('/rsshub/routes', require('./routes/rsshub/routes'));
-router.get('/rsshub/sponsors', require('./routes/rsshub/sponsors'));
+router.get('/rsshub/rss', lazyloadRouteHandler('./routes/rsshub/routes')); // 弃用
+router.get('/rsshub/routes', lazyloadRouteHandler('./routes/rsshub/routes'));
+router.get('/rsshub/sponsors', lazyloadRouteHandler('./routes/rsshub/sponsors'));
 
 // 1draw
-router.get('/1draw', require('./routes/1draw/index'));
+router.get('/1draw', lazyloadRouteHandler('./routes/1draw/index'));
 
 // quicker
-router.get('/quicker/qa', require('./routes/quicker/qa.js'));
-router.get('/quicker/update', require('./routes/quicker/update.js'));
-router.get('/quicker/user/action/:uid/:person', require('./routes/quicker/person.js'));
-router.get('/quicker/user/:uid/:person', require('./routes/quicker/person.js'));
+router.get('/quicker/qa', lazyloadRouteHandler('./routes/quicker/qa.js'));
+router.get('/quicker/update', lazyloadRouteHandler('./routes/quicker/update.js'));
+router.get('/quicker/user/action/:uid/:person', lazyloadRouteHandler('./routes/quicker/person.js'));
+router.get('/quicker/user/:uid/:person', lazyloadRouteHandler('./routes/quicker/person.js'));
 
 // Benedict Evans
-router.get('/benedictevans', require('./routes/benedictevans/recent.js'));
+router.get('/benedictevans', lazyloadRouteHandler('./routes/benedictevans/recent.js'));
 
 // bilibili
-router.get('/bilibili/user/video/:uid/:disableEmbed?', require('./routes/bilibili/video'));
-router.get('/bilibili/user/article/:uid', require('./routes/bilibili/article'));
-router.get('/bilibili/user/fav/:uid/:disableEmbed?', require('./routes/bilibili/userFav'));
-router.get('/bilibili/user/coin/:uid/:disableEmbed?', require('./routes/bilibili/coin'));
-router.get('/bilibili/user/dynamic/:uid/:disableEmbed?', require('./routes/bilibili/dynamic'));
-router.get('/bilibili/user/followers/:uid', require('./routes/bilibili/followers'));
-router.get('/bilibili/user/followings/:uid', require('./routes/bilibili/followings'));
-router.get('/bilibili/user/bangumi/:uid/:type?', require('./routes/bilibili/user_bangumi'));
-router.get('/bilibili/partion/:tid/:disableEmbed?', require('./routes/bilibili/partion'));
-router.get('/bilibili/partion/ranking/:tid/:days?/:disableEmbed?', require('./routes/bilibili/partion-ranking'));
-router.get('/bilibili/bangumi/:seasonid', require('./routes/bilibili/bangumi')); // 弃用
-router.get('/bilibili/bangumi/media/:mediaid', require('./routes/bilibili/bangumi'));
-router.get('/bilibili/video/page/:bvid/:disableEmbed?', require('./routes/bilibili/page'));
-router.get('/bilibili/video/reply/:bvid', require('./routes/bilibili/reply'));
-router.get('/bilibili/video/danmaku/:bvid/:pid?', require('./routes/bilibili/danmaku'));
-router.get('/bilibili/link/news/:product', require('./routes/bilibili/linkNews'));
-router.get('/bilibili/live/room/:roomID', require('./routes/bilibili/liveRoom'));
-router.get('/bilibili/live/search/:key/:order', require('./routes/bilibili/liveSearch'));
-router.get('/bilibili/live/area/:areaID/:order', require('./routes/bilibili/liveArea'));
-router.get('/bilibili/fav/:uid/:fid/:disableEmbed?', require('./routes/bilibili/fav'));
-router.get('/bilibili/blackboard', require('./routes/bilibili/blackboard'));
-router.get('/bilibili/mall/new/:category?', require('./routes/bilibili/mallNew'));
-router.get('/bilibili/mall/ip/:id', require('./routes/bilibili/mallIP'));
-router.get('/bilibili/ranking/:rid?/:day?/:arc_type?/:disableEmbed?', require('./routes/bilibili/ranking'));
-router.get('/bilibili/user/channel/:uid/:cid/:disableEmbed?', require('./routes/bilibili/userChannel'));
-router.get('/bilibili/topic/:topic', require('./routes/bilibili/topic'));
-router.get('/bilibili/audio/:id', require('./routes/bilibili/audio'));
-router.get('/bilibili/vsearch/:kw/:order?/:disableEmbed?', require('./routes/bilibili/vsearch'));
-router.get('/bilibili/followings/dynamic/:uid/:disableEmbed?', require('./routes/bilibili/followings_dynamic'));
-router.get('/bilibili/followings/video/:uid/:disableEmbed?', require('./routes/bilibili/followings_video'));
-router.get('/bilibili/followings/article/:uid', require('./routes/bilibili/followings_article'));
-router.get('/bilibili/readlist/:listid', require('./routes/bilibili/readlist'));
-router.get('/bilibili/weekly', require('./routes/bilibili/weekly_recommend'));
-router.get('/bilibili/manga/update/:comicid', require('./routes/bilibili/manga_update'));
-router.get('/bilibili/manga/followings/:uid/:limits?', require('./routes/bilibili/manga_followings'));
-router.get('/bilibili/app/:id?', require('./routes/bilibili/app'));
+router.get('/bilibili/user/video/:uid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/video'));
+router.get('/bilibili/user/article/:uid', lazyloadRouteHandler('./routes/bilibili/article'));
+router.get('/bilibili/user/fav/:uid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/userFav'));
+router.get('/bilibili/user/coin/:uid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/coin'));
+router.get('/bilibili/user/dynamic/:uid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/dynamic'));
+router.get('/bilibili/user/followers/:uid', lazyloadRouteHandler('./routes/bilibili/followers'));
+router.get('/bilibili/user/followings/:uid', lazyloadRouteHandler('./routes/bilibili/followings'));
+router.get('/bilibili/user/bangumi/:uid/:type?', lazyloadRouteHandler('./routes/bilibili/user_bangumi'));
+router.get('/bilibili/partion/:tid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/partion'));
+router.get('/bilibili/partion/ranking/:tid/:days?/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/partion-ranking'));
+router.get('/bilibili/bangumi/:seasonid', lazyloadRouteHandler('./routes/bilibili/bangumi')); // 弃用
+router.get('/bilibili/bangumi/media/:mediaid', lazyloadRouteHandler('./routes/bilibili/bangumi'));
+router.get('/bilibili/video/page/:bvid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/page'));
+router.get('/bilibili/video/reply/:bvid', lazyloadRouteHandler('./routes/bilibili/reply'));
+router.get('/bilibili/video/danmaku/:bvid/:pid?', lazyloadRouteHandler('./routes/bilibili/danmaku'));
+router.get('/bilibili/link/news/:product', lazyloadRouteHandler('./routes/bilibili/linkNews'));
+router.get('/bilibili/live/room/:roomID', lazyloadRouteHandler('./routes/bilibili/liveRoom'));
+router.get('/bilibili/live/search/:key/:order', lazyloadRouteHandler('./routes/bilibili/liveSearch'));
+router.get('/bilibili/live/area/:areaID/:order', lazyloadRouteHandler('./routes/bilibili/liveArea'));
+router.get('/bilibili/fav/:uid/:fid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/fav'));
+router.get('/bilibili/blackboard', lazyloadRouteHandler('./routes/bilibili/blackboard'));
+router.get('/bilibili/mall/new/:category?', lazyloadRouteHandler('./routes/bilibili/mallNew'));
+router.get('/bilibili/mall/ip/:id', lazyloadRouteHandler('./routes/bilibili/mallIP'));
+router.get('/bilibili/ranking/:rid?/:day?/:arc_type?/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/ranking'));
+router.get('/bilibili/user/channel/:uid/:cid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/userChannel'));
+router.get('/bilibili/topic/:topic', lazyloadRouteHandler('./routes/bilibili/topic'));
+router.get('/bilibili/audio/:id', lazyloadRouteHandler('./routes/bilibili/audio'));
+router.get('/bilibili/vsearch/:kw/:order?/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/vsearch'));
+router.get('/bilibili/followings/dynamic/:uid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/followings_dynamic'));
+router.get('/bilibili/followings/video/:uid/:disableEmbed?', lazyloadRouteHandler('./routes/bilibili/followings_video'));
+router.get('/bilibili/followings/article/:uid', lazyloadRouteHandler('./routes/bilibili/followings_article'));
+router.get('/bilibili/readlist/:listid', lazyloadRouteHandler('./routes/bilibili/readlist'));
+router.get('/bilibili/weekly', lazyloadRouteHandler('./routes/bilibili/weekly_recommend'));
+router.get('/bilibili/manga/update/:comicid', lazyloadRouteHandler('./routes/bilibili/manga_update'));
+router.get('/bilibili/manga/followings/:uid/:limits?', lazyloadRouteHandler('./routes/bilibili/manga_followings'));
+router.get('/bilibili/app/:id?', lazyloadRouteHandler('./routes/bilibili/app'));
 
 // bangumi
-router.get('/bangumi/calendar/today', require('./routes/bangumi/calendar/today'));
-router.get('/bangumi/subject/:id/:type', require('./routes/bangumi/subject'));
-router.get('/bangumi/person/:id', require('./routes/bangumi/person'));
-router.get('/bangumi/topic/:id', require('./routes/bangumi/group/reply'));
-router.get('/bangumi/group/:id', require('./routes/bangumi/group/topic'));
-router.get('/bangumi/subject/:id', require('./routes/bangumi/subject'));
-router.get('/bangumi/user/blog/:id', require('./routes/bangumi/user/blog'));
+router.get('/bangumi/calendar/today', lazyloadRouteHandler('./routes/bangumi/calendar/today'));
+router.get('/bangumi/subject/:id/:type', lazyloadRouteHandler('./routes/bangumi/subject'));
+router.get('/bangumi/person/:id', lazyloadRouteHandler('./routes/bangumi/person'));
+router.get('/bangumi/topic/:id', lazyloadRouteHandler('./routes/bangumi/group/reply'));
+router.get('/bangumi/group/:id', lazyloadRouteHandler('./routes/bangumi/group/topic'));
+router.get('/bangumi/subject/:id', lazyloadRouteHandler('./routes/bangumi/subject'));
+router.get('/bangumi/user/blog/:id', lazyloadRouteHandler('./routes/bangumi/user/blog'));
 
 // 報導者
-router.get('/twreporter/newest', require('./routes/twreporter/newest'));
-router.get('/twreporter/photography', require('./routes/twreporter/photography'));
-router.get('/twreporter/category/:cid', require('./routes/twreporter/category'));
+router.get('/twreporter/newest', lazyloadRouteHandler('./routes/twreporter/newest'));
+router.get('/twreporter/photography', lazyloadRouteHandler('./routes/twreporter/photography'));
+router.get('/twreporter/category/:cid', lazyloadRouteHandler('./routes/twreporter/category'));
 
 // 微博
-router.get('/weibo/user/:uid/:routeParams?', require('./routes/weibo/user'));
-router.get('/weibo/keyword/:keyword/:routeParams?', require('./routes/weibo/keyword'));
-router.get('/weibo/search/hot', require('./routes/weibo/search/hot'));
-router.get('/weibo/super_index/:id/:routeParams?', require('./routes/weibo/super_index'));
-router.get('/weibo/oasis/user/:userid', require('./routes/weibo/oasis/user'));
+router.get('/weibo/user/:uid/:routeParams?', lazyloadRouteHandler('./routes/weibo/user'));
+router.get('/weibo/keyword/:keyword/:routeParams?', lazyloadRouteHandler('./routes/weibo/keyword'));
+router.get('/weibo/search/hot', lazyloadRouteHandler('./routes/weibo/search/hot'));
+router.get('/weibo/super_index/:id/:routeParams?', lazyloadRouteHandler('./routes/weibo/super_index'));
+router.get('/weibo/oasis/user/:userid', lazyloadRouteHandler('./routes/weibo/oasis/user'));
 
 // 贴吧
-router.get('/tieba/forum/:kw', require('./routes/tieba/forum'));
-router.get('/tieba/forum/good/:kw/:cid?', require('./routes/tieba/forum'));
-router.get('/tieba/post/:id', require('./routes/tieba/post'));
-router.get('/tieba/post/lz/:id', require('./routes/tieba/post'));
-router.get('/tieba/user/:uid', require('./routes/tieba/user'));
+router.get('/tieba/forum/:kw', lazyloadRouteHandler('./routes/tieba/forum'));
+router.get('/tieba/forum/good/:kw/:cid?', lazyloadRouteHandler('./routes/tieba/forum'));
+router.get('/tieba/post/:id', lazyloadRouteHandler('./routes/tieba/post'));
+router.get('/tieba/post/lz/:id', lazyloadRouteHandler('./routes/tieba/post'));
+router.get('/tieba/user/:uid', lazyloadRouteHandler('./routes/tieba/user'));
 
 // 网易云音乐
-router.get('/ncm/playlist/:id', require('./routes/ncm/playlist'));
-router.get('/ncm/user/playlist/:uid', require('./routes/ncm/userplaylist'));
-router.get('/ncm/artist/:id', require('./routes/ncm/artist'));
-router.get('/ncm/djradio/:id', require('./routes/ncm/djradio'));
+router.get('/ncm/playlist/:id', lazyloadRouteHandler('./routes/ncm/playlist'));
+router.get('/ncm/user/playlist/:uid', lazyloadRouteHandler('./routes/ncm/userplaylist'));
+router.get('/ncm/artist/:id', lazyloadRouteHandler('./routes/ncm/artist'));
+router.get('/ncm/djradio/:id', lazyloadRouteHandler('./routes/ncm/djradio'));
 
 // 掘金
-router.get('/juejin/category/:category', require('./routes/juejin/category'));
-router.get('/juejin/tag/:tag', require('./routes/juejin/tag'));
-router.get('/juejin/trending/:category/:type', require('./routes/juejin/trending'));
-router.get('/juejin/books', require('./routes/juejin/books'));
-router.get('/juejin/pins/:type?', require('./routes/juejin/pins'));
-router.get('/juejin/posts/:id', require('./routes/juejin/posts'));
-router.get('/juejin/collections/:userId', require('./routes/juejin/favorites'));
-router.get('/juejin/collection/:collectionId', require('./routes/juejin/collection'));
-router.get('/juejin/shares/:userId', require('./routes/juejin/shares'));
-router.get('/juejin/column/:id', require('./routes/juejin/column'));
+router.get('/juejin/category/:category', lazyloadRouteHandler('./routes/juejin/category'));
+router.get('/juejin/tag/:tag', lazyloadRouteHandler('./routes/juejin/tag'));
+router.get('/juejin/trending/:category/:type', lazyloadRouteHandler('./routes/juejin/trending'));
+router.get('/juejin/books', lazyloadRouteHandler('./routes/juejin/books'));
+router.get('/juejin/pins/:type?', lazyloadRouteHandler('./routes/juejin/pins'));
+router.get('/juejin/posts/:id', lazyloadRouteHandler('./routes/juejin/posts'));
+router.get('/juejin/collections/:userId', lazyloadRouteHandler('./routes/juejin/favorites'));
+router.get('/juejin/collection/:collectionId', lazyloadRouteHandler('./routes/juejin/collection'));
+router.get('/juejin/shares/:userId', lazyloadRouteHandler('./routes/juejin/shares'));
+router.get('/juejin/column/:id', lazyloadRouteHandler('./routes/juejin/column'));
 
 // 自如
-router.get('/ziroom/room/:city/:iswhole/:room/:keyword', require('./routes/ziroom/room'));
+router.get('/ziroom/room/:city/:iswhole/:room/:keyword', lazyloadRouteHandler('./routes/ziroom/room'));
 
 // 简书
-router.get('/jianshu/home', require('./routes/jianshu/home'));
-router.get('/jianshu/trending/:timeframe', require('./routes/jianshu/trending'));
-router.get('/jianshu/collection/:id', require('./routes/jianshu/collection'));
-router.get('/jianshu/user/:id', require('./routes/jianshu/user'));
+router.get('/jianshu/home', lazyloadRouteHandler('./routes/jianshu/home'));
+router.get('/jianshu/trending/:timeframe', lazyloadRouteHandler('./routes/jianshu/trending'));
+router.get('/jianshu/collection/:id', lazyloadRouteHandler('./routes/jianshu/collection'));
+router.get('/jianshu/user/:id', lazyloadRouteHandler('./routes/jianshu/user'));
 
 // 知乎
-router.get('/zhihu/collection/:id', require('./routes/zhihu/collection'));
-router.get('/zhihu/people/activities/:id', require('./routes/zhihu/activities'));
-router.get('/zhihu/people/answers/:id', require('./routes/zhihu/answers'));
-router.get('/zhihu/posts/:usertype/:id', require('./routes/zhihu/posts'));
-router.get('/zhihu/zhuanlan/:id', require('./routes/zhihu/zhuanlan'));
-router.get('/zhihu/daily', require('./routes/zhihu/daily'));
-router.get('/zhihu/daily/section/:sectionId', require('./routes/zhihu/daily_section'));
-router.get('/zhihu/hotlist', require('./routes/zhihu/hotlist'));
-router.get('/zhihu/pin/hotlist', require('./routes/zhihu/pin/hotlist'));
-router.get('/zhihu/question/:questionId', require('./routes/zhihu/question'));
-router.get('/zhihu/topic/:topicId', require('./routes/zhihu/topic'));
-router.get('/zhihu/people/pins/:id', require('./routes/zhihu/pin/people'));
-router.get('/zhihu/bookstore/newest', require('./routes/zhihu/bookstore/newest'));
-router.get('/zhihu/pin/daily', require('./routes/zhihu/pin/daily'));
-router.get('/zhihu/weekly', require('./routes/zhihu/weekly'));
-router.get('/zhihu/timeline', require('./routes/zhihu/timeline'));
-router.get('/zhihu/hot/:category?', require('./routes/zhihu/hot'));
+router.get('/zhihu/collection/:id', lazyloadRouteHandler('./routes/zhihu/collection'));
+router.get('/zhihu/people/activities/:id', lazyloadRouteHandler('./routes/zhihu/activities'));
+router.get('/zhihu/people/answers/:id', lazyloadRouteHandler('./routes/zhihu/answers'));
+router.get('/zhihu/posts/:usertype/:id', lazyloadRouteHandler('./routes/zhihu/posts'));
+router.get('/zhihu/zhuanlan/:id', lazyloadRouteHandler('./routes/zhihu/zhuanlan'));
+router.get('/zhihu/daily', lazyloadRouteHandler('./routes/zhihu/daily'));
+router.get('/zhihu/daily/section/:sectionId', lazyloadRouteHandler('./routes/zhihu/daily_section'));
+router.get('/zhihu/hotlist', lazyloadRouteHandler('./routes/zhihu/hotlist'));
+router.get('/zhihu/pin/hotlist', lazyloadRouteHandler('./routes/zhihu/pin/hotlist'));
+router.get('/zhihu/question/:questionId', lazyloadRouteHandler('./routes/zhihu/question'));
+router.get('/zhihu/topic/:topicId', lazyloadRouteHandler('./routes/zhihu/topic'));
+router.get('/zhihu/people/pins/:id', lazyloadRouteHandler('./routes/zhihu/pin/people'));
+router.get('/zhihu/bookstore/newest', lazyloadRouteHandler('./routes/zhihu/bookstore/newest'));
+router.get('/zhihu/pin/daily', lazyloadRouteHandler('./routes/zhihu/pin/daily'));
+router.get('/zhihu/weekly', lazyloadRouteHandler('./routes/zhihu/weekly'));
+router.get('/zhihu/timeline', lazyloadRouteHandler('./routes/zhihu/timeline'));
+router.get('/zhihu/hot/:category?', lazyloadRouteHandler('./routes/zhihu/hot'));
 
 // 妹子图
-router.get('/mzitu/home/:type?', require('./routes/mzitu/home'));
-router.get('/mzitu/tags', require('./routes/mzitu/tags'));
-router.get('/mzitu/category/:category', require('./routes/mzitu/category'));
-router.get('/mzitu/post/:id', require('./routes/mzitu/post'));
-router.get('/mzitu/tag/:tag', require('./routes/mzitu/tag'));
+router.get('/mzitu/home/:type?', lazyloadRouteHandler('./routes/mzitu/home'));
+router.get('/mzitu/tags', lazyloadRouteHandler('./routes/mzitu/tags'));
+router.get('/mzitu/category/:category', lazyloadRouteHandler('./routes/mzitu/category'));
+router.get('/mzitu/post/:id', lazyloadRouteHandler('./routes/mzitu/post'));
+router.get('/mzitu/tag/:tag', lazyloadRouteHandler('./routes/mzitu/tag'));
 
 // pixiv
-router.get('/pixiv/user/bookmarks/:id', require('./routes/pixiv/bookmarks'));
-router.get('/pixiv/user/illustfollows', require('./routes/pixiv/illustfollow'));
-router.get('/pixiv/user/:id', require('./routes/pixiv/user'));
-router.get('/pixiv/ranking/:mode/:date?', require('./routes/pixiv/ranking'));
-router.get('/pixiv/search/:keyword/:order?/:mode?', require('./routes/pixiv/search'));
+router.get('/pixiv/user/bookmarks/:id', lazyloadRouteHandler('./routes/pixiv/bookmarks'));
+router.get('/pixiv/user/illustfollows', lazyloadRouteHandler('./routes/pixiv/illustfollow'));
+router.get('/pixiv/user/:id', lazyloadRouteHandler('./routes/pixiv/user'));
+router.get('/pixiv/ranking/:mode/:date?', lazyloadRouteHandler('./routes/pixiv/ranking'));
+router.get('/pixiv/search/:keyword/:order?/:mode?', lazyloadRouteHandler('./routes/pixiv/search'));
 
 // pixiv-fanbox
-router.get('/fanbox/:user?', require('./routes/fanbox/main'));
+router.get('/fanbox/:user?', lazyloadRouteHandler('./routes/fanbox/main'));
 
 // 豆瓣
-router.get('/douban/movie/playing', require('./routes/douban/playing'));
-router.get('/douban/movie/playing/:score', require('./routes/douban/playing'));
-router.get('/douban/movie/playing/:score/:city', require('./routes/douban/playing'));
-router.get('/douban/movie/later', require('./routes/douban/later'));
-router.get('/douban/movie/ustop', require('./routes/douban/ustop'));
-router.get('/douban/movie/weekly/:type?', require('./routes/douban/weekly_best'));
-router.get('/douban/movie/classification/:sort?/:score?/:tags?', require('./routes/douban/classification.js'));
-router.get('/douban/group/:groupid/:type?', require('./routes/douban/group'));
-router.get('/douban/explore', require('./routes/douban/explore'));
-router.get('/douban/music/latest/:area?', require('./routes/douban/latest_music'));
-router.get('/douban/book/latest', require('./routes/douban/latest_book'));
-router.get('/douban/event/hot/:locationId', require('./routes/douban/event/hot'));
-router.get('/douban/commercialpress/latest', require('./routes/douban/commercialpress/latest'));
-router.get('/douban/bookstore', require('./routes/douban/bookstore'));
-router.get('/douban/book/rank/:type?', require('./routes/douban/book/rank'));
-router.get('/douban/doulist/:id', require('./routes/douban/doulist'));
-router.get('/douban/explore/column/:id', require('./routes/douban/explore_column'));
-router.get('/douban/people/:userid/status/:routeParams?', require('./routes/douban/people/status.js'));
-router.get('/douban/people/:userid/wish/:routeParams?', require('./routes/douban/people/wish.js'));
-router.get('/douban/replies/:uid', require('./routes/douban/replies'));
-router.get('/douban/replied/:uid', require('./routes/douban/replied'));
-router.get('/douban/topic/:id/:sort?', require('./routes/douban/topic.js'));
-router.get('/douban/channel/:id/:nav?', require('./routes/douban/channel/topic.js'));
-router.get('/douban/channel/:id/subject/:nav', require('./routes/douban/channel/subject.js'));
-router.get('/douban/celebrity/:id/:sort?', require('./routes/douban/celebrity.js'));
+router.get('/douban/movie/playing', lazyloadRouteHandler('./routes/douban/playing'));
+router.get('/douban/movie/playing/:score', lazyloadRouteHandler('./routes/douban/playing'));
+router.get('/douban/movie/playing/:score/:city', lazyloadRouteHandler('./routes/douban/playing'));
+router.get('/douban/movie/later', lazyloadRouteHandler('./routes/douban/later'));
+router.get('/douban/movie/ustop', lazyloadRouteHandler('./routes/douban/ustop'));
+router.get('/douban/movie/weekly/:type?', lazyloadRouteHandler('./routes/douban/weekly_best'));
+router.get('/douban/movie/classification/:sort?/:score?/:tags?', lazyloadRouteHandler('./routes/douban/classification.js'));
+router.get('/douban/group/:groupid/:type?', lazyloadRouteHandler('./routes/douban/group'));
+router.get('/douban/explore', lazyloadRouteHandler('./routes/douban/explore'));
+router.get('/douban/music/latest/:area?', lazyloadRouteHandler('./routes/douban/latest_music'));
+router.get('/douban/book/latest', lazyloadRouteHandler('./routes/douban/latest_book'));
+router.get('/douban/event/hot/:locationId', lazyloadRouteHandler('./routes/douban/event/hot'));
+router.get('/douban/commercialpress/latest', lazyloadRouteHandler('./routes/douban/commercialpress/latest'));
+router.get('/douban/bookstore', lazyloadRouteHandler('./routes/douban/bookstore'));
+router.get('/douban/book/rank/:type?', lazyloadRouteHandler('./routes/douban/book/rank'));
+router.get('/douban/doulist/:id', lazyloadRouteHandler('./routes/douban/doulist'));
+router.get('/douban/explore/column/:id', lazyloadRouteHandler('./routes/douban/explore_column'));
+router.get('/douban/people/:userid/status/:routeParams?', lazyloadRouteHandler('./routes/douban/people/status.js'));
+router.get('/douban/people/:userid/wish/:routeParams?', lazyloadRouteHandler('./routes/douban/people/wish.js'));
+router.get('/douban/replies/:uid', lazyloadRouteHandler('./routes/douban/replies'));
+router.get('/douban/replied/:uid', lazyloadRouteHandler('./routes/douban/replied'));
+router.get('/douban/topic/:id/:sort?', lazyloadRouteHandler('./routes/douban/topic.js'));
+router.get('/douban/channel/:id/:nav?', lazyloadRouteHandler('./routes/douban/channel/topic.js'));
+router.get('/douban/channel/:id/subject/:nav', lazyloadRouteHandler('./routes/douban/channel/subject.js'));
+router.get('/douban/celebrity/:id/:sort?', lazyloadRouteHandler('./routes/douban/celebrity.js'));
 
 // 法律白話文運動
-router.get('/plainlaw/archives', require('./routes/plainlaw/archives.js'));
+router.get('/plainlaw/archives', lazyloadRouteHandler('./routes/plainlaw/archives.js'));
 
 // 煎蛋
-router.get('/jandan/article', require('./routes/jandan/article'));
-router.get('/jandan/:sub_model', require('./routes/jandan/pic'));
+router.get('/jandan/article', lazyloadRouteHandler('./routes/jandan/article'));
+router.get('/jandan/:sub_model', lazyloadRouteHandler('./routes/jandan/pic'));
 
 // 喷嚏
-router.get('/dapenti/tugua', require('./routes/dapenti/tugua'));
-router.get('/dapenti/subject/:id', require('./routes/dapenti/subject'));
+router.get('/dapenti/tugua', lazyloadRouteHandler('./routes/dapenti/tugua'));
+router.get('/dapenti/subject/:id', lazyloadRouteHandler('./routes/dapenti/subject'));
 
 // Dockone
-router.get('/dockone/weekly', require('./routes/dockone/weekly'));
+router.get('/dockone/weekly', lazyloadRouteHandler('./routes/dockone/weekly'));
 
 // 开发者头条
-router.get('/toutiao/today', require('./routes/toutiao/today'));
-router.get('/toutiao/user/:id', require('./routes/toutiao/user'));
+router.get('/toutiao/today', lazyloadRouteHandler('./routes/toutiao/today'));
+router.get('/toutiao/user/:id', lazyloadRouteHandler('./routes/toutiao/user'));
 
 // 众成翻译
-router.get('/zcfy', require('./routes/zcfy/index'));
-router.get('/zcfy/index', require('./routes/zcfy/index')); // 废弃
-router.get('/zcfy/hot', require('./routes/zcfy/hot'));
+router.get('/zcfy', lazyloadRouteHandler('./routes/zcfy/index'));
+router.get('/zcfy/index', lazyloadRouteHandler('./routes/zcfy/index')); // 废弃
+router.get('/zcfy/hot', lazyloadRouteHandler('./routes/zcfy/hot'));
 
 // 今日头条
-router.get('/jinritoutiao/keyword/:keyword', require('./routes/jinritoutiao/keyword'));
+router.get('/jinritoutiao/keyword/:keyword', lazyloadRouteHandler('./routes/jinritoutiao/keyword'));
 
 // Disqus
-router.get('/disqus/posts/:forum', require('./routes/disqus/posts'));
+router.get('/disqus/posts/:forum', lazyloadRouteHandler('./routes/disqus/posts'));
 
 // Twitter
-router.get('/twitter/user/:id/:routeParams?', require('./routes/twitter/user'));
-router.get('/twitter/list/:id/:name/:routeParams?', require('./routes/twitter/list'));
-router.get('/twitter/likes/:id/:routeParams?', require('./routes/twitter/likes'));
-router.get('/twitter/followings/:id/:routeParams?', require('./routes/twitter/followings'));
-router.get('/twitter/keyword/:keyword/:routeParams?', require('./routes/twitter/keyword'));
-router.get('/twitter/trends/:woeid?', require('./routes/twitter/trends'));
+router.get('/twitter/user/:id/:routeParams?', lazyloadRouteHandler('./routes/twitter/user'));
+router.get('/twitter/list/:id/:name/:routeParams?', lazyloadRouteHandler('./routes/twitter/list'));
+router.get('/twitter/likes/:id/:routeParams?', lazyloadRouteHandler('./routes/twitter/likes'));
+router.get('/twitter/followings/:id/:routeParams?', lazyloadRouteHandler('./routes/twitter/followings'));
+router.get('/twitter/keyword/:keyword/:routeParams?', lazyloadRouteHandler('./routes/twitter/keyword'));
+router.get('/twitter/trends/:woeid?', lazyloadRouteHandler('./routes/twitter/trends'));
 
 // YouTube
-router.get('/youtube/user/:username/:embed?', require('./routes/youtube/user'));
-router.get('/youtube/channel/:id/:embed?', require('./routes/youtube/channel'));
-router.get('/youtube/playlist/:id/:embed?', require('./routes/youtube/playlist'));
+router.get('/youtube/user/:username/:embed?', lazyloadRouteHandler('./routes/youtube/user'));
+router.get('/youtube/channel/:id/:embed?', lazyloadRouteHandler('./routes/youtube/channel'));
+router.get('/youtube/playlist/:id/:embed?', lazyloadRouteHandler('./routes/youtube/playlist'));
 
 // 极客时间
-router.get('/geektime/column/:cid', require('./routes/geektime/column'));
-router.get('/geektime/news', require('./routes/geektime/news'));
+router.get('/geektime/column/:cid', lazyloadRouteHandler('./routes/geektime/column'));
+router.get('/geektime/news', lazyloadRouteHandler('./routes/geektime/news'));
 
 // 界面新闻
-router.get('/jiemian/list/:cid', require('./routes/jiemian/list.js'));
+router.get('/jiemian/list/:cid', lazyloadRouteHandler('./routes/jiemian/list.js'));
 
 // 好奇心日报
-router.get('/qdaily/:type/:id', require('./routes/qdaily/index'));
+router.get('/qdaily/:type/:id', lazyloadRouteHandler('./routes/qdaily/index'));
 
 // 爱奇艺
-router.get('/iqiyi/dongman/:id', require('./routes/iqiyi/dongman'));
-router.get('/iqiyi/user/video/:uid', require('./routes/iqiyi/video'));
+router.get('/iqiyi/dongman/:id', lazyloadRouteHandler('./routes/iqiyi/dongman'));
+router.get('/iqiyi/user/video/:uid', lazyloadRouteHandler('./routes/iqiyi/video'));
 
 // 南方周末
-router.get('/infzm/:id', require('./routes/infzm/news'));
+router.get('/infzm/:id', lazyloadRouteHandler('./routes/infzm/news'));
 
 // Dribbble
-router.get('/dribbble/popular/:timeframe?', require('./routes/dribbble/popular'));
-router.get('/dribbble/user/:name', require('./routes/dribbble/user'));
-router.get('/dribbble/keyword/:keyword', require('./routes/dribbble/keyword'));
+router.get('/dribbble/popular/:timeframe?', lazyloadRouteHandler('./routes/dribbble/popular'));
+router.get('/dribbble/user/:name', lazyloadRouteHandler('./routes/dribbble/user'));
+router.get('/dribbble/keyword/:keyword', lazyloadRouteHandler('./routes/dribbble/keyword'));
 
 // 斗鱼
-router.get('/douyu/room/:id', require('./routes/douyu/room'));
+router.get('/douyu/room/:id', lazyloadRouteHandler('./routes/douyu/room'));
 
 // 虎牙
-router.get('/huya/live/:id', require('./routes/huya/live'));
+router.get('/huya/live/:id', lazyloadRouteHandler('./routes/huya/live'));
 
 // 浪Play(原kingkong)直播
-router.get('/kingkong/room/:id', require('./routes/langlive/room'));
-router.get('/langlive/room/:id', require('./routes/langlive/room'));
+router.get('/kingkong/room/:id', lazyloadRouteHandler('./routes/langlive/room'));
+router.get('/langlive/room/:id', lazyloadRouteHandler('./routes/langlive/room'));
 
 // SHOWROOM直播
-router.get('/showroom/room/:id', require('./routes/showroom/room'));
+router.get('/showroom/room/:id', lazyloadRouteHandler('./routes/showroom/room'));
 
 // v2ex
-router.get('/v2ex/topics/:type', require('./routes/v2ex/topics'));
-router.get('/v2ex/post/:postid', require('./routes/v2ex/post'));
-router.get('/v2ex/tab/:tabid', require('./routes/v2ex/tab'));
+router.get('/v2ex/topics/:type', lazyloadRouteHandler('./routes/v2ex/topics'));
+router.get('/v2ex/post/:postid', lazyloadRouteHandler('./routes/v2ex/post'));
+router.get('/v2ex/tab/:tabid', lazyloadRouteHandler('./routes/v2ex/tab'));
 
 // Telegram
-router.get('/telegram/channel/:username/:searchQuery?', require('./routes/telegram/channel'));
-router.get('/telegram/stickerpack/:name', require('./routes/telegram/stickerpack'));
-router.get('/telegram/blog', require('./routes/telegram/blog'));
+router.get('/telegram/channel/:username/:searchQuery?', lazyloadRouteHandler('./routes/telegram/channel'));
+router.get('/telegram/stickerpack/:name', lazyloadRouteHandler('./routes/telegram/stickerpack'));
+router.get('/telegram/blog', lazyloadRouteHandler('./routes/telegram/blog'));
 
 // readhub
-router.get('/readhub/category/:category', require('./routes/readhub/category'));
+router.get('/readhub/category/:category', lazyloadRouteHandler('./routes/readhub/category'));
 
 // GitHub
-router.get('/github/repos/:user', require('./routes/github/repos'));
-router.get('/github/trending/:since/:language?', require('./routes/github/trending'));
-router.get('/github/issue/:user/:repo/:state?/:labels?', require('./routes/github/issue'));
-router.get('/github/pull/:user/:repo', require('./routes/github/pulls'));
-router.get('/github/user/followers/:user', require('./routes/github/follower'));
-router.get('/github/stars/:user/:repo', require('./routes/github/star'));
-router.get('/github/search/:query/:sort?/:order?', require('./routes/github/search'));
-router.get('/github/branches/:user/:repo', require('./routes/github/branches'));
-router.get('/github/file/:user/:repo/:branch/:filepath+', require('./routes/github/file'));
-router.get('/github/starred_repos/:user', require('./routes/github/starred_repos'));
-router.get('/github/contributors/:user/:repo/:order?/:anon?', require('./routes/github/contributors'));
-router.get('/github/topics/:name/:qs?', require('./routes/github/topic'));
+router.get('/github/repos/:user', lazyloadRouteHandler('./routes/github/repos'));
+router.get('/github/trending/:since/:language?', lazyloadRouteHandler('./routes/github/trending'));
+router.get('/github/issue/:user/:repo/:state?/:labels?', lazyloadRouteHandler('./routes/github/issue'));
+router.get('/github/pull/:user/:repo', lazyloadRouteHandler('./routes/github/pulls'));
+router.get('/github/user/followers/:user', lazyloadRouteHandler('./routes/github/follower'));
+router.get('/github/stars/:user/:repo', lazyloadRouteHandler('./routes/github/star'));
+router.get('/github/search/:query/:sort?/:order?', lazyloadRouteHandler('./routes/github/search'));
+router.get('/github/branches/:user/:repo', lazyloadRouteHandler('./routes/github/branches'));
+router.get('/github/file/:user/:repo/:branch/:filepath+', lazyloadRouteHandler('./routes/github/file'));
+router.get('/github/starred_repos/:user', lazyloadRouteHandler('./routes/github/starred_repos'));
+router.get('/github/contributors/:user/:repo/:order?/:anon?', lazyloadRouteHandler('./routes/github/contributors'));
+router.get('/github/topics/:name/:qs?', lazyloadRouteHandler('./routes/github/topic'));
 
 // f-droid
-router.get('/fdroid/apprelease/:app', require('./routes/fdroid/apprelease'));
+router.get('/fdroid/apprelease/:app', lazyloadRouteHandler('./routes/fdroid/apprelease'));
 
 // konachan
-router.get('/konachan/post/popular_recent', require('./routes/konachan/post_popular_recent'));
-router.get('/konachan.com/post/popular_recent', require('./routes/konachan/post_popular_recent'));
-router.get('/konachan.net/post/popular_recent', require('./routes/konachan/post_popular_recent'));
-router.get('/konachan/post/popular_recent/:period', require('./routes/konachan/post_popular_recent'));
-router.get('/konachan.com/post/popular_recent/:period', require('./routes/konachan/post_popular_recent'));
-router.get('/konachan.net/post/popular_recent/:period', require('./routes/konachan/post_popular_recent'));
+router.get('/konachan/post/popular_recent', lazyloadRouteHandler('./routes/konachan/post_popular_recent'));
+router.get('/konachan.com/post/popular_recent', lazyloadRouteHandler('./routes/konachan/post_popular_recent'));
+router.get('/konachan.net/post/popular_recent', lazyloadRouteHandler('./routes/konachan/post_popular_recent'));
+router.get('/konachan/post/popular_recent/:period', lazyloadRouteHandler('./routes/konachan/post_popular_recent'));
+router.get('/konachan.com/post/popular_recent/:period', lazyloadRouteHandler('./routes/konachan/post_popular_recent'));
+router.get('/konachan.net/post/popular_recent/:period', lazyloadRouteHandler('./routes/konachan/post_popular_recent'));
 
 // PornHub
-router.get('/pornhub/category/:caty', require('./routes/pornhub/category'));
-router.get('/pornhub/search/:keyword', require('./routes/pornhub/search'));
-router.get('/pornhub/:language?/category_url/:url?', require('./routes/pornhub/category_url'));
-router.get('/pornhub/:language?/users/:username', require('./routes/pornhub/users'));
-router.get('/pornhub/:language?/model/:username/:sort?', require('./routes/pornhub/model'));
-router.get('/pornhub/:language?/pornstar/:username/:sort?', require('./routes/pornhub/pornstar'));
+router.get('/pornhub/category/:caty', lazyloadRouteHandler('./routes/pornhub/category'));
+router.get('/pornhub/search/:keyword', lazyloadRouteHandler('./routes/pornhub/search'));
+router.get('/pornhub/:language?/category_url/:url?', lazyloadRouteHandler('./routes/pornhub/category_url'));
+router.get('/pornhub/:language?/users/:username', lazyloadRouteHandler('./routes/pornhub/users'));
+router.get('/pornhub/:language?/model/:username/:sort?', lazyloadRouteHandler('./routes/pornhub/model'));
+router.get('/pornhub/:language?/pornstar/:username/:sort?', lazyloadRouteHandler('./routes/pornhub/pornstar'));
 
 // Prestige
-router.get('/prestige-av/series/:mid/:sort?', require('./routes/prestige-av/series'));
+router.get('/prestige-av/series/:mid/:sort?', lazyloadRouteHandler('./routes/prestige-av/series'));
 
 // yande.re
-router.get('/yande.re/post/popular_recent', require('./routes/yande.re/post_popular_recent'));
-router.get('/yande.re/post/popular_recent/:period', require('./routes/yande.re/post_popular_recent'));
+router.get('/yande.re/post/popular_recent', lazyloadRouteHandler('./routes/yande.re/post_popular_recent'));
+router.get('/yande.re/post/popular_recent/:period', lazyloadRouteHandler('./routes/yande.re/post_popular_recent'));
 
 // 纽约时报
-router.get('/nytimes/daily_briefing_chinese', require('./routes/nytimes/daily_briefing_chinese'));
-router.get('/nytimes/book/:category?', require('./routes/nytimes/book.js'));
-router.get('/nytimes/:lang?', require('./routes/nytimes/index'));
+router.get('/nytimes/daily_briefing_chinese', lazyloadRouteHandler('./routes/nytimes/daily_briefing_chinese'));
+router.get('/nytimes/book/:category?', lazyloadRouteHandler('./routes/nytimes/book.js'));
+router.get('/nytimes/:lang?', lazyloadRouteHandler('./routes/nytimes/index'));
 
 // 3dm
-router.get('/3dm/:name/:type', require('./routes/3dm/game'));
-router.get('/3dm/news', require('./routes/3dm/news_center'));
+router.get('/3dm/:name/:type', lazyloadRouteHandler('./routes/3dm/game'));
+router.get('/3dm/news', lazyloadRouteHandler('./routes/3dm/news_center'));
 
 // 旅法师营地
-router.get('/lfsyd/:typecode', require('./routes/lfsyd/index'));
-router.get('/lfsyd/user/:id', require('./routes/lfsyd/user'));
-router.get('/lfsyd/tag/:tag', require('./routes/lfsyd/tag'));
+router.get('/lfsyd/:typecode', lazyloadRouteHandler('./routes/lfsyd/index'));
+router.get('/lfsyd/user/:id', lazyloadRouteHandler('./routes/lfsyd/user'));
+router.get('/lfsyd/tag/:tag', lazyloadRouteHandler('./routes/lfsyd/tag'));
 
 // 喜马拉雅
-router.get('/ximalaya/album/:id/:all?', require('./routes/ximalaya/album'));
-router.get('/ximalaya/album/:id/:all/:shownote?', require('./routes/ximalaya/album'));
+router.get('/ximalaya/album/:id/:all?', lazyloadRouteHandler('./routes/ximalaya/album'));
+router.get('/ximalaya/album/:id/:all/:shownote?', lazyloadRouteHandler('./routes/ximalaya/album'));
 
 // EZTV
-router.get('/eztv/torrents/:imdb_id', require('./routes/eztv/imdb'));
+router.get('/eztv/torrents/:imdb_id', lazyloadRouteHandler('./routes/eztv/imdb'));
 
 // 什么值得买
-router.get('/smzdm/keyword/:keyword', require('./routes/smzdm/keyword'));
-router.get('/smzdm/ranking/:rank_type/:rank_id/:hour', require('./routes/smzdm/ranking'));
-router.get('/smzdm/haowen/:day?', require('./routes/smzdm/haowen'));
-router.get('/smzdm/haowen/fenlei/:name/:sort?', require('./routes/smzdm/haowen_fenlei'));
-router.get('/smzdm/article/:uid', require('./routes/smzdm/article'));
-router.get('/smzdm/baoliao/:uid', require('./routes/smzdm/baoliao'));
+router.get('/smzdm/keyword/:keyword', lazyloadRouteHandler('./routes/smzdm/keyword'));
+router.get('/smzdm/ranking/:rank_type/:rank_id/:hour', lazyloadRouteHandler('./routes/smzdm/ranking'));
+router.get('/smzdm/haowen/:day?', lazyloadRouteHandler('./routes/smzdm/haowen'));
+router.get('/smzdm/haowen/fenlei/:name/:sort?', lazyloadRouteHandler('./routes/smzdm/haowen_fenlei'));
+router.get('/smzdm/article/:uid', lazyloadRouteHandler('./routes/smzdm/article'));
+router.get('/smzdm/baoliao/:uid', lazyloadRouteHandler('./routes/smzdm/baoliao'));
 
 // 新京报
-router.get('/bjnews/:cat', require('./routes/bjnews/news'));
-router.get('/bjnews/epaper/:cat', require('./routes/bjnews/epaper'));
+router.get('/bjnews/:cat', lazyloadRouteHandler('./routes/bjnews/news'));
+router.get('/bjnews/epaper/:cat', lazyloadRouteHandler('./routes/bjnews/epaper'));
 
 // 停水通知
-router.get('/tingshuitz/hangzhou', require('./routes/tingshuitz/hangzhou'));
-router.get('/tingshuitz/xiaoshan', require('./routes/tingshuitz/xiaoshan'));
-router.get('/tingshuitz/dalian', require('./routes/tingshuitz/dalian'));
-router.get('/tingshuitz/guangzhou', require('./routes/tingshuitz/guangzhou'));
-router.get('/tingshuitz/dongguan', require('./routes/tingshuitz/dongguan'));
-router.get('/tingshuitz/xian', require('./routes/tingshuitz/xian'));
-router.get('/tingshuitz/yangjiang', require('./routes/tingshuitz/yangjiang'));
-router.get('/tingshuitz/nanjing', require('./routes/tingshuitz/nanjing'));
-router.get('/tingshuitz/wuhan', require('./routes/tingshuitz/wuhan'));
+router.get('/tingshuitz/hangzhou', lazyloadRouteHandler('./routes/tingshuitz/hangzhou'));
+router.get('/tingshuitz/xiaoshan', lazyloadRouteHandler('./routes/tingshuitz/xiaoshan'));
+router.get('/tingshuitz/dalian', lazyloadRouteHandler('./routes/tingshuitz/dalian'));
+router.get('/tingshuitz/guangzhou', lazyloadRouteHandler('./routes/tingshuitz/guangzhou'));
+router.get('/tingshuitz/dongguan', lazyloadRouteHandler('./routes/tingshuitz/dongguan'));
+router.get('/tingshuitz/xian', lazyloadRouteHandler('./routes/tingshuitz/xian'));
+router.get('/tingshuitz/yangjiang', lazyloadRouteHandler('./routes/tingshuitz/yangjiang'));
+router.get('/tingshuitz/nanjing', lazyloadRouteHandler('./routes/tingshuitz/nanjing'));
+router.get('/tingshuitz/wuhan', lazyloadRouteHandler('./routes/tingshuitz/wuhan'));
 
 // 米哈游
-router.get('/mihoyo/bh3/:type', require('./routes/mihoyo/bh3'));
-router.get('/mihoyo/bh2/:type', require('./routes/mihoyo/bh2'));
+router.get('/mihoyo/bh3/:type', lazyloadRouteHandler('./routes/mihoyo/bh3'));
+router.get('/mihoyo/bh2/:type', lazyloadRouteHandler('./routes/mihoyo/bh2'));
 
 // 新闻联播
-router.get('/cctv/xwlb', require('./routes/cctv/xwlb'));
+router.get('/cctv/xwlb', lazyloadRouteHandler('./routes/cctv/xwlb'));
 
 // 央视新闻
-router.get('/cctv/:category', require('./routes/cctv/category'));
-router.get('/cctv/photo/jx', require('./routes/cctv/jx'));
-router.get('/cctv-special/:id?', require('./routes/cctv/special'));
+router.get('/cctv/:category', lazyloadRouteHandler('./routes/cctv/category'));
+router.get('/cctv/photo/jx', lazyloadRouteHandler('./routes/cctv/jx'));
+router.get('/cctv-special/:id?', lazyloadRouteHandler('./routes/cctv/special'));
 
 // 财新博客
-router.get('/caixin/blog/:column', require('./routes/caixin/blog'));
-router.get('/caixin/article', require('./routes/caixin/article'));
-router.get('/caixin/database', require('./routes/caixin/database'));
-router.get('/caixin/yxnews', require('./routes/caixin/yxnews'));
-router.get('/caixin/:column/:category', require('./routes/caixin/category'));
+router.get('/caixin/blog/:column', lazyloadRouteHandler('./routes/caixin/blog'));
+router.get('/caixin/article', lazyloadRouteHandler('./routes/caixin/article'));
+router.get('/caixin/database', lazyloadRouteHandler('./routes/caixin/database'));
+router.get('/caixin/yxnews', lazyloadRouteHandler('./routes/caixin/yxnews'));
+router.get('/caixin/:column/:category', lazyloadRouteHandler('./routes/caixin/category'));
 
 // 草榴社区
-router.get('/t66y/post/:tid', require('./routes/t66y/post'));
-router.get('/t66y/:id/:type?', require('./routes/t66y/index'));
+router.get('/t66y/post/:tid', lazyloadRouteHandler('./routes/t66y/post'));
+router.get('/t66y/:id/:type?', lazyloadRouteHandler('./routes/t66y/index'));
 
 // 色中色
-router.get('/sexinsex/:id/:type?', require('./routes/sexinsex/index'));
+router.get('/sexinsex/:id/:type?', lazyloadRouteHandler('./routes/sexinsex/index'));
 
 // 机核
-router.get('/gcores/category/:category', require('./routes/gcores/category'));
+router.get('/gcores/category/:category', lazyloadRouteHandler('./routes/gcores/category'));
 
 // 国家地理
-router.get('/natgeo/dailyphoto', require('./routes/natgeo/dailyphoto'));
-router.get('/natgeo/:cat/:type?', require('./routes/natgeo/natgeo'));
+router.get('/natgeo/dailyphoto', lazyloadRouteHandler('./routes/natgeo/dailyphoto'));
+router.get('/natgeo/:cat/:type?', lazyloadRouteHandler('./routes/natgeo/natgeo'));
 
 // 一个
-router.get('/one', require('./routes/one/index'));
+router.get('/one', lazyloadRouteHandler('./routes/one/index'));
 
 // Firefox
-router.get('/firefox/release/:platform', require('./routes/firefox/release'));
-router.get('/firefox/addons/:id', require('./routes/firefox/addons'));
+router.get('/firefox/release/:platform', lazyloadRouteHandler('./routes/firefox/release'));
+router.get('/firefox/addons/:id', lazyloadRouteHandler('./routes/firefox/addons'));
 
 // Thunderbird
-router.get('/thunderbird/release', require('./routes/thunderbird/release'));
+router.get('/thunderbird/release', lazyloadRouteHandler('./routes/thunderbird/release'));
 
 // tuicool
-router.get('/tuicool/mags/:type', require('./routes/tuicool/mags'));
+router.get('/tuicool/mags/:type', lazyloadRouteHandler('./routes/tuicool/mags'));
 
 // Hexo
-router.get('/hexo/next/:url', require('./routes/hexo/next'));
-router.get('/hexo/yilia/:url', require('./routes/hexo/yilia'));
+router.get('/hexo/next/:url', lazyloadRouteHandler('./routes/hexo/next'));
+router.get('/hexo/yilia/:url', lazyloadRouteHandler('./routes/hexo/yilia'));
 
 // cpython
-router.get('/cpython/:pre?', require('./routes/cpython'));
+router.get('/cpython/:pre?', lazyloadRouteHandler('./routes/cpython'));
 
 // 小米
-router.get('/mi/golden', require('./routes/mi/golden'));
-router.get('/mi/crowdfunding', require('./routes/mi/crowdfunding'));
-router.get('/mi/youpin/crowdfunding', require('./routes/mi/youpin/crowdfunding'));
-router.get('/mi/youpin/new/:sort?', require('./routes/mi/youpin/new'));
-router.get('/miui/:device/:type?/:region?', require('./routes/mi/miui/index'));
-router.get('/mi/bbs/board/:boardId', require('./routes/mi/board'));
+router.get('/mi/golden', lazyloadRouteHandler('./routes/mi/golden'));
+router.get('/mi/crowdfunding', lazyloadRouteHandler('./routes/mi/crowdfunding'));
+router.get('/mi/youpin/crowdfunding', lazyloadRouteHandler('./routes/mi/youpin/crowdfunding'));
+router.get('/mi/youpin/new/:sort?', lazyloadRouteHandler('./routes/mi/youpin/new'));
+router.get('/miui/:device/:type?/:region?', lazyloadRouteHandler('./routes/mi/miui/index'));
+router.get('/mi/bbs/board/:boardId', lazyloadRouteHandler('./routes/mi/board'));
 
 // Keep
-router.get('/keep/user/:id', require('./routes/keep/user'));
+router.get('/keep/user/:id', lazyloadRouteHandler('./routes/keep/user'));
 
 // 起点
-router.get('/qidian/chapter/:id', require('./routes/qidian/chapter'));
-router.get('/qidian/forum/:id', require('./routes/qidian/forum'));
-router.get('/qidian/free/:type?', require('./routes/qidian/free'));
-router.get('/qidian/free-next/:type?', require('./routes/qidian/free-next'));
+router.get('/qidian/chapter/:id', lazyloadRouteHandler('./routes/qidian/chapter'));
+router.get('/qidian/forum/:id', lazyloadRouteHandler('./routes/qidian/forum'));
+router.get('/qidian/free/:type?', lazyloadRouteHandler('./routes/qidian/free'));
+router.get('/qidian/free-next/:type?', lazyloadRouteHandler('./routes/qidian/free-next'));
 
 // 纵横
-router.get('/zongheng/chapter/:id', require('./routes/zongheng/chapter'));
+router.get('/zongheng/chapter/:id', lazyloadRouteHandler('./routes/zongheng/chapter'));
 
 // 刺猬猫
-router.get('/ciweimao/chapter/:id', require('./routes/ciweimao/chapter'));
+router.get('/ciweimao/chapter/:id', lazyloadRouteHandler('./routes/ciweimao/chapter'));
 
 // 中国美术馆
-router.get('/namoc/announcement', require('./routes/namoc/announcement'));
-router.get('/namoc/news', require('./routes/namoc/news'));
-router.get('/namoc/media', require('./routes/namoc/media'));
-router.get('/namoc/exhibition', require('./routes/namoc/exhibition'));
-router.get('/namoc/specials', require('./routes/namoc/specials'));
+router.get('/namoc/announcement', lazyloadRouteHandler('./routes/namoc/announcement'));
+router.get('/namoc/news', lazyloadRouteHandler('./routes/namoc/news'));
+router.get('/namoc/media', lazyloadRouteHandler('./routes/namoc/media'));
+router.get('/namoc/exhibition', lazyloadRouteHandler('./routes/namoc/exhibition'));
+router.get('/namoc/specials', lazyloadRouteHandler('./routes/namoc/specials'));
 
 // 懂球帝
-router.get('/dongqiudi/daily', require('./routes/dongqiudi/daily'));
-router.get('/dongqiudi/result/:team', require('./routes/dongqiudi/result'));
-router.get('/dongqiudi/team_news/:team', require('./routes/dongqiudi/team_news'));
-router.get('/dongqiudi/player_news/:id', require('./routes/dongqiudi/player_news'));
-router.get('/dongqiudi/special/:id', require('./routes/dongqiudi/special'));
-router.get('/dongqiudi/top_news/:id?', require('./routes/dongqiudi/top_news'));
+router.get('/dongqiudi/daily', lazyloadRouteHandler('./routes/dongqiudi/daily'));
+router.get('/dongqiudi/result/:team', lazyloadRouteHandler('./routes/dongqiudi/result'));
+router.get('/dongqiudi/team_news/:team', lazyloadRouteHandler('./routes/dongqiudi/team_news'));
+router.get('/dongqiudi/player_news/:id', lazyloadRouteHandler('./routes/dongqiudi/player_news'));
+router.get('/dongqiudi/special/:id', lazyloadRouteHandler('./routes/dongqiudi/special'));
+router.get('/dongqiudi/top_news/:id?', lazyloadRouteHandler('./routes/dongqiudi/top_news'));
 
 // 维基百科 Wikipedia
-router.get('/wikipedia/mainland', require('./routes/wikipedia/mainland'));
+router.get('/wikipedia/mainland', lazyloadRouteHandler('./routes/wikipedia/mainland'));
 
 // 联合国 United Nations
-router.get('/un/scveto', require('./routes/un/scveto'));
+router.get('/un/scveto', lazyloadRouteHandler('./routes/un/scveto'));
 
 // e 公司
-router.get('/egsea/flash', require('./routes/egsea/flash'));
+router.get('/egsea/flash', lazyloadRouteHandler('./routes/egsea/flash'));
 
 // 选股宝
-router.get('/xuangubao/subject/:subject_id', require('./routes/xuangubao/subject'));
+router.get('/xuangubao/subject/:subject_id', lazyloadRouteHandler('./routes/xuangubao/subject'));
 
 // 雪球
-router.get('/xueqiu/user/:id/:type?', require('./routes/xueqiu/user'));
-router.get('/xueqiu/favorite/:id', require('./routes/xueqiu/favorite'));
-router.get('/xueqiu/user_stock/:id', require('./routes/xueqiu/user_stock'));
-router.get('/xueqiu/fund/:id', require('./routes/xueqiu/fund'));
-router.get('/xueqiu/stock_info/:id/:type?', require('./routes/xueqiu/stock_info'));
-router.get('/xueqiu/snb/:id', require('./routes/xueqiu/snb'));
-router.get('/xueqiu/hots', require('./routes/xueqiu/hots'));
-router.get('/xueqiu/stock_comments/:id/:titleLength?', require('./routes/xueqiu/stock_comments'));
+router.get('/xueqiu/user/:id/:type?', lazyloadRouteHandler('./routes/xueqiu/user'));
+router.get('/xueqiu/favorite/:id', lazyloadRouteHandler('./routes/xueqiu/favorite'));
+router.get('/xueqiu/user_stock/:id', lazyloadRouteHandler('./routes/xueqiu/user_stock'));
+router.get('/xueqiu/fund/:id', lazyloadRouteHandler('./routes/xueqiu/fund'));
+router.get('/xueqiu/stock_info/:id/:type?', lazyloadRouteHandler('./routes/xueqiu/stock_info'));
+router.get('/xueqiu/snb/:id', lazyloadRouteHandler('./routes/xueqiu/snb'));
+router.get('/xueqiu/hots', lazyloadRouteHandler('./routes/xueqiu/hots'));
+router.get('/xueqiu/stock_comments/:id/:titleLength?', lazyloadRouteHandler('./routes/xueqiu/stock_comments'));
 
 // Greasy Fork
-router.get('/greasyfork/:language/:domain?', require('./routes/greasyfork/scripts'));
+router.get('/greasyfork/:language/:domain?', lazyloadRouteHandler('./routes/greasyfork/scripts'));
 
 // Gwern Bran­wen
-router.get('/gwern/:category', require('./routes/gwern/category'));
+router.get('/gwern/:category', lazyloadRouteHandler('./routes/gwern/category'));
 
 // LinkedKeeper
-router.get('/linkedkeeper/:type/:id?', require('./routes/linkedkeeper/index'));
+router.get('/linkedkeeper/:type/:id?', lazyloadRouteHandler('./routes/linkedkeeper/index'));
 
 // 开源中国
-router.get('/oschina/news/:category?', require('./routes/oschina/news'));
-router.get('/oschina/user/:id', require('./routes/oschina/user'));
-router.get('/oschina/u/:id', require('./routes/oschina/u'));
-router.get('/oschina/topic/:topic', require('./routes/oschina/topic'));
+router.get('/oschina/news/:category?', lazyloadRouteHandler('./routes/oschina/news'));
+router.get('/oschina/user/:id', lazyloadRouteHandler('./routes/oschina/user'));
+router.get('/oschina/u/:id', lazyloadRouteHandler('./routes/oschina/u'));
+router.get('/oschina/topic/:topic', lazyloadRouteHandler('./routes/oschina/topic'));
 
 // MIT Technology Review
-router.get('/technologyreview', require('./routes/technologyreview/index'));
-router.get('/technologyreview/:category_name', require('./routes/technologyreview/topic'));
+router.get('/technologyreview', lazyloadRouteHandler('./routes/technologyreview/index'));
+router.get('/technologyreview/:category_name', lazyloadRouteHandler('./routes/technologyreview/topic'));
 
 // 安全客
-router.get('/aqk/vul', require('./routes/aqk/vul'));
-router.get('/aqk/:category', require('./routes/aqk/category'));
+router.get('/aqk/vul', lazyloadRouteHandler('./routes/aqk/vul'));
+router.get('/aqk/:category', lazyloadRouteHandler('./routes/aqk/category'));
 
 // 腾讯游戏开发者社区
-router.get('/gameinstitute/community/:tag?', require('./routes/tencent/gameinstitute/community'));
+router.get('/gameinstitute/community/:tag?', lazyloadRouteHandler('./routes/tencent/gameinstitute/community'));
 
 // 腾讯视频 SDK
-router.get('/qcloud/mlvb/changelog', require('./routes/tencent/qcloud/mlvb/changelog'));
+router.get('/qcloud/mlvb/changelog', lazyloadRouteHandler('./routes/tencent/qcloud/mlvb/changelog'));
 
 // 腾讯吐个槽
-router.get('/tucaoqq/post/:project/:key', require('./routes/tencent/tucaoqq/post'));
+router.get('/tucaoqq/post/:project/:key', lazyloadRouteHandler('./routes/tencent/tucaoqq/post'));
 
 // Bugly SDK
-router.get('/bugly/changelog/:platform', require('./routes/tencent/bugly/changelog'));
+router.get('/bugly/changelog/:platform', lazyloadRouteHandler('./routes/tencent/bugly/changelog'));
 
 // wechat
-router.get('/wechat/wemp/:id', require('./routes/tencent/wechat/wemp'));
-router.get('/wechat/csm/:id', require('./routes/tencent/wechat/csm'));
-router.get('/wechat/ce/:id', require('./routes/tencent/wechat/ce'));
-router.get('/wechat/announce', require('./routes/tencent/wechat/announce'));
-router.get('/wechat/miniprogram/plugins', require('./routes/tencent/wechat/miniprogram/plugins'));
-router.get('/wechat/tgchannel/:id', require('./routes/tencent/wechat/tgchannel'));
-router.get('/wechat/uread/:userid', require('./routes/tencent/wechat/uread'));
-router.get('/wechat/ershicimi/:id', require('./routes/tencent/wechat/ershcimi'));
-router.get('/wechat/wjdn/:id', require('./routes/tencent/wechat/wjdn'));
-router.get('/wechat/wxnmh/:id', require('./routes/tencent/wechat/wxnmh'));
-router.get('/wechat/mp/homepage/:biz/:hid/:cid?', require('./routes/tencent/wechat/mp'));
-router.get('/wechat/mp/msgalbum/:biz/:aid', require('./routes/tencent/wechat/msgalbum'));
-router.get('/wechat/feeds/:id', require('./routes/tencent/wechat/feeds'));
+router.get('/wechat/wemp/:id', lazyloadRouteHandler('./routes/tencent/wechat/wemp'));
+router.get('/wechat/csm/:id', lazyloadRouteHandler('./routes/tencent/wechat/csm'));
+router.get('/wechat/ce/:id', lazyloadRouteHandler('./routes/tencent/wechat/ce'));
+router.get('/wechat/announce', lazyloadRouteHandler('./routes/tencent/wechat/announce'));
+router.get('/wechat/miniprogram/plugins', lazyloadRouteHandler('./routes/tencent/wechat/miniprogram/plugins'));
+router.get('/wechat/tgchannel/:id', lazyloadRouteHandler('./routes/tencent/wechat/tgchannel'));
+router.get('/wechat/uread/:userid', lazyloadRouteHandler('./routes/tencent/wechat/uread'));
+router.get('/wechat/ershicimi/:id', lazyloadRouteHandler('./routes/tencent/wechat/ershcimi'));
+router.get('/wechat/wjdn/:id', lazyloadRouteHandler('./routes/tencent/wechat/wjdn'));
+router.get('/wechat/wxnmh/:id', lazyloadRouteHandler('./routes/tencent/wechat/wxnmh'));
+router.get('/wechat/mp/homepage/:biz/:hid/:cid?', lazyloadRouteHandler('./routes/tencent/wechat/mp'));
+router.get('/wechat/mp/msgalbum/:biz/:aid', lazyloadRouteHandler('./routes/tencent/wechat/msgalbum'));
+router.get('/wechat/feeds/:id', lazyloadRouteHandler('./routes/tencent/wechat/feeds'));
 
 // All the Flight Deals
-router.get('/atfd/:locations/:nearby?', require('./routes/atfd/index'));
+router.get('/atfd/:locations/:nearby?', lazyloadRouteHandler('./routes/atfd/index'));
 
 // Fir
-router.get('/fir/update/:id', require('./routes/fir/update'));
+router.get('/fir/update/:id', lazyloadRouteHandler('./routes/fir/update'));
 
 // Nvidia Web Driver
-router.get('/nvidia/webdriverupdate', require('./routes/nvidia/webdriverupdate'));
+router.get('/nvidia/webdriverupdate', lazyloadRouteHandler('./routes/nvidia/webdriverupdate'));
 
 // Google
-router.get('/google/citations/:id', require('./routes/google/citations'));
-router.get('/google/scholar/:query', require('./routes/google/scholar'));
-router.get('/google/doodles/:language?', require('./routes/google/doodles'));
-router.get('/google/album/:id', require('./routes/google/album'));
-router.get('/google/sites/:id', require('./routes/google/sites'));
+router.get('/google/citations/:id', lazyloadRouteHandler('./routes/google/citations'));
+router.get('/google/scholar/:query', lazyloadRouteHandler('./routes/google/scholar'));
+router.get('/google/doodles/:language?', lazyloadRouteHandler('./routes/google/doodles'));
+router.get('/google/album/:id', lazyloadRouteHandler('./routes/google/album'));
+router.get('/google/sites/:id', lazyloadRouteHandler('./routes/google/sites'));
 
 // 每日环球展览 iMuseum
-router.get('/imuseum/:city/:type?', require('./routes/imuseum'));
+router.get('/imuseum/:city/:type?', lazyloadRouteHandler('./routes/imuseum'));
 
 // AppStore
-router.get('/appstore/update/:country/:id', require('./routes/apple/appstore/update'));
-router.get('/appstore/price/:country/:type/:id', require('./routes/apple/appstore/price'));
-router.get('/appstore/iap/:country/:id', require('./routes/apple/appstore/in-app-purchase'));
-router.get('/appstore/xianmian', require('./routes/apple/appstore/xianmian'));
-router.get('/appstore/gofans', require('./routes/apple/appstore/gofans'));
+router.get('/appstore/update/:country/:id', lazyloadRouteHandler('./routes/apple/appstore/update'));
+router.get('/appstore/price/:country/:type/:id', lazyloadRouteHandler('./routes/apple/appstore/price'));
+router.get('/appstore/iap/:country/:id', lazyloadRouteHandler('./routes/apple/appstore/in-app-purchase'));
+router.get('/appstore/xianmian', lazyloadRouteHandler('./routes/apple/appstore/xianmian'));
+router.get('/appstore/gofans', lazyloadRouteHandler('./routes/apple/appstore/gofans'));
 
 // Hopper
-router.get('/hopper/:lowestOnly/:from/:to?', require('./routes/hopper/index'));
+router.get('/hopper/:lowestOnly/:from/:to?', lazyloadRouteHandler('./routes/hopper/index'));
 
 // 马蜂窝
-router.get('/mafengwo/note/:type', require('./routes/mafengwo/note'));
-router.get('/mafengwo/ziyouxing/:code', require('./routes/mafengwo/ziyouxing'));
+router.get('/mafengwo/note/:type', lazyloadRouteHandler('./routes/mafengwo/note'));
+router.get('/mafengwo/ziyouxing/:code', lazyloadRouteHandler('./routes/mafengwo/ziyouxing'));
 
 // 中国地震局震情速递（与地震台网同步更新）
-router.get('/earthquake/:region?', require('./routes/earthquake'));
+router.get('/earthquake/:region?', lazyloadRouteHandler('./routes/earthquake'));
 
 // 中国地震台网
-router.get('/earthquake/ceic/:type', require('./routes/earthquake/ceic'));
+router.get('/earthquake/ceic/:type', lazyloadRouteHandler('./routes/earthquake/ceic'));
 
 // 小说
-router.get('/novel/biquge/:id', require('./routes/novel/biquge'));
-router.get('/novel/biqugeinfo/:id/:limit?', require('./routes/novel/biqugeinfo'));
-router.get('/novel/uukanshu/:uid', require('./routes/novel/uukanshu'));
-router.get('/novel/wenxuemi/:id1/:id2', require('./routes/novel/wenxuemi'));
-router.get('/novel/booksky/:id', require('./routes/novel/booksky'));
-router.get('/novel/shuquge/:id', require('./routes/novel/shuquge'));
-router.get('/novel/ptwxz/:id1/:id2', require('./routes/novel/ptwxz'));
-router.get('/novel/zhaishuyuan/:id', require('./routes/novel/zhaishuyuan'));
+router.get('/novel/biquge/:id', lazyloadRouteHandler('./routes/novel/biquge'));
+router.get('/novel/biqugeinfo/:id/:limit?', lazyloadRouteHandler('./routes/novel/biqugeinfo'));
+router.get('/novel/uukanshu/:uid', lazyloadRouteHandler('./routes/novel/uukanshu'));
+router.get('/novel/wenxuemi/:id1/:id2', lazyloadRouteHandler('./routes/novel/wenxuemi'));
+router.get('/novel/booksky/:id', lazyloadRouteHandler('./routes/novel/booksky'));
+router.get('/novel/shuquge/:id', lazyloadRouteHandler('./routes/novel/shuquge'));
+router.get('/novel/ptwxz/:id1/:id2', lazyloadRouteHandler('./routes/novel/ptwxz'));
+router.get('/novel/zhaishuyuan/:id', lazyloadRouteHandler('./routes/novel/zhaishuyuan'));
 
 // 中国气象网
-router.get('/weatheralarm/:province?', require('./routes/weatheralarm'));
+router.get('/weatheralarm/:province?', lazyloadRouteHandler('./routes/weatheralarm'));
 
 // Gitlab
-router.get('/gitlab/explore/:type/:host?', require('./routes/gitlab/explore'));
-router.get('/gitlab/release/:namespace/:project/:host?', require('./routes/gitlab/release'));
-router.get('/gitlab/tag/:namespace/:project/:host?', require('./routes/gitlab/tag'));
+router.get('/gitlab/explore/:type/:host?', lazyloadRouteHandler('./routes/gitlab/explore'));
+router.get('/gitlab/release/:namespace/:project/:host?', lazyloadRouteHandler('./routes/gitlab/release'));
+router.get('/gitlab/tag/:namespace/:project/:host?', lazyloadRouteHandler('./routes/gitlab/tag'));
 
 // 忧郁的loli
-router.get('/mygalgame', require('./routes/galgame/hhgal')); // 废弃
-router.get('/mmgal', require('./routes/galgame/hhgal')); // 废弃
-router.get('/hhgal', require('./routes/galgame/hhgal'));
+router.get('/mygalgame', lazyloadRouteHandler('./routes/galgame/hhgal')); // 废弃
+router.get('/mmgal', lazyloadRouteHandler('./routes/galgame/hhgal')); // 废弃
+router.get('/hhgal', lazyloadRouteHandler('./routes/galgame/hhgal'));
 
 // say花火
-router.get('/sayhuahuo', require('./routes/galgame/sayhuahuo'));
+router.get('/sayhuahuo', lazyloadRouteHandler('./routes/galgame/sayhuahuo'));
 
 // 终点分享
-router.get('/zdfx', require('./routes/galgame/zdfx'));
+router.get('/zdfx', lazyloadRouteHandler('./routes/galgame/zdfx'));
 
 // 北京林业大学
-router.get('/bjfu/grs', require('./routes/universities/bjfu/grs'));
-router.get('/bjfu/kjc', require('./routes/universities/bjfu/kjc'));
-router.get('/bjfu/jwc/:type', require('./routes/universities/bjfu/jwc/index'));
-router.get('/bjfu/news/:type', require('./routes/universities/bjfu/news/index'));
+router.get('/bjfu/grs', lazyloadRouteHandler('./routes/universities/bjfu/grs'));
+router.get('/bjfu/kjc', lazyloadRouteHandler('./routes/universities/bjfu/kjc'));
+router.get('/bjfu/jwc/:type', lazyloadRouteHandler('./routes/universities/bjfu/jwc/index'));
+router.get('/bjfu/news/:type', lazyloadRouteHandler('./routes/universities/bjfu/news/index'));
 
 // 北京理工大学
-router.get('/bit/jwc', require('./routes/universities/bit/jwc/jwc'));
-router.get('/bit/cs', require('./routes/universities/bit/cs/cs'));
+router.get('/bit/jwc', lazyloadRouteHandler('./routes/universities/bit/jwc/jwc'));
+router.get('/bit/cs', lazyloadRouteHandler('./routes/universities/bit/cs/cs'));
 
 // 北京交通大学
-router.get('/bjtu/gs/:type', require('./routes/universities/bjtu/gs'));
+router.get('/bjtu/gs/:type', lazyloadRouteHandler('./routes/universities/bjtu/gs'));
 
 // 大连工业大学
-router.get('/dpu/jiaowu/news/:type?', require('./routes/universities/dpu/jiaowu/news'));
-router.get('/dpu/wlfw/news/:type?', require('./routes/universities/dpu/wlfw/news'));
+router.get('/dpu/jiaowu/news/:type?', lazyloadRouteHandler('./routes/universities/dpu/jiaowu/news'));
+router.get('/dpu/wlfw/news/:type?', lazyloadRouteHandler('./routes/universities/dpu/wlfw/news'));
 
 // 大连理工大学
-router.get('/dut/:subsite/:type', require('./routes/universities/dut/index'));
+router.get('/dut/:subsite/:type', lazyloadRouteHandler('./routes/universities/dut/index'));
 
 // 东南大学
-router.get('/seu/radio/academic', require('./routes/universities/seu/radio/academic'));
-router.get('/seu/yzb/:type', require('./routes/universities/seu/yzb'));
-router.get('/seu/cse/:type?', require('./routes/universities/seu/cse'));
+router.get('/seu/radio/academic', lazyloadRouteHandler('./routes/universities/seu/radio/academic'));
+router.get('/seu/yzb/:type', lazyloadRouteHandler('./routes/universities/seu/yzb'));
+router.get('/seu/cse/:type?', lazyloadRouteHandler('./routes/universities/seu/cse'));
 
 // 南京工业大学
-router.get('/njtech/jwc', require('./routes/universities/njtech/jwc'));
+router.get('/njtech/jwc', lazyloadRouteHandler('./routes/universities/njtech/jwc'));
 
 // 南京航空航天大学
-router.get('/nuaa/jwc/:type?', require('./routes/universities/nuaa/jwc/jwc'));
-router.get('/nuaa/cs/:type?', require('./routes/universities/nuaa/cs/index'));
-router.get('/nuaa/yjsy/:type?', require('./routes/universities/nuaa/yjsy/yjsy'));
+router.get('/nuaa/jwc/:type?', lazyloadRouteHandler('./routes/universities/nuaa/jwc/jwc'));
+router.get('/nuaa/cs/:type?', lazyloadRouteHandler('./routes/universities/nuaa/cs/index'));
+router.get('/nuaa/yjsy/:type?', lazyloadRouteHandler('./routes/universities/nuaa/yjsy/yjsy'));
 
 // 河海大学
-router.get('/hhu/libNews', require('./routes/universities/hhu/libNews'));
+router.get('/hhu/libNews', lazyloadRouteHandler('./routes/universities/hhu/libNews'));
 // 河海大学常州校区
-router.get('/hhu/libNewsc', require('./routes/universities/hhu/libNewsc'));
+router.get('/hhu/libNewsc', lazyloadRouteHandler('./routes/universities/hhu/libNewsc'));
 
 // 哈尔滨工业大学
-router.get('/hit/jwc', require('./routes/universities/hit/jwc'));
-router.get('/hit/today/:category', require('./routes/universities/hit/today'));
+router.get('/hit/jwc', lazyloadRouteHandler('./routes/universities/hit/jwc'));
+router.get('/hit/today/:category', lazyloadRouteHandler('./routes/universities/hit/today'));
 
 // 哈尔滨工业大学（深圳）
-router.get('/hitsz/article/:category?', require('./routes/universities/hitsz/article'));
+router.get('/hitsz/article/:category?', lazyloadRouteHandler('./routes/universities/hitsz/article'));
 
 // 哈尔滨工业大学（威海）
-router.get('/hitwh/today', require('./routes/universities/hitwh/today'));
+router.get('/hitwh/today', lazyloadRouteHandler('./routes/universities/hitwh/today'));
 
 // 上海科技大学
-router.get('/shanghaitech/activity', require('./routes/universities/shanghaitech/activity'));
-router.get('/shanghaitech/sist/activity', require('./routes/universities/shanghaitech/sist/activity'));
+router.get('/shanghaitech/activity', lazyloadRouteHandler('./routes/universities/shanghaitech/activity'));
+router.get('/shanghaitech/sist/activity', lazyloadRouteHandler('./routes/universities/shanghaitech/sist/activity'));
 
 // 上海交通大学
-router.get('/sjtu/seiee/academic', require('./routes/universities/sjtu/seiee/academic'));
-router.get('/sjtu/seiee/bjwb/:type', require('./routes/universities/sjtu/seiee/bjwb'));
-router.get('/sjtu/seiee/xsb/:type?', require('./routes/universities/sjtu/seiee/xsb'));
+router.get('/sjtu/seiee/academic', lazyloadRouteHandler('./routes/universities/sjtu/seiee/academic'));
+router.get('/sjtu/seiee/bjwb/:type', lazyloadRouteHandler('./routes/universities/sjtu/seiee/bjwb'));
+router.get('/sjtu/seiee/xsb/:type?', lazyloadRouteHandler('./routes/universities/sjtu/seiee/xsb'));
 
-router.get('/sjtu/gs/tzgg/:type?', require('./routes/universities/sjtu/gs/tzgg'));
-router.get('/sjtu/jwc/:type?', require('./routes/universities/sjtu/jwc'));
-router.get('/sjtu/tongqu/:type?', require('./routes/universities/sjtu/tongqu/activity'));
-router.get('/sjtu/yzb/zkxx/:type', require('./routes/universities/sjtu/yzb/zkxx'));
+router.get('/sjtu/gs/tzgg/:type?', lazyloadRouteHandler('./routes/universities/sjtu/gs/tzgg'));
+router.get('/sjtu/jwc/:type?', lazyloadRouteHandler('./routes/universities/sjtu/jwc'));
+router.get('/sjtu/tongqu/:type?', lazyloadRouteHandler('./routes/universities/sjtu/tongqu/activity'));
+router.get('/sjtu/yzb/zkxx/:type', lazyloadRouteHandler('./routes/universities/sjtu/yzb/zkxx'));
 
 // 江南大学
-router.get('/ju/jwc/:type?', require('./routes/universities/ju/jwc'));
+router.get('/ju/jwc/:type?', lazyloadRouteHandler('./routes/universities/ju/jwc'));
 
 // 洛阳理工学院
-router.get('/lit/jwc', require('./routes/universities/lit/jwc'));
-router.get('/lit/xwzx/:name?', require('./routes/universities/lit/xwzx'));
-router.get('/lit/tw/:name?', require('./routes/universities/lit/tw'));
+router.get('/lit/jwc', lazyloadRouteHandler('./routes/universities/lit/jwc'));
+router.get('/lit/xwzx/:name?', lazyloadRouteHandler('./routes/universities/lit/xwzx'));
+router.get('/lit/tw/:name?', lazyloadRouteHandler('./routes/universities/lit/tw'));
 
 // 清华大学
-router.get('/thu/career', require('./routes/universities/thu/career'));
-router.get('/thu/:type', require('./routes/universities/thu/index'));
+router.get('/thu/career', lazyloadRouteHandler('./routes/universities/thu/career'));
+router.get('/thu/:type', lazyloadRouteHandler('./routes/universities/thu/index'));
 
 // 北京大学
-router.get('/pku/eecs/:type?', require('./routes/universities/pku/eecs'));
-router.get('/pku/rccp/mzyt', require('./routes/universities/pku/rccp/mzyt'));
-router.get('/pku/cls/lecture', require('./routes/universities/pku/cls/lecture'));
-router.get('/pku/bbs/hot', require('./routes/universities/pku/bbs/hot'));
+router.get('/pku/eecs/:type?', lazyloadRouteHandler('./routes/universities/pku/eecs'));
+router.get('/pku/rccp/mzyt', lazyloadRouteHandler('./routes/universities/pku/rccp/mzyt'));
+router.get('/pku/cls/lecture', lazyloadRouteHandler('./routes/universities/pku/cls/lecture'));
+router.get('/pku/bbs/hot', lazyloadRouteHandler('./routes/universities/pku/bbs/hot'));
 
 // 上海海事大学
-router.get('/shmtu/www/:type', require('./routes/universities/shmtu/www'));
-router.get('/shmtu/jwc/:type', require('./routes/universities/shmtu/jwc'));
+router.get('/shmtu/www/:type', lazyloadRouteHandler('./routes/universities/shmtu/www'));
+router.get('/shmtu/jwc/:type', lazyloadRouteHandler('./routes/universities/shmtu/jwc'));
 
 // 上海海洋大学
-router.get('/shou/www/:type', require('./routes/universities/shou/www'));
+router.get('/shou/www/:type', lazyloadRouteHandler('./routes/universities/shou/www'));
 
 // 西南科技大学
-router.get('/swust/jwc/news', require('./routes/universities/swust/jwc_news'));
-router.get('/swust/jwc/notice/:type?', require('./routes/universities/swust/jwc_notice'));
-router.get('/swust/cs/:type?', require('./routes/universities/swust/cs'));
+router.get('/swust/jwc/news', lazyloadRouteHandler('./routes/universities/swust/jwc_news'));
+router.get('/swust/jwc/notice/:type?', lazyloadRouteHandler('./routes/universities/swust/jwc_notice'));
+router.get('/swust/cs/:type?', lazyloadRouteHandler('./routes/universities/swust/cs'));
 
 // 华南师范大学
-router.get('/scnu/jw', require('./routes/universities/scnu/jw'));
-router.get('/scnu/library', require('./routes/universities/scnu/library'));
-router.get('/scnu/cs/match', require('./routes/universities/scnu/cs/match'));
+router.get('/scnu/jw', lazyloadRouteHandler('./routes/universities/scnu/jw'));
+router.get('/scnu/library', lazyloadRouteHandler('./routes/universities/scnu/library'));
+router.get('/scnu/cs/match', lazyloadRouteHandler('./routes/universities/scnu/cs/match'));
 
 // 广东工业大学
-router.get('/gdut/news', require('./routes/universities/gdut/news'));
+router.get('/gdut/news', lazyloadRouteHandler('./routes/universities/gdut/news'));
 
 // 中国科学院
-router.get('/cas/sim/academic', require('./routes/universities/cas/sim/academic'));
-router.get('/cas/mesalab/kb', require('./routes/universities/cas/mesalab/kb'));
-router.get('/cas/iee/kydt', require('./routes/universities/cas/iee/kydt'));
-router.get('/cas/cg/:caty?', require('./routes/universities/cas/cg/index'));
+router.get('/cas/sim/academic', lazyloadRouteHandler('./routes/universities/cas/sim/academic'));
+router.get('/cas/mesalab/kb', lazyloadRouteHandler('./routes/universities/cas/mesalab/kb'));
+router.get('/cas/iee/kydt', lazyloadRouteHandler('./routes/universities/cas/iee/kydt'));
+router.get('/cas/cg/:caty?', lazyloadRouteHandler('./routes/universities/cas/cg/index'));
 
 // 中国传媒大学
-router.get('/cuc/yz', require('./routes/universities/cuc/yz'));
+router.get('/cuc/yz', lazyloadRouteHandler('./routes/universities/cuc/yz'));
 
 // 中国科学技术大学
-router.get('/ustc/news/:type?', require('./routes/universities/ustc/index'));
-router.get('/ustc/jwc/:type?', require('./routes/universities/ustc/jwc/index'));
-router.get('/ustc/job/:category?', require('./routes/universities/ustc/job'));
+router.get('/ustc/news/:type?', lazyloadRouteHandler('./routes/universities/ustc/index'));
+router.get('/ustc/jwc/:type?', lazyloadRouteHandler('./routes/universities/ustc/jwc/index'));
+router.get('/ustc/job/:category?', lazyloadRouteHandler('./routes/universities/ustc/job'));
 
 // UTdallas ISSO
-router.get('/utdallas/isso', require('./routes/universities/utdallas/isso'));
+router.get('/utdallas/isso', lazyloadRouteHandler('./routes/universities/utdallas/isso'));
 
 // 南京邮电大学
-router.get('/njupt/jwc/:type?', require('./routes/universities/njupt/jwc'));
+router.get('/njupt/jwc/:type?', lazyloadRouteHandler('./routes/universities/njupt/jwc'));
 
 // 南昌航空大学
-router.get('/nchu/jwc/:type?', require('./routes/universities/nchu/jwc'));
+router.get('/nchu/jwc/:type?', lazyloadRouteHandler('./routes/universities/nchu/jwc'));
 
 // 哈尔滨工程大学
-router.get('/heu/ugs/news/:author?/:category?', require('./routes/universities/heu/ugs/news'));
-router.get('/heu/yjsy/:type?', require('./routes/universities/heu/yjsy'));
-router.get('/heu/gongxue/:type?', require('./routes/universities/heu/news'));
-router.get('/heu/news/:type?', require('./routes/universities/heu/news'));
-router.get('/heu/shuisheng/:type?', require('./routes/universities/heu/uae'));
-router.get('/heu/uae/:type?', require('./routes/universities/heu/uae'));
-router.get('/heu/job/:type?', require('./routes/universities/heu/job'));
+router.get('/heu/ugs/news/:author?/:category?', lazyloadRouteHandler('./routes/universities/heu/ugs/news'));
+router.get('/heu/yjsy/:type?', lazyloadRouteHandler('./routes/universities/heu/yjsy'));
+router.get('/heu/gongxue/:type?', lazyloadRouteHandler('./routes/universities/heu/news'));
+router.get('/heu/news/:type?', lazyloadRouteHandler('./routes/universities/heu/news'));
+router.get('/heu/shuisheng/:type?', lazyloadRouteHandler('./routes/universities/heu/uae'));
+router.get('/heu/uae/:type?', lazyloadRouteHandler('./routes/universities/heu/uae'));
+router.get('/heu/job/:type?', lazyloadRouteHandler('./routes/universities/heu/job'));
 
 // 重庆大学
-router.get('/cqu/jwc/:path*', require('./routes/universities/cqu/jwc/announcement'));
-router.get('/cqu/news/jzyg', require('./routes/universities/cqu/news/jzyg'));
-router.get('/cqu/news/tz', require('./routes/universities/cqu/news/tz'));
-router.get('/cqu/youth/:category', require('./routes/universities/cqu/youth/info'));
-router.get('/cqu/sci/:category', require('./routes/universities/cqu/sci/info'));
-router.get('/cqu/net/:category', require('./routes/universities/cqu/net/info'));
+router.get('/cqu/jwc/:path*', lazyloadRouteHandler('./routes/universities/cqu/jwc/announcement'));
+router.get('/cqu/news/jzyg', lazyloadRouteHandler('./routes/universities/cqu/news/jzyg'));
+router.get('/cqu/news/tz', lazyloadRouteHandler('./routes/universities/cqu/news/tz'));
+router.get('/cqu/youth/:category', lazyloadRouteHandler('./routes/universities/cqu/youth/info'));
+router.get('/cqu/sci/:category', lazyloadRouteHandler('./routes/universities/cqu/sci/info'));
+router.get('/cqu/net/:category', lazyloadRouteHandler('./routes/universities/cqu/net/info'));
 
 // 重庆文理学院
-router.get('/cqwu/news/:type?', require('./routes/universities/cqwu/news'));
+router.get('/cqwu/news/:type?', lazyloadRouteHandler('./routes/universities/cqwu/news'));
 
 // 南京信息工程大学
-router.get('/nuist/bulletin/:category?', require('./routes/universities/nuist/bulletin'));
-router.get('/nuist/jwc/:category?', require('./routes/universities/nuist/jwc'));
-router.get('/nuist/yjs/:category?', require('./routes/universities/nuist/yjs'));
-router.get('/nuist/xgc', require('./routes/universities/nuist/xgc'));
-router.get('/nuist/scs/:category?', require('./routes/universities/nuist/scs'));
-router.get('/nuist/lib', require('./routes/universities/nuist/library/lib'));
-router.get('/nuist/sese/:category?', require('./routes/universities/nuist/sese'));
-router.get('/nuist/cas/:category?', require('./routes/universities/nuist/cas'));
+router.get('/nuist/bulletin/:category?', lazyloadRouteHandler('./routes/universities/nuist/bulletin'));
+router.get('/nuist/jwc/:category?', lazyloadRouteHandler('./routes/universities/nuist/jwc'));
+router.get('/nuist/yjs/:category?', lazyloadRouteHandler('./routes/universities/nuist/yjs'));
+router.get('/nuist/xgc', lazyloadRouteHandler('./routes/universities/nuist/xgc'));
+router.get('/nuist/scs/:category?', lazyloadRouteHandler('./routes/universities/nuist/scs'));
+router.get('/nuist/lib', lazyloadRouteHandler('./routes/universities/nuist/library/lib'));
+router.get('/nuist/sese/:category?', lazyloadRouteHandler('./routes/universities/nuist/sese'));
+router.get('/nuist/cas/:category?', lazyloadRouteHandler('./routes/universities/nuist/cas'));
 
 // 成都信息工程大学
-router.get('/cuit/cxxww/:type?', require('./routes/universities/cuit/cxxww'));
+router.get('/cuit/cxxww/:type?', lazyloadRouteHandler('./routes/universities/cuit/cxxww'));
 
 // 郑州大学
-router.get('/zzu/news/:type', require('./routes/universities/zzu/news'));
-router.get('/zzu/soft/news/:type', require('./routes/universities/zzu/soft/news'));
+router.get('/zzu/news/:type', lazyloadRouteHandler('./routes/universities/zzu/news'));
+router.get('/zzu/soft/news/:type', lazyloadRouteHandler('./routes/universities/zzu/soft/news'));
 
 // 郑州轻工业大学
-router.get('/zzuli/campus/:type', require('./routes/universities/zzuli/campus'));
-router.get('/zzuli/yjsc/:type', require('./routes/universities/zzuli/yjsc'));
+router.get('/zzuli/campus/:type', lazyloadRouteHandler('./routes/universities/zzuli/campus'));
+router.get('/zzuli/yjsc/:type', lazyloadRouteHandler('./routes/universities/zzuli/yjsc'));
 
 // 重庆科技学院
-router.get('/cqust/jw/:type?', require('./routes/universities/cqust/jw'));
-router.get('/cqust/lib/:type?', require('./routes/universities/cqust/lib'));
+router.get('/cqust/jw/:type?', lazyloadRouteHandler('./routes/universities/cqust/jw'));
+router.get('/cqust/lib/:type?', lazyloadRouteHandler('./routes/universities/cqust/lib'));
 
 // 常州大学
-router.get('/cczu/jwc/:category?', require('./routes/universities/cczu/jwc'));
-router.get('/cczu/news/:category?', require('./routes/universities/cczu/news'));
+router.get('/cczu/jwc/:category?', lazyloadRouteHandler('./routes/universities/cczu/jwc'));
+router.get('/cczu/news/:category?', lazyloadRouteHandler('./routes/universities/cczu/news'));
 
 // 南京理工大学
-router.get('/njust/jwc/:type', require('./routes/universities/njust/jwc'));
-router.get('/njust/cwc/:type', require('./routes/universities/njust/cwc'));
-router.get('/njust/gs/:type', require('./routes/universities/njust/gs'));
-router.get('/njust/eo/:grade?/:type?', require('./routes/universities/njust/eo'));
+router.get('/njust/jwc/:type', lazyloadRouteHandler('./routes/universities/njust/jwc'));
+router.get('/njust/cwc/:type', lazyloadRouteHandler('./routes/universities/njust/cwc'));
+router.get('/njust/gs/:type', lazyloadRouteHandler('./routes/universities/njust/gs'));
+router.get('/njust/eo/:grade?/:type?', lazyloadRouteHandler('./routes/universities/njust/eo'));
 
 // 四川旅游学院
-router.get('/sctu/xgxy', require('./routes/universities/sctu/information-engineer-faculty/index'));
-router.get('/sctu/xgxy/:id', require('./routes/universities/sctu/information-engineer-faculty/context'));
-router.get('/sctu/jwc/:type?', require('./routes/universities/sctu/jwc/index'));
-router.get('/sctu/jwc/:type/:id', require('./routes/universities/sctu/jwc/context'));
+router.get('/sctu/xgxy', lazyloadRouteHandler('./routes/universities/sctu/information-engineer-faculty/index'));
+router.get('/sctu/xgxy/:id', lazyloadRouteHandler('./routes/universities/sctu/information-engineer-faculty/context'));
+router.get('/sctu/jwc/:type?', lazyloadRouteHandler('./routes/universities/sctu/jwc/index'));
+router.get('/sctu/jwc/:type/:id', lazyloadRouteHandler('./routes/universities/sctu/jwc/context'));
 
 // 电子科技大学
-router.get('/uestc/jwc/:type?', require('./routes/universities/uestc/jwc'));
-router.get('/uestc/is/:type?', require('./routes/universities/uestc/is'));
-router.get('/uestc/news/:type?', require('./routes/universities/uestc/news'));
-router.get('/uestc/auto/:type?', require('./routes/universities/uestc/auto'));
-router.get('/uestc/cs/:type?', require('./routes/universities/uestc/cs'));
-router.get('/uestc/cqe/:type?', require('./routes/universities/uestc/cqe'));
-router.get('/uestc/gr', require('./routes/universities/uestc/gr'));
-router.get('/uestc/sice', require('./routes/universities/uestc/sice'));
+router.get('/uestc/jwc/:type?', lazyloadRouteHandler('./routes/universities/uestc/jwc'));
+router.get('/uestc/is/:type?', lazyloadRouteHandler('./routes/universities/uestc/is'));
+router.get('/uestc/news/:type?', lazyloadRouteHandler('./routes/universities/uestc/news'));
+router.get('/uestc/auto/:type?', lazyloadRouteHandler('./routes/universities/uestc/auto'));
+router.get('/uestc/cs/:type?', lazyloadRouteHandler('./routes/universities/uestc/cs'));
+router.get('/uestc/cqe/:type?', lazyloadRouteHandler('./routes/universities/uestc/cqe'));
+router.get('/uestc/gr', lazyloadRouteHandler('./routes/universities/uestc/gr'));
+router.get('/uestc/sice', lazyloadRouteHandler('./routes/universities/uestc/sice'));
 
 // 西北农林科技大学
-router.get('/nwafu/news', require('./routes/universities/nwafu/news'));
-router.get('/nwafu/jiaowu', require('./routes/universities/nwafu/jiaowu'));
-router.get('/nwafu/gs', require('./routes/universities/nwafu/gs'));
-router.get('/nwafu/lib', require('./routes/universities/nwafu/lib'));
-router.get('/nwafu/nic', require('./routes/universities/nwafu/nic'));
-router.get('/nwafu/54youth', require('./routes/universities/nwafu/54youth'));
-router.get('/nwafu/jcc', require('./routes/universities/nwafu/jcc'));
-router.get('/nwafu/yjshy', require('./routes/universities/nwafu/yjshy'));
-router.get('/nwafu/cie', require('./routes/universities/nwafu/cie'));
+router.get('/nwafu/news', lazyloadRouteHandler('./routes/universities/nwafu/news'));
+router.get('/nwafu/jiaowu', lazyloadRouteHandler('./routes/universities/nwafu/jiaowu'));
+router.get('/nwafu/gs', lazyloadRouteHandler('./routes/universities/nwafu/gs'));
+router.get('/nwafu/lib', lazyloadRouteHandler('./routes/universities/nwafu/lib'));
+router.get('/nwafu/nic', lazyloadRouteHandler('./routes/universities/nwafu/nic'));
+router.get('/nwafu/54youth', lazyloadRouteHandler('./routes/universities/nwafu/54youth'));
+router.get('/nwafu/jcc', lazyloadRouteHandler('./routes/universities/nwafu/jcc'));
+router.get('/nwafu/yjshy', lazyloadRouteHandler('./routes/universities/nwafu/yjshy'));
+router.get('/nwafu/cie', lazyloadRouteHandler('./routes/universities/nwafu/cie'));
 
 // 云南大学
-router.get('/ynu/grs/zytz', require('./routes/universities/ynu/grs/zytz'));
-router.get('/ynu/grs/qttz/:category', require('./routes/universities/ynu/grs/qttz'));
-router.get('/ynu/jwc/:category', require('./routes/universities/ynu/jwc/zytz'));
-router.get('/ynu/home', require('./routes/universities/ynu/home/main'));
+router.get('/ynu/grs/zytz', lazyloadRouteHandler('./routes/universities/ynu/grs/zytz'));
+router.get('/ynu/grs/qttz/:category', lazyloadRouteHandler('./routes/universities/ynu/grs/qttz'));
+router.get('/ynu/jwc/:category', lazyloadRouteHandler('./routes/universities/ynu/jwc/zytz'));
+router.get('/ynu/home', lazyloadRouteHandler('./routes/universities/ynu/home/main'));
 
 // 昆明理工大学
-router.get('/kmust/jwc/:type?', require('./routes/universities/kmust/jwc'));
-router.get('/kmust/job/careers/:type?', require('./routes/universities/kmust/job/careers'));
-router.get('/kmust/job/jobfairs', require('./routes/universities/kmust/job/jobfairs'));
+router.get('/kmust/jwc/:type?', lazyloadRouteHandler('./routes/universities/kmust/jwc'));
+router.get('/kmust/job/careers/:type?', lazyloadRouteHandler('./routes/universities/kmust/job/careers'));
+router.get('/kmust/job/jobfairs', lazyloadRouteHandler('./routes/universities/kmust/job/jobfairs'));
 
 // 武汉大学
-router.get('/whu/cs/:type', require('./routes/universities/whu/cs'));
-router.get('/whu/news/:type?', require('./routes/universities/whu/news'));
+router.get('/whu/cs/:type', lazyloadRouteHandler('./routes/universities/whu/cs'));
+router.get('/whu/news/:type?', lazyloadRouteHandler('./routes/universities/whu/news'));
 
 // 华中科技大学
-router.get('/hust/auto/notice/:type?', require('./routes/universities/hust/aia/notice'));
-router.get('/hust/auto/news', require('./routes/universities/hust/aia/news'));
-router.get('/hust/aia/news', require('./routes/universities/hust/aia/news'));
-router.get('/hust/aia/notice/:type?', require('./routes/universities/hust/aia/notice'));
+router.get('/hust/auto/notice/:type?', lazyloadRouteHandler('./routes/universities/hust/aia/notice'));
+router.get('/hust/auto/news', lazyloadRouteHandler('./routes/universities/hust/aia/news'));
+router.get('/hust/aia/news', lazyloadRouteHandler('./routes/universities/hust/aia/news'));
+router.get('/hust/aia/notice/:type?', lazyloadRouteHandler('./routes/universities/hust/aia/notice'));
 
 // 井冈山大学
-router.get('/jgsu/jwc', require('./routes/universities/jgsu/jwc'));
+router.get('/jgsu/jwc', lazyloadRouteHandler('./routes/universities/jgsu/jwc'));
 
 // 中南大学
-router.get('/csu/job/:type?', require('./routes/universities/csu/job'));
+router.get('/csu/job/:type?', lazyloadRouteHandler('./routes/universities/csu/job'));
 
 // 山东大学
-router.get('/sdu/sc/:type?', require('./routes/universities/sdu/sc'));
-router.get('/sdu/cs/:type?', require('./routes/universities/sdu/cs'));
-router.get('/sdu/cmse/:type?', require('./routes/universities/sdu/cmse'));
-router.get('/sdu/mech/:type?', require('./routes/universities/sdu/mech'));
-router.get('/sdu/epe/:type?', require('./routes/universities/sdu/epe'));
+router.get('/sdu/sc/:type?', lazyloadRouteHandler('./routes/universities/sdu/sc'));
+router.get('/sdu/cs/:type?', lazyloadRouteHandler('./routes/universities/sdu/cs'));
+router.get('/sdu/cmse/:type?', lazyloadRouteHandler('./routes/universities/sdu/cmse'));
+router.get('/sdu/mech/:type?', lazyloadRouteHandler('./routes/universities/sdu/mech'));
+router.get('/sdu/epe/:type?', lazyloadRouteHandler('./routes/universities/sdu/epe'));
 
 // 中国海洋大学
-router.get('/ouc/it/:type?', require('./routes/universities/ouc/it'));
+router.get('/ouc/it/:type?', lazyloadRouteHandler('./routes/universities/ouc/it'));
 
 // 大连大学
-router.get('/dlu/jiaowu/news', require('./routes/universities/dlu/jiaowu/news'));
+router.get('/dlu/jiaowu/news', lazyloadRouteHandler('./routes/universities/dlu/jiaowu/news'));
 
 // 东莞理工学院
-router.get('/dgut/jwc/:type?', require('./routes/universities/dgut/jwc'));
-router.get('/dgut/xsc/:type?', require('./routes/universities/dgut/xsc'));
+router.get('/dgut/jwc/:type?', lazyloadRouteHandler('./routes/universities/dgut/jwc'));
+router.get('/dgut/xsc/:type?', lazyloadRouteHandler('./routes/universities/dgut/xsc'));
 
 // 同济大学
-router.get('/tju/sse/:type?', require('./routes/universities/tju/sse/notice'));
+router.get('/tju/sse/:type?', lazyloadRouteHandler('./routes/universities/tju/sse/notice'));
 
 // 华南理工大学
-router.get('/scut/jwc/notice/:category?', require('./routes/universities/scut/jwc/notice'));
-router.get('/scut/jwc/news', require('./routes/universities/scut/jwc/news'));
+router.get('/scut/jwc/notice/:category?', lazyloadRouteHandler('./routes/universities/scut/jwc/notice'));
+router.get('/scut/jwc/news', lazyloadRouteHandler('./routes/universities/scut/jwc/news'));
 
 // 温州商学院
-router.get('/wzbc/:type?', require('./routes/universities/wzbc/news'));
+router.get('/wzbc/:type?', lazyloadRouteHandler('./routes/universities/wzbc/news'));
 
 // 河南大学
-router.get('/henu/:type?', require('./routes/universities/henu/news'));
+router.get('/henu/:type?', lazyloadRouteHandler('./routes/universities/henu/news'));
 
 // 天津大学
-router.get('/tjpyu/ooa/:type?', require('./routes/universities/tjpyu/ooa'));
+router.get('/tjpyu/ooa/:type?', lazyloadRouteHandler('./routes/universities/tjpyu/ooa'));
 
 // 南开大学
-router.get('/nku/jwc/:type?', require('./routes/universities/nku/jwc/index'));
+router.get('/nku/jwc/:type?', lazyloadRouteHandler('./routes/universities/nku/jwc/index'));
 
 // 北京航空航天大学
-router.get('/buaa/news/:type', require('./routes/universities/buaa/news/index'));
+router.get('/buaa/news/:type', lazyloadRouteHandler('./routes/universities/buaa/news/index'));
 
 // 浙江工业大学
-router.get('/zjut/:type', require('./routes/universities/zjut/index'));
-router.get('/zjut/design/:type', require('./routes/universities/zjut/design'));
+router.get('/zjut/:type', lazyloadRouteHandler('./routes/universities/zjut/index'));
+router.get('/zjut/design/:type', lazyloadRouteHandler('./routes/universities/zjut/design'));
 
 // 上海大学
-router.get('/shu/:type?', require('./routes/universities/shu/index'));
-router.get('/shu/jwc/:type?', require('./routes/universities/shu/jwc'));
+router.get('/shu/:type?', lazyloadRouteHandler('./routes/universities/shu/index'));
+router.get('/shu/jwc/:type?', lazyloadRouteHandler('./routes/universities/shu/jwc'));
 
 // 北京科技大学天津学院
-router.get('/ustb/tj/news/:type?', require('./routes/universities/ustb/tj/news'));
+router.get('/ustb/tj/news/:type?', lazyloadRouteHandler('./routes/universities/ustb/tj/news'));
 
 // 深圳大学
-router.get('/szu/yz/:type?', require('./routes/universities/szu/yz'));
+router.get('/szu/yz/:type?', lazyloadRouteHandler('./routes/universities/szu/yz'));
 
 // 中国石油大学（华东）
-router.get('/upc/main/:type?', require('./routes/universities/upc/main'));
-router.get('/upc/jsj/:type?', require('./routes/universities/upc/jsj'));
+router.get('/upc/main/:type?', lazyloadRouteHandler('./routes/universities/upc/main'));
+router.get('/upc/jsj/:type?', lazyloadRouteHandler('./routes/universities/upc/jsj'));
 
 // 华北水利水电大学
-router.get('/ncwu/notice', require('./routes/universities/ncwu/notice'));
+router.get('/ncwu/notice', lazyloadRouteHandler('./routes/universities/ncwu/notice'));
 
 // 太原师范学院
-router.get('/tynu', require('./routes/universities/tynu/tynu'));
+router.get('/tynu', lazyloadRouteHandler('./routes/universities/tynu/tynu'));
 
 // 中北大学
-router.get('/nuc/:type', require('./routes/universities/nuc/index'));
+router.get('/nuc/:type', lazyloadRouteHandler('./routes/universities/nuc/index'));
 
 // 安徽农业大学
-router.get('/ahau/cs_news/:type', require('./routes/universities/ahau/cs_news/index'));
-router.get('/ahau/jwc/:type', require('./routes/universities/ahau/jwc/index'));
-router.get('/ahau/main/:type', require('./routes/universities/ahau/main/index'));
+router.get('/ahau/cs_news/:type', lazyloadRouteHandler('./routes/universities/ahau/cs_news/index'));
+router.get('/ahau/jwc/:type', lazyloadRouteHandler('./routes/universities/ahau/jwc/index'));
+router.get('/ahau/main/:type', lazyloadRouteHandler('./routes/universities/ahau/main/index'));
 
 // 安徽医科大学研究生学院
-router.get('/ahmu/news', require('./routes/universities/ahmu/news'));
+router.get('/ahmu/news', lazyloadRouteHandler('./routes/universities/ahmu/news'));
 
 // 安徽工业大学
-router.get('/ahut/news', require('./routes/universities/ahut/news'));
-router.get('/ahut/jwc', require('./routes/universities/ahut/jwc'));
-router.get('/ahut/cstzgg', require('./routes/universities/ahut/cstzgg'));
+router.get('/ahut/news', lazyloadRouteHandler('./routes/universities/ahut/news'));
+router.get('/ahut/jwc', lazyloadRouteHandler('./routes/universities/ahut/jwc'));
+router.get('/ahut/cstzgg', lazyloadRouteHandler('./routes/universities/ahut/cstzgg'));
 
 // 上海理工大学
-router.get('/usst/jwc', require('./routes/universities/usst/jwc'));
+router.get('/usst/jwc', lazyloadRouteHandler('./routes/universities/usst/jwc'));
 
 // 临沂大学
-router.get('/lyu/news/:type', require('./routes/universities/lyu/news/index'));
+router.get('/lyu/news/:type', lazyloadRouteHandler('./routes/universities/lyu/news/index'));
 
 // 福州大学
-router.get('/fzu/:type', require('./routes/universities/fzu/news'));
+router.get('/fzu/:type', lazyloadRouteHandler('./routes/universities/fzu/news'));
 
 // ifanr
-router.get('/ifanr/:channel?', require('./routes/ifanr/index'));
+router.get('/ifanr/:channel?', lazyloadRouteHandler('./routes/ifanr/index'));
 
 // 果壳网
-router.get('/guokr/scientific', require('./routes/guokr/scientific'));
-router.get('/guokr/:channel', require('./routes/guokr/calendar'));
+router.get('/guokr/scientific', lazyloadRouteHandler('./routes/guokr/scientific'));
+router.get('/guokr/:channel', lazyloadRouteHandler('./routes/guokr/calendar'));
 
 // 联合早报
-router.get('/zaobao/realtime/:section?', require('./routes/zaobao/realtime'));
-router.get('/zaobao/znews/:section?', require('./routes/zaobao/znews'));
-router.get('/zaobao/:type/:section', require('./routes/zaobao/index'));
-router.get('/zaobao/interactive-graphics', require('./routes/zaobao/interactive'));
+router.get('/zaobao/realtime/:section?', lazyloadRouteHandler('./routes/zaobao/realtime'));
+router.get('/zaobao/znews/:section?', lazyloadRouteHandler('./routes/zaobao/znews'));
+router.get('/zaobao/:type/:section', lazyloadRouteHandler('./routes/zaobao/index'));
+router.get('/zaobao/interactive-graphics', lazyloadRouteHandler('./routes/zaobao/interactive'));
 
 // Apple
-router.get('/apple/exchange_repair/:country?', require('./routes/apple/exchange_repair'));
+router.get('/apple/exchange_repair/:country?', lazyloadRouteHandler('./routes/apple/exchange_repair'));
 
 // IPSW.me
-router.get('/ipsw/index/:ptype/:pname', require('./routes/ipsw/index'));
+router.get('/ipsw/index/:ptype/:pname', lazyloadRouteHandler('./routes/ipsw/index'));
 
 // Minecraft CurseForge
-router.get('/curseforge/files/:project', require('./routes/curseforge/files'));
+router.get('/curseforge/files/:project', lazyloadRouteHandler('./routes/curseforge/files'));
 
 // 少数派 sspai
-router.get('/sspai/series', require('./routes/sspai/series'));
-router.get('/sspai/shortcuts', require('./routes/sspai/shortcutsGallery'));
-router.get('/sspai/matrix', require('./routes/sspai/matrix'));
-router.get('/sspai/column/:id', require('./routes/sspai/column'));
-router.get('/sspai/author/:id', require('./routes/sspai/author'));
-router.get('/sspai/topics', require('./routes/sspai/topics'));
-router.get('/sspai/topic/:id', require('./routes/sspai/topic'));
-router.get('/sspai/tag/:keyword', require('./routes/sspai/tag'));
-router.get('/sspai/activity/:slug', require('./routes/sspai/activity'));
+router.get('/sspai/series', lazyloadRouteHandler('./routes/sspai/series'));
+router.get('/sspai/shortcuts', lazyloadRouteHandler('./routes/sspai/shortcutsGallery'));
+router.get('/sspai/matrix', lazyloadRouteHandler('./routes/sspai/matrix'));
+router.get('/sspai/column/:id', lazyloadRouteHandler('./routes/sspai/column'));
+router.get('/sspai/author/:id', lazyloadRouteHandler('./routes/sspai/author'));
+router.get('/sspai/topics', lazyloadRouteHandler('./routes/sspai/topics'));
+router.get('/sspai/topic/:id', lazyloadRouteHandler('./routes/sspai/topic'));
+router.get('/sspai/tag/:keyword', lazyloadRouteHandler('./routes/sspai/tag'));
+router.get('/sspai/activity/:slug', lazyloadRouteHandler('./routes/sspai/activity'));
 
 // 异次元软件世界
-router.get('/iplay/home', require('./routes/iplay/home'));
+router.get('/iplay/home', lazyloadRouteHandler('./routes/iplay/home'));
 
 // xclient.info
-router.get('/xclient/app/:name', require('./routes/xclient/app'));
+router.get('/xclient/app/:name', lazyloadRouteHandler('./routes/xclient/app'));
 
 // 中国驻外使领事馆
-router.get('/embassy/:country/:city?', require('./routes/embassy/index'));
+router.get('/embassy/:country/:city?', lazyloadRouteHandler('./routes/embassy/index'));
 
 // 澎湃新闻
-router.get('/thepaper/featured', require('./routes/thepaper/featured'));
-router.get('/thepaper/channel/:id', require('./routes/thepaper/channel'));
-router.get('/thepaper/list/:id', require('./routes/thepaper/list'));
+router.get('/thepaper/featured', lazyloadRouteHandler('./routes/thepaper/featured'));
+router.get('/thepaper/channel/:id', lazyloadRouteHandler('./routes/thepaper/channel'));
+router.get('/thepaper/list/:id', lazyloadRouteHandler('./routes/thepaper/list'));
 
 // 澎湃美数课
-router.get('/thepaper/839studio', require('./routes/thepaper/839studio/studio.js'));
-router.get('/thepaper/839studio/:id', require('./routes/thepaper/839studio/category.js'));
+router.get('/thepaper/839studio', lazyloadRouteHandler('./routes/thepaper/839studio/studio.js'));
+router.get('/thepaper/839studio/:id', lazyloadRouteHandler('./routes/thepaper/839studio/category.js'));
 
 // 电影首发站
-router.get('/dysfz', require('./routes/dysfz/index'));
-router.get('/dysfz/index', require('./routes/dysfz/index')); // 废弃
+router.get('/dysfz', lazyloadRouteHandler('./routes/dysfz/index'));
+router.get('/dysfz/index', lazyloadRouteHandler('./routes/dysfz/index')); // 废弃
 
 // きららファンタジア
-router.get('/kirara/news', require('./routes/kirara/news'));
+router.get('/kirara/news', lazyloadRouteHandler('./routes/kirara/news'));
 
 // 电影天堂
-router.get('/dytt', require('./routes/dytt/index'));
-router.get('/dytt/index', require('./routes/dytt/index')); // 废弃
+router.get('/dytt', lazyloadRouteHandler('./routes/dytt/index'));
+router.get('/dytt/index', lazyloadRouteHandler('./routes/dytt/index')); // 废弃
 
 // BT之家
-router.get('/btzj/:type?', require('./routes/btzj/index'));
+router.get('/btzj/:type?', lazyloadRouteHandler('./routes/btzj/index'));
 
 // 人生05电影网
-router.get('/rs05/rs05', require('./routes/rs05/rs05'));
+router.get('/rs05/rs05', lazyloadRouteHandler('./routes/rs05/rs05'));
 
 // 人人影视 (评测推荐)
-router.get('/rrys/review', require('./routes/rrys/review'));
+router.get('/rrys/review', lazyloadRouteHandler('./routes/rrys/review'));
 
 // 人人影视（每日更新）
-router.get('/yyets/todayfilelist', require('./routes/yyets/todayfilelist'));
+router.get('/yyets/todayfilelist', lazyloadRouteHandler('./routes/yyets/todayfilelist'));
 
 // 趣头条
-router.get('/qutoutiao/category/:cid', require('./routes/qutoutiao/category'));
+router.get('/qutoutiao/category/:cid', lazyloadRouteHandler('./routes/qutoutiao/category'));
 
 // NHK NEW WEB EASY
-router.get('/nhk/news_web_easy', require('./routes/nhk/news_web_easy'));
+router.get('/nhk/news_web_easy', lazyloadRouteHandler('./routes/nhk/news_web_easy'));
 
 // BBC
-router.get('/bbc/:site?/:channel?', require('./routes/bbc/index'));
+router.get('/bbc/:site?/:channel?', lazyloadRouteHandler('./routes/bbc/index'));
 
 // Financial Times
-router.get('/ft/myft/:key', require('./routes/ft/myft'));
-router.get('/ft/:language/:channel?', require('./routes/ft/channel'));
+router.get('/ft/myft/:key', lazyloadRouteHandler('./routes/ft/myft'));
+router.get('/ft/:language/:channel?', lazyloadRouteHandler('./routes/ft/channel'));
 
 // The Verge
-router.get('/verge', require('./routes/verge/index'));
+router.get('/verge', lazyloadRouteHandler('./routes/verge/index'));
 
 // 看雪
-router.get('/pediy/topic/:category?/:type?', require('./routes/pediy/topic'));
+router.get('/pediy/topic/:category?/:type?', lazyloadRouteHandler('./routes/pediy/topic'));
 
 // 多维新闻网
-router.get('/dwnews/yaowen/:region?', require('./routes/dwnews/yaowen'));
-router.get('/dwnews/rank/:type?/:range?', require('./routes/dwnews/rank'));
+router.get('/dwnews/yaowen/:region?', lazyloadRouteHandler('./routes/dwnews/yaowen'));
+router.get('/dwnews/rank/:type?/:range?', lazyloadRouteHandler('./routes/dwnews/rank'));
 
 // 知晓程序
-router.get('/miniapp/article/:category', require('./routes/miniapp/article'));
-router.get('/miniapp/store/newest', require('./routes/miniapp/store/newest'));
+router.get('/miniapp/article/:category', lazyloadRouteHandler('./routes/miniapp/article'));
+router.get('/miniapp/store/newest', lazyloadRouteHandler('./routes/miniapp/store/newest'));
 
 // 后续
-router.get('/houxu/live/:id/:timeline?', require('./routes/houxu/live'));
-router.get('/houxu/events', require('./routes/houxu/events'));
-router.get('/houxu/lives/:type', require('./routes/houxu/lives'));
+router.get('/houxu/live/:id/:timeline?', lazyloadRouteHandler('./routes/houxu/live'));
+router.get('/houxu/events', lazyloadRouteHandler('./routes/houxu/events'));
+router.get('/houxu/lives/:type', lazyloadRouteHandler('./routes/houxu/lives'));
 
 // 老司机
-router.get('/laosiji/hot', require('./routes/laosiji/hot'));
-router.get('/laosiji/feed', require('./routes/laosiji/feed'));
-router.get('/laosiji/hotshow/:id', require('./routes/laosiji/hotshow'));
+router.get('/laosiji/hot', lazyloadRouteHandler('./routes/laosiji/hot'));
+router.get('/laosiji/feed', lazyloadRouteHandler('./routes/laosiji/feed'));
+router.get('/laosiji/hotshow/:id', lazyloadRouteHandler('./routes/laosiji/hotshow'));
 
 // Scientific American 60-Second Science
-router.get('/60s-science', require('./routes/60s-science/transcript'));
+router.get('/60s-science', lazyloadRouteHandler('./routes/60s-science/transcript'));
 
 // 99% Invisible
-router.get('/99percentinvisible/transcript', require('./routes/99percentinvisible/transcript'));
+router.get('/99percentinvisible/transcript', lazyloadRouteHandler('./routes/99percentinvisible/transcript'));
 
 // 青空文庫
-router.get('/aozora/newbook/:count?', require('./routes/aozora/newbook'));
+router.get('/aozora/newbook/:count?', lazyloadRouteHandler('./routes/aozora/newbook'));
 
 // solidot
-router.get('/solidot/:type?', require('./routes/solidot/main'));
+router.get('/solidot/:type?', lazyloadRouteHandler('./routes/solidot/main'));
 
 // Hermes UK
-router.get('/parcel/hermesuk/:tracking', require('./routes/parcel/hermesuk'));
+router.get('/parcel/hermesuk/:tracking', lazyloadRouteHandler('./routes/parcel/hermesuk'));
 
 // 数字尾巴
-router.get('/dgtle', require('./routes/dgtle/index'));
-router.get('/dgtle/whale/category/:category', require('./routes/dgtle/whale'));
-router.get('/dgtle/whale/rank/:type/:rule', require('./routes/dgtle/whale_rank'));
-router.get('/dgtle/trade/:typeId?', require('./routes/dgtle/trade'));
-router.get('/dgtle/trade/search/:keyword', require('./routes/dgtle/keyword'));
+router.get('/dgtle', lazyloadRouteHandler('./routes/dgtle/index'));
+router.get('/dgtle/whale/category/:category', lazyloadRouteHandler('./routes/dgtle/whale'));
+router.get('/dgtle/whale/rank/:type/:rule', lazyloadRouteHandler('./routes/dgtle/whale_rank'));
+router.get('/dgtle/trade/:typeId?', lazyloadRouteHandler('./routes/dgtle/trade'));
+router.get('/dgtle/trade/search/:keyword', lazyloadRouteHandler('./routes/dgtle/keyword'));
 
 // 抽屉新热榜
-router.get('/chouti/top/:hour?', require('./routes/chouti/top'));
-router.get('/chouti/:subject?', require('./routes/chouti'));
+router.get('/chouti/top/:hour?', lazyloadRouteHandler('./routes/chouti/top'));
+router.get('/chouti/:subject?', lazyloadRouteHandler('./routes/chouti'));
 
 // 西安电子科技大学
-router.get('/xidian/jwc/:category?', require('./routes/universities/xidian/jwc'));
+router.get('/xidian/jwc/:category?', lazyloadRouteHandler('./routes/universities/xidian/jwc'));
 
 // Westore
-router.get('/westore/new', require('./routes/westore/new'));
+router.get('/westore/new', lazyloadRouteHandler('./routes/westore/new'));
 
 // 优酷
-router.get('/youku/channel/:channelId/:embed?', require('./routes/youku/channel'));
+router.get('/youku/channel/:channelId/:embed?', lazyloadRouteHandler('./routes/youku/channel'));
 
 // 油价
-router.get('/oilprice/:area', require('./routes/oilprice'));
+router.get('/oilprice/:area', lazyloadRouteHandler('./routes/oilprice'));
 
 // nHentai
-router.get('/nhentai/search/:keyword/:mode?', require('./routes/nhentai/search'));
-router.get('/nhentai/:key/:keyword/:mode?', require('./routes/nhentai/other'));
+router.get('/nhentai/search/:keyword/:mode?', lazyloadRouteHandler('./routes/nhentai/search'));
+router.get('/nhentai/:key/:keyword/:mode?', lazyloadRouteHandler('./routes/nhentai/other'));
 
 // 龙腾网
-router.get('/ltaaa/:category?', require('./routes/ltaaa/index'));
+router.get('/ltaaa/:category?', lazyloadRouteHandler('./routes/ltaaa/index'));
 
 // AcFun
-router.get('/acfun/bangumi/:id', require('./routes/acfun/bangumi'));
-router.get('/acfun/user/video/:uid', require('./routes/acfun/video'));
+router.get('/acfun/bangumi/:id', lazyloadRouteHandler('./routes/acfun/bangumi'));
+router.get('/acfun/user/video/:uid', lazyloadRouteHandler('./routes/acfun/video'));
 
 // Auto Trader
-router.get('/autotrader/:query', require('./routes/autotrader'));
+router.get('/autotrader/:query', lazyloadRouteHandler('./routes/autotrader'));
 
 // 极客公园
-router.get('/geekpark/breakingnews', require('./routes/geekpark/breakingnews'));
+router.get('/geekpark/breakingnews', lazyloadRouteHandler('./routes/geekpark/breakingnews'));
 
 // 百度
-router.get('/baidu/doodles', require('./routes/baidu/doodles'));
-router.get('/baidu/topwords/:boardId?', require('./routes/baidu/topwords'));
-router.get('/baidu/daily', require('./routes/baidu/daily'));
+router.get('/baidu/doodles', lazyloadRouteHandler('./routes/baidu/doodles'));
+router.get('/baidu/topwords/:boardId?', lazyloadRouteHandler('./routes/baidu/topwords'));
+router.get('/baidu/daily', lazyloadRouteHandler('./routes/baidu/daily'));
 
 // 搜狗
-router.get('/sogou/doodles', require('./routes/sogou/doodles'));
+router.get('/sogou/doodles', lazyloadRouteHandler('./routes/sogou/doodles'));
 
 // 香港天文台
-router.get('/hko/weather', require('./routes/hko/weather'));
+router.get('/hko/weather', lazyloadRouteHandler('./routes/hko/weather'));
 
 // sankakucomplex
-router.get('/sankakucomplex/post', require('./routes/sankakucomplex/post'));
+router.get('/sankakucomplex/post', lazyloadRouteHandler('./routes/sankakucomplex/post'));
 
 // 技术头条
-router.get('/blogread/newest', require('./routes/blogread/newest'));
+router.get('/blogread/newest', lazyloadRouteHandler('./routes/blogread/newest'));
 
 // gnn游戏新闻
-router.get('/gnn/gnn', require('./routes/gnn/gnn'));
+router.get('/gnn/gnn', lazyloadRouteHandler('./routes/gnn/gnn'));
 
 // a9vg游戏新闻
-router.get('/a9vg/a9vg', require('./routes/a9vg/a9vg'));
+router.get('/a9vg/a9vg', lazyloadRouteHandler('./routes/a9vg/a9vg'));
 
 // IT桔子
-router.get('/itjuzi/invest', require('./routes/itjuzi/invest'));
-router.get('/itjuzi/merge', require('./routes/itjuzi/merge'));
+router.get('/itjuzi/invest', lazyloadRouteHandler('./routes/itjuzi/invest'));
+router.get('/itjuzi/merge', lazyloadRouteHandler('./routes/itjuzi/merge'));
 
 // 探物
-router.get('/tanwu/products', require('./routes/tanwu/products'));
+router.get('/tanwu/products', lazyloadRouteHandler('./routes/tanwu/products'));
 
 // GitChat
-router.get('/gitchat/newest/:category?/:selected?', require('./routes/gitchat/newest'));
+router.get('/gitchat/newest/:category?/:selected?', lazyloadRouteHandler('./routes/gitchat/newest'));
 
 // The Guardian
-router.get('/guardian/:type', require('./routes/guardian/guardian'));
+router.get('/guardian/:type', lazyloadRouteHandler('./routes/guardian/guardian'));
 
 // 下厨房
-router.get('/xiachufang/user/cooked/:id', require('./routes/xiachufang/user/cooked'));
-router.get('/xiachufang/user/created/:id', require('./routes/xiachufang/user/created'));
-router.get('/xiachufang/popular/:timeframe?', require('./routes/xiachufang/popular'));
+router.get('/xiachufang/user/cooked/:id', lazyloadRouteHandler('./routes/xiachufang/user/cooked'));
+router.get('/xiachufang/user/created/:id', lazyloadRouteHandler('./routes/xiachufang/user/created'));
+router.get('/xiachufang/popular/:timeframe?', lazyloadRouteHandler('./routes/xiachufang/popular'));
 
 // 经济观察报
-router.get('/eeo/:column?/:category?', require('./routes/eeo/index'));
+router.get('/eeo/:column?/:category?', lazyloadRouteHandler('./routes/eeo/index'));
 
 // 腾讯视频
-router.get('/tencentvideo/playlist/:id', require('./routes/tencent/video/playlist'));
+router.get('/tencentvideo/playlist/:id', lazyloadRouteHandler('./routes/tencent/video/playlist'));
 
 // 看漫画
-router.get('/manhuagui/comic/:id', require('./routes/manhuagui/comic'));
-router.get('/mhgui/comic/:id', require('./routes/mhgui/comic'));
-router.get('/twmanhuagui/comic/:id', require('./routes/twmanhuagui/comic'));
+router.get('/manhuagui/comic/:id', lazyloadRouteHandler('./routes/manhuagui/comic'));
+router.get('/mhgui/comic/:id', lazyloadRouteHandler('./routes/mhgui/comic'));
+router.get('/twmanhuagui/comic/:id', lazyloadRouteHandler('./routes/twmanhuagui/comic'));
 
 // 動漫狂
-router.get('/cartoonmad/comic/:id', require('./routes/cartoonmad/comic'));
+router.get('/cartoonmad/comic/:id', lazyloadRouteHandler('./routes/cartoonmad/comic'));
 // Vol
-router.get('/vol/:mode?', require('./routes/vol/lastupdate'));
+router.get('/vol/:mode?', lazyloadRouteHandler('./routes/vol/lastupdate'));
 // 咚漫
-router.get('/dongmanmanhua/:category/:name/:id', require('./routes/dongmanmanhua/comic'));
+router.get('/dongmanmanhua/:category/:name/:id', lazyloadRouteHandler('./routes/dongmanmanhua/comic'));
 // webtoons
-router.get('/webtoons/:lang/:category/:name/:id', require('./routes/webtoons/comic'));
-router.get('/webtoons/naver/:id', require('./routes/webtoons/naver'));
+router.get('/webtoons/:lang/:category/:name/:id', lazyloadRouteHandler('./routes/webtoons/comic'));
+router.get('/webtoons/naver/:id', lazyloadRouteHandler('./routes/webtoons/naver'));
 
 // Tits Guru
-router.get('/tits-guru/home', require('./routes/titsguru/home'));
-router.get('/tits-guru/daily', require('./routes/titsguru/daily'));
-router.get('/tits-guru/category/:type', require('./routes/titsguru/category'));
-router.get('/tits-guru/model/:name', require('./routes/titsguru/model'));
+router.get('/tits-guru/home', lazyloadRouteHandler('./routes/titsguru/home'));
+router.get('/tits-guru/daily', lazyloadRouteHandler('./routes/titsguru/daily'));
+router.get('/tits-guru/category/:type', lazyloadRouteHandler('./routes/titsguru/category'));
+router.get('/tits-guru/model/:name', lazyloadRouteHandler('./routes/titsguru/model'));
 
 // typora
-router.get('/typora/changelog', require('./routes/typora/changelog'));
-router.get('/typora/changelog-dev/:os?', require('./routes/typora/changelog-dev'));
+router.get('/typora/changelog', lazyloadRouteHandler('./routes/typora/changelog'));
+router.get('/typora/changelog-dev/:os?', lazyloadRouteHandler('./routes/typora/changelog-dev'));
 
 // TSSstatus
-router.get('/tssstatus/:board/:build', require('./routes/tssstatus'));
+router.get('/tssstatus/:board/:build', lazyloadRouteHandler('./routes/tssstatus'));
 
 // Anime1
-router.get('/anime1/anime/:time/:name', require('./routes/anime1/anime'));
-router.get('/anime1/search/:keyword', require('./routes/anime1/search'));
+router.get('/anime1/anime/:time/:name', lazyloadRouteHandler('./routes/anime1/anime'));
+router.get('/anime1/search/:keyword', lazyloadRouteHandler('./routes/anime1/search'));
 
 // Global UDN
-router.get('/udn/global/:tid', require('./routes/udn/global'));
+router.get('/udn/global/:tid', lazyloadRouteHandler('./routes/udn/global'));
 
 // gitea
-router.get('/gitea/blog', require('./routes/gitea/blog'));
+router.get('/gitea/blog', lazyloadRouteHandler('./routes/gitea/blog'));
 
 // iDownloadBlog
-router.get('/idownloadblog', require('./routes/idownloadblog/index'));
+router.get('/idownloadblog', lazyloadRouteHandler('./routes/idownloadblog/index'));
 
 // 9to5
-router.get('/9to5/:subsite/:tag?', require('./routes/9to5/subsite'));
+router.get('/9to5/:subsite/:tag?', lazyloadRouteHandler('./routes/9to5/subsite'));
 
 // TesterHome
-router.get('/testerhome/newest', require('./routes/testerhome/newest'));
+router.get('/testerhome/newest', lazyloadRouteHandler('./routes/testerhome/newest'));
 
 // 刷屏
-router.get('/weseepro/newest', require('./routes/weseepro/newest'));
-router.get('/weseepro/newest-direct', require('./routes/weseepro/newest-direct'));
-router.get('/weseepro/circle', require('./routes/weseepro/circle'));
+router.get('/weseepro/newest', lazyloadRouteHandler('./routes/weseepro/newest'));
+router.get('/weseepro/newest-direct', lazyloadRouteHandler('./routes/weseepro/newest-direct'));
+router.get('/weseepro/circle', lazyloadRouteHandler('./routes/weseepro/circle'));
 
 // 玩物志
-router.get('/coolbuy/newest', require('./routes/coolbuy/newest'));
+router.get('/coolbuy/newest', lazyloadRouteHandler('./routes/coolbuy/newest'));
 
 // MiniFlux
-router.get('/miniflux/subscription/:parameters?', require('./routes/miniflux/get_feeds'));
-router.get('/miniflux/:feeds/:parameters?', require('./routes/miniflux/get_entries'));
+router.get('/miniflux/subscription/:parameters?', lazyloadRouteHandler('./routes/miniflux/get_feeds'));
+router.get('/miniflux/:feeds/:parameters?', lazyloadRouteHandler('./routes/miniflux/get_entries'));
 
 // NGA
-router.get('/nga/forum/:fid/:recommend?', require('./routes/nga/forum'));
-router.get('/nga/post/:tid', require('./routes/nga/post'));
+router.get('/nga/forum/:fid/:recommend?', lazyloadRouteHandler('./routes/nga/forum'));
+router.get('/nga/post/:tid', lazyloadRouteHandler('./routes/nga/post'));
 
 // Nautilus
-router.get('/nautilus/topic/:tid', require('./routes/nautilus/topics'));
+router.get('/nautilus/topic/:tid', lazyloadRouteHandler('./routes/nautilus/topics'));
 
 // JavBus
-router.get('/javbus/home', require('./routes/javbus/home'));
-router.get('/javbus/genre/:gid', require('./routes/javbus/genre'));
-router.get('/javbus/star/:sid', require('./routes/javbus/star'));
-router.get('/javbus/series/:seriesid', require('./routes/javbus/series'));
-router.get('/javbus/uncensored/home', require('./routes/javbus/uncensored/home'));
-router.get('/javbus/uncensored/genre/:gid', require('./routes/javbus/uncensored/genre'));
-router.get('/javbus/uncensored/star/:sid', require('./routes/javbus/uncensored/star'));
-router.get('/javbus/uncensored/series/:seriesid', require('./routes/javbus/uncensored/series'));
-router.get('/javbus/western/home', require('./routes/javbus/western/home'));
-router.get('/javbus/western/genre/:gid', require('./routes/javbus/western/genre'));
-router.get('/javbus/western/star/:sid', require('./routes/javbus/western/star'));
-router.get('/javbus/western/series/:seriesid', require('./routes/javbus/western/series'));
+router.get('/javbus/home', lazyloadRouteHandler('./routes/javbus/home'));
+router.get('/javbus/genre/:gid', lazyloadRouteHandler('./routes/javbus/genre'));
+router.get('/javbus/star/:sid', lazyloadRouteHandler('./routes/javbus/star'));
+router.get('/javbus/series/:seriesid', lazyloadRouteHandler('./routes/javbus/series'));
+router.get('/javbus/uncensored/home', lazyloadRouteHandler('./routes/javbus/uncensored/home'));
+router.get('/javbus/uncensored/genre/:gid', lazyloadRouteHandler('./routes/javbus/uncensored/genre'));
+router.get('/javbus/uncensored/star/:sid', lazyloadRouteHandler('./routes/javbus/uncensored/star'));
+router.get('/javbus/uncensored/series/:seriesid', lazyloadRouteHandler('./routes/javbus/uncensored/series'));
+router.get('/javbus/western/home', lazyloadRouteHandler('./routes/javbus/western/home'));
+router.get('/javbus/western/genre/:gid', lazyloadRouteHandler('./routes/javbus/western/genre'));
+router.get('/javbus/western/star/:sid', lazyloadRouteHandler('./routes/javbus/western/star'));
+router.get('/javbus/western/series/:seriesid', lazyloadRouteHandler('./routes/javbus/western/series'));
 
 // 中山大学
-router.get('/sysu/sdcs', require('./routes/universities/sysu/sdcs'));
+router.get('/sysu/sdcs', lazyloadRouteHandler('./routes/universities/sysu/sdcs'));
 
 // 動畫瘋
-router.get('/anigamer/new_anime', require('./routes/anigamer/new_anime'));
-router.get('/anigamer/anime/:sn', require('./routes/anigamer/anime'));
+router.get('/anigamer/new_anime', lazyloadRouteHandler('./routes/anigamer/new_anime'));
+router.get('/anigamer/anime/:sn', lazyloadRouteHandler('./routes/anigamer/anime'));
 
 // Apkpure
-router.get('/apkpure/versions/:region/:pkg', require('./routes/apkpure/versions'));
+router.get('/apkpure/versions/:region/:pkg', lazyloadRouteHandler('./routes/apkpure/versions'));
 
 // 豆瓣美女
-router.get('/dbmv/:category?', require('./routes/dbmv/index'));
+router.get('/dbmv/:category?', lazyloadRouteHandler('./routes/dbmv/index'));
 
 // 中国药科大学
-router.get('/cpu/home', require('./routes/universities/cpu/home'));
-router.get('/cpu/jwc', require('./routes/universities/cpu/jwc'));
-router.get('/cpu/yjsy', require('./routes/universities/cpu/yjsy'));
+router.get('/cpu/home', lazyloadRouteHandler('./routes/universities/cpu/home'));
+router.get('/cpu/jwc', lazyloadRouteHandler('./routes/universities/cpu/jwc'));
+router.get('/cpu/yjsy', lazyloadRouteHandler('./routes/universities/cpu/yjsy'));
 
 // 字幕组
-router.get('/zimuzu/resource/:id?', require('./routes/zimuzu/resource'));
-router.get('/zimuzu/top/:range/:type', require('./routes/zimuzu/top'));
+router.get('/zimuzu/resource/:id?', lazyloadRouteHandler('./routes/zimuzu/resource'));
+router.get('/zimuzu/top/:range/:type', lazyloadRouteHandler('./routes/zimuzu/top'));
 
 // 字幕库
-router.get('/zimuku/:type?', require('./routes/zimuku/index'));
+router.get('/zimuku/:type?', lazyloadRouteHandler('./routes/zimuku/index'));
 
 // SubHD.tv
-router.get('/subhd/newest', require('./routes/subhd/newest'));
+router.get('/subhd/newest', lazyloadRouteHandler('./routes/subhd/newest'));
 
 // 虎嗅
-router.get('/huxiu/tag/:id', require('./routes/huxiu/tag'));
-router.get('/huxiu/search/:keyword', require('./routes/huxiu/search'));
-router.get('/huxiu/author/:id', require('./routes/huxiu/author'));
-router.get('/huxiu/article', require('./routes/huxiu/article'));
-router.get('/huxiu/collection/:id', require('./routes/huxiu/collection'));
+router.get('/huxiu/tag/:id', lazyloadRouteHandler('./routes/huxiu/tag'));
+router.get('/huxiu/search/:keyword', lazyloadRouteHandler('./routes/huxiu/search'));
+router.get('/huxiu/author/:id', lazyloadRouteHandler('./routes/huxiu/author'));
+router.get('/huxiu/article', lazyloadRouteHandler('./routes/huxiu/article'));
+router.get('/huxiu/collection/:id', lazyloadRouteHandler('./routes/huxiu/collection'));
 
 // Steam
-router.get('/steam/search/:params', require('./routes/steam/search'));
+router.get('/steam/search/:params', lazyloadRouteHandler('./routes/steam/search'));
 
 // Steamgifts
-router.get('/steamgifts/discussions/:category?', require('./routes/steam/steamgifts/discussions'));
+router.get('/steamgifts/discussions/:category?', lazyloadRouteHandler('./routes/steam/steamgifts/discussions'));
 
 // 扇贝
-router.get('/shanbay/checkin/:id', require('./routes/shanbay/checkin'));
-router.get('/shanbay/footprints/:category?', require('./routes/shanbay/footprints'));
+router.get('/shanbay/checkin/:id', lazyloadRouteHandler('./routes/shanbay/checkin'));
+router.get('/shanbay/footprints/:category?', lazyloadRouteHandler('./routes/shanbay/footprints'));
 
 // Facebook
-router.get('/facebook/page/:id', require('./routes/facebook/page'));
+router.get('/facebook/page/:id', lazyloadRouteHandler('./routes/facebook/page'));
 
 // 币乎
-router.get('/bihu/activaties/:id', require('./routes/bihu/activaties'));
+router.get('/bihu/activaties/:id', lazyloadRouteHandler('./routes/bihu/activaties'));
 
 // 停电通知
-router.get('/tingdiantz/nanjing', require('./routes/tingdiantz/nanjing'));
-router.get('/tingdiantz/95598/:province/:city/:district?', require('./routes/tingdiantz/95598'));
+router.get('/tingdiantz/nanjing', lazyloadRouteHandler('./routes/tingdiantz/nanjing'));
+router.get('/tingdiantz/95598/:province/:city/:district?', lazyloadRouteHandler('./routes/tingdiantz/95598'));
 
 // 36kr
-router.get('/36kr/search/article/:keyword', require('./routes/36kr/search/article'));
-router.get('/36kr/newsflashes', require('./routes/36kr/newsflashes'));
-router.get('/36kr/news/:caty', require('./routes/36kr/news'));
-router.get('/36kr/user/:uid', require('./routes/36kr/user'));
-router.get('/36kr/motif/:mid', require('./routes/36kr/motif'));
+router.get('/36kr/search/article/:keyword', lazyloadRouteHandler('./routes/36kr/search/article'));
+router.get('/36kr/newsflashes', lazyloadRouteHandler('./routes/36kr/newsflashes'));
+router.get('/36kr/news/:caty', lazyloadRouteHandler('./routes/36kr/news'));
+router.get('/36kr/user/:uid', lazyloadRouteHandler('./routes/36kr/user'));
+router.get('/36kr/motif/:mid', lazyloadRouteHandler('./routes/36kr/motif'));
 
 // PMCAFF
-router.get('/pmcaff/list/:typeid', require('./routes/pmcaff/list'));
-router.get('/pmcaff/feed/:typeid', require('./routes/pmcaff/feed'));
-router.get('/pmcaff/user/:userid', require('./routes/pmcaff/user'));
+router.get('/pmcaff/list/:typeid', lazyloadRouteHandler('./routes/pmcaff/list'));
+router.get('/pmcaff/feed/:typeid', lazyloadRouteHandler('./routes/pmcaff/feed'));
+router.get('/pmcaff/user/:userid', lazyloadRouteHandler('./routes/pmcaff/user'));
 
 // icourse163
-router.get('/icourse163/newest', require('./routes/icourse163/newest'));
+router.get('/icourse163/newest', lazyloadRouteHandler('./routes/icourse163/newest'));
 
 // patchwork.kernel.org
-router.get('/patchwork.kernel.org/comments/:id', require('./routes/patchwork.kernel.org/comments'));
+router.get('/patchwork.kernel.org/comments/:id', lazyloadRouteHandler('./routes/patchwork.kernel.org/comments'));
 
 // 京东众筹
-router.get('/jingdong/zhongchou/:type/:status/:sort', require('./routes/jingdong/zhongchou'));
+router.get('/jingdong/zhongchou/:type/:status/:sort', lazyloadRouteHandler('./routes/jingdong/zhongchou'));
 
 // 淘宝众筹
-router.get('/taobao/zhongchou/:type?', require('./routes/taobao/zhongchou'));
+router.get('/taobao/zhongchou/:type?', lazyloadRouteHandler('./routes/taobao/zhongchou'));
 
 // All Poetry
-router.get('/allpoetry/:order?', require('./routes/allpoetry/order'));
+router.get('/allpoetry/:order?', lazyloadRouteHandler('./routes/allpoetry/order'));
 
 // 华尔街见闻
-router.get('/wallstreetcn/news/global', require('./routes/wallstreetcn/news'));
-router.get('/wallstreetcn/live/:channel?', require('./routes/wallstreetcn/live'));
+router.get('/wallstreetcn/news/global', lazyloadRouteHandler('./routes/wallstreetcn/news'));
+router.get('/wallstreetcn/live/:channel?', lazyloadRouteHandler('./routes/wallstreetcn/live'));
 
 // 多抓鱼搜索
-router.get('/duozhuayu/search/:wd', require('./routes/duozhuayu/search'));
+router.get('/duozhuayu/search/:wd', lazyloadRouteHandler('./routes/duozhuayu/search'));
 
 // 创业邦
-router.get('/cyzone/author/:id', require('./routes/cyzone/author'));
-router.get('/cyzone/label/:name', require('./routes/cyzone/label'));
+router.get('/cyzone/author/:id', lazyloadRouteHandler('./routes/cyzone/author'));
+router.get('/cyzone/label/:name', lazyloadRouteHandler('./routes/cyzone/label'));
 
 // 政府
-router.get('/gov/zhengce/zuixin', require('./routes/gov/zhengce/zuixin'));
-router.get('/gov/zhengce/wenjian/:pcodeJiguan?', require('./routes/gov/zhengce/wenjian'));
-router.get('/gov/zhengce/govall/:advance?', require('./routes/gov/zhengce/govall'));
-router.get('/gov/province/:name/:category', require('./routes/gov/province'));
-router.get('/gov/city/:name/:category', require('./routes/gov/city'));
-router.get('/gov/statecouncil/briefing', require('./routes/gov/statecouncil/briefing'));
-router.get('/gov/news/:uid', require('./routes/gov/news'));
-router.get('/gov/shuju/:caty/:item', require('./routes/gov/shuju'));
-router.get('/gov/xinwen/tujie/:caty', require('./routes/gov/xinwen/tujie'));
+router.get('/gov/zhengce/zuixin', lazyloadRouteHandler('./routes/gov/zhengce/zuixin'));
+router.get('/gov/zhengce/wenjian/:pcodeJiguan?', lazyloadRouteHandler('./routes/gov/zhengce/wenjian'));
+router.get('/gov/zhengce/govall/:advance?', lazyloadRouteHandler('./routes/gov/zhengce/govall'));
+router.get('/gov/province/:name/:category', lazyloadRouteHandler('./routes/gov/province'));
+router.get('/gov/city/:name/:category', lazyloadRouteHandler('./routes/gov/city'));
+router.get('/gov/statecouncil/briefing', lazyloadRouteHandler('./routes/gov/statecouncil/briefing'));
+router.get('/gov/news/:uid', lazyloadRouteHandler('./routes/gov/news'));
+router.get('/gov/shuju/:caty/:item', lazyloadRouteHandler('./routes/gov/shuju'));
+router.get('/gov/xinwen/tujie/:caty', lazyloadRouteHandler('./routes/gov/xinwen/tujie'));
 
 // 苏州
-router.get('/gov/suzhou/news/:uid', require('./routes/gov/suzhou/news'));
-router.get('/gov/suzhou/doc', require('./routes/gov/suzhou/doc'));
+router.get('/gov/suzhou/news/:uid', lazyloadRouteHandler('./routes/gov/suzhou/news'));
+router.get('/gov/suzhou/doc', lazyloadRouteHandler('./routes/gov/suzhou/doc'));
 
 // 江苏
-router.get('/gov/jiangsu/eea/:type?', require('./routes/gov/jiangsu/eea'));
+router.get('/gov/jiangsu/eea/:type?', lazyloadRouteHandler('./routes/gov/jiangsu/eea'));
 
 // 山西
-router.get('/gov/shanxi/rst/:category', require('./routes/gov/shanxi/rst'));
+router.get('/gov/shanxi/rst/:category', lazyloadRouteHandler('./routes/gov/shanxi/rst'));
 
 // 湖南
-router.get('/gov/hunan/notice/:type', require('./routes/gov/hunan/notice'));
+router.get('/gov/hunan/notice/:type', lazyloadRouteHandler('./routes/gov/hunan/notice'));
 
 // 中华人民共和国国家发展和改革委员会
-router.get('/gov/ndrc/xwdt/:caty?', require('./routes/gov/ndrc/xwdt'));
+router.get('/gov/ndrc/xwdt/:caty?', lazyloadRouteHandler('./routes/gov/ndrc/xwdt'));
 
 // 中华人民共和国-海关总署
-router.get('/gov/customs/list/:gchannel', require('./routes/gov/customs/list'));
+router.get('/gov/customs/list/:gchannel', lazyloadRouteHandler('./routes/gov/customs/list'));
 
 // 中华人民共和国生态环境部
-router.get('/gov/mee/gs', require('./routes/gov/mee/gs'));
+router.get('/gov/mee/gs', lazyloadRouteHandler('./routes/gov/mee/gs'));
 
 // 中华人民共和国教育部
-router.get('/gov/moe/:type', require('./routes/gov/moe/moe'));
+router.get('/gov/moe/:type', lazyloadRouteHandler('./routes/gov/moe/moe'));
 
 // 中华人民共和国外交部
-router.get('/gov/fmprc/fyrbt', require('./routes/gov/fmprc/fyrbt'));
+router.get('/gov/fmprc/fyrbt', lazyloadRouteHandler('./routes/gov/fmprc/fyrbt'));
 
 // 中华人民共和国住房和城乡建设部
-router.get('/gov/mohurd/policy', require('./routes/gov/mohurd/policy'));
+router.get('/gov/mohurd/policy', lazyloadRouteHandler('./routes/gov/mohurd/policy'));
 
 // 国家新闻出版广电总局
-router.get('/gov/sapprft/approval/:channel/:detail?', require('./routes/gov/sapprft/7026'));
+router.get('/gov/sapprft/approval/:channel/:detail?', lazyloadRouteHandler('./routes/gov/sapprft/7026'));
 
 // 国家新闻出版署
-router.get('/gov/nppa/:channel', require('./routes/gov/nppa/channels'));
-router.get('/gov/nppa/:channel/:content', require('./routes/gov/nppa/contents'));
+router.get('/gov/nppa/:channel', lazyloadRouteHandler('./routes/gov/nppa/channels'));
+router.get('/gov/nppa/:channel/:content', lazyloadRouteHandler('./routes/gov/nppa/contents'));
 
 // 北京卫生健康委员会
-router.get('/gov/beijing/mhc/:caty', require('./routes/gov/beijing/mhc'));
+router.get('/gov/beijing/mhc/:caty', lazyloadRouteHandler('./routes/gov/beijing/mhc'));
 
 // 北京考试院
-router.get('/gov/beijing/bjeea/:type', require('./routes/gov/beijing/eea'));
+router.get('/gov/beijing/bjeea/:type', lazyloadRouteHandler('./routes/gov/beijing/eea'));
 
 // 广东省教育厅
-router.get('/gov/guangdong/edu/:caty', require('./routes/gov/guangdong/edu'));
+router.get('/gov/guangdong/edu/:caty', lazyloadRouteHandler('./routes/gov/guangdong/edu'));
 
 // 广东省教育考试院
-router.get('/gov/guangdong/eea/:caty', require('./routes/gov/guangdong/eea'));
+router.get('/gov/guangdong/eea/:caty', lazyloadRouteHandler('./routes/gov/guangdong/eea'));
 
 // 广东省深圳市
-router.get('/gov/shenzhen/xxgk/zfxxgj/:caty', require('./routes/gov/shenzhen/xxgk/zfxxgj'));
+router.get('/gov/shenzhen/xxgk/zfxxgj/:caty', lazyloadRouteHandler('./routes/gov/shenzhen/xxgk/zfxxgj'));
 
 // 日本国外務省記者会見
-router.get('/go.jp/mofa', require('./routes/go.jp/mofa/main'));
+router.get('/go.jp/mofa', lazyloadRouteHandler('./routes/go.jp/mofa/main'));
 
 // 小黑盒
-router.get('/xiaoheihe/user/:id', require('./routes/xiaoheihe/user'));
-router.get('/xiaoheihe/news', require('./routes/xiaoheihe/news'));
-router.get('/xiaoheihe/discount/:platform?', require('./routes/xiaoheihe/discount'));
+router.get('/xiaoheihe/user/:id', lazyloadRouteHandler('./routes/xiaoheihe/user'));
+router.get('/xiaoheihe/news', lazyloadRouteHandler('./routes/xiaoheihe/news'));
+router.get('/xiaoheihe/discount/:platform?', lazyloadRouteHandler('./routes/xiaoheihe/discount'));
 
 // 惠誉评级
-router.get('/fitchratings/site/:type', require('./routes/fitchratings/site'));
+router.get('/fitchratings/site/:type', lazyloadRouteHandler('./routes/fitchratings/site'));
 
 // 移动支付
-router.get('/mpaypass/news', require('./routes/mpaypass/news'));
-router.get('/mpaypass/main/:type?', require('./routes/mpaypass/main'));
+router.get('/mpaypass/news', lazyloadRouteHandler('./routes/mpaypass/news'));
+router.get('/mpaypass/main/:type?', lazyloadRouteHandler('./routes/mpaypass/main'));
 
 // 新浪科技探索
-router.get('/sina/discovery/:type', require('./routes/sina/discovery'));
+router.get('/sina/discovery/:type', lazyloadRouteHandler('./routes/sina/discovery'));
 
 // 新浪科技滚动新闻
-router.get('/sina/rollnews', require('./routes/sina/rollnews'));
+router.get('/sina/rollnews', lazyloadRouteHandler('./routes/sina/rollnews'));
 
 // 新浪体育
-router.get('/sina/sports/:type', require('./routes/sina/sports'));
+router.get('/sina/sports/:type', lazyloadRouteHandler('./routes/sina/sports'));
 
 // 新浪专栏创事记
-router.get('/sina/csj', require('./routes/sina/chuangshiji'));
+router.get('/sina/csj', lazyloadRouteHandler('./routes/sina/chuangshiji'));
 
 // 新浪财经－国內
-router.get('/sina/finance', require('./routes/sina/finance'));
+router.get('/sina/finance', lazyloadRouteHandler('./routes/sina/finance'));
 
 // Animen
-router.get('/animen/news/:type', require('./routes/animen/news'));
+router.get('/animen/news/:type', lazyloadRouteHandler('./routes/animen/news'));
 
 // D2 资源库
-router.get('/d2/daily', require('./routes/d2/daily'));
+router.get('/d2/daily', lazyloadRouteHandler('./routes/d2/daily'));
 
 // ebb
-router.get('/ebb', require('./routes/ebb'));
+router.get('/ebb', lazyloadRouteHandler('./routes/ebb'));
 
 // Indienova
-router.get('/indienova/:type', require('./routes/indienova/article'));
+router.get('/indienova/:type', lazyloadRouteHandler('./routes/indienova/article'));
 
 // JPMorgan Chase Institute
-router.get('/jpmorganchase', require('./routes/jpmorganchase/research'));
+router.get('/jpmorganchase', lazyloadRouteHandler('./routes/jpmorganchase/research'));
 
 // 美拍
-router.get('/meipai/user/:uid', require('./routes/meipai/user'));
+router.get('/meipai/user/:uid', lazyloadRouteHandler('./routes/meipai/user'));
 
 // 多知网
-router.get('/duozhi', require('./routes/duozhi'));
+router.get('/duozhi', lazyloadRouteHandler('./routes/duozhi'));
 
 // Docker Hub
-router.get('/dockerhub/build/:owner/:image/:tag?', require('./routes/dockerhub/build'));
+router.get('/dockerhub/build/:owner/:image/:tag?', lazyloadRouteHandler('./routes/dockerhub/build'));
 
 // 人人都是产品经理
-router.get('/woshipm/popular', require('./routes/woshipm/popular'));
-router.get('/woshipm/wen', require('./routes/woshipm/wen'));
-router.get('/woshipm/bookmarks/:id', require('./routes/woshipm/bookmarks'));
-router.get('/woshipm/user_article/:id', require('./routes/woshipm/user_article'));
-router.get('/woshipm/latest', require('./routes/woshipm/latest'));
+router.get('/woshipm/popular', lazyloadRouteHandler('./routes/woshipm/popular'));
+router.get('/woshipm/wen', lazyloadRouteHandler('./routes/woshipm/wen'));
+router.get('/woshipm/bookmarks/:id', lazyloadRouteHandler('./routes/woshipm/bookmarks'));
+router.get('/woshipm/user_article/:id', lazyloadRouteHandler('./routes/woshipm/user_article'));
+router.get('/woshipm/latest', lazyloadRouteHandler('./routes/woshipm/latest'));
 
 // 高清电台
-router.get('/gaoqing/latest', require('./routes/gaoqing/latest'));
+router.get('/gaoqing/latest', lazyloadRouteHandler('./routes/gaoqing/latest'));
 
 // 轻小说文库
-router.get('/wenku8/chapter/:id', require('./routes/wenku8/chapter'));
+router.get('/wenku8/chapter/:id', lazyloadRouteHandler('./routes/wenku8/chapter'));
 
 // 鲸跃汽车
-router.get('/whalegogo/home', require('./routes/whalegogo/home'));
-router.get('/whalegogo/portal/:type_id/:tagid?', require('./routes/whalegogo/portal'));
+router.get('/whalegogo/home', lazyloadRouteHandler('./routes/whalegogo/home'));
+router.get('/whalegogo/portal/:type_id/:tagid?', lazyloadRouteHandler('./routes/whalegogo/portal'));
 
 // 爱思想
-router.get('/aisixiang/column/:id', require('./routes/aisixiang/column'));
-router.get('/aisixiang/ranking/:type?/:range?', require('./routes/aisixiang/ranking'));
-router.get('/aisixiang/thinktank/:name/:type?', require('./routes/aisixiang/thinktank'));
+router.get('/aisixiang/column/:id', lazyloadRouteHandler('./routes/aisixiang/column'));
+router.get('/aisixiang/ranking/:type?/:range?', lazyloadRouteHandler('./routes/aisixiang/ranking'));
+router.get('/aisixiang/thinktank/:name/:type?', lazyloadRouteHandler('./routes/aisixiang/thinktank'));
 
 // Hacker News
-router.get('/hackernews/:section/:type?', require('./routes/hackernews/story'));
+router.get('/hackernews/:section/:type?', lazyloadRouteHandler('./routes/hackernews/story'));
 
 // LeetCode
-router.get('/leetcode/articles', require('./routes/leetcode/articles'));
-router.get('/leetcode/submission/us/:user', require('./routes/leetcode/check-us'));
-router.get('/leetcode/submission/cn/:user', require('./routes/leetcode/check-cn'));
+router.get('/leetcode/articles', lazyloadRouteHandler('./routes/leetcode/articles'));
+router.get('/leetcode/submission/us/:user', lazyloadRouteHandler('./routes/leetcode/check-us'));
+router.get('/leetcode/submission/cn/:user', lazyloadRouteHandler('./routes/leetcode/check-cn'));
 
 // segmentfault
-router.get('/segmentfault/channel/:name', require('./routes/segmentfault/channel'));
-router.get('/segmentfault/user/:name', require('./routes/segmentfault/user'));
+router.get('/segmentfault/channel/:name', lazyloadRouteHandler('./routes/segmentfault/channel'));
+router.get('/segmentfault/user/:name', lazyloadRouteHandler('./routes/segmentfault/user'));
 
 // 虎扑
-router.get('/hupu/bxj/:id/:order?', require('./routes/hupu/bbs'));
-router.get('/hupu/bbs/:id/:order?', require('./routes/hupu/bbs'));
-router.get('/hupu/all/:caty', require('./routes/hupu/all'));
-router.get('/hupu/dept/:dept', require('./routes/hupu/dept'));
+router.get('/hupu/bxj/:id/:order?', lazyloadRouteHandler('./routes/hupu/bbs'));
+router.get('/hupu/bbs/:id/:order?', lazyloadRouteHandler('./routes/hupu/bbs'));
+router.get('/hupu/all/:caty', lazyloadRouteHandler('./routes/hupu/all'));
+router.get('/hupu/dept/:dept', lazyloadRouteHandler('./routes/hupu/dept'));
 
 // 牛客网
-router.get('/nowcoder/discuss/:type/:order', require('./routes/nowcoder/discuss'));
-router.get('/nowcoder/schedule/:propertyId?/:typeId?', require('./routes/nowcoder/schedule'));
-router.get('/nowcoder/recommend', require('./routes/nowcoder/recommend'));
-router.get('/nowcoder/jobcenter/:recruitType?/:city?/:type?/:order?/:latest?', require('./routes/nowcoder/jobcenter'));
+router.get('/nowcoder/discuss/:type/:order', lazyloadRouteHandler('./routes/nowcoder/discuss'));
+router.get('/nowcoder/schedule/:propertyId?/:typeId?', lazyloadRouteHandler('./routes/nowcoder/schedule'));
+router.get('/nowcoder/recommend', lazyloadRouteHandler('./routes/nowcoder/recommend'));
+router.get('/nowcoder/jobcenter/:recruitType?/:city?/:type?/:order?/:latest?', lazyloadRouteHandler('./routes/nowcoder/jobcenter'));
 
 // Xiaomi.eu
-router.get('/xiaomieu/releases', require('./routes/xiaomieu/releases'));
+router.get('/xiaomieu/releases', lazyloadRouteHandler('./routes/xiaomieu/releases'));
 
 // sketch.com
-router.get('/sketch/beta', require('./routes/sketch/beta'));
-router.get('/sketch/updates', require('./routes/sketch/updates'));
+router.get('/sketch/beta', lazyloadRouteHandler('./routes/sketch/beta'));
+router.get('/sketch/updates', lazyloadRouteHandler('./routes/sketch/updates'));
 
 // 每日安全
-router.get('/security/pulses', require('./routes/security/pulses'));
+router.get('/security/pulses', lazyloadRouteHandler('./routes/security/pulses'));
 
 // DoNews
-router.get('/donews/:column?', require('./routes/donews/index'));
+router.get('/donews/:column?', lazyloadRouteHandler('./routes/donews/index'));
 
 // WeGene
-router.get('/wegene/column/:type/:category', require('./routes/wegene/column'));
-router.get('/wegene/newest', require('./routes/wegene/newest'));
+router.get('/wegene/column/:type/:category', lazyloadRouteHandler('./routes/wegene/column'));
+router.get('/wegene/newest', lazyloadRouteHandler('./routes/wegene/newest'));
 
 // instapaper
-router.get('/instapaper/person/:name', require('./routes/instapaper/person'));
+router.get('/instapaper/person/:name', lazyloadRouteHandler('./routes/instapaper/person'));
 
 // UI 中国
-router.get('/ui-cn/article', require('./routes/ui-cn/article'));
-router.get('/ui-cn/user/:id', require('./routes/ui-cn/user'));
+router.get('/ui-cn/article', lazyloadRouteHandler('./routes/ui-cn/article'));
+router.get('/ui-cn/user/:id', lazyloadRouteHandler('./routes/ui-cn/user'));
 
 // Dcard
-router.get('/dcard/:section/:type?', require('./routes/dcard/section'));
+router.get('/dcard/:section/:type?', lazyloadRouteHandler('./routes/dcard/section'));
 
 // 12306
-router.get('/12306/zxdt/:id?', require('./routes/12306/zxdt'));
+router.get('/12306/zxdt/:id?', lazyloadRouteHandler('./routes/12306/zxdt'));
 
 // 北京天文馆每日一图
-router.get('/bjp/apod', require('./routes/bjp/apod'));
+router.get('/bjp/apod', lazyloadRouteHandler('./routes/bjp/apod'));
 
 // 洛谷
-router.get('/luogu/daily/:id?', require('./routes/luogu/daily'));
-router.get('/luogu/contest', require('./routes/luogu/contest'));
-router.get('/luogu/user/feed/:uid', require('./routes/luogu/userFeed'));
+router.get('/luogu/daily/:id?', lazyloadRouteHandler('./routes/luogu/daily'));
+router.get('/luogu/contest', lazyloadRouteHandler('./routes/luogu/contest'));
+router.get('/luogu/user/feed/:uid', lazyloadRouteHandler('./routes/luogu/userFeed'));
 
 // 决胜网
-router.get('/juesheng', require('./routes/juesheng'));
+router.get('/juesheng', lazyloadRouteHandler('./routes/juesheng'));
 
 // 播客IBCラジオ イヤーマイッタマイッタ
-router.get('/maitta', require('./routes/maitta'));
+router.get('/maitta', lazyloadRouteHandler('./routes/maitta'));
 
 // 一些博客
 // 敬维-以认真的态度做完美的事情: https://jingwei.link/
-router.get('/blogs/jingwei.link', require('./routes/blogs/jingwei_link'));
+router.get('/blogs/jingwei.link', lazyloadRouteHandler('./routes/blogs/jingwei_link'));
 
 // 王垠的博客-当然我在扯淡
-router.get('/blogs/wangyin', require('./routes/blogs/wangyin'));
+router.get('/blogs/wangyin', lazyloadRouteHandler('./routes/blogs/wangyin'));
 
 // 王五四文集
-router.get('/blogs/wang54/:id?', require('./routes/blogs/wang54'));
+router.get('/blogs/wang54/:id?', lazyloadRouteHandler('./routes/blogs/wang54'));
 
 // WordPress
-router.get('/blogs/wordpress/:domain/:https?', require('./routes/blogs/wordpress'));
+router.get('/blogs/wordpress/:domain/:https?', lazyloadRouteHandler('./routes/blogs/wordpress'));
 
 // 裏垢女子まとめ
-router.get('/uraaka-joshi', require('./routes/uraaka-joshi/uraaka-joshi'));
-router.get('/uraaka-joshi/:id', require('./routes/uraaka-joshi/uraaka-joshi-user'));
+router.get('/uraaka-joshi', lazyloadRouteHandler('./routes/uraaka-joshi/uraaka-joshi'));
+router.get('/uraaka-joshi/:id', lazyloadRouteHandler('./routes/uraaka-joshi/uraaka-joshi-user'));
 
 // 西祠胡同
-router.get('/xici/:id?', require('./routes/xici'));
+router.get('/xici/:id?', lazyloadRouteHandler('./routes/xici'));
 
 // 淘股吧论坛
-router.get('/taoguba/index', require('./routes/taoguba/index'));
-router.get('/taoguba/user/:uid', require('./routes/taoguba/user'));
+router.get('/taoguba/index', lazyloadRouteHandler('./routes/taoguba/index'));
+router.get('/taoguba/user/:uid', lazyloadRouteHandler('./routes/taoguba/user'));
 
 // 今日热榜
-router.get('/tophub/:id', require('./routes/tophub'));
+router.get('/tophub/:id', lazyloadRouteHandler('./routes/tophub'));
 
 // 游戏时光
-router.get('/vgtime/news', require('./routes/vgtime/news.js'));
-router.get('/vgtime/release', require('./routes/vgtime/release'));
-router.get('/vgtime/keyword/:keyword', require('./routes/vgtime/keyword'));
+router.get('/vgtime/news', lazyloadRouteHandler('./routes/vgtime/news.js'));
+router.get('/vgtime/release', lazyloadRouteHandler('./routes/vgtime/release'));
+router.get('/vgtime/keyword/:keyword', lazyloadRouteHandler('./routes/vgtime/keyword'));
 
 // MP4吧
-router.get('/mp4ba/:param', require('./routes/mp4ba'));
+router.get('/mp4ba/:param', lazyloadRouteHandler('./routes/mp4ba'));
 
 // anitama
-router.get('/anitama/:channel?', require('./routes/anitama/channel'));
+router.get('/anitama/:channel?', lazyloadRouteHandler('./routes/anitama/channel'));
 
 // 親子王國
-router.get('/babykingdom/:id/:order?', require('./routes/babykingdom'));
+router.get('/babykingdom/:id/:order?', lazyloadRouteHandler('./routes/babykingdom'));
 
 // 四川大学
-router.get('/scu/jwc/notice', require('./routes/universities/scu/jwc'));
-router.get('/scu/xg/notice', require('./routes/universities/scu/xg'));
+router.get('/scu/jwc/notice', lazyloadRouteHandler('./routes/universities/scu/jwc'));
+router.get('/scu/xg/notice', lazyloadRouteHandler('./routes/universities/scu/xg'));
 
 // 浙江工商大学
-router.get('/zjgsu/tzgg', require('./routes/universities/zjgsu/tzgg/scripts'));
-router.get('/zjgsu/gsgg', require('./routes/universities/zjgsu/gsgg/scripts'));
-router.get('/zjgsu/xszq', require('./routes/universities/zjgsu/xszq/scripts'));
+router.get('/zjgsu/tzgg', lazyloadRouteHandler('./routes/universities/zjgsu/tzgg/scripts'));
+router.get('/zjgsu/gsgg', lazyloadRouteHandler('./routes/universities/zjgsu/gsgg/scripts'));
+router.get('/zjgsu/xszq', lazyloadRouteHandler('./routes/universities/zjgsu/xszq/scripts'));
 
 // 大众点评
-router.get('/dianping/user/:id?', require('./routes/dianping/user'));
+router.get('/dianping/user/:id?', lazyloadRouteHandler('./routes/dianping/user'));
 
 // 半月谈
-router.get('/banyuetan/byt/:time?', require('./routes/banyuetan/byt'));
-router.get('/banyuetan/:name', require('./routes/banyuetan'));
+router.get('/banyuetan/byt/:time?', lazyloadRouteHandler('./routes/banyuetan/byt'));
+router.get('/banyuetan/:name', lazyloadRouteHandler('./routes/banyuetan'));
 
 // 人民日报
-router.get('/people/opinion/:id', require('./routes/people/opinion'));
-router.get('/people/env/:id', require('./routes/people/env'));
-router.get('/people/xjpjh/:keyword?/:year?', require('./routes/people/xjpjh'));
-router.get('/people/cpc/24h', require('./routes/people/cpc/24h'));
+router.get('/people/opinion/:id', lazyloadRouteHandler('./routes/people/opinion'));
+router.get('/people/env/:id', lazyloadRouteHandler('./routes/people/env'));
+router.get('/people/xjpjh/:keyword?/:year?', lazyloadRouteHandler('./routes/people/xjpjh'));
+router.get('/people/cpc/24h', lazyloadRouteHandler('./routes/people/cpc/24h'));
 
 // 北极星电力网
-router.get('/bjx/huanbao', require('./routes/bjx/huanbao'));
+router.get('/bjx/huanbao', lazyloadRouteHandler('./routes/bjx/huanbao'));
 
 // gamersky
-router.get('/gamersky/news', require('./routes/gamersky/news'));
-router.get('/gamersky/ent/:category', require('./routes/gamersky/ent'));
+router.get('/gamersky/news', lazyloadRouteHandler('./routes/gamersky/news'));
+router.get('/gamersky/ent/:category', lazyloadRouteHandler('./routes/gamersky/ent'));
 
 // 游研社
-router.get('/yystv/category/:category', require('./routes/yystv/category'));
-router.get('/yystv/docs', require('./routes/yystv/docs'));
+router.get('/yystv/category/:category', lazyloadRouteHandler('./routes/yystv/category'));
+router.get('/yystv/docs', lazyloadRouteHandler('./routes/yystv/docs'));
 
 // konami
-router.get('/konami/pesmobile/:lang?/:os?', require('./routes/konami/pesmobile'));
+router.get('/konami/pesmobile/:lang?/:os?', lazyloadRouteHandler('./routes/konami/pesmobile'));
 
 // psnine
-router.get('/psnine/index', require('./routes/psnine/index'));
-router.get('/psnine/shuzhe', require('./routes/psnine/shuzhe'));
-router.get('/psnine/trade', require('./routes/psnine/trade'));
-router.get('/psnine/game', require('./routes/psnine/game'));
-router.get('/psnine/news/:order?', require('./routes/psnine/news'));
-router.get('/psnine/node/:id?/:order?', require('./routes/psnine/node'));
+router.get('/psnine/index', lazyloadRouteHandler('./routes/psnine/index'));
+router.get('/psnine/shuzhe', lazyloadRouteHandler('./routes/psnine/shuzhe'));
+router.get('/psnine/trade', lazyloadRouteHandler('./routes/psnine/trade'));
+router.get('/psnine/game', lazyloadRouteHandler('./routes/psnine/game'));
+router.get('/psnine/news/:order?', lazyloadRouteHandler('./routes/psnine/news'));
+router.get('/psnine/node/:id?/:order?', lazyloadRouteHandler('./routes/psnine/node'));
 
 // 浙江大学
-router.get('/zju/list/:type', require('./routes/universities/zju/list'));
-router.get('/zju/physics/:type', require('./routes/universities/zju/physics'));
-router.get('/zju/grs/:type', require('./routes/universities/zju/grs'));
-router.get('/zju/career/:type', require('./routes/universities/zju/career'));
-router.get('/zju/cst/:type', require('./routes/universities/zju/cst'));
-router.get('/zju/cst/custom/:id', require('./routes/universities/zju/cst/custom'));
+router.get('/zju/list/:type', lazyloadRouteHandler('./routes/universities/zju/list'));
+router.get('/zju/physics/:type', lazyloadRouteHandler('./routes/universities/zju/physics'));
+router.get('/zju/grs/:type', lazyloadRouteHandler('./routes/universities/zju/grs'));
+router.get('/zju/career/:type', lazyloadRouteHandler('./routes/universities/zju/career'));
+router.get('/zju/cst/:type', lazyloadRouteHandler('./routes/universities/zju/cst'));
+router.get('/zju/cst/custom/:id', lazyloadRouteHandler('./routes/universities/zju/cst/custom'));
 
 // 浙江大学城市学院
-router.get('/zucc/news/latest', require('./routes/universities/zucc/news'));
-router.get('/zucc/cssearch/latest/:webVpn/:key', require('./routes/universities/zucc/cssearch'));
+router.get('/zucc/news/latest', lazyloadRouteHandler('./routes/universities/zucc/news'));
+router.get('/zucc/cssearch/latest/:webVpn/:key', lazyloadRouteHandler('./routes/universities/zucc/cssearch'));
 
 // 华中师范大学
-router.get('/ccnu/career', require('./routes/universities/ccnu/career'));
+router.get('/ccnu/career', lazyloadRouteHandler('./routes/universities/ccnu/career'));
 
 // Infoq
-router.get('/infoq/recommend', require('./routes/infoq/recommend'));
-router.get('/infoq/topic/:id', require('./routes/infoq/topic'));
+router.get('/infoq/recommend', lazyloadRouteHandler('./routes/infoq/recommend'));
+router.get('/infoq/topic/:id', lazyloadRouteHandler('./routes/infoq/topic'));
 
 // checkee
-router.get('/checkee/:dispdate', require('./routes/checkee/index'));
+router.get('/checkee/:dispdate', lazyloadRouteHandler('./routes/checkee/index'));
 
 // 艾瑞
-router.get('/iresearch/report', require('./routes/iresearch/report'));
+router.get('/iresearch/report', lazyloadRouteHandler('./routes/iresearch/report'));
 
 // ZAKER
-router.get('/zaker/:type/:id', require('./routes/zaker/source'));
-router.get('/zaker/focusread', require('./routes/zaker/focusread'));
+router.get('/zaker/:type/:id', lazyloadRouteHandler('./routes/zaker/source'));
+router.get('/zaker/focusread', lazyloadRouteHandler('./routes/zaker/focusread'));
 
 // Matters
-router.get('/matters/topics', require('./routes/matters/topics'));
-router.get('/matters/latest/:type?', require('./routes/matters/latest'));
+router.get('/matters/topics', lazyloadRouteHandler('./routes/matters/topics'));
+router.get('/matters/latest/:type?', lazyloadRouteHandler('./routes/matters/latest'));
 router.redirect('/matters/hot', '/matters/latest/heat'); // Deprecated
-router.get('/matters/tags/:tid', require('./routes/matters/tags'));
-router.get('/matters/author/:uid', require('./routes/matters/author'));
+router.get('/matters/tags/:tid', lazyloadRouteHandler('./routes/matters/tags'));
+router.get('/matters/author/:uid', lazyloadRouteHandler('./routes/matters/author'));
 
 // MobData
-router.get('/mobdata/report', require('./routes/mobdata/report'));
+router.get('/mobdata/report', lazyloadRouteHandler('./routes/mobdata/report'));
 
 // 谷雨
-router.get('/tencent/guyu/channel/:name', require('./routes/tencent/guyu/channel'));
+router.get('/tencent/guyu/channel/:name', lazyloadRouteHandler('./routes/tencent/guyu/channel'));
 
 // 古诗文网
-router.get('/gushiwen/recommend/:annotation?', require('./routes/gushiwen/recommend'));
+router.get('/gushiwen/recommend/:annotation?', lazyloadRouteHandler('./routes/gushiwen/recommend'));
 
 // 电商在线
-router.get('/imaijia/category/:category', require('./routes/imaijia/category'));
+router.get('/imaijia/category/:category', lazyloadRouteHandler('./routes/imaijia/category'));
 
 // 21财经
-router.get('/21caijing/channel/:name', require('./routes/21caijing/channel'));
+router.get('/21caijing/channel/:name', lazyloadRouteHandler('./routes/21caijing/channel'));
 
 // 北京邮电大学
-router.get('/bupt/yz/:type', require('./routes/universities/bupt/yz'));
-router.get('/bupt/grs', require('./routes/universities/bupt/grs'));
-router.get('/bupt/portal', require('./routes/universities/bupt/portal'));
-router.get('/bupt/news', require('./routes/universities/bupt/news'));
-router.get('/bupt/funbox', require('./routes/universities/bupt/funbox'));
+router.get('/bupt/yz/:type', lazyloadRouteHandler('./routes/universities/bupt/yz'));
+router.get('/bupt/grs', lazyloadRouteHandler('./routes/universities/bupt/grs'));
+router.get('/bupt/portal', lazyloadRouteHandler('./routes/universities/bupt/portal'));
+router.get('/bupt/news', lazyloadRouteHandler('./routes/universities/bupt/news'));
+router.get('/bupt/funbox', lazyloadRouteHandler('./routes/universities/bupt/funbox'));
 
 // VOCUS 方格子
-router.get('/vocus/publication/:id', require('./routes/vocus/publication'));
-router.get('/vocus/user/:id', require('./routes/vocus/user'));
+router.get('/vocus/publication/:id', lazyloadRouteHandler('./routes/vocus/publication'));
+router.get('/vocus/user/:id', lazyloadRouteHandler('./routes/vocus/user'));
 
 // 一亩三分地 1point3acres
-router.get('/1point3acres/blog/:category?', require('./routes/1point3acres/blog'));
-router.get('/1point3acres/user/:id/threads', require('./routes/1point3acres/threads'));
-router.get('/1point3acres/user/:id/posts', require('./routes/1point3acres/posts'));
-router.get('/1point3acres/offer/:year?/:major?/:school?', require('./routes/1point3acres/offer'));
-router.get('/1point3acres/post/:category', require('./routes/1point3acres/post'));
+router.get('/1point3acres/blog/:category?', lazyloadRouteHandler('./routes/1point3acres/blog'));
+router.get('/1point3acres/user/:id/threads', lazyloadRouteHandler('./routes/1point3acres/threads'));
+router.get('/1point3acres/user/:id/posts', lazyloadRouteHandler('./routes/1point3acres/posts'));
+router.get('/1point3acres/offer/:year?/:major?/:school?', lazyloadRouteHandler('./routes/1point3acres/offer'));
+router.get('/1point3acres/post/:category', lazyloadRouteHandler('./routes/1point3acres/post'));
 
 // 广东海洋大学
-router.get('/gdoujwc', require('./routes/universities/gdou/jwc/jwtz'));
+router.get('/gdoujwc', lazyloadRouteHandler('./routes/universities/gdou/jwc/jwtz'));
 
 // 中国高清网
-router.get('/gaoqingla/:tag?', require('./routes/gaoqingla/latest'));
+router.get('/gaoqingla/:tag?', lazyloadRouteHandler('./routes/gaoqingla/latest'));
 
 // 马良行
-router.get('/mlhang', require('./routes/mlhang/latest'));
+router.get('/mlhang', lazyloadRouteHandler('./routes/mlhang/latest'));
 
 // PlayStation Store
-router.get('/ps/list/:gridName', require('./routes/ps/list'));
-router.get('/ps/trophy/:id', require('./routes/ps/trophy'));
-router.get('/ps/ps4updates', require('./routes/ps/ps4updates'));
-router.get('/ps/:lang?/product/:gridName', require('./routes/ps/product'));
+router.get('/ps/list/:gridName', lazyloadRouteHandler('./routes/ps/list'));
+router.get('/ps/trophy/:id', lazyloadRouteHandler('./routes/ps/trophy'));
+router.get('/ps/ps4updates', lazyloadRouteHandler('./routes/ps/ps4updates'));
+router.get('/ps/:lang?/product/:gridName', lazyloadRouteHandler('./routes/ps/product'));
 
 // Quanta Magazine
-router.get('/quantamagazine/archive', require('./routes/quantamagazine/archive'));
+router.get('/quantamagazine/archive', lazyloadRouteHandler('./routes/quantamagazine/archive'));
 
 // Nintendo
-router.get('/nintendo/eshop/jp', require('./routes/nintendo/eshop_jp'));
-router.get('/nintendo/eshop/hk', require('./routes/nintendo/eshop_hk'));
-router.get('/nintendo/eshop/us', require('./routes/nintendo/eshop_us'));
-router.get('/nintendo/eshop/cn', require('./routes/nintendo/eshop_cn'));
-router.get('/nintendo/news', require('./routes/nintendo/news'));
-router.get('/nintendo/news/china', require('./routes/nintendo/news_china'));
-router.get('/nintendo/direct', require('./routes/nintendo/direct'));
-router.get('/nintendo/system-update', require('./routes/nintendo/system-update'));
+router.get('/nintendo/eshop/jp', lazyloadRouteHandler('./routes/nintendo/eshop_jp'));
+router.get('/nintendo/eshop/hk', lazyloadRouteHandler('./routes/nintendo/eshop_hk'));
+router.get('/nintendo/eshop/us', lazyloadRouteHandler('./routes/nintendo/eshop_us'));
+router.get('/nintendo/eshop/cn', lazyloadRouteHandler('./routes/nintendo/eshop_cn'));
+router.get('/nintendo/news', lazyloadRouteHandler('./routes/nintendo/news'));
+router.get('/nintendo/news/china', lazyloadRouteHandler('./routes/nintendo/news_china'));
+router.get('/nintendo/direct', lazyloadRouteHandler('./routes/nintendo/direct'));
+router.get('/nintendo/system-update', lazyloadRouteHandler('./routes/nintendo/system-update'));
 
 // 世界卫生组织
-router.get('/who/news-room/:type', require('./routes/who/news-room'));
+router.get('/who/news-room/:type', lazyloadRouteHandler('./routes/who/news-room'));
 
 // 福利资源-met.red
-router.get('/metred/fuli', require('./routes/metred/fuli'));
+router.get('/metred/fuli', lazyloadRouteHandler('./routes/metred/fuli'));
 
 // MIT
-router.get('/mit/graduateadmissions/:type/:name', require('./routes/universities/mit/graduateadmissions'));
-router.get('/mit/ocw-top', require('./routes/universities/mit/ocw-top'));
-router.get('/mit/csail/news', require('./routes/universities/mit/csail/news'));
+router.get('/mit/graduateadmissions/:type/:name', lazyloadRouteHandler('./routes/universities/mit/graduateadmissions'));
+router.get('/mit/ocw-top', lazyloadRouteHandler('./routes/universities/mit/ocw-top'));
+router.get('/mit/csail/news', lazyloadRouteHandler('./routes/universities/mit/csail/news'));
 
 // 毕马威
-router.get('/kpmg/insights', require('./routes/kpmg/insights'));
+router.get('/kpmg/insights', lazyloadRouteHandler('./routes/kpmg/insights'));
 
 // Saraba1st
-router.get('/saraba1st/thread/:tid', require('./routes/saraba1st/thread'));
+router.get('/saraba1st/thread/:tid', lazyloadRouteHandler('./routes/saraba1st/thread'));
 
 // gradcafe
-router.get('/gradcafe/result/:type', require('./routes/gradcafe/result'));
-router.get('/gradcafe/result', require('./routes/gradcafe/result'));
+router.get('/gradcafe/result/:type', lazyloadRouteHandler('./routes/gradcafe/result'));
+router.get('/gradcafe/result', lazyloadRouteHandler('./routes/gradcafe/result'));
 
 // The Economist
-router.get('/the-economist/download', require('./routes/the-economist/download'));
-router.get('/the-economist/gre-vocabulary', require('./routes/the-economist/gre-vocabulary'));
-router.get('/the-economist/:endpoint', require('./routes/the-economist/full'));
+router.get('/the-economist/download', lazyloadRouteHandler('./routes/the-economist/download'));
+router.get('/the-economist/gre-vocabulary', lazyloadRouteHandler('./routes/the-economist/gre-vocabulary'));
+router.get('/the-economist/:endpoint', lazyloadRouteHandler('./routes/the-economist/full'));
 
 // 鼠绘漫画
-router.get('/shuhui/comics/:id', require('./routes/shuhui/comics'));
+router.get('/shuhui/comics/:id', lazyloadRouteHandler('./routes/shuhui/comics'));
 
 // 朝日新闻
-router.get('/asahi/area/:id', require('./routes/asahi/area'));
-router.get('/asahi/:genre?/:category?', require('./routes/asahi/index'));
+router.get('/asahi/area/:id', lazyloadRouteHandler('./routes/asahi/area'));
+router.get('/asahi/:genre?/:category?', lazyloadRouteHandler('./routes/asahi/index'));
 
 // 7x24小时快讯
-router.get('/fx678/kx', require('./routes/fx678/kx'));
+router.get('/fx678/kx', lazyloadRouteHandler('./routes/fx678/kx'));
 
 // SoundCloud
-router.get('/soundcloud/tracks/:user', require('./routes/soundcloud/tracks'));
+router.get('/soundcloud/tracks/:user', lazyloadRouteHandler('./routes/soundcloud/tracks'));
 
 // dilidili
-router.get('/dilidili/fanju/:id', require('./routes/dilidili/fanju'));
+router.get('/dilidili/fanju/:id', lazyloadRouteHandler('./routes/dilidili/fanju'));
 
 // 且听风吟福利
-router.get('/qtfyfl/:category', require('./routes/qtfyfl/category'));
+router.get('/qtfyfl/:category', lazyloadRouteHandler('./routes/qtfyfl/category'));
 
 // 派代
-router.get('/paidai', require('./routes/paidai/index'));
-router.get('/paidai/bbs', require('./routes/paidai/bbs'));
-router.get('/paidai/news', require('./routes/paidai/news'));
+router.get('/paidai', lazyloadRouteHandler('./routes/paidai/index'));
+router.get('/paidai/bbs', lazyloadRouteHandler('./routes/paidai/bbs'));
+router.get('/paidai/news', lazyloadRouteHandler('./routes/paidai/news'));
 
 // 中国银行
-router.get('/boc/whpj/:format?', require('./routes/boc/whpj'));
+router.get('/boc/whpj/:format?', lazyloadRouteHandler('./routes/boc/whpj'));
 
 // 漫画db
-router.get('/manhuadb/comics/:id', require('./routes/manhuadb/comics'));
+router.get('/manhuadb/comics/:id', lazyloadRouteHandler('./routes/manhuadb/comics'));
 
 // 装备前线
-router.get('/zfrontier/postlist/:type', require('./routes/zfrontier/postlist'));
-router.get('/zfrontier/board/:boardId', require('./routes/zfrontier/board_postlist'));
+router.get('/zfrontier/postlist/:type', lazyloadRouteHandler('./routes/zfrontier/postlist'));
+router.get('/zfrontier/board/:boardId', lazyloadRouteHandler('./routes/zfrontier/board_postlist'));
 
 // 观察者网
-router.get('/guancha/headline', require('./routes/guancha/headline'));
-router.get('/guancha/topic/:id/:order?', require('./routes/guancha/topic'));
-router.get('/guancha/member/:caty?', require('./routes/guancha/member'));
-router.get('/guancha/personalpage/:uid', require('./routes/guancha/personalpage'));
-router.get('/guancha/:caty?', require('./routes/guancha/index'));
+router.get('/guancha/headline', lazyloadRouteHandler('./routes/guancha/headline'));
+router.get('/guancha/topic/:id/:order?', lazyloadRouteHandler('./routes/guancha/topic'));
+router.get('/guancha/member/:caty?', lazyloadRouteHandler('./routes/guancha/member'));
+router.get('/guancha/personalpage/:uid', lazyloadRouteHandler('./routes/guancha/personalpage'));
+router.get('/guancha/:caty?', lazyloadRouteHandler('./routes/guancha/index'));
 
-router.get('/guanchazhe/topic/:id/:order?', require('./routes/guancha/topic'));
-router.get('/guanchazhe/personalpage/:uid', require('./routes/guancha/personalpage'));
-router.get('/guanchazhe/index/:caty?', require('./routes/guancha/index'));
+router.get('/guanchazhe/topic/:id/:order?', lazyloadRouteHandler('./routes/guancha/topic'));
+router.get('/guanchazhe/personalpage/:uid', lazyloadRouteHandler('./routes/guancha/personalpage'));
+router.get('/guanchazhe/index/:caty?', lazyloadRouteHandler('./routes/guancha/index'));
 
 // Hpoi 手办维基
-router.get('/hpoi/info/:type?', require('./routes/hpoi/info'));
-router.get('/hpoi/:category/:words', require('./routes/hpoi'));
-router.get('/hpoi/user/:user_id/:caty', require('./routes/hpoi/user'));
+router.get('/hpoi/info/:type?', lazyloadRouteHandler('./routes/hpoi/info'));
+router.get('/hpoi/:category/:words', lazyloadRouteHandler('./routes/hpoi'));
+router.get('/hpoi/user/:user_id/:caty', lazyloadRouteHandler('./routes/hpoi/user'));
 
 // 通用CurseForge
-router.get('/curseforge/:gameid/:catagoryid/:projectid/files', require('./routes/curseforge/generalfiles'));
+router.get('/curseforge/:gameid/:catagoryid/:projectid/files', lazyloadRouteHandler('./routes/curseforge/generalfiles'));
 
 // 西南财经大学
-router.get('/swufe/seie/:type?', require('./routes/universities/swufe/seie'));
+router.get('/swufe/seie/:type?', lazyloadRouteHandler('./routes/universities/swufe/seie'));
 
 // Wired
-router.get('/wired/tag/:tag', require('./routes/wired/tag'));
+router.get('/wired/tag/:tag', lazyloadRouteHandler('./routes/wired/tag'));
 
 // 语雀文档
-router.get('/yuque/doc/:repo_id', require('./routes/yuque/doc'));
+router.get('/yuque/doc/:repo_id', lazyloadRouteHandler('./routes/yuque/doc'));
 
 // 飞地
-router.get('/enclavebooks/category/:id?', require('./routes/enclavebooks/category'));
-router.get('/enclavebooks/user/:uid', require('./routes/enclavebooks/user.js'));
-router.get('/enclavebooks/collection/:uid', require('./routes/enclavebooks/collection.js'));
+router.get('/enclavebooks/category/:id?', lazyloadRouteHandler('./routes/enclavebooks/category'));
+router.get('/enclavebooks/user/:uid', lazyloadRouteHandler('./routes/enclavebooks/user.js'));
+router.get('/enclavebooks/collection/:uid', lazyloadRouteHandler('./routes/enclavebooks/collection.js'));
 
 // 色花堂
-router.get('/dsndsht23/picture/:subforumid', require('./routes/dsndsht23/index'));
-router.get('/dsndsht23/bt/:subforumid?', require('./routes/dsndsht23/index'));
-router.get('/dsndsht23/:subforumid?/:type?', require('./routes/dsndsht23/index'));
-router.get('/dsndsht23/:subforumid?', require('./routes/dsndsht23/index'));
-router.get('/dsndsht23', require('./routes/dsndsht23/index'));
+router.get('/dsndsht23/picture/:subforumid', lazyloadRouteHandler('./routes/dsndsht23/index'));
+router.get('/dsndsht23/bt/:subforumid?', lazyloadRouteHandler('./routes/dsndsht23/index'));
+router.get('/dsndsht23/:subforumid?/:type?', lazyloadRouteHandler('./routes/dsndsht23/index'));
+router.get('/dsndsht23/:subforumid?', lazyloadRouteHandler('./routes/dsndsht23/index'));
+router.get('/dsndsht23', lazyloadRouteHandler('./routes/dsndsht23/index'));
 
 // 数英网最新文章
-router.get('/digitaling/index', require('./routes/digitaling/index'));
+router.get('/digitaling/index', lazyloadRouteHandler('./routes/digitaling/index'));
 
 // 数英网文章专题
-router.get('/digitaling/articles/:category/:subcate', require('./routes/digitaling/article'));
+router.get('/digitaling/articles/:category/:subcate', lazyloadRouteHandler('./routes/digitaling/article'));
 
 // 数英网项目专题
-router.get('/digitaling/projects/:category', require('./routes/digitaling/project'));
+router.get('/digitaling/projects/:category', lazyloadRouteHandler('./routes/digitaling/project'));
 
 // Bing壁纸
-router.get('/bing', require('./routes/bing/index'));
+router.get('/bing', lazyloadRouteHandler('./routes/bing/index'));
 
 // Maxjia News - DotA 2
-router.get('/maxnews/dota2', require('./routes/maxnews/dota2'));
+router.get('/maxnews/dota2', lazyloadRouteHandler('./routes/maxnews/dota2'));
 
 // 柠檬 - 私房歌
-router.get('/ningmeng/song', require('./routes/ningmeng/song'));
+router.get('/ningmeng/song', lazyloadRouteHandler('./routes/ningmeng/song'));
 
 // 紫竹张先生
-router.get('/zzz/:category?/:language?', require('./routes/zzz'));
+router.get('/zzz/:category?/:language?', lazyloadRouteHandler('./routes/zzz'));
 
 // AEON
-router.get('/aeon/:cid', require('./routes/aeon/category'));
+router.get('/aeon/:cid', lazyloadRouteHandler('./routes/aeon/category'));
 
 // AlgoCasts
-router.get('/algocasts', require('./routes/algocasts/all'));
+router.get('/algocasts', lazyloadRouteHandler('./routes/algocasts/all'));
 
 // aqicn
-router.get('/aqicn/:city/:pollution?', require('./routes/aqicn/index'));
+router.get('/aqicn/:city/:pollution?', lazyloadRouteHandler('./routes/aqicn/index'));
 
 // 猫眼电影
-router.get('/maoyan/hot', require('./routes/maoyan/hot'));
-router.get('/maoyan/upcoming', require('./routes/maoyan/upcoming'));
+router.get('/maoyan/hot', lazyloadRouteHandler('./routes/maoyan/hot'));
+router.get('/maoyan/upcoming', lazyloadRouteHandler('./routes/maoyan/upcoming'));
 
 // cnBeta
-router.get('/cnbeta', require('./routes/cnbeta/home'));
+router.get('/cnbeta', lazyloadRouteHandler('./routes/cnbeta/home'));
 
 // 国家退伍士兵信息
-router.get('/gov/veterans/:type', require('./routes/gov/veterans/china'));
+router.get('/gov/veterans/:type', lazyloadRouteHandler('./routes/gov/veterans/china'));
 
 // 河北省退伍士兵信息
-router.get('/gov/veterans/hebei/:type', require('./routes/gov/veterans/hebei'));
+router.get('/gov/veterans/hebei/:type', lazyloadRouteHandler('./routes/gov/veterans/hebei'));
 
 // Dilbert Comic Strip
-router.get('/dilbert/strip', require('./routes/dilbert/strip'));
+router.get('/dilbert/strip', lazyloadRouteHandler('./routes/dilbert/strip'));
 
 // 游戏打折情报
-router.get('/yxdzqb/:type', require('./routes/yxdzqb'));
+router.get('/yxdzqb/:type', lazyloadRouteHandler('./routes/yxdzqb'));
 
 // 怪物猎人
-router.get('/monsterhunter/update', require('./routes/mhw/update'));
-router.get('/mhw/update', require('./routes/mhw/update'));
-router.get('/mhw/news', require('./routes/mhw/news'));
+router.get('/monsterhunter/update', lazyloadRouteHandler('./routes/mhw/update'));
+router.get('/mhw/update', lazyloadRouteHandler('./routes/mhw/update'));
+router.get('/mhw/news', lazyloadRouteHandler('./routes/mhw/news'));
 
 // 005.tv
-router.get('/005tv/zx/latest', require('./routes/005tv/zx'));
+router.get('/005tv/zx/latest', lazyloadRouteHandler('./routes/005tv/zx'));
 
 // Polimi News
-router.get('/polimi/news/:language?', require('./routes/polimi/news'));
+router.get('/polimi/news/:language?', lazyloadRouteHandler('./routes/polimi/news'));
 
 // dekudeals
-router.get('/dekudeals/:type', require('./routes/dekudeals'));
+router.get('/dekudeals/:type', lazyloadRouteHandler('./routes/dekudeals'));
 
 // 直播吧
-router.get('/zhibo8/forum/:id', require('./routes/zhibo8/forum'));
-router.get('/zhibo8/post/:id', require('./routes/zhibo8/post'));
-router.get('/zhibo8/more/:caty', require('./routes/zhibo8/more'));
+router.get('/zhibo8/forum/:id', lazyloadRouteHandler('./routes/zhibo8/forum'));
+router.get('/zhibo8/post/:id', lazyloadRouteHandler('./routes/zhibo8/post'));
+router.get('/zhibo8/more/:caty', lazyloadRouteHandler('./routes/zhibo8/more'));
 
 // 东方网-上海
-router.get('/eastday/sh', require('./routes/eastday/sh'));
+router.get('/eastday/sh', lazyloadRouteHandler('./routes/eastday/sh'));
 
 // Metacritic
-router.get('/metacritic/release/:platform/:type/:sort?', require('./routes/metacritic/release'));
+router.get('/metacritic/release/:platform/:type/:sort?', lazyloadRouteHandler('./routes/metacritic/release'));
 
 // 快科技（原驱动之家）
-router.get('/kkj/news', require('./routes/kkj/news'));
+router.get('/kkj/news', lazyloadRouteHandler('./routes/kkj/news'));
 
 // Outage.Report
-router.get('/outagereport/:name/:count?', require('./routes/outagereport/service'));
+router.get('/outagereport/:name/:count?', lazyloadRouteHandler('./routes/outagereport/service'));
 
 // sixthtone
-router.get('/sixthtone/news', require('./routes/sixthtone/news'));
+router.get('/sixthtone/news', lazyloadRouteHandler('./routes/sixthtone/news'));
 
 // AI研习社
-router.get('/aiyanxishe/:id/:sort?', require('./routes/aiyanxishe/home'));
+router.get('/aiyanxishe/:id/:sort?', lazyloadRouteHandler('./routes/aiyanxishe/home'));
 
 // 活动行
-router.get('/huodongxing/explore', require('./routes/hdx/explore'));
+router.get('/huodongxing/explore', lazyloadRouteHandler('./routes/hdx/explore'));
 
 // 飞客茶馆优惠信息
-router.get('/flyertea/preferential', require('./routes/flyertea/preferential'));
-router.get('/flyertea/creditcard/:bank', require('./routes/flyertea/creditcard'));
+router.get('/flyertea/preferential', lazyloadRouteHandler('./routes/flyertea/preferential'));
+router.get('/flyertea/creditcard/:bank', lazyloadRouteHandler('./routes/flyertea/creditcard'));
 
 // 中国广播
-router.get('/radio/:channelname/:name', require('./routes/radio/radio'));
+router.get('/radio/:channelname/:name', lazyloadRouteHandler('./routes/radio/radio'));
 
 // TOPYS
-router.get('/topys/:category', require('./routes/topys/article'));
+router.get('/topys/:category', lazyloadRouteHandler('./routes/topys/article'));
 
 // 巴比特作者专栏
-router.get('/8btc/:authorid', require('./routes/8btc/author'));
-router.get('/8btc/news/flash', require('./routes/8btc/news/flash'));
+router.get('/8btc/:authorid', lazyloadRouteHandler('./routes/8btc/author'));
+router.get('/8btc/news/flash', lazyloadRouteHandler('./routes/8btc/news/flash'));
 
 // VueVlog
-router.get('/vuevideo/:userid', require('./routes/vuevideo/user'));
+router.get('/vuevideo/:userid', lazyloadRouteHandler('./routes/vuevideo/user'));
 
 // 证监会
-router.get('/csrc/news/:suffix?', require('./routes/csrc/news'));
-router.get('/csrc/fashenwei', require('./routes/csrc/fashenwei'));
-router.get('/csrc/auditstatus/:apply_id', require('./routes/csrc/auditstatus'));
+router.get('/csrc/news/:suffix?', lazyloadRouteHandler('./routes/csrc/news'));
+router.get('/csrc/fashenwei', lazyloadRouteHandler('./routes/csrc/fashenwei'));
+router.get('/csrc/auditstatus/:apply_id', lazyloadRouteHandler('./routes/csrc/auditstatus'));
 
 // LWN.net Alerts
-router.get('/lwn/alerts/:distributor', require('./routes/lwn/alerts'));
+router.get('/lwn/alerts/:distributor', lazyloadRouteHandler('./routes/lwn/alerts'));
 
 // 唱吧
-router.get('/changba/:userid', require('./routes/changba/user'));
+router.get('/changba/:userid', lazyloadRouteHandler('./routes/changba/user'));
 
 // 英雄联盟
-router.get('/lol/newsindex/:type', require('./routes/lol/newsindex'));
+router.get('/lol/newsindex/:type', lazyloadRouteHandler('./routes/lol/newsindex'));
 
 // 掌上英雄联盟
-router.get('/lolapp/recommend', require('./routes/lolapp/recommend'));
+router.get('/lolapp/recommend', lazyloadRouteHandler('./routes/lolapp/recommend'));
 
 // 左岸读书
-router.get('/zreading', require('./routes/zreading/home'));
+router.get('/zreading', lazyloadRouteHandler('./routes/zreading/home'));
 
 // NBA
-router.get('/nba/app_news', require('./routes/nba/app_news'));
+router.get('/nba/app_news', lazyloadRouteHandler('./routes/nba/app_news'));
 
 // 天津产权交易中心
-router.get('/tprtc/cqzr', require('./routes/tprtc/cqzr'));
-router.get('/tprtc/qyzc', require('./routes/tprtc/qyzc'));
-router.get('/tprtc/news', require('./routes/tprtc/news'));
+router.get('/tprtc/cqzr', lazyloadRouteHandler('./routes/tprtc/cqzr'));
+router.get('/tprtc/qyzc', lazyloadRouteHandler('./routes/tprtc/qyzc'));
+router.get('/tprtc/news', lazyloadRouteHandler('./routes/tprtc/news'));
 
 // ArchDaily
-router.get('/archdaily', require('./routes/archdaily/home'));
+router.get('/archdaily', lazyloadRouteHandler('./routes/archdaily/home'));
 
 // aptonic Dropzone actions
-router.get('/aptonic/action/:untested?', require('./routes/aptonic/action'));
+router.get('/aptonic/action/:untested?', lazyloadRouteHandler('./routes/aptonic/action'));
 
 // 印记中文周刊
-router.get('/docschina/jsweekly', require('./routes/docschina/jsweekly'));
+router.get('/docschina/jsweekly', lazyloadRouteHandler('./routes/docschina/jsweekly'));
 
 // im2maker
-router.get('/im2maker/:channel?', require('./routes/im2maker/index'));
+router.get('/im2maker/:channel?', lazyloadRouteHandler('./routes/im2maker/index'));
 
 // 巨潮资讯
-router.get('/cninfo/announcement/:column/:code/:orgId/:category?/:search?', require('./routes/cninfo/announcement'));
+router.get('/cninfo/announcement/:column/:code/:orgId/:category?/:search?', lazyloadRouteHandler('./routes/cninfo/announcement'));
 
 // 金十数据
-router.get('/jinshi/index', require('./routes/jinshi/index'));
+router.get('/jinshi/index', lazyloadRouteHandler('./routes/jinshi/index'));
 
 // 中央纪委国家监委网站
-router.get('/ccdi/scdc', require('./routes/ccdi/scdc'));
+router.get('/ccdi/scdc', lazyloadRouteHandler('./routes/ccdi/scdc'));
 
 // 中华人民共和国农业农村部
-router.get('/gov/moa/sjzxfb', require('./routes/gov/moa/sjzxfb'));
-router.get('/gov/moa/:suburl(.*)', require('./routes/gov/moa/moa'));
+router.get('/gov/moa/sjzxfb', lazyloadRouteHandler('./routes/gov/moa/sjzxfb'));
+router.get('/gov/moa/:suburl(.*)', lazyloadRouteHandler('./routes/gov/moa/moa'));
 
 // 香水时代
-router.get('/nosetime/:id/:type/:sort?', require('./routes/nosetime/comment'));
-router.get('/nosetime/home', require('./routes/nosetime/home'));
+router.get('/nosetime/:id/:type/:sort?', lazyloadRouteHandler('./routes/nosetime/comment'));
+router.get('/nosetime/home', lazyloadRouteHandler('./routes/nosetime/home'));
 
 // 涂鸦王国
-router.get('/gracg/:user/:love?', require('./routes/gracg/user'));
+router.get('/gracg/:user/:love?', lazyloadRouteHandler('./routes/gracg/user'));
 
 // 大侠阿木
-router.get('/daxiaamu/home', require('./routes/daxiaamu/home'));
+router.get('/daxiaamu/home', lazyloadRouteHandler('./routes/daxiaamu/home'));
 
 // 美团技术团队
-router.get('/meituan/tech/home', require('./routes//meituan/tech/home'));
+router.get('/meituan/tech/home', lazyloadRouteHandler('./routes//meituan/tech/home'));
 
 // 码农网
-router.get('/codeceo/home', require('./routes/codeceo/home'));
-router.get('/codeceo/:type/:category?', require('./routes/codeceo/category'));
+router.get('/codeceo/home', lazyloadRouteHandler('./routes/codeceo/home'));
+router.get('/codeceo/:type/:category?', lazyloadRouteHandler('./routes/codeceo/category'));
 
 // BOF
-router.get('/bof/home', require('./routes/bof/home'));
+router.get('/bof/home', lazyloadRouteHandler('./routes/bof/home'));
 
 // 爱发电
-router.get('/afdian/explore/:type?/:category?', require('./routes/afdian/explore'));
-router.get('/afdian/dynamic/:uid', require('./routes/afdian/dynamic'));
+router.get('/afdian/explore/:type?/:category?', lazyloadRouteHandler('./routes/afdian/explore'));
+router.get('/afdian/dynamic/:uid', lazyloadRouteHandler('./routes/afdian/dynamic'));
 
 // Simons Foundation
-router.get('/simonsfoundation/articles', require('./routes/simonsfoundation/articles'));
-router.get('/simonsfoundation/recommend', require('./routes/simonsfoundation/recommend'));
+router.get('/simonsfoundation/articles', lazyloadRouteHandler('./routes/simonsfoundation/articles'));
+router.get('/simonsfoundation/recommend', lazyloadRouteHandler('./routes/simonsfoundation/recommend'));
 
 // 王者荣耀
-router.get('/tencent/pvp/newsindex/:type', require('./routes/tencent/pvp/newsindex'));
+router.get('/tencent/pvp/newsindex/:type', lazyloadRouteHandler('./routes/tencent/pvp/newsindex'));
 
 // 《明日方舟》游戏
-router.get('/arknights/news', require('./routes/arknights/news'));
+router.get('/arknights/news', lazyloadRouteHandler('./routes/arknights/news'));
 // 塞壬唱片
-router.get('/siren/news', require('./routes/siren/index'));
+router.get('/siren/news', lazyloadRouteHandler('./routes/siren/index'));
 
 // ff14
-router.get('/ff14/ff14_zh/:type', require('./routes/ff14/ff14_zh'));
-router.get('/ff14/ff14_global/:lang/:type', require('./routes/ff14/ff14_global'));
+router.get('/ff14/ff14_zh/:type', lazyloadRouteHandler('./routes/ff14/ff14_zh'));
+router.get('/ff14/ff14_global/:lang/:type', lazyloadRouteHandler('./routes/ff14/ff14_global'));
 
 // 学堂在线
-router.get('/xuetangx/course/:cid/:type', require('./routes/xuetangx/course_info'));
-router.get('/xuetangx/course/list/:mode/:credential/:status/:type?', require('./routes/xuetangx/course_list'));
+router.get('/xuetangx/course/:cid/:type', lazyloadRouteHandler('./routes/xuetangx/course_info'));
+router.get('/xuetangx/course/list/:mode/:credential/:status/:type?', lazyloadRouteHandler('./routes/xuetangx/course_list'));
 
 // wikihow
-router.get('/wikihow/index', require('./routes/wikihow/index.js'));
-router.get('/wikihow/category/:category/:type', require('./routes/wikihow/category.js'));
+router.get('/wikihow/index', lazyloadRouteHandler('./routes/wikihow/index.js'));
+router.get('/wikihow/category/:category/:type', lazyloadRouteHandler('./routes/wikihow/category.js'));
 
 // 正版中国
-router.get('/getitfree/category/:category?', require('./routes/getitfree/category.js'));
-router.get('/getitfree/search/:keyword?', require('./routes/getitfree/search.js'));
+router.get('/getitfree/category/:category?', lazyloadRouteHandler('./routes/getitfree/category.js'));
+router.get('/getitfree/search/:keyword?', lazyloadRouteHandler('./routes/getitfree/search.js'));
 
 // 万联网
-router.get('/10000link/news/:category?', require('./routes/10000link/news'));
+router.get('/10000link/news/:category?', lazyloadRouteHandler('./routes/10000link/news'));
 
 // 站酷
-router.get('/zcool/discover/:query?/:subCate?/:hasVideo?/:city?/:collage?/:recommendLevel?/:sort?', require('./routes/zcool/discover'));
-router.get('/zcool/recommend/:query?/:subCate?/:hasVideo?/:city?/:collage?/:recommendLevel?/:sort?', require('./routes/zcool/discover')); // 兼容老版本
-router.get('/zcool/top/:type', require('./routes/zcool/top'));
-router.get('/zcool/top', require('./routes/zcool/top')); // 兼容老版本
-router.get('/zcool/user/:uid', require('./routes/zcool/user'));
+router.get('/zcool/discover/:query?/:subCate?/:hasVideo?/:city?/:collage?/:recommendLevel?/:sort?', lazyloadRouteHandler('./routes/zcool/discover'));
+router.get('/zcool/recommend/:query?/:subCate?/:hasVideo?/:city?/:collage?/:recommendLevel?/:sort?', lazyloadRouteHandler('./routes/zcool/discover')); // 兼容老版本
+router.get('/zcool/top/:type', lazyloadRouteHandler('./routes/zcool/top'));
+router.get('/zcool/top', lazyloadRouteHandler('./routes/zcool/top')); // 兼容老版本
+router.get('/zcool/user/:uid', lazyloadRouteHandler('./routes/zcool/user'));
 
 // 第一财经
-router.get('/yicai/brief', require('./routes/yicai/brief.js'));
+router.get('/yicai/brief', lazyloadRouteHandler('./routes/yicai/brief.js'));
 
 // 一兜糖
-router.get('/yidoutang/index', require('./routes/yidoutang/index.js'));
-router.get('/yidoutang/guide', require('./routes/yidoutang/guide.js'));
-router.get('/yidoutang/mtest', require('./routes/yidoutang/mtest.js'));
-router.get('/yidoutang/case/:type', require('./routes/yidoutang/case.js'));
+router.get('/yidoutang/index', lazyloadRouteHandler('./routes/yidoutang/index.js'));
+router.get('/yidoutang/guide', lazyloadRouteHandler('./routes/yidoutang/guide.js'));
+router.get('/yidoutang/mtest', lazyloadRouteHandler('./routes/yidoutang/mtest.js'));
+router.get('/yidoutang/case/:type', lazyloadRouteHandler('./routes/yidoutang/case.js'));
 
 // 开眼
-router.get('/kaiyan/index', require('./routes/kaiyan/index'));
+router.get('/kaiyan/index', lazyloadRouteHandler('./routes/kaiyan/index'));
 
 // 龙空
-router.get('/lkong/forum/:id/:digest?', require('./routes/lkong/forum'));
-router.get('/lkong/thread/:id', require('./routes/lkong/thread'));
-// router.get('/lkong/user/:id', require('./routes/lkong/user'));
+router.get('/lkong/forum/:id/:digest?', lazyloadRouteHandler('./routes/lkong/forum'));
+router.get('/lkong/thread/:id', lazyloadRouteHandler('./routes/lkong/thread'));
+// router.get('/lkong/user/:id', lazyloadRouteHandler('./routes/lkong/user'));
 
 // 坂道系列资讯
 // 坂道系列官网新闻
-router.get('/nogizaka46/news', require('./routes/nogizaka46/news'));
-router.get('/keyakizaka46/news', require('./routes/keyakizaka46/news'));
-router.get('/hinatazaka46/news', require('./routes/hinatazaka46/news'));
-router.get('/keyakizaka46/blog', require('./routes/keyakizaka46/blog'));
-router.get('/hinatazaka46/blog', require('./routes/hinatazaka46/blog'));
-router.get('/sakurazaka46/blog', require('./routes/sakurazaka46/blog'));
+router.get('/nogizaka46/news', lazyloadRouteHandler('./routes/nogizaka46/news'));
+router.get('/keyakizaka46/news', lazyloadRouteHandler('./routes/keyakizaka46/news'));
+router.get('/hinatazaka46/news', lazyloadRouteHandler('./routes/hinatazaka46/news'));
+router.get('/keyakizaka46/blog', lazyloadRouteHandler('./routes/keyakizaka46/blog'));
+router.get('/hinatazaka46/blog', lazyloadRouteHandler('./routes/hinatazaka46/blog'));
+router.get('/sakurazaka46/blog', lazyloadRouteHandler('./routes/sakurazaka46/blog'));
 
 // 酷安
-router.get('/coolapk/tuwen/:type?', require('./routes/coolapk/tuwen'));
-router.get('/coolapk/tuwen-xinxian', require('./routes/coolapk/tuwen'));
-router.get('/coolapk/toutiao/:type?', require('./routes/coolapk/toutiao'));
-router.get('/coolapk/huati/:tag', require('./routes/coolapk/huati'));
-router.get('/coolapk/user/:uid/dynamic', require('./routes/coolapk/userDynamic'));
-router.get('/coolapk/dyh/:dyhId', require('./routes/coolapk/dyh'));
-router.get('/coolapk/hot/:type?/:period?', require('./routes/coolapk/hot'));
+router.get('/coolapk/tuwen/:type?', lazyloadRouteHandler('./routes/coolapk/tuwen'));
+router.get('/coolapk/tuwen-xinxian', lazyloadRouteHandler('./routes/coolapk/tuwen'));
+router.get('/coolapk/toutiao/:type?', lazyloadRouteHandler('./routes/coolapk/toutiao'));
+router.get('/coolapk/huati/:tag', lazyloadRouteHandler('./routes/coolapk/huati'));
+router.get('/coolapk/user/:uid/dynamic', lazyloadRouteHandler('./routes/coolapk/userDynamic'));
+router.get('/coolapk/dyh/:dyhId', lazyloadRouteHandler('./routes/coolapk/dyh'));
+router.get('/coolapk/hot/:type?/:period?', lazyloadRouteHandler('./routes/coolapk/hot'));
 
 // 模型网
-router.get('/moxingnet', require('./routes/moxingnet'));
+router.get('/moxingnet', lazyloadRouteHandler('./routes/moxingnet'));
 
 // 湖北大学
-router.get('/hubu/news/:type', require('./routes/universities/hubu/news'));
+router.get('/hubu/news/:type', lazyloadRouteHandler('./routes/universities/hubu/news'));
 
 // 大连海事大学
-router.get('/dlmu/news/:type', require('./routes/universities/dlmu/news'));
-router.get('/dlmu/grs/zsgz/:type', require('./routes/universities/dlmu/grs/zsgz'));
+router.get('/dlmu/news/:type', lazyloadRouteHandler('./routes/universities/dlmu/news'));
+router.get('/dlmu/grs/zsgz/:type', lazyloadRouteHandler('./routes/universities/dlmu/grs/zsgz'));
 
 // Rockstar Games Social Club
-router.get('/socialclub/events/:game?', require('./routes/socialclub/events'));
+router.get('/socialclub/events/:game?', lazyloadRouteHandler('./routes/socialclub/events'));
 
 // CTFHub Event Calendar
-router.get('/ctfhub/upcoming/:limit?', require('./routes/ctfhub/upcoming'));
-router.get('/ctfhub/search/:limit?/:form?/:class?/:title?', require('./routes/ctfhub/search'));
+router.get('/ctfhub/upcoming/:limit?', lazyloadRouteHandler('./routes/ctfhub/upcoming'));
+router.get('/ctfhub/search/:limit?/:form?/:class?/:title?', lazyloadRouteHandler('./routes/ctfhub/search'));
 
 // 阿里云
-router.get('/aliyun/database_month', require('./routes/aliyun/database_month'));
-router.get('/aliyun/notice/:type?', require('./routes/aliyun/notice'));
-router.get('/aliyun/developer/group/:type', require('./routes/aliyun/developer/group'));
+router.get('/aliyun/database_month', lazyloadRouteHandler('./routes/aliyun/database_month'));
+router.get('/aliyun/notice/:type?', lazyloadRouteHandler('./routes/aliyun/notice'));
+router.get('/aliyun/developer/group/:type', lazyloadRouteHandler('./routes/aliyun/developer/group'));
 
 // 礼物说
-router.get('/liwushuo/index', require('./routes/liwushuo/index.js'));
+router.get('/liwushuo/index', lazyloadRouteHandler('./routes/liwushuo/index.js'));
 
 // 故事fm
-router.get('/storyfm/index', require('./routes/storyfm/index.js'));
+router.get('/storyfm/index', lazyloadRouteHandler('./routes/storyfm/index.js'));
 
 // 中国日报
-router.get('/chinadaily/english/:category', require('./routes/chinadaily/english.js'));
+router.get('/chinadaily/english/:category', lazyloadRouteHandler('./routes/chinadaily/english.js'));
 
 // leboncoin
-router.get('/leboncoin/ad/:query', require('./routes/leboncoin/ad.js'));
+router.get('/leboncoin/ad/:query', lazyloadRouteHandler('./routes/leboncoin/ad.js'));
 
 // DHL
-router.get('/dhl/:id', require('./routes/dhl/shipment-tracking'));
+router.get('/dhl/:id', lazyloadRouteHandler('./routes/dhl/shipment-tracking'));
 
 // Japanpost
-router.get('/japanpost/track/:reqCode/:locale?', require('./routes/japanpost/track'));
+router.get('/japanpost/track/:reqCode/:locale?', lazyloadRouteHandler('./routes/japanpost/track'));
 
 // 中华人民共和国商务部
-router.get('/mofcom/article/:suffix', require('./routes/mofcom/article'));
+router.get('/mofcom/article/:suffix', lazyloadRouteHandler('./routes/mofcom/article'));
 
 // 品玩
-router.get('/pingwest/status', require('./routes/pingwest/status'));
-router.get('/pingwest/tag/:tag/:type', require('./routes/pingwest/tag'));
-router.get('/pingwest/user/:uid/:type?', require('./routes/pingwest/user'));
+router.get('/pingwest/status', lazyloadRouteHandler('./routes/pingwest/status'));
+router.get('/pingwest/tag/:tag/:type', lazyloadRouteHandler('./routes/pingwest/tag'));
+router.get('/pingwest/user/:uid/:type?', lazyloadRouteHandler('./routes/pingwest/user'));
 
 // Hanime
-router.get('/hanime/video', require('./routes/hanime/video'));
+router.get('/hanime/video', lazyloadRouteHandler('./routes/hanime/video'));
 
 // Soul
-router.get('/soul/:id', require('./routes/soul'));
-router.get('/soul/posts/hot/:pid*', require('./routes/soul/hot'));
+router.get('/soul/:id', lazyloadRouteHandler('./routes/soul'));
+router.get('/soul/posts/hot/:pid*', lazyloadRouteHandler('./routes/soul/hot'));
 
 // 单向空间
-router.get('/owspace/read/:type?', require('./routes/owspace/read'));
+router.get('/owspace/read/:type?', lazyloadRouteHandler('./routes/owspace/read'));
 
 // 天涯论坛
-router.get('/tianya/index/:type', require('./routes/tianya/index'));
-router.get('/tianya/user/:userid', require('./routes/tianya/user'));
-router.get('/tianya/comments/:userid', require('./routes/tianya/comments'));
+router.get('/tianya/index/:type', lazyloadRouteHandler('./routes/tianya/index'));
+router.get('/tianya/user/:userid', lazyloadRouteHandler('./routes/tianya/user'));
+router.get('/tianya/comments/:userid', lazyloadRouteHandler('./routes/tianya/comments'));
 
 // eleme
-router.get('/eleme/open/announce', require('./routes/eleme/open/announce'));
-router.get('/eleme/open-be/announce', require('./routes/eleme/open-be/announce'));
+router.get('/eleme/open/announce', lazyloadRouteHandler('./routes/eleme/open/announce'));
+router.get('/eleme/open-be/announce', lazyloadRouteHandler('./routes/eleme/open-be/announce'));
 
 // 美团开放平台
-router.get('/meituan/open/announce', require('./routes/meituan/open/announce'));
+router.get('/meituan/open/announce', lazyloadRouteHandler('./routes/meituan/open/announce'));
 
 // 微信开放社区
-router.get('/wechat-open/community/:type', require('./routes/tencent/wechat/wechat-open/community/announce'));
+router.get('/wechat-open/community/:type', lazyloadRouteHandler('./routes/tencent/wechat/wechat-open/community/announce'));
 // 微信支付 - 商户平台公告
-router.get('/wechat-open/pay/announce', require('./routes/tencent/wechat/wechat-open/pay/announce'));
-router.get('/wechat-open/community/:type/:category', require('./routes/tencent/wechat/wechat-open/community/question'));
+router.get('/wechat-open/pay/announce', lazyloadRouteHandler('./routes/tencent/wechat/wechat-open/pay/announce'));
+router.get('/wechat-open/community/:type/:category', lazyloadRouteHandler('./routes/tencent/wechat/wechat-open/community/question'));
 
 // 微店
-router.get('/weidian/goods/:id', require('./routes/weidian/goods'));
+router.get('/weidian/goods/:id', lazyloadRouteHandler('./routes/weidian/goods'));
 
 // 有赞
-router.get('/youzan/goods/:id', require('./routes/youzan/goods'));
+router.get('/youzan/goods/:id', lazyloadRouteHandler('./routes/youzan/goods'));
 // 币世界快讯
-router.get('/bishijie/kuaixun', require('./routes/bishijie/kuaixun'));
+router.get('/bishijie/kuaixun', lazyloadRouteHandler('./routes/bishijie/kuaixun'));
 
 // 顺丰丰桥
-router.get('/sf/sffq-announce', require('./routes/sf/sffq-announce'));
+router.get('/sf/sffq-announce', lazyloadRouteHandler('./routes/sf/sffq-announce'));
 
 // 缺书网
-router.get('/queshu/sale', require('./routes/queshu/sale'));
-router.get('/queshu/book/:bookid', require('./routes/queshu/book'));
+router.get('/queshu/sale', lazyloadRouteHandler('./routes/queshu/sale'));
+router.get('/queshu/book/:bookid', lazyloadRouteHandler('./routes/queshu/book'));
 
 // MITRE
-router.get('/mitre/publications', require('./routes/mitre/publications'));
+router.get('/mitre/publications', lazyloadRouteHandler('./routes/mitre/publications'));
 
 // SANS
-router.get('/sans/summit_archive', require('./routes/sans/summit_archive'));
+router.get('/sans/summit_archive', lazyloadRouteHandler('./routes/sans/summit_archive'));
 
 // LaTeX 开源小屋
-router.get('/latexstudio/home', require('./routes/latexstudio/home'));
+router.get('/latexstudio/home', lazyloadRouteHandler('./routes/latexstudio/home'));
 
 // 上证债券信息网 - 可转换公司债券公告
-router.get('/sse/convert/:query?', require('./routes/sse/convert'));
-router.get('/sse/renewal', require('./routes/sse/renewal'));
-router.get('/sse/inquire', require('./routes/sse/inquire'));
+router.get('/sse/convert/:query?', lazyloadRouteHandler('./routes/sse/convert'));
+router.get('/sse/renewal', lazyloadRouteHandler('./routes/sse/renewal'));
+router.get('/sse/inquire', lazyloadRouteHandler('./routes/sse/inquire'));
 
 // 上海证券交易所
-router.get('/sse/disclosure/:query?', require('./routes/sse/disclosure'));
+router.get('/sse/disclosure/:query?', lazyloadRouteHandler('./routes/sse/disclosure'));
 
 // 深圳证券交易所
-router.get('/szse/notice', require('./routes/szse/notice'));
-router.get('/szse/inquire/:type', require('./routes/szse/inquire'));
-router.get('/szse/rule', require('./routes/szse/rule'));
-router.get('/szse/projectdynamic/:type?/:stage?/:status?', require('./routes/szse/projectdynamic'));
+router.get('/szse/notice', lazyloadRouteHandler('./routes/szse/notice'));
+router.get('/szse/inquire/:type', lazyloadRouteHandler('./routes/szse/inquire'));
+router.get('/szse/rule', lazyloadRouteHandler('./routes/szse/rule'));
+router.get('/szse/projectdynamic/:type?/:stage?/:status?', lazyloadRouteHandler('./routes/szse/projectdynamic'));
 
 // 前端艺术家每日整理&&飞冰早报
-router.get('/jskou/:type?', require('./routes/jskou/index'));
+router.get('/jskou/:type?', lazyloadRouteHandler('./routes/jskou/index'));
 
 // 国家应急广播
-router.get('/cneb/yjxx', require('./routes/cneb/yjxx'));
-router.get('/cneb/guoneinews', require('./routes/cneb/guoneinews'));
+router.get('/cneb/yjxx', lazyloadRouteHandler('./routes/cneb/yjxx'));
+router.get('/cneb/guoneinews', lazyloadRouteHandler('./routes/cneb/guoneinews'));
 
 // 邮箱
-router.get('/mail/imap/:email', require('./routes/mail/imap'));
+router.get('/mail/imap/:email', lazyloadRouteHandler('./routes/mail/imap'));
 
 // 好队友
-router.get('/network360/jobs', require('./routes/network360/jobs'));
+router.get('/network360/jobs', lazyloadRouteHandler('./routes/network360/jobs'));
 
 // 智联招聘
-router.get('/zhilian/:city/:keyword', require('./routes/zhilian/index'));
+router.get('/zhilian/:city/:keyword', lazyloadRouteHandler('./routes/zhilian/index'));
 
 // 电鸭社区
-router.get('/eleduck/jobs', require('./routes/eleduck/jobs'));
+router.get('/eleduck/jobs', lazyloadRouteHandler('./routes/eleduck/jobs'));
 
 // 北华航天工业学院 - 新闻
-router.get('/nciae/news', require('./routes/universities/nciae/news'));
+router.get('/nciae/news', lazyloadRouteHandler('./routes/universities/nciae/news'));
 
 // 北华航天工业学院 - 通知公告
-router.get('/nciae/tzgg', require('./routes/universities/nciae/tzgg'));
+router.get('/nciae/tzgg', lazyloadRouteHandler('./routes/universities/nciae/tzgg'));
 
 // 北华航天工业学院 - 学术信息
-router.get('/nciae/xsxx', require('./routes/universities/nciae/xsxx'));
+router.get('/nciae/xsxx', lazyloadRouteHandler('./routes/universities/nciae/xsxx'));
 
 // cfan
-router.get('/cfan/news', require('./routes/cfan/news'));
+router.get('/cfan/news', lazyloadRouteHandler('./routes/cfan/news'));
 
 // 搜狐 - 搜狐号
-router.get('/sohu/mp/:id', require('./routes/sohu/mp'));
+router.get('/sohu/mp/:id', lazyloadRouteHandler('./routes/sohu/mp'));
 
 // 腾讯企鹅号
-router.get('/tencent/news/author/:mid', require('./routes/tencent/news/author'));
+router.get('/tencent/news/author/:mid', lazyloadRouteHandler('./routes/tencent/news/author'));
 
 // 奈菲影视
-router.get('/nfmovies/:id?', require('./routes/nfmovies/index'));
+router.get('/nfmovies/:id?', lazyloadRouteHandler('./routes/nfmovies/index'));
 
 // 书友社区
-router.get('/andyt/:view?', require('./routes/andyt/index'));
+router.get('/andyt/:view?', lazyloadRouteHandler('./routes/andyt/index'));
 
 // 品途商业评论
-router.get('/pintu360/:type?', require('./routes/pintu360/index'));
+router.get('/pintu360/:type?', lazyloadRouteHandler('./routes/pintu360/index'));
 
 // engadget中国版
-router.get('/engadget-cn', require('./routes/engadget/home'));
+router.get('/engadget-cn', lazyloadRouteHandler('./routes/engadget/home'));
 
 // engadget
-router.get('/engadget/:lang?', require('./routes/engadget/home'));
+router.get('/engadget/:lang?', lazyloadRouteHandler('./routes/engadget/home'));
 
 // 吹牛部落
-router.get('/chuiniu/column/:id', require('./routes/chuiniu/column'));
-router.get('/chuiniu/column_list', require('./routes/chuiniu/column_list'));
+router.get('/chuiniu/column/:id', lazyloadRouteHandler('./routes/chuiniu/column'));
+router.get('/chuiniu/column_list', lazyloadRouteHandler('./routes/chuiniu/column_list'));
 
 // leemeng
-router.get('/leemeng', require('./routes/blogs/leemeng'));
+router.get('/leemeng', lazyloadRouteHandler('./routes/blogs/leemeng'));
 
 // 中国地质大学（武汉）
-router.get('/cug/graduate', require('./routes/universities/cug/graduate'));
-router.get('/cug/undergraduate', require('./routes/universities/cug/undergraduate'));
-router.get('/cug/xgxy', require('./routes/universities/cug/xgxy'));
-router.get('/cug/news', require('./routes/universities/cug/news'));
-router.get('/cug/gcxy/:type?', require('./routes/universities/cug/gcxy/index'));
+router.get('/cug/graduate', lazyloadRouteHandler('./routes/universities/cug/graduate'));
+router.get('/cug/undergraduate', lazyloadRouteHandler('./routes/universities/cug/undergraduate'));
+router.get('/cug/xgxy', lazyloadRouteHandler('./routes/universities/cug/xgxy'));
+router.get('/cug/news', lazyloadRouteHandler('./routes/universities/cug/news'));
+router.get('/cug/gcxy/:type?', lazyloadRouteHandler('./routes/universities/cug/gcxy/index'));
 
 // 海猫吧
-router.get('/haimaoba/:id?', require('./routes/haimaoba/comics'));
+router.get('/haimaoba/:id?', lazyloadRouteHandler('./routes/haimaoba/comics'));
 
 // 路透社
-router.get('/reuters/channel/:site/:channel', require('./routes/reuters/channel'));
+router.get('/reuters/channel/:site/:channel', lazyloadRouteHandler('./routes/reuters/channel'));
 
 // 蒲公英
-router.get('/pgyer/:app?', require('./routes/pgyer/app'));
+router.get('/pgyer/:app?', lazyloadRouteHandler('./routes/pgyer/app'));
 
 // 微博个人时间线
-router.get('/weibo/timeline/:uid/:feature?', require('./routes/weibo/timeline'));
+router.get('/weibo/timeline/:uid/:feature?', lazyloadRouteHandler('./routes/weibo/timeline'));
 
 // TAPTAP
-router.get('/taptap/topic/:id/:label?', require('./routes/taptap/topic'));
-router.get('/taptap/changelog/:id', require('./routes/taptap/changelog'));
-router.get('/taptap/review/:id/:order?', require('./routes/taptap/review'));
+router.get('/taptap/topic/:id/:label?', lazyloadRouteHandler('./routes/taptap/topic'));
+router.get('/taptap/changelog/:id', lazyloadRouteHandler('./routes/taptap/changelog'));
+router.get('/taptap/review/:id/:order?', lazyloadRouteHandler('./routes/taptap/review'));
 
 // lofter
-router.get('/lofter/tag/:name/:type?', require('./routes/lofter/tag'));
-router.get('/lofter/user/:username', require('./routes/lofter/posts'));
+router.get('/lofter/tag/:name/:type?', lazyloadRouteHandler('./routes/lofter/tag'));
+router.get('/lofter/user/:username', lazyloadRouteHandler('./routes/lofter/posts'));
 
 // 米坛社区表盘
-router.get('/watchface/:watch_type?/:list_type?', require('./routes/watchface/update'));
+router.get('/watchface/:watch_type?/:list_type?', lazyloadRouteHandler('./routes/watchface/update'));
 
 // CNU视觉联盟
-router.get('/cnu/selected', require('./routes/cnu/selected'));
-router.get('/cnu/discovery/:type?/:category?', require('./routes/cnu/discovery'));
+router.get('/cnu/selected', lazyloadRouteHandler('./routes/cnu/selected'));
+router.get('/cnu/discovery/:type?/:category?', lazyloadRouteHandler('./routes/cnu/discovery'));
 
 // 战旗直播
-router.get('/zhanqi/room/:id', require('./routes/zhanqi/room'));
+router.get('/zhanqi/room/:id', lazyloadRouteHandler('./routes/zhanqi/room'));
 
 // 酒云网
-router.get('/wineyun/:category', require('./routes/wineyun'));
+router.get('/wineyun/:category', lazyloadRouteHandler('./routes/wineyun'));
 
 // 小红书
-router.get('/xiaohongshu/user/:user_id/:category', require('./routes/xiaohongshu/user'));
-router.get('/xiaohongshu/board/:board_id', require('./routes/xiaohongshu/board'));
+router.get('/xiaohongshu/user/:user_id/:category', lazyloadRouteHandler('./routes/xiaohongshu/user'));
+router.get('/xiaohongshu/board/:board_id', lazyloadRouteHandler('./routes/xiaohongshu/board'));
 
 // 每经网
-router.get('/nbd/daily', require('./routes/nbd/article'));
-router.get('/nbd/:id?', require('./routes/nbd/index'));
+router.get('/nbd/daily', lazyloadRouteHandler('./routes/nbd/article'));
+router.get('/nbd/:id?', lazyloadRouteHandler('./routes/nbd/index'));
 
 // 快知
-router.get('/kzfeed/topic/:id', require('./routes/kzfeed/topic'));
+router.get('/kzfeed/topic/:id', lazyloadRouteHandler('./routes/kzfeed/topic'));
 
 // 腾讯新闻较真查证平台
-router.get('/factcheck', require('./routes/tencent/factcheck'));
+router.get('/factcheck', lazyloadRouteHandler('./routes/tencent/factcheck'));
 
 // X-MOL化学资讯平台
-router.get('/x-mol/news/:tag?', require('./routes/x-mol/news.js'));
-router.get('/x-mol/paper/:type/:magazine', require('./routes/x-mol/paper'));
+router.get('/x-mol/news/:tag?', lazyloadRouteHandler('./routes/x-mol/news.js'));
+router.get('/x-mol/paper/:type/:magazine', lazyloadRouteHandler('./routes/x-mol/paper'));
 
 // 知识分子
-router.get('/zhishifenzi/news/:type?', require('./routes/zhishifenzi/news'));
-router.get('/zhishifenzi/depth', require('./routes/zhishifenzi/depth'));
-router.get('/zhishifenzi/innovation/:type?', require('./routes/zhishifenzi/innovation'));
+router.get('/zhishifenzi/news/:type?', lazyloadRouteHandler('./routes/zhishifenzi/news'));
+router.get('/zhishifenzi/depth', lazyloadRouteHandler('./routes/zhishifenzi/depth'));
+router.get('/zhishifenzi/innovation/:type?', lazyloadRouteHandler('./routes/zhishifenzi/innovation'));
 
 // 電撃Online
-router.get('/dengekionline/:type?', require('./routes/dengekionline/new'));
+router.get('/dengekionline/:type?', lazyloadRouteHandler('./routes/dengekionline/new'));
 
 // 4Gamers
-router.get('/4gamers/category/:category', require('./routes/4gamers/category'));
-router.get('/4gamers/tag/:tag', require('./routes/4gamers/tag'));
-router.get('/4gamers/topic/:topic', require('./routes/4gamers/topic'));
+router.get('/4gamers/category/:category', lazyloadRouteHandler('./routes/4gamers/category'));
+router.get('/4gamers/tag/:tag', lazyloadRouteHandler('./routes/4gamers/tag'));
+router.get('/4gamers/topic/:topic', lazyloadRouteHandler('./routes/4gamers/topic'));
 
 // 大麦网
-router.get('/damai/activity/:city/:category/:subcategory/:keyword?', require('./routes/damai/activity'));
+router.get('/damai/activity/:city/:category/:subcategory/:keyword?', lazyloadRouteHandler('./routes/damai/activity'));
 
 // 桂林电子科技大学新闻资讯
-router.get('/guet/xwzx/:type?', require('./routes/guet/news'));
+router.get('/guet/xwzx/:type?', lazyloadRouteHandler('./routes/guet/news'));
 
 // はてな匿名ダイアリー
-router.get('/hatena/anonymous_diary/archive', require('./routes/hatena/anonymous_diary/archive'));
+router.get('/hatena/anonymous_diary/archive', lazyloadRouteHandler('./routes/hatena/anonymous_diary/archive'));
 
 // kaggle
-router.get('/kaggle/discussion/:forumId/:sort?', require('./routes/kaggle/discussion'));
-router.get('/kaggle/competitions/:category?', require('./routes/kaggle/competitions'));
-router.get('/kaggle/user/:user', require('./routes/kaggle/user'));
+router.get('/kaggle/discussion/:forumId/:sort?', lazyloadRouteHandler('./routes/kaggle/discussion'));
+router.get('/kaggle/competitions/:category?', lazyloadRouteHandler('./routes/kaggle/competitions'));
+router.get('/kaggle/user/:user', lazyloadRouteHandler('./routes/kaggle/user'));
 
 // PubMed Trending
-router.get('/pubmed/trending', require('./routes/pubmed/trending'));
+router.get('/pubmed/trending', lazyloadRouteHandler('./routes/pubmed/trending'));
 
 // 领科 (linkresearcher.com)
-router.get('/linkresearcher/:params', require('./routes/linkresearcher/index'));
+router.get('/linkresearcher/:params', lazyloadRouteHandler('./routes/linkresearcher/index'));
 
 // eLife [Sci Journal]
-router.get('/elife/:tid', require('./routes/elife/index'));
+router.get('/elife/:tid', lazyloadRouteHandler('./routes/elife/index'));
 
 // IEEE Xplore [Sci Journal]
-router.get('/ieee/author/:aid/:sortType/:count?', require('./routes/ieee/author'));
+router.get('/ieee/author/:aid/:sortType/:count?', lazyloadRouteHandler('./routes/ieee/author'));
 
 // PNAS [Sci Journal]
-router.get('/pnas/:topic?', require('./routes/pnas/index'));
+router.get('/pnas/:topic?', lazyloadRouteHandler('./routes/pnas/index'));
 
 // cell [Sci Journal]
-router.get('/cell/cell/:category', require('./routes/cell/cell/index'));
-router.get('/cell/cover', require('./routes/cell/cover'));
+router.get('/cell/cell/:category', lazyloadRouteHandler('./routes/cell/cell/index'));
+router.get('/cell/cover', lazyloadRouteHandler('./routes/cell/cover'));
 
 // nature + nature 子刊 [Sci Journal]
-router.get('/nature/research/:journal?', require('./routes/nature/research'));
-router.get('/nature/news-and-comment/:journal?', require('./routes/nature/news-and-comment'));
-router.get('/nature/cover', require('./routes/nature/cover'));
-router.get('/nature/news', require('./routes/nature/news'));
-router.get('/nature/highlight', require('./routes/nature/highlight'));
+router.get('/nature/research/:journal?', lazyloadRouteHandler('./routes/nature/research'));
+router.get('/nature/news-and-comment/:journal?', lazyloadRouteHandler('./routes/nature/news-and-comment'));
+router.get('/nature/cover', lazyloadRouteHandler('./routes/nature/cover'));
+router.get('/nature/news', lazyloadRouteHandler('./routes/nature/news'));
+router.get('/nature/highlight', lazyloadRouteHandler('./routes/nature/highlight'));
 
 // science [Sci Journal]
-router.get('/sciencemag/current/:journal?', require('./routes/sciencemag/current'));
-router.get('/sciencemag/cover', require('./routes/sciencemag/cover'));
-router.get('/sciencemag/early/science', require('./routes/sciencemag/early'));
+router.get('/sciencemag/current/:journal?', lazyloadRouteHandler('./routes/sciencemag/current'));
+router.get('/sciencemag/cover', lazyloadRouteHandler('./routes/sciencemag/cover'));
+router.get('/sciencemag/early/science', lazyloadRouteHandler('./routes/sciencemag/early'));
 
 // dlsite
-router.get('/dlsite/new/:type', require('./routes/dlsite/new'));
-router.get('/dlsite/campaign/:type/:free?', require('./routes/dlsite/campaign'));
+router.get('/dlsite/new/:type', lazyloadRouteHandler('./routes/dlsite/new'));
+router.get('/dlsite/campaign/:type/:free?', lazyloadRouteHandler('./routes/dlsite/campaign'));
 
 // mcbbs
-router.get('/mcbbs/forum/:type', require('./routes/mcbbs/forum'));
-router.get('/mcbbs/post/:tid/:authorid?', require('./routes/mcbbs/post'));
+router.get('/mcbbs/forum/:type', lazyloadRouteHandler('./routes/mcbbs/forum'));
+router.get('/mcbbs/post/:tid/:authorid?', lazyloadRouteHandler('./routes/mcbbs/post'));
 
 // Pocket
-router.get('/pocket/trending', require('./routes/pocket/trending'));
+router.get('/pocket/trending', lazyloadRouteHandler('./routes/pocket/trending'));
 
 // HK01
-router.get('/hk01/zone/:id', require('./routes/hk01/zone'));
-router.get('/hk01/channel/:id', require('./routes/hk01/channel'));
-router.get('/hk01/issue/:id', require('./routes/hk01/issue'));
-router.get('/hk01/tag/:id', require('./routes/hk01/tag'));
-router.get('/hk01/hot', require('./routes/hk01/hot'));
+router.get('/hk01/zone/:id', lazyloadRouteHandler('./routes/hk01/zone'));
+router.get('/hk01/channel/:id', lazyloadRouteHandler('./routes/hk01/channel'));
+router.get('/hk01/issue/:id', lazyloadRouteHandler('./routes/hk01/issue'));
+router.get('/hk01/tag/:id', lazyloadRouteHandler('./routes/hk01/tag'));
+router.get('/hk01/hot', lazyloadRouteHandler('./routes/hk01/hot'));
 
 // 码农周刊
-router.get('/manong-weekly', require('./routes/manong-weekly/issues'));
+router.get('/manong-weekly', lazyloadRouteHandler('./routes/manong-weekly/issues'));
 
 // 每日猪价
-router.get('/pork-price', require('./routes/pork-price'));
+router.get('/pork-price', lazyloadRouteHandler('./routes/pork-price'));
 
 // NOI 全国青少年信息学奥林匹克竞赛
-router.get('/noi', require('./routes/noi'));
-router.get('/noi/winners-list', require('./routes/noi/winners-list'));
-router.get('/noi/province-news', require('./routes/noi/province-news'));
-router.get('/noi/rg-news', require('./routes/noi/rg-news'));
+router.get('/noi', lazyloadRouteHandler('./routes/noi'));
+router.get('/noi/winners-list', lazyloadRouteHandler('./routes/noi/winners-list'));
+router.get('/noi/province-news', lazyloadRouteHandler('./routes/noi/province-news'));
+router.get('/noi/rg-news', lazyloadRouteHandler('./routes/noi/rg-news'));
 
 // 中国工业化和信息部
-router.get('/gov/miit/zcwj', require('./routes/gov/miit/zcwj'));
-router.get('/gov/miit/wjgs', require('./routes/gov/miit/wjgs'));
-router.get('/gov/miit/zcjd', require('./routes/gov/miit/zcjd'));
+router.get('/gov/miit/zcwj', lazyloadRouteHandler('./routes/gov/miit/zcwj'));
+router.get('/gov/miit/wjgs', lazyloadRouteHandler('./routes/gov/miit/wjgs'));
+router.get('/gov/miit/zcjd', lazyloadRouteHandler('./routes/gov/miit/zcjd'));
 
 // 中国国家认证认可监管管理员会
-router.get('/gov/cnca/jgdt', require('./routes/gov/cnca/jgdt'));
-router.get('/gov/cnca/hydt', require('./routes/gov/cnca/hydt'));
+router.get('/gov/cnca/jgdt', lazyloadRouteHandler('./routes/gov/cnca/jgdt'));
+router.get('/gov/cnca/hydt', lazyloadRouteHandler('./routes/gov/cnca/hydt'));
 
-router.get('/gov/cnca/zxtz', require('./routes/gov/cnca/zxtz'));
+router.get('/gov/cnca/zxtz', lazyloadRouteHandler('./routes/gov/cnca/zxtz'));
 
 // clickme
-router.get('/clickme/:site/:grouping/:name', require('./routes/clickme'));
+router.get('/clickme/:site/:grouping/:name', lazyloadRouteHandler('./routes/clickme'));
 
 // 文汇报
-router.get('/whb/:category', require('./routes/whb/zhuzhan'));
+router.get('/whb/:category', lazyloadRouteHandler('./routes/whb/zhuzhan'));
 
 // 三界异次元
-router.get('/3ycy/home', require('./routes/3ycy/home.js'));
+router.get('/3ycy/home', lazyloadRouteHandler('./routes/3ycy/home.js'));
 
 // Emi Nitta official website
-router.get('/emi-nitta/:type', require('./routes/emi-nitta/home'));
+router.get('/emi-nitta/:type', lazyloadRouteHandler('./routes/emi-nitta/home'));
 
 // Alter China
-router.get('/alter-cn/news', require('./routes/alter-cn/news'));
+router.get('/alter-cn/news', lazyloadRouteHandler('./routes/alter-cn/news'));
 
 // Visual Studio Code Marketplace
-router.get('/vscode/marketplace/:type?', require('./routes/vscode/marketplace'));
+router.get('/vscode/marketplace/:type?', lazyloadRouteHandler('./routes/vscode/marketplace'));
 
 // 饭否
-router.get('/fanfou/user_timeline/:uid', require('./routes/fanfou/user_timeline'));
-router.get('/fanfou/home_timeline', require('./routes/fanfou/home_timeline'));
-router.get('/fanfou/favorites/:uid', require('./routes/fanfou/favorites'));
-router.get('/fanfou/trends', require('./routes/fanfou/trends'));
-router.get('/fanfou/public_timeline/:keyword', require('./routes/fanfou/public_timeline'));
+router.get('/fanfou/user_timeline/:uid', lazyloadRouteHandler('./routes/fanfou/user_timeline'));
+router.get('/fanfou/home_timeline', lazyloadRouteHandler('./routes/fanfou/home_timeline'));
+router.get('/fanfou/favorites/:uid', lazyloadRouteHandler('./routes/fanfou/favorites'));
+router.get('/fanfou/trends', lazyloadRouteHandler('./routes/fanfou/trends'));
+router.get('/fanfou/public_timeline/:keyword', lazyloadRouteHandler('./routes/fanfou/public_timeline'));
 
 // ITSlide
-router.get('/itslide/new', require('./routes/itslide/new'));
+router.get('/itslide/new', lazyloadRouteHandler('./routes/itslide/new'));
 
 // Remote Work
-router.get('/remote-work/:caty?', require('./routes/remote-work/index'));
+router.get('/remote-work/:caty?', lazyloadRouteHandler('./routes/remote-work/index'));
 
 // China Times
-router.get('/chinatimes/:caty', require('./routes/chinatimes/index'));
+router.get('/chinatimes/:caty', lazyloadRouteHandler('./routes/chinatimes/index'));
 
 // TransferWise
-router.get('/transferwise/pair/:source/:target', require('./routes/transferwise/pair'));
+router.get('/transferwise/pair/:source/:target', lazyloadRouteHandler('./routes/transferwise/pair'));
 
 // chocolatey
-router.get('/chocolatey/software/:name?', require('./routes/chocolatey/software'));
+router.get('/chocolatey/software/:name?', lazyloadRouteHandler('./routes/chocolatey/software'));
 
 // Nyaa
-router.get('/nyaa/search/:query?', require('./routes/nyaa/search'));
+router.get('/nyaa/search/:query?', lazyloadRouteHandler('./routes/nyaa/search'));
 
 // 片源网
-router.get('/pianyuan/:media?', require('./routes/pianyuan/app'));
+router.get('/pianyuan/:media?', lazyloadRouteHandler('./routes/pianyuan/app'));
 
 // ITHome
-router.get('/ithome/:caty', require('./routes/ithome/index'));
-router.get('/ithome/ranking/:type', require('./routes/ithome/ranking'));
+router.get('/ithome/:caty', lazyloadRouteHandler('./routes/ithome/index'));
+router.get('/ithome/ranking/:type', lazyloadRouteHandler('./routes/ithome/ranking'));
 
 // 巴哈姆特
-router.get('/bahamut/creation/:author/:category?', require('./routes/bahamut/creation'));
-router.get('/bahamut/creation_index/:category?/:subcategory?/:type?', require('./routes/bahamut/creation_index'));
+router.get('/bahamut/creation/:author/:category?', lazyloadRouteHandler('./routes/bahamut/creation'));
+router.get('/bahamut/creation_index/:category?/:subcategory?/:type?', lazyloadRouteHandler('./routes/bahamut/creation_index'));
 
 // CentBrowser
-router.get('/centbrowser/history', require('./routes/centbrowser/history'));
+router.get('/centbrowser/history', lazyloadRouteHandler('./routes/centbrowser/history'));
 
 // 755
-router.get('/755/user/:username', require('./routes/755/user'));
+router.get('/755/user/:username', lazyloadRouteHandler('./routes/755/user'));
 
 // IKEA
-router.get('/ikea/uk/new', require('./routes/ikea/uk/new'));
-router.get('/ikea/uk/offer', require('./routes/ikea/uk/offer'));
+router.get('/ikea/uk/new', lazyloadRouteHandler('./routes/ikea/uk/new'));
+router.get('/ikea/uk/offer', lazyloadRouteHandler('./routes/ikea/uk/offer'));
 
 // Mastodon
-router.get('/mastodon/timeline/:site/:only_media?', require('./routes/mastodon/timeline_local'));
-router.get('/mastodon/remote/:site/:only_media?', require('./routes/mastodon/timeline_remote'));
-router.get('/mastodon/account_id/:site/:account_id/statuses/:only_media?', require('./routes/mastodon/account_id'));
-router.get('/mastodon/acct/:acct/statuses/:only_media?', require('./routes/mastodon/acct'));
+router.get('/mastodon/timeline/:site/:only_media?', lazyloadRouteHandler('./routes/mastodon/timeline_local'));
+router.get('/mastodon/remote/:site/:only_media?', lazyloadRouteHandler('./routes/mastodon/timeline_remote'));
+router.get('/mastodon/account_id/:site/:account_id/statuses/:only_media?', lazyloadRouteHandler('./routes/mastodon/account_id'));
+router.get('/mastodon/acct/:acct/statuses/:only_media?', lazyloadRouteHandler('./routes/mastodon/acct'));
 
 // Kernel Aliyun
-router.get('/aliyun-kernel/index', require('./routes/aliyun-kernel/index'));
+router.get('/aliyun-kernel/index', lazyloadRouteHandler('./routes/aliyun-kernel/index'));
 
 // Vulture
-router.get('/vulture/:tag/:excludetags?', require('./routes/vulture/index'));
+router.get('/vulture/:tag/:excludetags?', lazyloadRouteHandler('./routes/vulture/index'));
 
 // xinwenlianbo
-router.get('/xinwenlianbo/index', require('./routes/xinwenlianbo/index'));
+router.get('/xinwenlianbo/index', lazyloadRouteHandler('./routes/xinwenlianbo/index'));
 
 // Paul Graham - Essays
-router.get('/blogs/paulgraham', require('./routes/blogs/paulgraham'));
+router.get('/blogs/paulgraham', lazyloadRouteHandler('./routes/blogs/paulgraham'));
 
 // invisionapp
-router.get('/invisionapp/inside-design', require('./routes/invisionapp/inside-design'));
+router.get('/invisionapp/inside-design', lazyloadRouteHandler('./routes/invisionapp/inside-design'));
 
 // producthunt
-router.get('/producthunt/today', require('./routes/producthunt/today'));
+router.get('/producthunt/today', lazyloadRouteHandler('./routes/producthunt/today'));
 
 // mlog.club
-router.get('/mlog-club/topics/:node', require('./routes/mlog-club/topics'));
-router.get('/mlog-club/projects', require('./routes/mlog-club/projects'));
+router.get('/mlog-club/topics/:node', lazyloadRouteHandler('./routes/mlog-club/topics'));
+router.get('/mlog-club/projects', lazyloadRouteHandler('./routes/mlog-club/projects'));
 
 // Chrome 网上应用店
-router.get('/chrome/webstore/extensions/:id', require('./routes/chrome/extensions'));
+router.get('/chrome/webstore/extensions/:id', lazyloadRouteHandler('./routes/chrome/extensions'));
 
 // RTHK
-router.get('/rthk-news/:lang/:category', require('./routes/rthk-news/index'));
+router.get('/rthk-news/:lang/:category', lazyloadRouteHandler('./routes/rthk-news/index'));
 
 // yahoo
-router.get('/yahoo-news/:region/:category?', require('./routes/yahoo-news/index'));
+router.get('/yahoo-news/:region/:category?', lazyloadRouteHandler('./routes/yahoo-news/index'));
 
 // Yahoo!テレビ
-router.get('/yahoo-jp-tv/:query', require('./routes/yahoo-jp-tv/index'));
+router.get('/yahoo-jp-tv/:query', lazyloadRouteHandler('./routes/yahoo-jp-tv/index'));
 
 // Yahoo! by Author
-router.get('/yahoo-author/:author', require('./routes/yahoo-author/index'));
+router.get('/yahoo-author/:author', lazyloadRouteHandler('./routes/yahoo-author/index'));
 
 // 白鲸出海
-router.get('/baijing', require('./routes/baijing'));
+router.get('/baijing', lazyloadRouteHandler('./routes/baijing'));
 
 // 低端影视
-router.get('/ddrk/update/:name/:season?', require('./routes/ddrk/index'));
-router.get('/ddrk/tag/:tag', require('./routes/ddrk/list'));
-router.get('/ddrk/category/:category', require('./routes/ddrk/list'));
-router.get('/ddrk/index', require('./routes/ddrk/list'));
+router.get('/ddrk/update/:name/:season?', lazyloadRouteHandler('./routes/ddrk/index'));
+router.get('/ddrk/tag/:tag', lazyloadRouteHandler('./routes/ddrk/list'));
+router.get('/ddrk/category/:category', lazyloadRouteHandler('./routes/ddrk/list'));
+router.get('/ddrk/index', lazyloadRouteHandler('./routes/ddrk/list'));
 
 // avgle
-router.get('/avgle/videos/:order?/:time?/:top?', require('./routes/avgle/videos.js'));
-router.get('/avgle/search/:keyword/:order?/:time?/:top?', require('./routes/avgle/videos.js'));
+router.get('/avgle/videos/:order?/:time?/:top?', lazyloadRouteHandler('./routes/avgle/videos.js'));
+router.get('/avgle/search/:keyword/:order?/:time?/:top?', lazyloadRouteHandler('./routes/avgle/videos.js'));
 
 // 公主链接公告
-router.get('/pcr/news', require('./routes/pcr/news'));
-router.get('/pcr/news-tw', require('./routes/pcr/news-tw'));
-router.get('/pcr/news-cn', require('./routes/pcr/news-cn'));
+router.get('/pcr/news', lazyloadRouteHandler('./routes/pcr/news'));
+router.get('/pcr/news-tw', lazyloadRouteHandler('./routes/pcr/news-tw'));
+router.get('/pcr/news-cn', lazyloadRouteHandler('./routes/pcr/news-cn'));
 
 // project-zero issues
-router.get('/project-zero-issues', require('./routes/project-zero-issues/index'));
+router.get('/project-zero-issues', lazyloadRouteHandler('./routes/project-zero-issues/index'));
 
 // 平安银河实验室
-router.get('/galaxylab', require('./routes/galaxylab/index'));
+router.get('/galaxylab', lazyloadRouteHandler('./routes/galaxylab/index'));
 
 // NOSEC 安全讯息平台
-router.get('/nosec/:keykind?', require('./routes/nosec/index'));
+router.get('/nosec/:keykind?', lazyloadRouteHandler('./routes/nosec/index'));
 
 // Hex-Rays News
-router.get('/hex-rays/news', require('./routes/hex-rays/index'));
+router.get('/hex-rays/news', lazyloadRouteHandler('./routes/hex-rays/index'));
 
 // 新趣集
-router.get('/xinquji/today', require('./routes/xinquji/today'));
-router.get('/xinquji/today/internal', require('./routes/xinquji/internal'));
+router.get('/xinquji/today', lazyloadRouteHandler('./routes/xinquji/today'));
+router.get('/xinquji/today/internal', lazyloadRouteHandler('./routes/xinquji/internal'));
 
 // 英中协会
-router.get('/gbcc/trust', require('./routes/gbcc/trust'));
+router.get('/gbcc/trust', lazyloadRouteHandler('./routes/gbcc/trust'));
 
 // Associated Press
-router.get('/apnews/topics/:topic', require('./routes/apnews/topics'));
+router.get('/apnews/topics/:topic', lazyloadRouteHandler('./routes/apnews/topics'));
 
 // CBC
-router.get('/cbc/topics/:topic?', require('./routes/cbc/topics'));
+router.get('/cbc/topics/:topic?', lazyloadRouteHandler('./routes/cbc/topics'));
 
 // discuz
-router.get('/discuz/:ver([7|x])/:cid([0-9]{2})/:link(.*)', require('./routes/discuz/discuz'));
-router.get('/discuz/:ver([7|x])/:link(.*)', require('./routes/discuz/discuz'));
-router.get('/discuz/:link(.*)', require('./routes/discuz/discuz'));
+router.get('/discuz/:ver([7|x])/:cid([0-9]{2})/:link(.*)', lazyloadRouteHandler('./routes/discuz/discuz'));
+router.get('/discuz/:ver([7|x])/:link(.*)', lazyloadRouteHandler('./routes/discuz/discuz'));
+router.get('/discuz/:link(.*)', lazyloadRouteHandler('./routes/discuz/discuz'));
 
 // China Dialogue 中外对话
-router.get('/chinadialogue/topics/:topic', require('./routes/chinadialogue/topics'));
-router.get('/chinadialogue/:column', require('./routes/chinadialogue/column'));
+router.get('/chinadialogue/topics/:topic', lazyloadRouteHandler('./routes/chinadialogue/topics'));
+router.get('/chinadialogue/:column', lazyloadRouteHandler('./routes/chinadialogue/column'));
 
 // 人民日报社 国际金融报
-router.get('/ifnews/:cid', require('./routes/ifnews/column'));
+router.get('/ifnews/:cid', lazyloadRouteHandler('./routes/ifnews/column'));
 
 // Scala Blog
-router.get('/scala/blog/:part?', require('./routes/scala-blog/scala-blog'));
+router.get('/scala/blog/:part?', lazyloadRouteHandler('./routes/scala-blog/scala-blog'));
 
 // Minecraft Java版游戏更新
-router.get('/minecraft/version', require('./routes/minecraft/version'));
+router.get('/minecraft/version', lazyloadRouteHandler('./routes/minecraft/version'));
 
 // 微信更新日志
-router.get('/weixin/miniprogram/release', require('./routes/tencent/wechat/miniprogram/framework')); // 基础库更新日志
-router.get('/weixin/miniprogram/framework', require('./routes/tencent/wechat/miniprogram/framework')); // 基础库更新日志
-router.get('/weixin/miniprogram/devtools', require('./routes/tencent/wechat/miniprogram/devtools')); // 开发者工具更新日志
-router.get('/weixin/miniprogram/wxcloud/:caty?', require('./routes/tencent/wechat/miniprogram/wxcloud')); // 云开发更新日志
+router.get('/weixin/miniprogram/release', lazyloadRouteHandler('./routes/tencent/wechat/miniprogram/framework')); // 基础库更新日志
+router.get('/weixin/miniprogram/framework', lazyloadRouteHandler('./routes/tencent/wechat/miniprogram/framework')); // 基础库更新日志
+router.get('/weixin/miniprogram/devtools', lazyloadRouteHandler('./routes/tencent/wechat/miniprogram/devtools')); // 开发者工具更新日志
+router.get('/weixin/miniprogram/wxcloud/:caty?', lazyloadRouteHandler('./routes/tencent/wechat/miniprogram/wxcloud')); // 云开发更新日志
 
 // 武汉肺炎疫情动态
-router.get('/coronavirus/caixin', require('./routes/coronavirus/caixin'));
-router.get('/coronavirus/dxy/data/:province?/:city?', require('./routes/coronavirus/dxy-data'));
-router.get('/coronavirus/dxy', require('./routes/coronavirus/dxy'));
-router.get('/coronavirus/scmp', require('./routes/coronavirus/scmp'));
-router.get('/coronavirus/nhc', require('./routes/coronavirus/nhc'));
-router.get('/coronavirus/mogov-2019ncov/:lang', require('./routes/coronavirus/mogov-2019ncov'));
-router.get('/coronavirus/qq/fact', require('./routes/tencent/factcheck'));
-router.get('/coronavirus/sg-moh', require('./routes/coronavirus/sg-moh'));
+router.get('/coronavirus/caixin', lazyloadRouteHandler('./routes/coronavirus/caixin'));
+router.get('/coronavirus/dxy/data/:province?/:city?', lazyloadRouteHandler('./routes/coronavirus/dxy-data'));
+router.get('/coronavirus/dxy', lazyloadRouteHandler('./routes/coronavirus/dxy'));
+router.get('/coronavirus/scmp', lazyloadRouteHandler('./routes/coronavirus/scmp'));
+router.get('/coronavirus/nhc', lazyloadRouteHandler('./routes/coronavirus/nhc'));
+router.get('/coronavirus/mogov-2019ncov/:lang', lazyloadRouteHandler('./routes/coronavirus/mogov-2019ncov'));
+router.get('/coronavirus/qq/fact', lazyloadRouteHandler('./routes/tencent/factcheck'));
+router.get('/coronavirus/sg-moh', lazyloadRouteHandler('./routes/coronavirus/sg-moh'));
 
 // 南京林业大学教务处
-router.get('/njfu/jwc/:category?', require('./routes/universities/njfu/jwc'));
+router.get('/njfu/jwc/:category?', lazyloadRouteHandler('./routes/universities/njfu/jwc'));
 
 // 日本経済新聞
-router.get('/nikkei/index', require('./routes/nikkei/index'));
-router.get('/nikkei/:category/:article_type?', require('./routes/nikkei/news'));
+router.get('/nikkei/index', lazyloadRouteHandler('./routes/nikkei/index'));
+router.get('/nikkei/:category/:article_type?', lazyloadRouteHandler('./routes/nikkei/news'));
 
 // MQube
-router.get('/mqube/user/:user', require('./routes/mqube/user'));
-router.get('/mqube/tag/:tag', require('./routes/mqube/tag'));
-router.get('/mqube/latest', require('./routes/mqube/latest'));
-router.get('/mqube/top', require('./routes/mqube/top'));
+router.get('/mqube/user/:user', lazyloadRouteHandler('./routes/mqube/user'));
+router.get('/mqube/tag/:tag', lazyloadRouteHandler('./routes/mqube/tag'));
+router.get('/mqube/latest', lazyloadRouteHandler('./routes/mqube/latest'));
+router.get('/mqube/top', lazyloadRouteHandler('./routes/mqube/top'));
 
 // Letterboxd
-router.get('/letterboxd/user/diary/:username', require('./routes/letterboxd/userdiary'));
-router.get('/letterboxd/user/followingdiary/:username', require('./routes/letterboxd/followingdiary'));
+router.get('/letterboxd/user/diary/:username', lazyloadRouteHandler('./routes/letterboxd/userdiary'));
+router.get('/letterboxd/user/followingdiary/:username', lazyloadRouteHandler('./routes/letterboxd/followingdiary'));
 
 // javlibrary
-router.get('/javlibrary/users/:uid/:utype', require('./routes/javlibrary/users'));
-router.get('/javlibrary/videos/:vtype', require('./routes/javlibrary/videos'));
-router.get('/javlibrary/stars/:sid', require('./routes/javlibrary/stars'));
-router.get('/javlibrary/bestreviews', require('./routes/javlibrary/bestreviews'));
+router.get('/javlibrary/users/:uid/:utype', lazyloadRouteHandler('./routes/javlibrary/users'));
+router.get('/javlibrary/videos/:vtype', lazyloadRouteHandler('./routes/javlibrary/videos'));
+router.get('/javlibrary/stars/:sid', lazyloadRouteHandler('./routes/javlibrary/stars'));
+router.get('/javlibrary/bestreviews', lazyloadRouteHandler('./routes/javlibrary/bestreviews'));
 
 // Last.FM
-router.get('/lastfm/recent/:user', require('./routes/lastfm/recent'));
-router.get('/lastfm/loved/:user', require('./routes/lastfm/loved'));
-router.get('/lastfm/top/:country?', require('./routes/lastfm/top'));
+router.get('/lastfm/recent/:user', lazyloadRouteHandler('./routes/lastfm/recent'));
+router.get('/lastfm/loved/:user', lazyloadRouteHandler('./routes/lastfm/loved'));
+router.get('/lastfm/top/:country?', lazyloadRouteHandler('./routes/lastfm/top'));
 
 // piapro
-router.get('/piapro/user/:pid', require('./routes/piapro/user'));
-router.get('/piapro/public/:type/:tag?/:category?', require('./routes/piapro/public'));
+router.get('/piapro/user/:pid', lazyloadRouteHandler('./routes/piapro/user'));
+router.get('/piapro/public/:type/:tag?/:category?', lazyloadRouteHandler('./routes/piapro/public'));
 
 // 凤凰网
-router.get('/ifeng/feng/:id/:type', require('./routes/ifeng/feng'));
+router.get('/ifeng/feng/:id/:type', lazyloadRouteHandler('./routes/ifeng/feng'));
 
 // 第一版主
-router.get('/novel/d1bz/:category/:id', require('./routes/d1bz/novel'));
+router.get('/novel/d1bz/:category/:id', lazyloadRouteHandler('./routes/d1bz/novel'));
 
 // 爱下电子书
-router.get('/axdzs/:id1/:id2', require('./routes/novel/axdzs'));
+router.get('/axdzs/:id1/:id2', lazyloadRouteHandler('./routes/novel/axdzs'));
 
 // HackerOne
-router.get('/hackerone/hacktivity', require('./routes/hackerone/hacktivity'));
-router.get('/hackerone/search/:search', require('./routes/hackerone/search'));
+router.get('/hackerone/hacktivity', lazyloadRouteHandler('./routes/hackerone/hacktivity'));
+router.get('/hackerone/search/:search', lazyloadRouteHandler('./routes/hackerone/search'));
 
 // 奶牛关
-router.get('/cowlevel/element/:id', require('./routes/cowlevel/element'));
+router.get('/cowlevel/element/:id', lazyloadRouteHandler('./routes/cowlevel/element'));
 
 // 2048
-router.get('/2048/bbs/:fid', require('./routes/2048/bbs'));
+router.get('/2048/bbs/:fid', lazyloadRouteHandler('./routes/2048/bbs'));
 
 // Google News
-router.get('/google/news/:category/:locale', require('./routes/google/news'));
+router.get('/google/news/:category/:locale', lazyloadRouteHandler('./routes/google/news'));
 
 // 虛詞
-router.get('/p-articles/section/:section', require('./routes/p-articles/section'));
-router.get('/p-articles/contributors/:author', require('./routes/p-articles/contributors'));
+router.get('/p-articles/section/:section', lazyloadRouteHandler('./routes/p-articles/section'));
+router.get('/p-articles/contributors/:author', lazyloadRouteHandler('./routes/p-articles/contributors'));
 
 // finviz
 
-router.get('/finviz/news/:ticker', require('./routes/finviz/news'));
+router.get('/finviz/news/:ticker', lazyloadRouteHandler('./routes/finviz/news'));
 
 // 好好住
-router.get('/haohaozhu/whole-house/:keyword?', require('./routes/haohaozhu/whole-house'));
-router.get('/haohaozhu/discover/:keyword?', require('./routes/haohaozhu/discover'));
+router.get('/haohaozhu/whole-house/:keyword?', lazyloadRouteHandler('./routes/haohaozhu/whole-house'));
+router.get('/haohaozhu/discover/:keyword?', lazyloadRouteHandler('./routes/haohaozhu/discover'));
 
 // 东北大学
-router.get('/neu/news/:type', require('./routes/universities/neu/news'));
+router.get('/neu/news/:type', lazyloadRouteHandler('./routes/universities/neu/news'));
 
 // 快递100
-router.get('/kuaidi100/track/:number/:id/:phone?', require('./routes/kuaidi100/index'));
-router.get('/kuaidi100/company', require('./routes/kuaidi100/supported_company'));
+router.get('/kuaidi100/track/:number/:id/:phone?', lazyloadRouteHandler('./routes/kuaidi100/index'));
+router.get('/kuaidi100/company', lazyloadRouteHandler('./routes/kuaidi100/supported_company'));
 
 // 稻草人书屋
-router.get('/dcrsw/:name/:count?', require('./routes/novel/dcrsw'));
+router.get('/dcrsw/:name/:count?', lazyloadRouteHandler('./routes/novel/dcrsw'));
 
 // 魔法纪录
-router.get('/magireco/announcements', require('./routes/magireco/announcements'));
-router.get('/magireco/event_banner', require('./routes/magireco/event_banner'));
+router.get('/magireco/announcements', lazyloadRouteHandler('./routes/magireco/announcements'));
+router.get('/magireco/event_banner', lazyloadRouteHandler('./routes/magireco/event_banner'));
 
 // wolley
-router.get('/wolley', require('./routes/wolley/index'));
-router.get('/wolley/user/:id', require('./routes/wolley/user'));
-router.get('/wolley/host/:host', require('./routes/wolley/host'));
+router.get('/wolley', lazyloadRouteHandler('./routes/wolley/index'));
+router.get('/wolley/user/:id', lazyloadRouteHandler('./routes/wolley/user'));
+router.get('/wolley/host/:host', lazyloadRouteHandler('./routes/wolley/host'));
 
 // 西安交大
-router.get('/xjtu/gs/tzgg', require('./routes/universities/xjtu/gs/tzgg'));
-router.get('/xjtu/dean/:subpath+', require('./routes/universities/xjtu/dean'));
-router.get('/xjtu/international/:subpath+', require('./routes/universities/xjtu/international'));
-router.get('/xjtu/job/:subpath?', require('./routes/universities/xjtu/job'));
-router.get('/xjtu/ee/:id?', require('./routes/universities/xjtu/ee'));
+router.get('/xjtu/gs/tzgg', lazyloadRouteHandler('./routes/universities/xjtu/gs/tzgg'));
+router.get('/xjtu/dean/:subpath+', lazyloadRouteHandler('./routes/universities/xjtu/dean'));
+router.get('/xjtu/international/:subpath+', lazyloadRouteHandler('./routes/universities/xjtu/international'));
+router.get('/xjtu/job/:subpath?', lazyloadRouteHandler('./routes/universities/xjtu/job'));
+router.get('/xjtu/ee/:id?', lazyloadRouteHandler('./routes/universities/xjtu/ee'));
 
 // booksource
-router.get('/booksource', require('./routes/booksource/index'));
+router.get('/booksource', lazyloadRouteHandler('./routes/booksource/index'));
 
 // ku
-router.get('/ku/:name?', require('./routes/ku/index'));
+router.get('/ku/:name?', lazyloadRouteHandler('./routes/ku/index'));
 
 // 我有一片芝麻地
-router.get('/blogs/hedwig/:type', require('./routes/blogs/hedwig'));
+router.get('/blogs/hedwig/:type', lazyloadRouteHandler('./routes/blogs/hedwig'));
 
 // LoveHeaven
-router.get('/loveheaven/update/:slug', require('./routes/loveheaven/update'));
+router.get('/loveheaven/update/:slug', lazyloadRouteHandler('./routes/loveheaven/update'));
 
 // 拉勾
-router.get('/lagou/jobs/:position/:city', require('./routes/lagou/jobs'));
+router.get('/lagou/jobs/:position/:city', lazyloadRouteHandler('./routes/lagou/jobs'));
 
 // 扬州大学
-router.get('/yzu/home/:type', require('./routes/universities/yzu/home'));
-router.get('/yzu/yjszs/:type', require('./routes/universities/yzu/yjszs'));
+router.get('/yzu/home/:type', lazyloadRouteHandler('./routes/universities/yzu/home'));
+router.get('/yzu/yjszs/:type', lazyloadRouteHandler('./routes/universities/yzu/yjszs'));
 
 // 国家自然科学基金委员会
-router.get('/nsfc/news/:type?', require('./routes/nsfc/news'));
+router.get('/nsfc/news/:type?', lazyloadRouteHandler('./routes/nsfc/news'));
 
 // 德国新闻社卫健新闻
-router.get('/krankenkassen', require('./routes/krankenkassen'));
+router.get('/krankenkassen', lazyloadRouteHandler('./routes/krankenkassen'));
 
 // 桂林航天工业学院
-router.get('/guat/news/:type?', require('./routes/guat/news'));
+router.get('/guat/news/:type?', lazyloadRouteHandler('./routes/guat/news'));
 
 // 国家留学网
-router.get('/csc/notice/:type?', require('./routes/csc/notice'));
+router.get('/csc/notice/:type?', lazyloadRouteHandler('./routes/csc/notice'));
 
 // LearnKu
-router.get('/learnku/:community/:category?', require('./routes/learnku/topic'));
+router.get('/learnku/:community/:category?', lazyloadRouteHandler('./routes/learnku/topic'));
 
 // NEEA
-router.get('/neea/:type', require('./routes/neea'));
+router.get('/neea/:type', lazyloadRouteHandler('./routes/neea'));
 
 // 中国农业大学
-router.get('/cauyjs', require('./routes/universities/cauyjs/cauyjs'));
+router.get('/cauyjs', lazyloadRouteHandler('./routes/universities/cauyjs/cauyjs'));
 
 // 南方科技大学
-router.get('/sustyjs', require('./routes/universities/sustyjs/sustyjs'));
-router.get('/sustech/newshub-zh', require('./routes/universities/sustech/newshub-zh'));
-router.get('/sustech/bidding', require('./routes/universities/sustech/bidding'));
+router.get('/sustyjs', lazyloadRouteHandler('./routes/universities/sustyjs/sustyjs'));
+router.get('/sustech/newshub-zh', lazyloadRouteHandler('./routes/universities/sustech/newshub-zh'));
+router.get('/sustech/bidding', lazyloadRouteHandler('./routes/universities/sustech/bidding'));
 
 // 广州航海学院
-router.get('/gzmtu/jwc', require('./routes/universities/gzmtu/jwc'));
-router.get('/gzmtu/tsg', require('./routes/universities/gzmtu/tsg'));
+router.get('/gzmtu/jwc', lazyloadRouteHandler('./routes/universities/gzmtu/jwc'));
+router.get('/gzmtu/tsg', lazyloadRouteHandler('./routes/universities/gzmtu/tsg'));
 
 // 广州大学
-router.get('/gzyjs', require('./routes/universities/gzyjs/gzyjs'));
+router.get('/gzyjs', lazyloadRouteHandler('./routes/universities/gzyjs/gzyjs'));
 
 // 暨南大学
-router.get('/jnu/xysx/:type', require('./routes/universities/jnu/xysx/index'));
-router.get('/jnu/yw/:type?', require('./routes/universities/jnu/yw/index'));
+router.get('/jnu/xysx/:type', lazyloadRouteHandler('./routes/universities/jnu/xysx/index'));
+router.get('/jnu/yw/:type?', lazyloadRouteHandler('./routes/universities/jnu/yw/index'));
 
 // 深圳大学
-router.get('/szuyjs', require('./routes/universities/szuyjs/szuyjs'));
+router.get('/szuyjs', lazyloadRouteHandler('./routes/universities/szuyjs/szuyjs'));
 
 // 中国传媒大学
-router.get('/cucyjs', require('./routes/universities/cucyjs/cucyjs'));
+router.get('/cucyjs', lazyloadRouteHandler('./routes/universities/cucyjs/cucyjs'));
 
 // 中国农业大学信电学院
-router.get('/cauele', require('./routes/universities/cauyjs/cauyjs'));
+router.get('/cauele', lazyloadRouteHandler('./routes/universities/cauyjs/cauyjs'));
 
 // moxingfans
-router.get('/moxingfans', require('./routes/moxingfans'));
+router.get('/moxingfans', lazyloadRouteHandler('./routes/moxingfans'));
 
 // Chiphell
-router.get('/chiphell/forum/:forumId?', require('./routes/chiphell/forum'));
+router.get('/chiphell/forum/:forumId?', lazyloadRouteHandler('./routes/chiphell/forum'));
 
 // 华东理工大学研究生院
-router.get('/ecustyjs', require('./routes/universities/ecustyjs/ecustyjs'));
+router.get('/ecustyjs', lazyloadRouteHandler('./routes/universities/ecustyjs/ecustyjs'));
 
 // 同济大学研究生院
-router.get('/tjuyjs', require('./routes/universities/tjuyjs/tjuyjs'));
+router.get('/tjuyjs', lazyloadRouteHandler('./routes/universities/tjuyjs/tjuyjs'));
 
 // 中国石油大学研究生院
-router.get('/upcyjs', require('./routes/universities/upcyjs/upcyjs'));
+router.get('/upcyjs', lazyloadRouteHandler('./routes/universities/upcyjs/upcyjs'));
 
 // 中国海洋大学研究生院
-router.get('/outyjs', require('./routes/universities/outyjs/outyjs'));
+router.get('/outyjs', lazyloadRouteHandler('./routes/universities/outyjs/outyjs'));
 
 // 中科院人工智能所
-router.get('/zkyai', require('./routes/universities/zkyai/zkyai'));
+router.get('/zkyai', lazyloadRouteHandler('./routes/universities/zkyai/zkyai'));
 
 // 中科院自动化所
-router.get('/zkyyjs', require('./routes/universities/zkyyjs/zkyyjs'));
+router.get('/zkyyjs', lazyloadRouteHandler('./routes/universities/zkyyjs/zkyyjs'));
 
 // 中国海洋大学信电学院
-router.get('/outele', require('./routes/universities/outele/outele'));
+router.get('/outele', lazyloadRouteHandler('./routes/universities/outele/outele'));
 
 // 华东师范大学研究生院
-router.get('/ecnuyjs', require('./routes/universities/ecnuyjs/ecnuyjs'));
+router.get('/ecnuyjs', lazyloadRouteHandler('./routes/universities/ecnuyjs/ecnuyjs'));
 
 // 考研帮调剂信息
-router.get('/kaoyan', require('./routes/kaoyan/kaoyan'));
+router.get('/kaoyan', lazyloadRouteHandler('./routes/kaoyan/kaoyan'));
 
 // 华中科技大学研究生院
-router.get('/hustyjs', require('./routes/universities/hustyjs/hustyjs'));
+router.get('/hustyjs', lazyloadRouteHandler('./routes/universities/hustyjs/hustyjs'));
 
 // 华中师范大学研究生院
-router.get('/ccnuyjs', require('./routes/universities/ccnu/ccnuyjs'));
+router.get('/ccnuyjs', lazyloadRouteHandler('./routes/universities/ccnu/ccnuyjs'));
 
 // 华中师范大学计算机学院
-router.get('/ccnucs', require('./routes/universities/ccnu/ccnucs'));
+router.get('/ccnucs', lazyloadRouteHandler('./routes/universities/ccnu/ccnucs'));
 
 // 华中师范大学伍论贡学院
-router.get('/ccnuwu', require('./routes/universities/ccnu/ccnuwu'));
+router.get('/ccnuwu', lazyloadRouteHandler('./routes/universities/ccnu/ccnuwu'));
 
 // WEEX
-router.get('/weexcn/news/:typeid', require('./routes/weexcn/index'));
+router.get('/weexcn/news/:typeid', lazyloadRouteHandler('./routes/weexcn/index'));
 
 // 天天基金
-router.get('/eastmoney/user/:uid', require('./routes/eastmoney/user'));
+router.get('/eastmoney/user/:uid', lazyloadRouteHandler('./routes/eastmoney/user'));
 
 // 紳士漫畫
-router.get('/ssmh', require('./routes/ssmh'));
-router.get('/ssmh/category/:cid', require('./routes/ssmh/category'));
+router.get('/ssmh', lazyloadRouteHandler('./routes/ssmh'));
+router.get('/ssmh/category/:cid', lazyloadRouteHandler('./routes/ssmh/category'));
 
 // 武昌首义学院
-router.get('/wsyu/news/:type?', require('./routes/universities/wsyu/news'));
+router.get('/wsyu/news/:type?', lazyloadRouteHandler('./routes/universities/wsyu/news'));
 
 // 华南师范大学研究生学院
-router.get('/scnuyjs', require('./routes/universities/scnu/scnuyjs'));
+router.get('/scnuyjs', lazyloadRouteHandler('./routes/universities/scnu/scnuyjs'));
 
 // 华南师范大学软件学院
-router.get('/scnucs', require('./routes/universities/scnu/scnucs'));
+router.get('/scnucs', lazyloadRouteHandler('./routes/universities/scnu/scnucs'));
 
 // 华南理工大学研究生院
-router.get('/scutyjs', require('./routes/universities/scut/scutyjs'));
+router.get('/scutyjs', lazyloadRouteHandler('./routes/universities/scut/scutyjs'));
 
 // 华南农业大学研究生院通知公告
-router.get('/scauyjs', require('./routes/universities/scauyjs/scauyjs'));
+router.get('/scauyjs', lazyloadRouteHandler('./routes/universities/scauyjs/scauyjs'));
 
 // 北京大学研究生招生网通知公告
-router.get('/pkuyjs', require('./routes/universities/pku/pkuyjs'));
+router.get('/pkuyjs', lazyloadRouteHandler('./routes/universities/pku/pkuyjs'));
 
 // 北京理工大学研究生通知公告
-router.get('/bityjs', require('./routes/universities/bit/bityjs'));
+router.get('/bityjs', lazyloadRouteHandler('./routes/universities/bit/bityjs'));
 
 // 湖南科技大学教务处
-router.get('/hnust/jwc', require('./routes/universities/hnust/jwc/index'));
-router.get('/hnust/computer', require('./routes/universities/hnust/computer/index'));
-router.get('/hnust/art', require('./routes/universities/hnust/art/index'));
-router.get('/hnust/chem', require('./routes/universities/hnust/chem/index'));
-router.get('/hnust/graduate/:type?', require('./routes/universities/hnust/graduate/index'));
+router.get('/hnust/jwc', lazyloadRouteHandler('./routes/universities/hnust/jwc/index'));
+router.get('/hnust/computer', lazyloadRouteHandler('./routes/universities/hnust/computer/index'));
+router.get('/hnust/art', lazyloadRouteHandler('./routes/universities/hnust/art/index'));
+router.get('/hnust/chem', lazyloadRouteHandler('./routes/universities/hnust/chem/index'));
+router.get('/hnust/graduate/:type?', lazyloadRouteHandler('./routes/universities/hnust/graduate/index'));
 
 // 西南交通大学
-router.get('/swjtu/tl/news', require('./routes/swjtu/tl/news'));
+router.get('/swjtu/tl/news', lazyloadRouteHandler('./routes/swjtu/tl/news'));
 
 // AGE动漫
-router.get('/agefans/detail/:id', require('./routes/agefans/detail'));
-router.get('/agefans/update', require('./routes/agefans/update'));
+router.get('/agefans/detail/:id', lazyloadRouteHandler('./routes/agefans/detail'));
+router.get('/agefans/update', lazyloadRouteHandler('./routes/agefans/update'));
 
 // Checkra1n
-router.get('/checkra1n/releases', require('./routes/checkra1n/releases'));
+router.get('/checkra1n/releases', lazyloadRouteHandler('./routes/checkra1n/releases'));
 
 // 四川省科学技术厅
-router.get('/sckjt/news/:type?', require('./routes/sckjt/news'));
+router.get('/sckjt/news/:type?', lazyloadRouteHandler('./routes/sckjt/news'));
 
 // 绝对领域
-router.get('/jdlingyu/:type', require('./routes/jdlingyu/index'));
+router.get('/jdlingyu/:type', lazyloadRouteHandler('./routes/jdlingyu/index'));
 
 // Hi, DIYgod
-router.get('/blogs/diygod/animal-crossing', require('./routes/blogs/diygod/animal-crossing'));
-router.get('/blogs/diygod/gk', require('./routes/blogs/diygod/gk'));
+router.get('/blogs/diygod/animal-crossing', lazyloadRouteHandler('./routes/blogs/diygod/animal-crossing'));
+router.get('/blogs/diygod/gk', lazyloadRouteHandler('./routes/blogs/diygod/gk'));
 
 // 湖北工业大学
-router.get('/hbut/news/:type', require('./routes/universities/hbut/news'));
-router.get('/hbut/cs/:type', require('./routes/universities/hbut/cs'));
+router.get('/hbut/news/:type', lazyloadRouteHandler('./routes/universities/hbut/news'));
+router.get('/hbut/cs/:type', lazyloadRouteHandler('./routes/universities/hbut/cs'));
 
 // acwifi
-router.get('/acwifi', require('./routes/acwifi'));
+router.get('/acwifi', lazyloadRouteHandler('./routes/acwifi'));
 
 // a岛匿名版
-router.get('/adnmb/:pid', require('./routes/adnmb/index'));
+router.get('/adnmb/:pid', lazyloadRouteHandler('./routes/adnmb/index'));
 
 // MIT科技评论
-router.get('/mittrchina/:type', require('./routes/mittrchina'));
+router.get('/mittrchina/:type', lazyloadRouteHandler('./routes/mittrchina'));
 
 // 消费者报道
-router.get('/ccreports/article', require('./routes/ccreports'));
+router.get('/ccreports/article', lazyloadRouteHandler('./routes/ccreports'));
 
 // iYouPort
-router.get('/iyouport/article', require('./routes/iyouport'));
-router.get('/iyouport/:category?', require('./routes/iyouport'));
+router.get('/iyouport/article', lazyloadRouteHandler('./routes/iyouport'));
+router.get('/iyouport/:category?', lazyloadRouteHandler('./routes/iyouport'));
 
 // girlimg
-router.get('/girlimg/album/:tag?/:mode?', require('./routes/girlimg/album'));
+router.get('/girlimg/album/:tag?/:mode?', lazyloadRouteHandler('./routes/girlimg/album'));
 
 // etoland
-router.get('/etoland/:bo_table', require('./routes/etoland/board'));
+router.get('/etoland/:bo_table', lazyloadRouteHandler('./routes/etoland/board'));
 
 // 辽宁工程技术大学教务在线公告
-router.get('/lntu/jwnews', require('./routes/universities/lntu/jwnews'));
+router.get('/lntu/jwnews', lazyloadRouteHandler('./routes/universities/lntu/jwnews'));
 
 // 51voa
-router.get('/51voa/:channel', require('./routes/51voa/channel'));
+router.get('/51voa/:channel', lazyloadRouteHandler('./routes/51voa/channel'));
 
 // zhuixinfan
-router.get('/zhuixinfan/list', require('./routes/zhuixinfan/list'));
+router.get('/zhuixinfan/list', lazyloadRouteHandler('./routes/zhuixinfan/list'));
 
 // scoresaber
-router.get('/scoresaber/user/:id', require('./routes/scoresaber/user'));
+router.get('/scoresaber/user/:id', lazyloadRouteHandler('./routes/scoresaber/user'));
 
 // blur-studio
-router.get('/blur-studio', require('./routes/blur-studio/index'));
+router.get('/blur-studio', lazyloadRouteHandler('./routes/blur-studio/index'));
 
 // method-studios
-router.get('/method-studios/:menu?', require('./routes/method-studios/index'));
+router.get('/method-studios/:menu?', lazyloadRouteHandler('./routes/method-studios/index'));
 
 // blow-studio
-router.get('/blow-studio', require('./routes/blow-studio/work'));
+router.get('/blow-studio', lazyloadRouteHandler('./routes/blow-studio/work'));
 
 // axis-studios
-router.get('/axis-studios/:type/:tag?', require('./routes/axis-studios/work'));
+router.get('/axis-studios/:type/:tag?', lazyloadRouteHandler('./routes/axis-studios/work'));
 
 // 人民邮电出版社
-router.get('/ptpress/book/:type?', require('./routes/ptpress/book'));
+router.get('/ptpress/book/:type?', lazyloadRouteHandler('./routes/ptpress/book'));
 
 // uniqlo styling book
-router.get('/uniqlo/stylingbook/:category?', require('./routes/uniqlo/stylingbook'));
+router.get('/uniqlo/stylingbook/:category?', lazyloadRouteHandler('./routes/uniqlo/stylingbook'));
 
 // 本地宝焦点资讯
-router.get('/bendibao/news/:city', require('./routes/bendibao/news'));
+router.get('/bendibao/news/:city', lazyloadRouteHandler('./routes/bendibao/news'));
 
 // unit-image
-router.get('/unit-image/films/:type?', require('./routes/unit-image/films'));
+router.get('/unit-image/films/:type?', lazyloadRouteHandler('./routes/unit-image/films'));
 
 // digic-picture
-router.get('/digic-pictures/:menu/:tags?', require('./routes/digic-pictures/index'));
+router.get('/digic-pictures/:menu/:tags?', lazyloadRouteHandler('./routes/digic-pictures/index'));
 
 // cve.mitre.org
-router.get('/cve/search/:keyword', require('./routes/cve/search'));
+router.get('/cve/search/:keyword', lazyloadRouteHandler('./routes/cve/search'));
 
 // Xposed Module Repository
-router.get('/xposed/module/:mod', require('./routes/xposed/module'));
+router.get('/xposed/module/:mod', lazyloadRouteHandler('./routes/xposed/module'));
 
 // Microsoft Edge
-router.get('/edge/addon/:crxid', require('./routes/edge/addon'));
+router.get('/edge/addon/:crxid', lazyloadRouteHandler('./routes/edge/addon'));
 
 // Microsoft Store
-router.get('/microsoft-store/updates/:productid/:market?', require('./routes/microsoft-store/updates'));
+router.get('/microsoft-store/updates/:productid/:market?', lazyloadRouteHandler('./routes/microsoft-store/updates'));
 
 // 上海立信会计金融学院
-router.get('/slu/tzgg/:id', require('./routes/universities/slu/tzgg'));
-router.get('/slu/jwc/:id', require('./routes/universities/slu/jwc'));
-router.get('/slu/tyyjkxy/:id', require('./routes/universities/slu/tyyjkxy'));
-router.get('/slu/kjxy/:id', require('./routes/universities/slu/kjxy'));
-router.get('/slu/xsc/:id', require('./routes/universities/slu/xsc'));
-router.get('/slu/csggxy/:id', require('./routes/universities/slu/csggxy'));
+router.get('/slu/tzgg/:id', lazyloadRouteHandler('./routes/universities/slu/tzgg'));
+router.get('/slu/jwc/:id', lazyloadRouteHandler('./routes/universities/slu/jwc'));
+router.get('/slu/tyyjkxy/:id', lazyloadRouteHandler('./routes/universities/slu/tyyjkxy'));
+router.get('/slu/kjxy/:id', lazyloadRouteHandler('./routes/universities/slu/kjxy'));
+router.get('/slu/xsc/:id', lazyloadRouteHandler('./routes/universities/slu/xsc'));
+router.get('/slu/csggxy/:id', lazyloadRouteHandler('./routes/universities/slu/csggxy'));
 
 // Ruby China
-router.get('/ruby-china/topics/:type?', require('./routes/ruby-china/topics'));
-router.get('/ruby-china/jobs', require('./routes/ruby-china/jobs'));
+router.get('/ruby-china/topics/:type?', lazyloadRouteHandler('./routes/ruby-china/topics'));
+router.get('/ruby-china/jobs', lazyloadRouteHandler('./routes/ruby-china/jobs'));
 
 // 中国人事考试网
-router.get('/cpta/notice', require('./routes/cpta/notice'));
+router.get('/cpta/notice', lazyloadRouteHandler('./routes/cpta/notice'));
 
 // 广告网
-router.get('/adquan/:type?', require('./routes/adquan/index'));
+router.get('/adquan/:type?', lazyloadRouteHandler('./routes/adquan/index'));
 
 // 齐鲁晚报
-router.get('/qlwb/news', require('./routes/qlwb/news'));
-router.get('/qlwb/city/:city', require('./routes/qlwb/city'));
+router.get('/qlwb/news', lazyloadRouteHandler('./routes/qlwb/news'));
+router.get('/qlwb/city/:city', lazyloadRouteHandler('./routes/qlwb/city'));
 
 // 蜻蜓FM
-router.get('/qingting/channel/:id', require('./routes/qingting/channel'));
+router.get('/qingting/channel/:id', lazyloadRouteHandler('./routes/qingting/channel'));
 
 // 金色财经
-router.get('/jinse/lives', require('./routes/jinse/lives'));
-router.get('/jinse/timeline', require('./routes/jinse/timeline'));
-router.get('/jinse/catalogue/:caty', require('./routes/jinse/catalogue'));
+router.get('/jinse/lives', lazyloadRouteHandler('./routes/jinse/lives'));
+router.get('/jinse/timeline', lazyloadRouteHandler('./routes/jinse/timeline'));
+router.get('/jinse/catalogue/:caty', lazyloadRouteHandler('./routes/jinse/catalogue'));
 
 // deeplearning.ai
-router.get('/deeplearningai/thebatch', require('./routes/deeplearningai/thebatch'));
+router.get('/deeplearningai/thebatch', lazyloadRouteHandler('./routes/deeplearningai/thebatch'));
 
 // Fate Grand Order
-router.get('/fgo/news', require('./routes/fgo/news'));
+router.get('/fgo/news', lazyloadRouteHandler('./routes/fgo/news'));
 
 // RF技术社区
-router.get('/rf/article', require('./routes/rf/article'));
+router.get('/rf/article', lazyloadRouteHandler('./routes/rf/article'));
 
 // University of Massachusetts Amherst
-router.get('/umass/amherst/ecenews', require('./routes/umass/amherst/ecenews'));
-router.get('/umass/amherst/eceseminar', require('./routes/umass/amherst/eceseminar'));
-router.get('/umass/amherst/csnews', require('./routes/umass/amherst/csnews'));
-router.get('/umass/amherst/ipoevents', require('./routes/umass/amherst/ipoevents'));
-router.get('/umass/amherst/ipostories', require('./routes/umass/amherst/ipostories'));
+router.get('/umass/amherst/ecenews', lazyloadRouteHandler('./routes/umass/amherst/ecenews'));
+router.get('/umass/amherst/eceseminar', lazyloadRouteHandler('./routes/umass/amherst/eceseminar'));
+router.get('/umass/amherst/csnews', lazyloadRouteHandler('./routes/umass/amherst/csnews'));
+router.get('/umass/amherst/ipoevents', lazyloadRouteHandler('./routes/umass/amherst/ipoevents'));
+router.get('/umass/amherst/ipostories', lazyloadRouteHandler('./routes/umass/amherst/ipostories'));
 
 // 飘花电影网
-router.get('/piaohua/hot', require('./routes/piaohua/hot'));
+router.get('/piaohua/hot', lazyloadRouteHandler('./routes/piaohua/hot'));
 
 // 快媒体
-router.get('/kuai', require('./routes/kuai/index'));
-router.get('/kuai/:id', require('./routes/kuai/id'));
+router.get('/kuai', lazyloadRouteHandler('./routes/kuai/index'));
+router.get('/kuai/:id', lazyloadRouteHandler('./routes/kuai/id'));
 
 // 生物帮
-router.get('/biobio/:id', require('./routes/biobio/index'));
-router.get('/biobio/:column/:id', require('./routes/biobio/others'));
+router.get('/biobio/:id', lazyloadRouteHandler('./routes/biobio/index'));
+router.get('/biobio/:column/:id', lazyloadRouteHandler('./routes/biobio/others'));
 
 // 199it
-router.get('/199it', require('./routes/199it/index'));
-router.get('/199it/category/:caty', require('./routes/199it/category'));
-router.get('/199it/tag/:tag', require('./routes/199it/tag'));
+router.get('/199it', lazyloadRouteHandler('./routes/199it/index'));
+router.get('/199it/category/:caty', lazyloadRouteHandler('./routes/199it/category'));
+router.get('/199it/tag/:tag', lazyloadRouteHandler('./routes/199it/tag'));
 
 // 唧唧堂
-router.get('/jijitang/article/:id', require('./routes/jijitang/article'));
-router.get('/jijitang/publication', require('./routes/jijitang/publication'));
+router.get('/jijitang/article/:id', lazyloadRouteHandler('./routes/jijitang/article'));
+router.get('/jijitang/publication', lazyloadRouteHandler('./routes/jijitang/publication'));
 
 // 新闻联播
-router.get('/xwlb', require('./routes/xwlb/index'));
+router.get('/xwlb', lazyloadRouteHandler('./routes/xwlb/index'));
 
 // 端传媒
-router.get('/initium/:type?/:language?', require('./routes/initium/full'));
-router.get('/theinitium/:model/:type?/:language?', require('./routes/initium/full'));
+router.get('/initium/:type?/:language?', lazyloadRouteHandler('./routes/initium/full'));
+router.get('/theinitium/:model/:type?/:language?', lazyloadRouteHandler('./routes/initium/full'));
 
 // Grub Street
-router.get('/grubstreet', require('./routes/grubstreet/index'));
+router.get('/grubstreet', lazyloadRouteHandler('./routes/grubstreet/index'));
 
 // 漫画堆
-router.get('/manhuadui/manhua/:name/:serial?', require('./routes/manhuadui/manhua'));
+router.get('/manhuadui/manhua/:name/:serial?', lazyloadRouteHandler('./routes/manhuadui/manhua'));
 
 // 风之漫画
-router.get('/fzdm/manhua/:id', require('./routes/fzdm/manhua'));
+router.get('/fzdm/manhua/:id', lazyloadRouteHandler('./routes/fzdm/manhua'));
 
 // Aljazeera 半岛网
-router.get('/aljazeera/news', require('./routes/aljazeera/news'));
+router.get('/aljazeera/news', lazyloadRouteHandler('./routes/aljazeera/news'));
 
 // CFD indices dividend adjustment
-router.get('/cfd/gbp_div', require('./routes/cfd/gbp_div'));
+router.get('/cfd/gbp_div', lazyloadRouteHandler('./routes/cfd/gbp_div'));
 
 // 中国人民银行
-router.get('/pbc/goutongjiaoliu', require('./routes/pbc/goutongjiaoliu'));
-router.get('/pbc/tradeAnnouncement', require('./routes/pbc/tradeAnnouncement'));
+router.get('/pbc/goutongjiaoliu', lazyloadRouteHandler('./routes/pbc/goutongjiaoliu'));
+router.get('/pbc/tradeAnnouncement', lazyloadRouteHandler('./routes/pbc/tradeAnnouncement'));
 
 // Monotype
-router.get('/monotype/article', require('./routes/monotype/article'));
+router.get('/monotype/article', lazyloadRouteHandler('./routes/monotype/article'));
 
 // Stork
-router.get('/stork/keyword/:trackID/:displayKey', require('./routes/stork/keyword'));
+router.get('/stork/keyword/:trackID/:displayKey', lazyloadRouteHandler('./routes/stork/keyword'));
 
 // 致美化
-router.get('/zhutix/latest', require('./routes/zhutix/latest'));
+router.get('/zhutix/latest', lazyloadRouteHandler('./routes/zhutix/latest'));
 
 // arXiv
-router.get('/arxiv/:query', require('./routes/arxiv/query'));
+router.get('/arxiv/:query', lazyloadRouteHandler('./routes/arxiv/query'));
 
 // 生物谷
-router.get('/shengwugu/:uid?', require('./routes/shengwugu/index'));
+router.get('/shengwugu/:uid?', lazyloadRouteHandler('./routes/shengwugu/index'));
 
 // 环球律师事务所文章
-router.get('/law/hq', require('./routes/law/hq'));
+router.get('/law/hq', lazyloadRouteHandler('./routes/law/hq'));
 
 // 海问律师事务所文章
-router.get('/law/hw', require('./routes/law/hw'));
+router.get('/law/hw', lazyloadRouteHandler('./routes/law/hw'));
 
 // 国枫律师事务所文章
-router.get('/law/gf', require('./routes/law/gf'));
+router.get('/law/gf', lazyloadRouteHandler('./routes/law/gf'));
 
 // 通商律师事务所文章
-router.get('/law/ts', require('./routes/law/ts'));
+router.get('/law/ts', lazyloadRouteHandler('./routes/law/ts'));
 
 // 锦天城律师事务所文章
-router.get('/law/jtc', require('./routes/law/jtc'));
+router.get('/law/jtc', lazyloadRouteHandler('./routes/law/jtc'));
 
 // 中伦律师事务所文章
-router.get('/law/zl', require('./routes/law/zl'));
+router.get('/law/zl', lazyloadRouteHandler('./routes/law/zl'));
 
 // 君合律师事务所文章
-router.get('/law/jh', require('./routes/law/jh'));
+router.get('/law/jh', lazyloadRouteHandler('./routes/law/jh'));
 
 // 德恒律师事务所文章
-router.get('/law/dh', require('./routes/law/dh'));
+router.get('/law/dh', lazyloadRouteHandler('./routes/law/dh'));
 
 // 金诚同达律师事务所文章
-router.get('/law/jctd', require('./routes/law/jctd'));
+router.get('/law/jctd', lazyloadRouteHandler('./routes/law/jctd'));
 
 // Mobilism
-router.get('/mobilism/release', require('./routes/mobilism/release'));
+router.get('/mobilism/release', lazyloadRouteHandler('./routes/mobilism/release'));
 
 // 三星盖乐世社区
-router.get('/samsungmembers/latest', require('./routes/samsungmembers/latest'));
+router.get('/samsungmembers/latest', lazyloadRouteHandler('./routes/samsungmembers/latest'));
 
 // 东莞教研网
-router.get('/dgjyw/:type', require('./routes/dgjyw/index'));
+router.get('/dgjyw/:type', lazyloadRouteHandler('./routes/dgjyw/index'));
 
 // 中国信息通信研究院
-router.get('/gov/caict/bps', require('./routes/gov/caict/bps'));
-router.get('/gov/caict/qwsj', require('./routes/gov/caict/qwsj'));
-router.get('/gov/caict/caictgd', require('./routes/gov/caict/caictgd'));
+router.get('/gov/caict/bps', lazyloadRouteHandler('./routes/gov/caict/bps'));
+router.get('/gov/caict/qwsj', lazyloadRouteHandler('./routes/gov/caict/qwsj'));
+router.get('/gov/caict/caictgd', lazyloadRouteHandler('./routes/gov/caict/caictgd'));
 
 // 中证网
-router.get('/cs/news/:caty', require('./routes/cs/news'));
+router.get('/cs/news/:caty', lazyloadRouteHandler('./routes/cs/news'));
 
 // 财联社
-router.get('/cls/depth/:category?', require('./routes/cls/depth'));
-router.get('/cls/telegraph/:category?', require('./routes/cls/telegraph'));
+router.get('/cls/depth/:category?', lazyloadRouteHandler('./routes/cls/depth'));
+router.get('/cls/telegraph/:category?', lazyloadRouteHandler('./routes/cls/telegraph'));
 
 // hentai-cosplays
-router.get('/hentai-cosplays/:type?/:name?', require('./routes/hentai-cosplays/hentai-cosplays'));
-router.get('/porn-images-xxx/:type?/:name?', require('./routes/hentai-cosplays/porn-images-xxx'));
+router.get('/hentai-cosplays/:type?/:name?', lazyloadRouteHandler('./routes/hentai-cosplays/hentai-cosplays'));
+router.get('/porn-images-xxx/:type?/:name?', lazyloadRouteHandler('./routes/hentai-cosplays/porn-images-xxx'));
 
 // dcinside
-router.get('/dcinside/board/:id', require('./routes/dcinside/board'));
+router.get('/dcinside/board/:id', lazyloadRouteHandler('./routes/dcinside/board'));
 
 // 企鹅电竞
-router.get('/egameqq/room/:id', require('./routes/tencent/egame/room'));
+router.get('/egameqq/room/:id', lazyloadRouteHandler('./routes/tencent/egame/room'));
 
 // 国家税务总局
-router.get('/gov/chinatax/latest', require('./routes/gov/chinatax/latest'));
+router.get('/gov/chinatax/latest', lazyloadRouteHandler('./routes/gov/chinatax/latest'));
 
 // 荔枝FM
-router.get('/lizhi/user/:id', require('./routes/lizhi/user'));
+router.get('/lizhi/user/:id', lazyloadRouteHandler('./routes/lizhi/user'));
 
 // 富途牛牛
-router.get('/futunn/highlights', require('./routes/futunn/highlights'));
+router.get('/futunn/highlights', lazyloadRouteHandler('./routes/futunn/highlights'));
 
 // 外接大脑
-router.get('/waijiedanao/article/:caty', require('./routes/waijiedanao/article'));
+router.get('/waijiedanao/article/:caty', lazyloadRouteHandler('./routes/waijiedanao/article'));
 
 // 即刻
-router.get('/jike/topic/:id', require('./routes/jike/topic'));
-router.get('/jike/topic/text/:id', require('./routes/jike/topicText'));
-router.get('/jike/user/:id', require('./routes/jike/user'));
+router.get('/jike/topic/:id', lazyloadRouteHandler('./routes/jike/topic'));
+router.get('/jike/topic/text/:id', lazyloadRouteHandler('./routes/jike/topicText'));
+router.get('/jike/user/:id', lazyloadRouteHandler('./routes/jike/user'));
 
 // 网易新闻
-router.get('/netease/news/rank/:category?/:type?/:time?', require('./routes/netease/news/rank'));
-router.get('/netease/news/special/:type?', require('./routes/netease/news/special'));
+router.get('/netease/news/rank/:category?/:type?/:time?', lazyloadRouteHandler('./routes/netease/news/rank'));
+router.get('/netease/news/special/:type?', lazyloadRouteHandler('./routes/netease/news/special'));
 
 // 网易 - 网易号
-router.get('/netease/dy/:id', require('./routes/netease/dy'));
-router.get('/netease/dy2/:id', require('./routes/netease/dy2'));
+router.get('/netease/dy/:id', lazyloadRouteHandler('./routes/netease/dy'));
+router.get('/netease/dy2/:id', lazyloadRouteHandler('./routes/netease/dy2'));
 
 // 网易大神
-router.get('/netease/ds/:id', require('./routes/netease/ds'));
+router.get('/netease/ds/:id', lazyloadRouteHandler('./routes/netease/ds'));
 
 // 网易公开课
-router.get('/open163/vip', require('./routes/netease/open/vip'));
-router.get('/open163/latest', require('./routes/netease/open/latest'));
+router.get('/open163/vip', lazyloadRouteHandler('./routes/netease/open/vip'));
+router.get('/open163/latest', lazyloadRouteHandler('./routes/netease/open/latest'));
 
 // Boston.com
-router.get('/boston/:tag?', require('./routes/boston/index'));
+router.get('/boston/:tag?', lazyloadRouteHandler('./routes/boston/index'));
 
 // 中国邮政速递物流
-router.get('/ems/news', require('./routes/ems/news'));
+router.get('/ems/news', lazyloadRouteHandler('./routes/ems/news'));
 
 // 场库
-router.get('/changku', require('./routes/changku/index'));
-router.get('/changku/cate/:postid', require('./routes/changku/index'));
+router.get('/changku', lazyloadRouteHandler('./routes/changku/index'));
+router.get('/changku/cate/:postid', lazyloadRouteHandler('./routes/changku/index'));
 
 // SCMP
-router.get('/scmp/:category_id', require('./routes/scmp/index'));
+router.get('/scmp/:category_id', lazyloadRouteHandler('./routes/scmp/index'));
 
 // 上海市生态环境局
-router.get('/gov/shanghai/sthj', require('./routes/gov/shanghai/sthj'));
+router.get('/gov/shanghai/sthj', lazyloadRouteHandler('./routes/gov/shanghai/sthj'));
 
 // 才符
-router.get('/91ddcc/user/:user', require('./routes/91ddcc/user'));
-router.get('/91ddcc/stage/:stage', require('./routes/91ddcc/stage'));
+router.get('/91ddcc/user/:user', lazyloadRouteHandler('./routes/91ddcc/user'));
+router.get('/91ddcc/stage/:stage', lazyloadRouteHandler('./routes/91ddcc/stage'));
 
 // BookwalkerTW热门新书
-router.get('/bookwalkertw/news', require('./routes/bookwalkertw/news'));
+router.get('/bookwalkertw/news', lazyloadRouteHandler('./routes/bookwalkertw/news'));
 
 // Chicago Tribune
-router.get('/chicagotribune/:category/:subcategory?', require('./routes/chicagotribune/index'));
+router.get('/chicagotribune/:category/:subcategory?', lazyloadRouteHandler('./routes/chicagotribune/index'));
 
 // Amazfit Watch Faces
-router.get('/amazfitwatchfaces/fresh/:model/:type?/:lang?', require('./routes/amazfitwatchfaces/fresh'));
-router.get('/amazfitwatchfaces/updated/:model/:type?/:lang?', require('./routes/amazfitwatchfaces/updated'));
-router.get('/amazfitwatchfaces/top/:model/:type?/:time?/:sortBy?/:lang?', require('./routes/amazfitwatchfaces/top'));
-router.get('/amazfitwatchfaces/search/:model/:keyword?/:sortBy?', require('./routes/amazfitwatchfaces/search'));
+router.get('/amazfitwatchfaces/fresh/:model/:type?/:lang?', lazyloadRouteHandler('./routes/amazfitwatchfaces/fresh'));
+router.get('/amazfitwatchfaces/updated/:model/:type?/:lang?', lazyloadRouteHandler('./routes/amazfitwatchfaces/updated'));
+router.get('/amazfitwatchfaces/top/:model/:type?/:time?/:sortBy?/:lang?', lazyloadRouteHandler('./routes/amazfitwatchfaces/top'));
+router.get('/amazfitwatchfaces/search/:model/:keyword?/:sortBy?', lazyloadRouteHandler('./routes/amazfitwatchfaces/search'));
 
 // 猫耳FM
-router.get('/missevan/drama/latest', require('./routes/missevan/latest'));
-router.get('/missevan/drama/:id', require('./routes/missevan/drama'));
+router.get('/missevan/drama/latest', lazyloadRouteHandler('./routes/missevan/latest'));
+router.get('/missevan/drama/:id', lazyloadRouteHandler('./routes/missevan/drama'));
 
 // Go语言爱好者周刊
-router.get('/go-weekly', require('./routes/go-weekly'));
+router.get('/go-weekly', lazyloadRouteHandler('./routes/go-weekly'));
 
 // popiask提问箱
-router.get('/popiask/:sharecode/:pagesize?', require('./routes/popiask/questions'));
+router.get('/popiask/:sharecode/:pagesize?', lazyloadRouteHandler('./routes/popiask/questions'));
 
 // Tapechat提问箱
-router.get('/tapechat/questionbox/:sharecode/:pagesize?', require('./routes/popiask/tapechat_questions'));
+router.get('/tapechat/questionbox/:sharecode/:pagesize?', lazyloadRouteHandler('./routes/popiask/tapechat_questions'));
 
 // AMD
-router.get('/amd/graphicsdrivers/:id/:rid?', require('./routes/amd/graphicsdrivers'));
+router.get('/amd/graphicsdrivers/:id/:rid?', lazyloadRouteHandler('./routes/amd/graphicsdrivers'));
 
 // 二柄APP
-router.get('/erbingapp/news', require('./routes/erbingapp/news'));
+router.get('/erbingapp/news', lazyloadRouteHandler('./routes/erbingapp/news'));
 
 // 电商报
-router.get('/dsb/area/:area', require('./routes/dsb/area'));
+router.get('/dsb/area/:area', lazyloadRouteHandler('./routes/dsb/area'));
 
 // 靠谱新闻
-router.get('/kaopunews/:language?', require('./routes/kaopunews'));
+router.get('/kaopunews/:language?', lazyloadRouteHandler('./routes/kaopunews'));
 
 // Reuters
-router.get('/reuters/theWire', require('./routes/reuters/theWire'));
+router.get('/reuters/theWire', lazyloadRouteHandler('./routes/reuters/theWire'));
 
 // 格隆汇
-router.get('/gelonghui/user/:id', require('./routes/gelonghui/user'));
-router.get('/gelonghui/subject/:id', require('./routes/gelonghui/subject'));
-router.get('/gelonghui/keyword/:keyword', require('./routes/gelonghui/keyword'));
+router.get('/gelonghui/user/:id', lazyloadRouteHandler('./routes/gelonghui/user'));
+router.get('/gelonghui/subject/:id', lazyloadRouteHandler('./routes/gelonghui/subject'));
+router.get('/gelonghui/keyword/:keyword', lazyloadRouteHandler('./routes/gelonghui/keyword'));
 
 // 光谷社区
-router.get('/guanggoo/:category?', require('./routes/guanggoo/index'));
+router.get('/guanggoo/:category?', lazyloadRouteHandler('./routes/guanggoo/index'));
 
 // 万维读者
-router.get('/creaders/headline', require('./routes/creaders/headline'));
+router.get('/creaders/headline', lazyloadRouteHandler('./routes/creaders/headline'));
 
 // 金山词霸
-router.get('/iciba/:days?/:img_type?', require('./routes/iciba/index'));
+router.get('/iciba/:days?/:img_type?', lazyloadRouteHandler('./routes/iciba/index'));
 
 // 重庆市两江新区信息公开网
-router.get('/gov/chongqing/ljxq/dwgk', require('./routes/gov/chongqing/ljxq/dwgk'));
-router.get('/gov/chongqing/ljxq/zwgk/:caty', require('./routes/gov/chongqing/ljxq/zwgk'));
+router.get('/gov/chongqing/ljxq/dwgk', lazyloadRouteHandler('./routes/gov/chongqing/ljxq/dwgk'));
+router.get('/gov/chongqing/ljxq/zwgk/:caty', lazyloadRouteHandler('./routes/gov/chongqing/ljxq/zwgk'));
 
 // 国家突发事件预警信息发布网
-router.get('/12379', require('./routes/12379/index'));
+router.get('/12379', lazyloadRouteHandler('./routes/12379/index'));
 
 // 鸟哥笔记
-router.get('/ngbj', require('./routes/niaogebiji/index'));
-router.get('/ngbj/today', require('./routes/niaogebiji/today'));
-router.get('/ngbj/cat/:cat', require('./routes/niaogebiji/cat'));
+router.get('/ngbj', lazyloadRouteHandler('./routes/niaogebiji/index'));
+router.get('/ngbj/today', lazyloadRouteHandler('./routes/niaogebiji/today'));
+router.get('/ngbj/cat/:cat', lazyloadRouteHandler('./routes/niaogebiji/cat'));
 
 // 梅花网
-router.get('/meihua/shots/:caty', require('./routes/meihua/shots'));
-router.get('/meihua/article/:caty', require('./routes/meihua/article'));
+router.get('/meihua/shots/:caty', lazyloadRouteHandler('./routes/meihua/shots'));
+router.get('/meihua/article/:caty', lazyloadRouteHandler('./routes/meihua/article'));
 
 // 看点快报
-router.get('/kuaibao', require('./routes/kuaibao/index'));
+router.get('/kuaibao', lazyloadRouteHandler('./routes/kuaibao/index'));
 
 // SocialBeta
-router.get('/socialbeta/home', require('./routes/socialbeta/home'));
-router.get('/socialbeta/hunt', require('./routes/socialbeta/hunt'));
+router.get('/socialbeta/home', lazyloadRouteHandler('./routes/socialbeta/home'));
+router.get('/socialbeta/hunt', lazyloadRouteHandler('./routes/socialbeta/hunt'));
 
 // 东方我乐多丛志
-router.get('/touhougarakuta/:language/:type', require('./routes/touhougarakuta'));
+router.get('/touhougarakuta/:language/:type', lazyloadRouteHandler('./routes/touhougarakuta'));
 
 // 猎趣TV
-router.get('/liequtv/room/:id', require('./routes/liequtv/room'));
+router.get('/liequtv/room/:id', lazyloadRouteHandler('./routes/liequtv/room'));
 
 // Behance
-router.get('/behance/:user/:type?', require('./routes/behance/index'));
+router.get('/behance/:user/:type?', lazyloadRouteHandler('./routes/behance/index'));
 
 // furstar.jp
-router.get('/furstar/characters/:lang?', require('./routes/furstar/index'));
-router.get('/furstar/artists/:lang?', require('./routes/furstar/artists'));
-router.get('/furstar/archive/:lang?', require('./routes/furstar/archive'));
+router.get('/furstar/characters/:lang?', lazyloadRouteHandler('./routes/furstar/index'));
+router.get('/furstar/artists/:lang?', lazyloadRouteHandler('./routes/furstar/artists'));
+router.get('/furstar/archive/:lang?', lazyloadRouteHandler('./routes/furstar/archive'));
 
 // 北京物资学院
-router.get('/bwu/news', require('./routes/universities/bwu/news'));
+router.get('/bwu/news', lazyloadRouteHandler('./routes/universities/bwu/news'));
 
 // Picuki
-router.get('/picuki/profile/:id/:displayVideo?', require('./routes/picuki/profile'));
+router.get('/picuki/profile/:id/:displayVideo?', lazyloadRouteHandler('./routes/picuki/profile'));
 
 // 新榜
-router.get('/newrank/wechat/:wxid', require('./routes/newrank/wechat'));
-router.get('/newrank/douyin/:dyid', require('./routes/newrank/douyin'));
+router.get('/newrank/wechat/:wxid', lazyloadRouteHandler('./routes/newrank/wechat'));
+router.get('/newrank/douyin/:dyid', lazyloadRouteHandler('./routes/newrank/douyin'));
 
 // 漫小肆
-router.get('/manxiaosi/book/:id', require('./routes/manxiaosi/book'));
+router.get('/manxiaosi/book/:id', lazyloadRouteHandler('./routes/manxiaosi/book'));
 
 // 吉林大学校内通知
-router.get('/jlu/oa', require('./routes/universities/jlu/oa'));
+router.get('/jlu/oa', lazyloadRouteHandler('./routes/universities/jlu/oa'));
 
 // 小宇宙
-router.get('/xiaoyuzhou', require('./routes/xiaoyuzhou/pickup'));
+router.get('/xiaoyuzhou', lazyloadRouteHandler('./routes/xiaoyuzhou/pickup'));
 
 // 合肥工业大学
-router.get('/hfut/tzgg', require('./routes/universities/hfut/tzgg'));
+router.get('/hfut/tzgg', lazyloadRouteHandler('./routes/universities/hfut/tzgg'));
 
 // Darwin Awards
-router.get('/darwinawards/all', require('./routes/darwinawards/articles'));
+router.get('/darwinawards/all', lazyloadRouteHandler('./routes/darwinawards/articles'));
 
 // 四川职业技术学院
-router.get('/scvtc/xygg', require('./routes/universities/scvtc/xygg'));
+router.get('/scvtc/xygg', lazyloadRouteHandler('./routes/universities/scvtc/xygg'));
 
 // 华南理工大学土木与交通学院
-router.get('/scut/scet/notice', require('./routes/universities/scut/scet/notice'));
+router.get('/scut/scet/notice', lazyloadRouteHandler('./routes/universities/scut/scet/notice'));
 
 // 华南理工大学电子与信息学院
-router.get('/scut/seie/news_center', require('./routes/universities/scut/seie/news_center'));
+router.get('/scut/seie/news_center', lazyloadRouteHandler('./routes/universities/scut/seie/news_center'));
 
 // OneJAV
-router.get('/onejav/:type/:key?', require('./routes/onejav/one'));
+router.get('/onejav/:type/:key?', lazyloadRouteHandler('./routes/onejav/one'));
 
 // 141jav
-router.get('/141jav/:type/:key?', require('./routes/141jav/141jav'));
+router.get('/141jav/:type/:key?', lazyloadRouteHandler('./routes/141jav/141jav'));
 
 // 141ppv
-router.get('/141ppv/:type/:key?', require('./routes/141ppv/141ppv'));
+router.get('/141ppv/:type/:key?', lazyloadRouteHandler('./routes/141ppv/141ppv'));
 
 // CuriousCat
-router.get('/curiouscat/user/:id', require('./routes/curiouscat/user'));
+router.get('/curiouscat/user/:id', lazyloadRouteHandler('./routes/curiouscat/user'));
 
 // Telecompaper
-router.get('/telecompaper/news/:caty/:year?/:country?/:type?', require('./routes/telecompaper/news'));
-router.get('/telecompaper/search/:keyword?/:company?/:sort?/:period?', require('./routes/telecompaper/search'));
+router.get('/telecompaper/news/:caty/:year?/:country?/:type?', lazyloadRouteHandler('./routes/telecompaper/news'));
+router.get('/telecompaper/search/:keyword?/:company?/:sort?/:period?', lazyloadRouteHandler('./routes/telecompaper/search'));
 
 // 水木社区
-router.get('/newsmth/account/:id', require('./routes/newsmth/account'));
-router.get('/newsmth/section/:section', require('./routes/newsmth/section'));
+router.get('/newsmth/account/:id', lazyloadRouteHandler('./routes/newsmth/account'));
+router.get('/newsmth/section/:section', lazyloadRouteHandler('./routes/newsmth/section'));
 
 // Kotaku
-router.get('/kotaku/story/:type', require('./routes/kotaku/story'));
+router.get('/kotaku/story/:type', lazyloadRouteHandler('./routes/kotaku/story'));
 
 // 梅斯医学
-router.get('/medsci/recommend', require('./routes/medsci/recommend'));
+router.get('/medsci/recommend', lazyloadRouteHandler('./routes/medsci/recommend'));
 
 // Wallpaperhub
-router.get('/wallpaperhub', require('./routes/wallpaperhub/index'));
+router.get('/wallpaperhub', lazyloadRouteHandler('./routes/wallpaperhub/index'));
 
 // 悟空问答
-router.get('/wukong/user/:id/:type?', require('./routes/wukong/user'));
+router.get('/wukong/user/:id/:type?', lazyloadRouteHandler('./routes/wukong/user'));
 
 // 腾讯大数据
-router.get('/tencent/bigdata', require('./routes/tencent/bigdata/index'));
+router.get('/tencent/bigdata', lazyloadRouteHandler('./routes/tencent/bigdata/index'));
 
 // 搜韵网
-router.get('/souyun/today', require('./routes/souyun/today'));
+router.get('/souyun/today', lazyloadRouteHandler('./routes/souyun/today'));
 
 // 生物谷
-router.get('/bioon/latest', require('./routes/bioon/latest'));
+router.get('/bioon/latest', lazyloadRouteHandler('./routes/bioon/latest'));
 
 // soomal
-router.get('/soomal/topics/:category/:language?', require('./routes/soomal/topics'));
+router.get('/soomal/topics/:category/:language?', lazyloadRouteHandler('./routes/soomal/topics'));
 
 // NASA
-router.get('/nasa/apod', require('./routes/nasa/apod'));
-router.get('/nasa/apod-ncku', require('./routes/nasa/apod-ncku'));
-router.get('/nasa/apod-cn', require('./routes/nasa/apod-cn'));
+router.get('/nasa/apod', lazyloadRouteHandler('./routes/nasa/apod'));
+router.get('/nasa/apod-ncku', lazyloadRouteHandler('./routes/nasa/apod-ncku'));
+router.get('/nasa/apod-cn', lazyloadRouteHandler('./routes/nasa/apod-cn'));
 
 // 爱Q生活网
-router.get('/iqshw/latest', require('./routes/3k8/latest'));
-router.get('/3k8/latest', require('./routes/3k8/latest'));
+router.get('/iqshw/latest', lazyloadRouteHandler('./routes/3k8/latest'));
+router.get('/3k8/latest', lazyloadRouteHandler('./routes/3k8/latest'));
 
 // JustRun
-router.get('/justrun', require('./routes/justrun/index'));
+router.get('/justrun', lazyloadRouteHandler('./routes/justrun/index'));
 
 // 上海电力大学
-router.get('/shiep/:type', require('./routes/universities/shiep/index'));
+router.get('/shiep/:type', lazyloadRouteHandler('./routes/universities/shiep/index'));
 
 // 福建新闻
-router.get('/fjnews/:city/:limit', require('./routes/fjnews/fznews'));
-router.get('/fjnews/jjnews', require('./routes/fjnews/jjnews'));
+router.get('/fjnews/:city/:limit', lazyloadRouteHandler('./routes/fjnews/fznews'));
+router.get('/fjnews/jjnews', lazyloadRouteHandler('./routes/fjnews/jjnews'));
 
 // 中山网新闻
-router.get('/zsnews/index/:cateid', require('./routes/zsnews/index'));
+router.get('/zsnews/index/:cateid', lazyloadRouteHandler('./routes/zsnews/index'));
 
 // 孔夫子旧书网
-router.get('/kongfz/people/:id', require('./routes/kongfz/people'));
-router.get('/kongfz/shop/:id/:cat?', require('./routes/kongfz/shop'));
+router.get('/kongfz/people/:id', lazyloadRouteHandler('./routes/kongfz/people'));
+router.get('/kongfz/shop/:id/:cat?', lazyloadRouteHandler('./routes/kongfz/shop'));
 
 // XMind
-router.get('/xmind/mindmap/:lang?', require('./routes/xmind/mindmap'));
+router.get('/xmind/mindmap/:lang?', lazyloadRouteHandler('./routes/xmind/mindmap'));
 
 // 小刀娱乐网
-router.get('/x6d/:id?', require('./routes/x6d/index'));
+router.get('/x6d/:id?', lazyloadRouteHandler('./routes/x6d/index'));
 
 // 思维导图社区
-router.get('/edrawsoft/mindmap/:classId?/:order?/:sort?/:lang?/:price?/:search?', require('./routes/edrawsoft/mindmap'));
+router.get('/edrawsoft/mindmap/:classId?/:order?/:sort?/:lang?/:price?/:search?', lazyloadRouteHandler('./routes/edrawsoft/mindmap'));
 
 // 它惠网
-router.get('/tahui/rptlist', require('./routes/tahui/rptlist'));
+router.get('/tahui/rptlist', lazyloadRouteHandler('./routes/tahui/rptlist'));
 
 // Guiltfree
-router.get('/guiltfree/onsale', require('./routes/guiltfree/onsale'));
+router.get('/guiltfree/onsale', lazyloadRouteHandler('./routes/guiltfree/onsale'));
 
 // 消费明鉴
-router.get('/mingjian', require('./routes/mingjian/index'));
+router.get('/mingjian', lazyloadRouteHandler('./routes/mingjian/index'));
 
 // hentaimama
-router.get('/hentaimama/videos', require('./routes/hentaimama/videos'));
+router.get('/hentaimama/videos', lazyloadRouteHandler('./routes/hentaimama/videos'));
 
 // 无讼
-router.get('/itslaw/judgements/:conditions', require('./routes/itslaw/judgements'));
+router.get('/itslaw/judgements/:conditions', lazyloadRouteHandler('./routes/itslaw/judgements'));
 
 // 文学城
-router.get('/wenxuecity/blog/:id', require('./routes/wenxuecity/blog'));
-router.get('/wenxuecity/bbs/:cat/:elite?', require('./routes/wenxuecity/bbs'));
-router.get('/wenxuecity/hot/:cid', require('./routes/wenxuecity/hot'));
-router.get('/wenxuecity/news', require('./routes/wenxuecity/news'));
+router.get('/wenxuecity/blog/:id', lazyloadRouteHandler('./routes/wenxuecity/blog'));
+router.get('/wenxuecity/bbs/:cat/:elite?', lazyloadRouteHandler('./routes/wenxuecity/bbs'));
+router.get('/wenxuecity/hot/:cid', lazyloadRouteHandler('./routes/wenxuecity/hot'));
+router.get('/wenxuecity/news', lazyloadRouteHandler('./routes/wenxuecity/news'));
 
 // 不安全
-router.get('/buaq', require('./routes/buaq/index'));
+router.get('/buaq', lazyloadRouteHandler('./routes/buaq/index'));
 
 // 快出海
-router.get('/kchuhai', require('./routes/kchuhai/index'));
+router.get('/kchuhai', lazyloadRouteHandler('./routes/kchuhai/index'));
 
 // i春秋资讯
-router.get('/ichunqiu', require('./routes/ichunqiu/index'));
+router.get('/ichunqiu', lazyloadRouteHandler('./routes/ichunqiu/index'));
 
 // 冰山博客
-router.get('/bsblog123', require('./routes/bsblog123/index'));
+router.get('/bsblog123', lazyloadRouteHandler('./routes/bsblog123/index'));
 
 // 纳威安全导航
-router.get('/navisec', require('./routes/navisec/index'));
+router.get('/navisec', lazyloadRouteHandler('./routes/navisec/index'));
 
 // 安全师
-router.get('/secshi', require('./routes/secshi/index'));
+router.get('/secshi', lazyloadRouteHandler('./routes/secshi/index'));
 
 // 出海笔记
-router.get('/chuhaibiji', require('./routes/chuhaibiji/index'));
+router.get('/chuhaibiji', lazyloadRouteHandler('./routes/chuhaibiji/index'));
 
 // 建宁闲谈
-router.get('/blogs/jianning', require('./routes/blogs/jianning'));
+router.get('/blogs/jianning', lazyloadRouteHandler('./routes/blogs/jianning'));
 
 // 妖火网
-router.get('/yaohuo/:type?', require('./routes/yaohuo/index'));
+router.get('/yaohuo/:type?', lazyloadRouteHandler('./routes/yaohuo/index'));
 
 // 互动吧
-router.get('/hudongba/:city/:id', require('./routes/hudongba/index'));
+router.get('/hudongba/:city/:id', lazyloadRouteHandler('./routes/hudongba/index'));
 
 // 差评
-router.get('/chaping/banner', require('./routes/chaping/banner'));
-router.get('/chaping/news/:caty?', require('./routes/chaping/news'));
+router.get('/chaping/banner', lazyloadRouteHandler('./routes/chaping/banner'));
+router.get('/chaping/news/:caty?', lazyloadRouteHandler('./routes/chaping/news'));
 
 // 飞雪娱乐网
-router.get('/feixuew/:id?', require('./routes/feixuew/index'));
+router.get('/feixuew/:id?', lazyloadRouteHandler('./routes/feixuew/index'));
 
 // 1X
-router.get('/1x/:category?', require('./routes/1x/index'));
+router.get('/1x/:category?', lazyloadRouteHandler('./routes/1x/index'));
 
 // 剑网3
-router.get('/jx3/:caty?', require('./routes/jx3/news'));
+router.get('/jx3/:caty?', lazyloadRouteHandler('./routes/jx3/news'));
 
 // GQ
-router.get('/gq/tw/:caty?/:subcaty?', require('./routes/gq/tw/index'));
+router.get('/gq/tw/:caty?/:subcaty?', lazyloadRouteHandler('./routes/gq/tw/index'));
 
 // 泉州市跨境电子商务协会
-router.get('/qzcea/:caty?', require('./routes/qzcea/index'));
+router.get('/qzcea/:caty?', lazyloadRouteHandler('./routes/qzcea/index'));
 
 // 福利年
-router.get('/fulinian/:caty?', require('./routes/fulinian/index'));
+router.get('/fulinian/:caty?', lazyloadRouteHandler('./routes/fulinian/index'));
 
 // CGTN
-router.get('/cgtn/top', require('./routes/cgtn/top'));
-router.get('/cgtn/most/:type?/:time?', require('./routes/cgtn/most'));
+router.get('/cgtn/top', lazyloadRouteHandler('./routes/cgtn/top'));
+router.get('/cgtn/most/:type?/:time?', lazyloadRouteHandler('./routes/cgtn/most'));
 
-router.get('/cgtn/pick', require('./routes/cgtn/pick'));
+router.get('/cgtn/pick', lazyloadRouteHandler('./routes/cgtn/pick'));
 
-router.get('/cgtn/opinions', require('./routes/cgtn/opinions'));
+router.get('/cgtn/opinions', lazyloadRouteHandler('./routes/cgtn/opinions'));
 
 // AppSales
-router.get('/appsales/:caty?/:time?', require('./routes/appsales/index'));
+router.get('/appsales/:caty?/:time?', lazyloadRouteHandler('./routes/appsales/index'));
 
 // Academy of Management
-router.get('/aom/journal/:id', require('./routes/aom/journal'));
+router.get('/aom/journal/:id', lazyloadRouteHandler('./routes/aom/journal'));
 
 // 巴哈姆特電玩資訊站
-router.get('/gamer/hot/:bsn', require('./routes/gamer/hot'));
+router.get('/gamer/hot/:bsn', lazyloadRouteHandler('./routes/gamer/hot'));
 
 // iCity
-router.get('/icity/:id', require('./routes/icity/index'));
+router.get('/icity/:id', lazyloadRouteHandler('./routes/icity/index'));
 
 // Anki
-router.get('/anki/changes', require('./routes/anki/changes'));
+router.get('/anki/changes', lazyloadRouteHandler('./routes/anki/changes'));
 
 // ABC News
-router.get('/abc/:site?', require('./routes/abc/index.js'));
+router.get('/abc/:site?', lazyloadRouteHandler('./routes/abc/index.js'));
 
 // 台湾中央通讯社
-router.get('/cna/:id?', require('./routes/cna/index'));
+router.get('/cna/:id?', lazyloadRouteHandler('./routes/cna/index'));
 
 // 华为心声社区
-router.get('/huawei/xinsheng/:caty?/:order?/:keyword?', require('./routes/huawei/xinsheng/index'));
+router.get('/huawei/xinsheng/:caty?/:order?/:keyword?', lazyloadRouteHandler('./routes/huawei/xinsheng/index'));
 
 // 守望先锋
-router.get('/ow/patch', require('./routes/ow/patch'));
+router.get('/ow/patch', lazyloadRouteHandler('./routes/ow/patch'));
 
 // MM范
-router.get('/95mm/tab/:tab?', require('./routes/95mm/tab'));
-router.get('/95mm/tag/:tag', require('./routes/95mm/tag'));
-router.get('/95mm/category/:category', require('./routes/95mm/category'));
+router.get('/95mm/tab/:tab?', lazyloadRouteHandler('./routes/95mm/tab'));
+router.get('/95mm/tag/:tag', lazyloadRouteHandler('./routes/95mm/tag'));
+router.get('/95mm/category/:category', lazyloadRouteHandler('./routes/95mm/category'));
 
 // 中国工程科技知识中心
-router.get('/cktest/app/:ctgroup?/:domain?', require('./routes/cktest/app'));
-router.get('/cktest/policy', require('./routes/cktest/policy'));
+router.get('/cktest/app/:ctgroup?/:domain?', lazyloadRouteHandler('./routes/cktest/app'));
+router.get('/cktest/policy', lazyloadRouteHandler('./routes/cktest/policy'));
 
 // 妈咪帮
-router.get('/mamibuy/:caty?/:age?/:sort?', require('./routes/mamibuy/index'));
+router.get('/mamibuy/:caty?/:age?/:sort?', lazyloadRouteHandler('./routes/mamibuy/index'));
 
 // Mercari
-router.get('/mercari/:type/:id', require('./routes/mercari/index'));
+router.get('/mercari/:type/:id', lazyloadRouteHandler('./routes/mercari/index'));
 
 // notefolio
-router.get('/notefolio/:caty?/:order?/:time?/:query?', require('./routes/notefolio/index'));
+router.get('/notefolio/:caty?/:order?/:time?/:query?', lazyloadRouteHandler('./routes/notefolio/index'));
 
 // JavDB
-router.get('/javdb/home/:caty?/:sort?/:filter?', require('./routes/javdb/home'));
-router.get('/javdb/search/:keyword?/:filter?', require('./routes/javdb/search'));
-router.get('/javdb/tags/:query?/:caty?', require('./routes/javdb/tags'));
-router.get('/javdb/actors/:id/:filter?', require('./routes/javdb/actors'));
-router.get('/javdb/makers/:id/:filter?', require('./routes/javdb/makers'));
-router.get('/javdb/series/:id/:filter?', require('./routes/javdb/series'));
-router.get('/javdb/rankings/:caty?/:time?', require('./routes/javdb/rankings'));
+router.get('/javdb/home/:caty?/:sort?/:filter?', lazyloadRouteHandler('./routes/javdb/home'));
+router.get('/javdb/search/:keyword?/:filter?', lazyloadRouteHandler('./routes/javdb/search'));
+router.get('/javdb/tags/:query?/:caty?', lazyloadRouteHandler('./routes/javdb/tags'));
+router.get('/javdb/actors/:id/:filter?', lazyloadRouteHandler('./routes/javdb/actors'));
+router.get('/javdb/makers/:id/:filter?', lazyloadRouteHandler('./routes/javdb/makers'));
+router.get('/javdb/series/:id/:filter?', lazyloadRouteHandler('./routes/javdb/series'));
+router.get('/javdb/rankings/:caty?/:time?', lazyloadRouteHandler('./routes/javdb/rankings'));
 
 // World Economic Forum
-router.get('/weforum/report/:lang?/:year?/:platform?', require('./routes/weforum/report'));
+router.get('/weforum/report/:lang?/:year?/:platform?', lazyloadRouteHandler('./routes/weforum/report'));
 
 // Nobel Prize
-router.get('/nobelprize/:caty?', require('./routes/nobelprize/index'));
+router.get('/nobelprize/:caty?', lazyloadRouteHandler('./routes/nobelprize/index'));
 
 // 中華民國國防部
-router.get('/gov/taiwan/mnd', require('./routes/gov/taiwan/mnd'));
+router.get('/gov/taiwan/mnd', lazyloadRouteHandler('./routes/gov/taiwan/mnd'));
 
 // 読売新聞
-router.get('/yomiuri/:category', require('./routes/yomiuri/news'));
+router.get('/yomiuri/:category', lazyloadRouteHandler('./routes/yomiuri/news'));
 
 // 巴哈姆特
 // GNN新闻
-router.get('/gamer/gnn/:category?', require('./routes/gamer/gnn_index'));
+router.get('/gamer/gnn/:category?', lazyloadRouteHandler('./routes/gamer/gnn_index'));
 
 // 中国人大网
-router.get('/npc/:caty', require('./routes/npc/index'));
+router.get('/npc/:caty', lazyloadRouteHandler('./routes/npc/index'));
 
 // 高科技行业门户
-router.get('/ofweek/news', require('./routes/ofweek/news'));
+router.get('/ofweek/news', lazyloadRouteHandler('./routes/ofweek/news'));
 
 // eventernote
-router.get('/eventernote/actors/:name/:id', require('./routes/eventernote/actors'));
+router.get('/eventernote/actors/:name/:id', lazyloadRouteHandler('./routes/eventernote/actors'));
 
 // 八阕
-router.get('/popyard/:caty?', require('./routes/popyard/index'));
+router.get('/popyard/:caty?', lazyloadRouteHandler('./routes/popyard/index'));
 
 // 原神
-router.get('/yuanshen/:location?/:category?', require('./routes/yuanshen/index'));
+router.get('/yuanshen/:location?/:category?', lazyloadRouteHandler('./routes/yuanshen/index'));
 
 // World Trade Organization
-router.get('/wto/dispute-settlement/:year?', require('./routes/wto/dispute-settlement'));
+router.get('/wto/dispute-settlement/:year?', lazyloadRouteHandler('./routes/wto/dispute-settlement'));
 
 // 4399论坛
-router.get('/forum4399/:mtag', require('./routes/game4399/forum'));
+router.get('/forum4399/:mtag', lazyloadRouteHandler('./routes/game4399/forum'));
 
 // 国防科技大学
-router.get('/nudt/yjszs/:id?', require('./routes/universities/nudt/yjszs'));
+router.get('/nudt/yjszs/:id?', lazyloadRouteHandler('./routes/universities/nudt/yjszs'));
 
 // 全现在
-router.get('/allnow/column/:id', require('./routes/allnow/column'));
-router.get('/allnow/tag/:id', require('./routes/allnow/tag'));
-router.get('/allnow/user/:id', require('./routes/allnow/user'));
-router.get('/allnow', require('./routes/allnow/index'));
+router.get('/allnow/column/:id', lazyloadRouteHandler('./routes/allnow/column'));
+router.get('/allnow/tag/:id', lazyloadRouteHandler('./routes/allnow/tag'));
+router.get('/allnow/user/:id', lazyloadRouteHandler('./routes/allnow/user'));
+router.get('/allnow', lazyloadRouteHandler('./routes/allnow/index'));
 
 // 证券时报网
-router.get('/stcn/news/:id?', require('./routes/stcn/news'));
-router.get('/stcn/data/:id?', require('./routes/stcn/data'));
-router.get('/stcn/kuaixun/:id?', require('./routes/stcn/kuaixun'));
+router.get('/stcn/news/:id?', lazyloadRouteHandler('./routes/stcn/news'));
+router.get('/stcn/data/:id?', lazyloadRouteHandler('./routes/stcn/data'));
+router.get('/stcn/kuaixun/:id?', lazyloadRouteHandler('./routes/stcn/kuaixun'));
 
 // dev.to
-router.get('/dev.to/top/:period', require('./routes/dev.to/top'));
+router.get('/dev.to/top/:period', lazyloadRouteHandler('./routes/dev.to/top'));
 
 // GameRes 游资网
-router.get('/gameres/hot', require('./routes/gameres/hot'));
-router.get('/gameres/list/:id', require('./routes/gameres/list'));
+router.get('/gameres/hot', lazyloadRouteHandler('./routes/gameres/hot'));
+router.get('/gameres/list/:id', lazyloadRouteHandler('./routes/gameres/list'));
 
 // ManicTime
-router.get('/manictime/releases', require('./routes/manictime/releases'));
+router.get('/manictime/releases', lazyloadRouteHandler('./routes/manictime/releases'));
 
 // Deutsche Welle 德国之声
-router.get('/dw/:lang?/:caty?', require('./routes/dw/index'));
+router.get('/dw/:lang?/:caty?', lazyloadRouteHandler('./routes/dw/index'));
 
 // Amazon
-router.get('/amazon/ku/:type?', require('./routes/amazon/ku'));
+router.get('/amazon/ku/:type?', lazyloadRouteHandler('./routes/amazon/ku'));
 
 // Citavi 中文网站论坛
-router.get('/citavi/:caty?', require('./routes/citavi/index'));
+router.get('/citavi/:caty?', lazyloadRouteHandler('./routes/citavi/index'));
 
 // Sesame
-router.get('/sesame/release_notes', require('./routes/sesame/release_notes'));
+router.get('/sesame/release_notes', lazyloadRouteHandler('./routes/sesame/release_notes'));
 
 // 佐川急便
-router.get('/sagawa/:id', require('./routes/sagawa/index'));
+router.get('/sagawa/:id', lazyloadRouteHandler('./routes/sagawa/index'));
 
 // QNAP
-router.get('/qnap/release-notes/:id', require('./routes/qnap/release-notes'));
+router.get('/qnap/release-notes/:id', lazyloadRouteHandler('./routes/qnap/release-notes'));
 
 // Liquipedia
-router.get('/liquipedia/dota2/matches/:id', require('./routes/liquipedia/dota2_matches.js'));
+router.get('/liquipedia/dota2/matches/:id', lazyloadRouteHandler('./routes/liquipedia/dota2_matches.js'));
 
 // 哈尔滨市科技局
-router.get('/gov/harbin/kjj', require('./routes/gov/harbin/kjj'));
+router.get('/gov/harbin/kjj', lazyloadRouteHandler('./routes/gov/harbin/kjj'));
 
 // WSJ
-router.get('/wsj/:lang/:category?', require('./routes/wsj/index'));
+router.get('/wsj/:lang/:category?', lazyloadRouteHandler('./routes/wsj/index'));
 
 // China File
-router.get('/chinafile/:category?', require('./routes/chinafile/index'));
+router.get('/chinafile/:category?', lazyloadRouteHandler('./routes/chinafile/index'));
 
 // 科技島讀
-router.get('/daodu/:caty?', require('./routes/daodu/index'));
+router.get('/daodu/:caty?', lazyloadRouteHandler('./routes/daodu/index'));
 
 // CNTV
-router.get('/cntv/:column', require('./routes/cntv/cntv'));
+router.get('/cntv/:column', lazyloadRouteHandler('./routes/cntv/cntv'));
 
 // Grand-Challenge
-router.get('/grandchallenge/user/:id', require('./routes/grandchallenge/user'));
-router.get('/grandchallenge/challenges', require('./routes/grandchallenge/challenges'));
+router.get('/grandchallenge/user/:id', lazyloadRouteHandler('./routes/grandchallenge/user'));
+router.get('/grandchallenge/challenges', lazyloadRouteHandler('./routes/grandchallenge/challenges'));
 
 // 西北工业大学
-router.get('/nwpu/:column', require('./routes/nwpu/index'));
+router.get('/nwpu/:column', lazyloadRouteHandler('./routes/nwpu/index'));
 
 // 美国联邦最高法院
-router.get('/us/supremecourt/argument_audio/:year?', require('./routes/us/supremecourt/argument_audio'));
+router.get('/us/supremecourt/argument_audio/:year?', lazyloadRouteHandler('./routes/us/supremecourt/argument_audio'));
 
 // 得到
-router.get('/dedao/list/:caty?', require('./routes/dedao/list'));
-router.get('/dedao/knowledge/:topic?/:type?', require('./routes/dedao/knowledge'));
-router.get('/dedao/:caty?', require('./routes/dedao/index'));
+router.get('/dedao/list/:caty?', lazyloadRouteHandler('./routes/dedao/list'));
+router.get('/dedao/knowledge/:topic?/:type?', lazyloadRouteHandler('./routes/dedao/knowledge'));
+router.get('/dedao/:caty?', lazyloadRouteHandler('./routes/dedao/index'));
 
 // 未名新闻
-router.get('/mitbbs/:caty?', require('./routes/mitbbs/index'));
+router.get('/mitbbs/:caty?', lazyloadRouteHandler('./routes/mitbbs/index'));
 
 // 8kcos
-router.get('/8kcos/', require('./routes/8kcos/latest'));
-router.get('/8kcos/cat/:cat*', require('./routes/8kcos/cat'));
+router.get('/8kcos/', lazyloadRouteHandler('./routes/8kcos/latest'));
+router.get('/8kcos/cat/:cat*', lazyloadRouteHandler('./routes/8kcos/cat'));
 
 // 贾真的电商108将
-router.get('/jiazhen108', require('./routes/jiazhen108/index'));
+router.get('/jiazhen108', lazyloadRouteHandler('./routes/jiazhen108/index'));
 
 // Instagram
-router.get('/instagram/:category/:key', require('./routes/instagram/index'));
+router.get('/instagram/:category/:key', lazyloadRouteHandler('./routes/instagram/index'));
 
 // 优设网
-router.get('/uisdc/talk/:sort?', require('./routes/uisdc/talk'));
-router.get('/uisdc/hangye/:caty?', require('./routes/uisdc/hangye'));
-router.get('/uisdc/news', require('./routes/uisdc/news'));
-router.get('/uisdc/zt/:title?', require('./routes/uisdc/zt'));
-router.get('/uisdc/topic/:title?/:sort?', require('./routes/uisdc/topic'));
+router.get('/uisdc/talk/:sort?', lazyloadRouteHandler('./routes/uisdc/talk'));
+router.get('/uisdc/hangye/:caty?', lazyloadRouteHandler('./routes/uisdc/hangye'));
+router.get('/uisdc/news', lazyloadRouteHandler('./routes/uisdc/news'));
+router.get('/uisdc/zt/:title?', lazyloadRouteHandler('./routes/uisdc/zt'));
+router.get('/uisdc/topic/:title?/:sort?', lazyloadRouteHandler('./routes/uisdc/topic'));
 
 // 中国劳工观察
-router.get('/chinalaborwatch/reports/:lang?/:industry?', require('./routes/chinalaborwatch/reports'));
+router.get('/chinalaborwatch/reports/:lang?/:industry?', lazyloadRouteHandler('./routes/chinalaborwatch/reports'));
 
 // Phoronix
-router.get('/phoronix/:page/:queryOrItem?', require('./routes/phoronix/index'));
+router.get('/phoronix/:page/:queryOrItem?', lazyloadRouteHandler('./routes/phoronix/index'));
 
 // 美国中央情报局
-router.get('/cia/foia-annual-report', require('./routes/us/cia/foia-annual-report'));
+router.get('/cia/foia-annual-report', lazyloadRouteHandler('./routes/us/cia/foia-annual-report'));
 
 // Everything
-router.get('/everything/changes', require('./routes/everything/changes'));
+router.get('/everything/changes', lazyloadRouteHandler('./routes/everything/changes'));
 
 // 中国劳工通讯
-router.get('/clb/commentary/:lang?', require('./routes/clb/commentary'));
+router.get('/clb/commentary/:lang?', lazyloadRouteHandler('./routes/clb/commentary'));
 
 // 国际教育研究所
-router.get('/iie/blog', require('./routes/iie/blog'));
+router.get('/iie/blog', lazyloadRouteHandler('./routes/iie/blog'));
 
 // McKinsey Greater China
-router.get('/mckinsey/:category?', require('./routes/mckinsey/index'));
+router.get('/mckinsey/:category?', lazyloadRouteHandler('./routes/mckinsey/index'));
 
 // 超理论坛
-router.get('/chaoli/:channel?', require('./routes/chaoli/index'));
+router.get('/chaoli/:channel?', lazyloadRouteHandler('./routes/chaoli/index'));
 
 // Polar
-router.get('/polar/blog', require('./routes/polar/blog'));
+router.get('/polar/blog', lazyloadRouteHandler('./routes/polar/blog'));
 
 // XYplorer
-router.get('/xyplorer/whatsnew', require('./routes/xyplorer/whatsnew'));
+router.get('/xyplorer/whatsnew', lazyloadRouteHandler('./routes/xyplorer/whatsnew'));
 
 // RescueTime
-router.get('/rescuetime/release-notes/:os?', require('./routes/rescuetime/release-notes'));
+router.get('/rescuetime/release-notes/:os?', lazyloadRouteHandler('./routes/rescuetime/release-notes'));
 
 // Total Commander
-router.get('/totalcommander/whatsnew', require('./routes/totalcommander/whatsnew'));
+router.get('/totalcommander/whatsnew', lazyloadRouteHandler('./routes/totalcommander/whatsnew'));
 
 // Blizzard
-router.get('/blizzard/news/:language?/:category?', require('./routes/blizzard/news'));
+router.get('/blizzard/news/:language?/:category?', lazyloadRouteHandler('./routes/blizzard/news'));
 
 // DeepMind
-router.get('/deepmind/blog/:category?', require('./routes/deepmind/blog'));
+router.get('/deepmind/blog/:category?', lazyloadRouteHandler('./routes/deepmind/blog'));
 
 // 东西智库
-router.get('/dx2025/:type?/:category?', require('./routes/dx2025/index'));
+router.get('/dx2025/:type?/:category?', lazyloadRouteHandler('./routes/dx2025/index'));
 
 // DeepL
-router.get('/deepl/blog/:lang?', require('./routes/deepl/blog'));
+router.get('/deepl/blog/:lang?', lazyloadRouteHandler('./routes/deepl/blog'));
 
 // OpenAI
-router.get('/openai/blog/:tag?', require('./routes/openai/blog'));
+router.get('/openai/blog/:tag?', lazyloadRouteHandler('./routes/openai/blog'));
 
 // 小木虫
-router.get('/muchong/journal/:type?', require('./routes/muchong/journal'));
-router.get('/muchong/:id/:type?/:sort?', require('./routes/muchong/index'));
+router.get('/muchong/journal/:type?', lazyloadRouteHandler('./routes/muchong/journal'));
+router.get('/muchong/:id/:type?/:sort?', lazyloadRouteHandler('./routes/muchong/index'));
 
 // 求是网
-router.get('/qstheory/:category?', require('./routes/qstheory/index'));
+router.get('/qstheory/:category?', lazyloadRouteHandler('./routes/qstheory/index'));
 
 // 生命时报
-router.get('/lifetimes/:category?', require('./routes/lifetimes/index'));
+router.get('/lifetimes/:category?', lazyloadRouteHandler('./routes/lifetimes/index'));
 
 // MakeUseOf
-router.get('/makeuseof/:category?', require('./routes/makeuseof/index'));
+router.get('/makeuseof/:category?', lazyloadRouteHandler('./routes/makeuseof/index'));
 
 // 瞬Matataki
 // 热门作品
-router.get('/matataki/posts/hot/:ipfsFlag?', require('./routes/matataki/site/posts/scoreranking'));
+router.get('/matataki/posts/hot/:ipfsFlag?', lazyloadRouteHandler('./routes/matataki/site/posts/scoreranking'));
 // 最新作品
-router.get('/matataki/posts/latest/:ipfsFlag?', require('./routes/matataki/site/posts/timeranking'));
+router.get('/matataki/posts/latest/:ipfsFlag?', lazyloadRouteHandler('./routes/matataki/site/posts/timeranking'));
 // 作者创作
-router.get('/matataki/users/:authorId/posts/:ipfsFlag?', require('./routes/matataki/site/posts/author'));
+router.get('/matataki/users/:authorId/posts/:ipfsFlag?', lazyloadRouteHandler('./routes/matataki/site/posts/author'));
 // Fan票关联作品
-router.get('/matataki/tokens/:id/posts/:filterCode/:ipfsFlag?', require('./routes/matataki/site/posts/token'));
+router.get('/matataki/tokens/:id/posts/:filterCode/:ipfsFlag?', lazyloadRouteHandler('./routes/matataki/site/posts/token'));
 // 标签关联作品
-router.get('/matataki/tags/:tagId/:tagName/posts/:ipfsFlag?', require('./routes/matataki/site/posts/tag'));
+router.get('/matataki/tags/:tagId/:tagName/posts/:ipfsFlag?', lazyloadRouteHandler('./routes/matataki/site/posts/tag'));
 // 收藏夹
-router.get('/matataki/users/:userId/favorites/:favoriteListId/posts/:ipfsFlag?', require('./routes/matataki/site/posts/favorite'));
+router.get('/matataki/users/:userId/favorites/:favoriteListId/posts/:ipfsFlag?', lazyloadRouteHandler('./routes/matataki/site/posts/favorite'));
 
 // SoBooks
-router.get('/sobooks/tag/:id?', require('./routes/sobooks/tag'));
-router.get('/sobooks/date/:date?', require('./routes/sobooks/date'));
-router.get('/sobooks/:category?', require('./routes/sobooks/index'));
+router.get('/sobooks/tag/:id?', lazyloadRouteHandler('./routes/sobooks/tag'));
+router.get('/sobooks/date/:date?', lazyloadRouteHandler('./routes/sobooks/date'));
+router.get('/sobooks/:category?', lazyloadRouteHandler('./routes/sobooks/index'));
 
 // Zhimap 知识导图社区
-router.get('/zhimap/:categoryUuid?/:recommend?', require('./routes/zhimap/index'));
+router.get('/zhimap/:categoryUuid?/:recommend?', lazyloadRouteHandler('./routes/zhimap/index'));
 
 // Fantia
-router.get('/fantia/search/:type?/:caty?/:peroid?/:order?/:rating?/:keyword?', require('./routes/fantia/search'));
-router.get('/fantia/user/:id', require('./routes/fantia/user'));
+router.get('/fantia/search/:type?/:caty?/:peroid?/:order?/:rating?/:keyword?', lazyloadRouteHandler('./routes/fantia/search'));
+router.get('/fantia/user/:id', lazyloadRouteHandler('./routes/fantia/user'));
 
 // i-Cable
-router.get('/icable/:category/:option?', require('./routes/icable/category'));
+router.get('/icable/:category/:option?', lazyloadRouteHandler('./routes/icable/category'));
 
 // ProcessOn
-router.get('/processon/popular/:cate?/:sort?', require('./routes/processon/popular'));
+router.get('/processon/popular/:cate?/:sort?', lazyloadRouteHandler('./routes/processon/popular'));
 
 // Mathpix
-router.get('/mathpix/blog', require('./routes/mathpix/blog'));
+router.get('/mathpix/blog', lazyloadRouteHandler('./routes/mathpix/blog'));
 
 // OneNote Gem Add-Ins
-router.get('/onenotegem/release', require('./routes/onenotegem/release'));
+router.get('/onenotegem/release', lazyloadRouteHandler('./routes/onenotegem/release'));
 
 // Mind42
-router.get('/mind42/tag/:id', require('./routes/mind42/tag'));
-router.get('/mind42/search/:keyword', require('./routes/mind42/search'));
-router.get('/mind42/:caty?', require('./routes/mind42/index'));
+router.get('/mind42/tag/:id', lazyloadRouteHandler('./routes/mind42/tag'));
+router.get('/mind42/search/:keyword', lazyloadRouteHandler('./routes/mind42/search'));
+router.get('/mind42/:caty?', lazyloadRouteHandler('./routes/mind42/index'));
 
 // 幕布网
-router.get('/mubu/explore/:category?/:title?', require('./routes/mubu/explore'));
+router.get('/mubu/explore/:category?/:title?', lazyloadRouteHandler('./routes/mubu/explore'));
 
 // Esquirehk
-router.get('/esquirehk/tag/:id', require('./routes/esquirehk/tag'));
+router.get('/esquirehk/tag/:id', lazyloadRouteHandler('./routes/esquirehk/tag'));
 
 // 国家普通话测试 杭州市
-router.get('/putonghua', require('./routes/putonghua/hangzhou'));
+router.get('/putonghua', lazyloadRouteHandler('./routes/putonghua/hangzhou'));
 
 // 有道云笔记
-router.get('/youdao/xueba', require('./routes/youdao/xueba'));
-router.get('/youdao/latest', require('./routes/youdao/latest'));
+router.get('/youdao/xueba', lazyloadRouteHandler('./routes/youdao/xueba'));
+router.get('/youdao/latest', lazyloadRouteHandler('./routes/youdao/latest'));
 
 // 印象识堂
-router.get('/yinxiang/note', require('./routes/yinxiang/note'));
-router.get('/yinxiang/tag/:id', require('./routes/yinxiang/tag'));
-router.get('/yinxiang/card/:id', require('./routes/yinxiang/card'));
-router.get('/yinxiang/personal/:id', require('./routes/yinxiang/personal'));
-router.get('/yinxiang/category/:id', require('./routes/yinxiang/category'));
+router.get('/yinxiang/note', lazyloadRouteHandler('./routes/yinxiang/note'));
+router.get('/yinxiang/tag/:id', lazyloadRouteHandler('./routes/yinxiang/tag'));
+router.get('/yinxiang/card/:id', lazyloadRouteHandler('./routes/yinxiang/card'));
+router.get('/yinxiang/personal/:id', lazyloadRouteHandler('./routes/yinxiang/personal'));
+router.get('/yinxiang/category/:id', lazyloadRouteHandler('./routes/yinxiang/category'));
 
 // 晚点LatePost
-router.get('/latepost/:proma?', require('./routes/latepost/index'));
+router.get('/latepost/:proma?', lazyloadRouteHandler('./routes/latepost/index'));
 
 // 西瓜视频
-router.get('/ixigua/user/video/:uid/:disableEmbed?', require('./routes/ixigua/userVideo'));
+router.get('/ixigua/user/video/:uid/:disableEmbed?', lazyloadRouteHandler('./routes/ixigua/userVideo'));
 
 // 遠見 gvm.com.tw
-router.get('/gvm/index/:category?', require('./routes/gvm/index'));
+router.get('/gvm/index/:category?', lazyloadRouteHandler('./routes/gvm/index'));
 
 // 触乐
-router.get('/chuapp/index/:category?', require('./routes/chuapp/index'));
+router.get('/chuapp/index/:category?', lazyloadRouteHandler('./routes/chuapp/index'));
 
 // Deloitte
-router.get('/deloitte/industries/:category?', require('./routes/deloitte/industries'));
+router.get('/deloitte/industries/:category?', lazyloadRouteHandler('./routes/deloitte/industries'));
 
 // 特斯拉系统更新
-router.get('/tesla', require('./routes/tesla/update'));
+router.get('/tesla', lazyloadRouteHandler('./routes/tesla/update'));
 
 // 复旦大学继续教育学院
-router.get('/fudan/cce', require('./routes/universities/fudan/cce'));
+router.get('/fudan/cce', lazyloadRouteHandler('./routes/universities/fudan/cce'));
 
 // LowEndTalk
-router.get('/lowendtalk/discussion/:id?', require('./routes/lowendtalk/discussion'));
+router.get('/lowendtalk/discussion/:id?', lazyloadRouteHandler('./routes/lowendtalk/discussion'));
 
 // 无产者评论
-router.get('/proletar/:type?/:id?', require('./routes/proletar/index'));
+router.get('/proletar/:type?/:id?', lazyloadRouteHandler('./routes/proletar/index'));
 
 // QTTabBar
-router.get('/qttabbar/change-log', require('./routes/qttabbar/change-log'));
+router.get('/qttabbar/change-log', lazyloadRouteHandler('./routes/qttabbar/change-log'));
 
 // 酷18
-router.get('/cool18/:id?/:type?/:keyword?', require('./routes/cool18/index'));
+router.get('/cool18/:id?/:type?/:keyword?', lazyloadRouteHandler('./routes/cool18/index'));
 
 // 美国贸易代表办公室
-router.get('/ustr/press-releases/:year?/:month?', require('./routes/us/ustr/press-releases'));
+router.get('/ustr/press-releases/:year?/:month?', lazyloadRouteHandler('./routes/us/ustr/press-releases'));
 
 // 游戏动力
-router.get('/vgn/:platform?', require('./routes/vgn/index'));
+router.get('/vgn/:platform?', lazyloadRouteHandler('./routes/vgn/index'));
 
 // 国际能源署
-router.get('/iea/:category?', require('./routes/iea/index'));
+router.get('/iea/:category?', lazyloadRouteHandler('./routes/iea/index'));
 
 // 中国计算机学会
-router.get('/ccf/news/:category?', require('./routes/ccf/news'));
+router.get('/ccf/news/:category?', lazyloadRouteHandler('./routes/ccf/news'));
 
 // The Brain
-router.get('/thebrain/:category?', require('./routes/thebrain/blog'));
+router.get('/thebrain/:category?', lazyloadRouteHandler('./routes/thebrain/blog'));
 
 // 美国财政部
-router.get('/treasury/press-releases/:category?/:title?', require('./routes/us/treasury/press-releases'));
+router.get('/treasury/press-releases/:category?/:title?', lazyloadRouteHandler('./routes/us/treasury/press-releases'));
 
 // Bandisoft
-router.get('/bandisoft/:id?/:lang?', require('./routes/bandisoft/index'));
+router.get('/bandisoft/:id?/:lang?', lazyloadRouteHandler('./routes/bandisoft/index'));
 
 // MarginNote
-router.get('/marginnote/tag/:id?', require('./routes/marginnote/tag'));
+router.get('/marginnote/tag/:id?', lazyloadRouteHandler('./routes/marginnote/tag'));
 
 // ASML
-router.get('/asml/press-releases', require('./routes/asml/press-releases'));
+router.get('/asml/press-releases', lazyloadRouteHandler('./routes/asml/press-releases'));
 
 // 中国机械工程学会
-router.get('/cmes/news/:category?', require('./routes/cmes/news'));
+router.get('/cmes/news/:category?', lazyloadRouteHandler('./routes/cmes/news'));
 
 // Craigslist
-router.get('/craigslist/:location/:type', require('./routes/craigslist/search'));
+router.get('/craigslist/:location/:type', lazyloadRouteHandler('./routes/craigslist/search'));
 
 // 有趣天文奇观
-router.get('/interesting-sky/astronomical_events/:year?', require('./routes/interesting-sky/astronomical_events'));
-router.get('/interesting-sky/recent-interesting', require('./routes/interesting-sky/recent-interesting'));
-router.get('/interesting-sky', require('./routes/interesting-sky/index'));
+router.get('/interesting-sky/astronomical_events/:year?', lazyloadRouteHandler('./routes/interesting-sky/astronomical_events'));
+router.get('/interesting-sky/recent-interesting', lazyloadRouteHandler('./routes/interesting-sky/recent-interesting'));
+router.get('/interesting-sky', lazyloadRouteHandler('./routes/interesting-sky/index'));
 
 // 国际数学联合会
-router.get('/mathunion/fields-medal', require('./routes/mathunion/fields-medal'));
+router.get('/mathunion/fields-medal', lazyloadRouteHandler('./routes/mathunion/fields-medal'));
 
 // ACM
-router.get('/acm/amturingaward', require('./routes/acm/amturingaward'));
+router.get('/acm/amturingaward', lazyloadRouteHandler('./routes/acm/amturingaward'));
 
 // 網路天文館
-router.get('/tam/forecast', require('./routes/tam/forecast'));
+router.get('/tam/forecast', lazyloadRouteHandler('./routes/tam/forecast'));
 
 // Day One
-router.get('/dayone/blog', require('./routes/dayone/blog'));
+router.get('/dayone/blog', lazyloadRouteHandler('./routes/dayone/blog'));
 
 // 滴答清单
-router.get('/dida365/habit/checkins', require('./routes/dida365/habit-checkins'));
+router.get('/dida365/habit/checkins', lazyloadRouteHandler('./routes/dida365/habit-checkins'));
 
 // Ditto clipboard manager
-router.get('/ditto/changes/:type?', require('./routes/ditto/changes'));
+router.get('/ditto/changes/:type?', lazyloadRouteHandler('./routes/ditto/changes'));
 
 // iDaily 每日环球视野
-router.get('/idaily/today', require('./routes/idaily/index'));
+router.get('/idaily/today', lazyloadRouteHandler('./routes/idaily/index'));
 
 // 北屋
-router.get('/northhouse/:category?', require('./routes/northhouse/index'));
+router.get('/northhouse/:category?', lazyloadRouteHandler('./routes/northhouse/index'));
 
 // Oak Ridge National Laboratory
-router.get('/ornl/news', require('./routes/ornl/news'));
+router.get('/ornl/news', lazyloadRouteHandler('./routes/ornl/news'));
 
 // 信阳师范学院 自考办
-router.get('/xynu/zkb/:category', require('./routes/universities/xynu/zkb'));
+router.get('/xynu/zkb/:category', lazyloadRouteHandler('./routes/universities/xynu/zkb'));
 
 // Bell Labs
-router.get('/bell-labs/events-news/:category?', require('./routes/bell-labs/events-news.js'));
+router.get('/bell-labs/events-news/:category?', lazyloadRouteHandler('./routes/bell-labs/events-news.js'));
 
 // 中国科学院青年创新促进会
-router.get('/yicas/blog', require('./routes/yicas/blog'));
+router.get('/yicas/blog', lazyloadRouteHandler('./routes/yicas/blog'));
 
 // 九三学社
-router.get('/93/:category?', require('./routes/93/index'));
+router.get('/93/:category?', lazyloadRouteHandler('./routes/93/index'));
 
 // 科学网
-router.get('/sciencenet/blog/:type?/:time?/:sort?', require('./routes/sciencenet/blog'));
+router.get('/sciencenet/blog/:type?/:time?/:sort?', lazyloadRouteHandler('./routes/sciencenet/blog'));
 
 // DailyArt
-router.get('/dailyart/:language?', require('./routes/dailyart/index'));
+router.get('/dailyart/:language?', lazyloadRouteHandler('./routes/dailyart/index'));
 
 // SCBOY
-router.get('/scboy/thread/:tid', require('./routes/scboy/thread'));
+router.get('/scboy/thread/:tid', lazyloadRouteHandler('./routes/scboy/thread'));
 
 // 猿料
-router.get('/yuanliao/:tag?/:sort?', require('./routes/yuanliao/index'));
+router.get('/yuanliao/:tag?/:sort?', lazyloadRouteHandler('./routes/yuanliao/index'));
 
 // 中国政协网
-router.get('/cppcc/:slug?', require('./routes/gov/cppcc/index'));
+router.get('/cppcc/:slug?', lazyloadRouteHandler('./routes/gov/cppcc/index'));
 
 // National Association of Colleges and Employers
-router.get('/nace/blog/:sort?', require('./routes/nace/blog'));
+router.get('/nace/blog/:sort?', lazyloadRouteHandler('./routes/nace/blog'));
 
 // Caixin Latest
-router.get('/caixin/latest', require('./routes/caixin/latest'));
+router.get('/caixin/latest', lazyloadRouteHandler('./routes/caixin/latest'));
 
 // Semiconductor Industry Association
-router.get('/semiconductors/latest-news', require('./routes/semiconductors/latest-news'));
+router.get('/semiconductors/latest-news', lazyloadRouteHandler('./routes/semiconductors/latest-news'));
 
 // VOA News
-router.get('/voa/day-photos', require('./routes/voa/day-photos'));
+router.get('/voa/day-photos', lazyloadRouteHandler('./routes/voa/day-photos'));
 
 // Voice of America
-router.get('/voa/:language/:channel?', require('./routes/voa/index'));
+router.get('/voa/:language/:channel?', lazyloadRouteHandler('./routes/voa/index'));
 
 // 留园网
-router.get('/6park/:id?/:type?/:keyword?', require('./routes/6park/index'));
+router.get('/6park/:id?/:type?/:keyword?', lazyloadRouteHandler('./routes/6park/index'));
 
 // 哔嘀影视
-router.get('/mp4er/:type?/:caty?/:area?/:year?/:order?', require('./routes/mp4er/index'));
-router.get('/bde4/:type?/:caty?/:area?/:year?/:order?', require('./routes/mp4er/index'));
+router.get('/mp4er/:type?/:caty?/:area?/:year?/:order?', lazyloadRouteHandler('./routes/mp4er/index'));
+router.get('/bde4/:type?/:caty?/:area?/:year?/:order?', lazyloadRouteHandler('./routes/mp4er/index'));
 
 // 上海证券交易所
-router.get('/sse/sserules/:slug?', require('./routes/sse/sserules'));
+router.get('/sse/sserules/:slug?', lazyloadRouteHandler('./routes/sse/sserules'));
 
 // 游戏葡萄
-router.get('/gamegrape/:id?', require('./routes/gamegrape/index'));
+router.get('/gamegrape/:id?', lazyloadRouteHandler('./routes/gamegrape/index'));
 
 // 阳光高考
-router.get('/chsi/zszcgd/:category?', require('./routes/chsi/zszcgd'));
+router.get('/chsi/zszcgd/:category?', lazyloadRouteHandler('./routes/chsi/zszcgd'));
 
 // 眾新聞
-router.get('/hkcnews/news/:category?', require('./routes/hkcnews/news'));
+router.get('/hkcnews/news/:category?', lazyloadRouteHandler('./routes/hkcnews/news'));
 
 // AnyTXT
-router.get('/anytxt/release-notes', require('./routes/anytxt/release-notes'));
+router.get('/anytxt/release-notes', lazyloadRouteHandler('./routes/anytxt/release-notes'));
 
 // 鱼塘热榜
-router.get('/mofish/:id', require('./routes/mofish/index'));
+router.get('/mofish/:id', lazyloadRouteHandler('./routes/mofish/index'));
 
 // Mcdonalds
-router.get('/mcdonalds/:category', require('./routes/mcdonalds/news'));
+router.get('/mcdonalds/:category', lazyloadRouteHandler('./routes/mcdonalds/news'));
 
 // Pincong 品葱
-router.get('/pincong/category/:category?/:sort?', require('./routes/pincong/index'));
-router.get('/pincong/hot/:category?', require('./routes/pincong/hot'));
-router.get('/pincong/topic/:topic', require('./routes/pincong/topic'));
+router.get('/pincong/category/:category?/:sort?', lazyloadRouteHandler('./routes/pincong/index'));
+router.get('/pincong/hot/:category?', lazyloadRouteHandler('./routes/pincong/hot'));
+router.get('/pincong/topic/:topic', lazyloadRouteHandler('./routes/pincong/topic'));
 
 // GoComics
-router.get('/gocomics/:name', require('./routes/gocomics/index'));
+router.get('/gocomics/:name', lazyloadRouteHandler('./routes/gocomics/index'));
 
 // Comics Kingdom
-router.get('/comicskingdom/:name', require('./routes/comicskingdom/index'));
+router.get('/comicskingdom/:name', lazyloadRouteHandler('./routes/comicskingdom/index'));
 
 // Media Digest
-router.get('/mediadigest/:range/:category?', require('./routes/mediadigest/category'));
+router.get('/mediadigest/:range/:category?', lazyloadRouteHandler('./routes/mediadigest/category'));
 
 // 中国农工民主党
-router.get('/ngd/:slug?', require('./routes/gov/ngd/index'));
+router.get('/ngd/:slug?', lazyloadRouteHandler('./routes/gov/ngd/index'));
 
 // SimpRead-消息通知
-router.get('/simpread/notice', require('./routes/simpread/notice'));
+router.get('/simpread/notice', lazyloadRouteHandler('./routes/simpread/notice'));
 // SimpRead-更新日志
-router.get('/simpread/changelog', require('./routes/simpread/changelog'));
+router.get('/simpread/changelog', lazyloadRouteHandler('./routes/simpread/changelog'));
 
 // Radio Free Asia
-router.get('/rfa/:language?/:channel?/:subChannel?', require('./routes/rfa/index'));
+router.get('/rfa/:language?/:channel?/:subChannel?', lazyloadRouteHandler('./routes/rfa/index'));
 
 // booth.pm
-router.get('/booth.pm/shop/:subdomain', require('./routes/booth-pm/shop'));
+router.get('/booth.pm/shop/:subdomain', lazyloadRouteHandler('./routes/booth-pm/shop'));
 
 // Minecraft feed the beast
-router.get('/feed-the-beast/modpack/:modpackEntry', require('./routes/feed-the-beast/modpack'));
+router.get('/feed-the-beast/modpack/:modpackEntry', lazyloadRouteHandler('./routes/feed-the-beast/modpack'));
 
 // Gab
-router.get('/gab/user/:username', require('./routes/gab/user'));
-router.get('/gab/popular/:sort?', require('./routes/gab/explore'));
+router.get('/gab/user/:username', lazyloadRouteHandler('./routes/gab/user'));
+router.get('/gab/popular/:sort?', lazyloadRouteHandler('./routes/gab/explore'));
 
 // NEW 字幕组
-router.get('/newzmz/view/:id', require('./routes/newzmz/view'));
-router.get('/newzmz/:category?', require('./routes/newzmz/index'));
+router.get('/newzmz/view/:id', lazyloadRouteHandler('./routes/newzmz/view'));
+router.get('/newzmz/:category?', lazyloadRouteHandler('./routes/newzmz/index'));
 
 // Phrack Magazine
-router.get('/phrack', require('./routes/phrack/index'));
+router.get('/phrack', lazyloadRouteHandler('./routes/phrack/index'));
 
 // 通識·現代中國
-router.get('/chiculture/topic/:category?', require('./routes/chiculture/topic'));
+router.get('/chiculture/topic/:category?', lazyloadRouteHandler('./routes/chiculture/topic'));
 
 // CQUT News
-router.get('/cqut/news', require('./routes/universities/cqut/cqut-news'));
-router.get('/cqut/libnews', require('./routes/universities/cqut/cqut-libnews'));
+router.get('/cqut/news', lazyloadRouteHandler('./routes/universities/cqut/cqut-news'));
+router.get('/cqut/libnews', lazyloadRouteHandler('./routes/universities/cqut/cqut-libnews'));
 
 // 城农 Growin' City
-router.get('/growincity/news/:id?', require('./routes/growincity/news'));
+router.get('/growincity/news/:id?', lazyloadRouteHandler('./routes/growincity/news'));
 
 // Thrillist
-router.get('/thrillist/:tag?', require('./routes/thrillist/index'));
+router.get('/thrillist/:tag?', lazyloadRouteHandler('./routes/thrillist/index'));
 
 // 丁香园
-router.get('/dxy/vaccine/:province?/:city?/:location?', require('./routes/dxy/vaccine'));
+router.get('/dxy/vaccine/:province?/:city?/:location?', lazyloadRouteHandler('./routes/dxy/vaccine'));
 
 // Wtu
-router.get('/wtu/:type', require('./routes/universities/wtu'));
+router.get('/wtu/:type', lazyloadRouteHandler('./routes/universities/wtu'));
 
 // 中国庭审公开网
-router.get('/tingshen', require('./routes/tingshen/tingshen'));
+router.get('/tingshen', lazyloadRouteHandler('./routes/tingshen/tingshen'));
 
 // 中华人民共和国人力资源和社会保障部
-router.get('/gov/mohrss/sbjm/:category?', require('./routes/gov/mohrss/sbjm'));
+router.get('/gov/mohrss/sbjm/:category?', lazyloadRouteHandler('./routes/gov/mohrss/sbjm'));
 
 // 深影译站
-router.get('/shinybbs/latest', require('./routes/shinybbs/latest'));
-router.get('/shinybbs/p/:id', require('./routes/shinybbs/p'));
-router.get('/shinybbs/page/:id?', require('./routes/shinybbs/index'));
-router.get('/shinybbs', require('./routes/shinybbs/index'));
+router.get('/shinybbs/latest', lazyloadRouteHandler('./routes/shinybbs/latest'));
+router.get('/shinybbs/p/:id', lazyloadRouteHandler('./routes/shinybbs/p'));
+router.get('/shinybbs/page/:id?', lazyloadRouteHandler('./routes/shinybbs/index'));
+router.get('/shinybbs', lazyloadRouteHandler('./routes/shinybbs/index'));
 
 // 天眼查
-router.get('/tianyancha/hot', require('./routes/tianyancha/hot'));
+router.get('/tianyancha/hot', lazyloadRouteHandler('./routes/tianyancha/hot'));
 
 // King Arthur
-router.get('/kingarthur/:type', require('./routes/kingarthur/index'));
+router.get('/kingarthur/:type', lazyloadRouteHandler('./routes/kingarthur/index'));
 
 // 新华网
-router.get('/news/whxw', require('./routes/news/whxw'));
+router.get('/news/whxw', lazyloadRouteHandler('./routes/news/whxw'));
 
 // 游讯网
-router.get('/yxdown/recommend', require('./routes/yxdown/recommend'));
-router.get('/yxdown/news/:category?', require('./routes/yxdown/news'));
+router.get('/yxdown/recommend', lazyloadRouteHandler('./routes/yxdown/recommend'));
+router.get('/yxdown/news/:category?', lazyloadRouteHandler('./routes/yxdown/news'));
 
 // BabeHub
-router.get('/babehub/search/:keyword?', require('./routes/babehub/search'));
-router.get('/babehub/:category?', require('./routes/babehub/index'));
+router.get('/babehub/search/:keyword?', lazyloadRouteHandler('./routes/babehub/search'));
+router.get('/babehub/:category?', lazyloadRouteHandler('./routes/babehub/index'));
 
 // 深圳新闻网
-router.get('/sznews/press', require('./routes/sznews/press'));
-router.get('/sznews/ranking', require('./routes/sznews/ranking'));
+router.get('/sznews/press', lazyloadRouteHandler('./routes/sznews/press'));
+router.get('/sznews/ranking', lazyloadRouteHandler('./routes/sznews/ranking'));
 
 // Shuax
-router.get('/shuax/project/:name?', require('./routes/shuax/project'));
+router.get('/shuax/project/:name?', lazyloadRouteHandler('./routes/shuax/project'));
 
 // BioOne
-router.get('/bioone/featured', require('./routes/bioone/featured'));
+router.get('/bioone/featured', lazyloadRouteHandler('./routes/bioone/featured'));
 
 // Obsidian
-router.get('/obsidian/announcements', require('./routes/obsidian/announcements'));
+router.get('/obsidian/announcements', lazyloadRouteHandler('./routes/obsidian/announcements'));
 
 // 吉林工商学院
-router.get('/jlbtc/kyc/:category?', require('./routes/universities/jlbtc/kyc'));
-router.get('/jlbtc/jwc/:id?', require('./routes/universities/jlbtc/jwc'));
-router.get('/jlbtc/:category?', require('./routes/universities/jlbtc/index'));
+router.get('/jlbtc/kyc/:category?', lazyloadRouteHandler('./routes/universities/jlbtc/kyc'));
+router.get('/jlbtc/jwc/:id?', lazyloadRouteHandler('./routes/universities/jlbtc/jwc'));
+router.get('/jlbtc/:category?', lazyloadRouteHandler('./routes/universities/jlbtc/index'));
 
 // DT 财经
-router.get('/dtcj/datahero/:category?', require('./routes/dtcj/datahero'));
+router.get('/dtcj/datahero/:category?', lazyloadRouteHandler('./routes/dtcj/datahero'));
 
 // 劍心．回憶
-router.get('/kenshin/:category?/:type?', require('./routes/kenshin/index'));
+router.get('/kenshin/:category?/:type?', lazyloadRouteHandler('./routes/kenshin/index'));
 
 // av01
-router.get('/av01/actor/:name/:type?', require('./routes/av01/actor'));
-router.get('/av01/tag/:name/:type?', require('./routes/av01/tag'));
+router.get('/av01/actor/:name/:type?', lazyloadRouteHandler('./routes/av01/actor'));
+router.get('/av01/tag/:name/:type?', lazyloadRouteHandler('./routes/av01/tag'));
 
 // macked
-router.get('/macked/app/:name', require('./routes/macked/app'));
+router.get('/macked/app/:name', lazyloadRouteHandler('./routes/macked/app'));
 
 // 美国劳工联合会-产业工会联合会
-router.get('/aflcio/blog', require('./routes/aflcio/blog'));
+router.get('/aflcio/blog', lazyloadRouteHandler('./routes/aflcio/blog'));
 
 // Fur Affinity
-router.get('/furaffinity/home/:type?/:nsfw?', require('./routes/furaffinity/home'));
-router.get('/furaffinity/browse/:nsfw?', require('./routes/furaffinity/browse'));
-router.get('/furaffinity/status', require('./routes/furaffinity/status'));
-router.get('/furaffinity/search/:keyword/:nsfw?', require('./routes/furaffinity/search'));
-router.get('/furaffinity/user/:username', require('./routes/furaffinity/user'));
-router.get('/furaffinity/watching/:username', require('./routes/furaffinity/watching'));
-router.get('/furaffinity/watchers/:username', require('./routes/furaffinity/watchers'));
-router.get('/furaffinity/commissions/:username', require('./routes/furaffinity/commissions'));
-router.get('/furaffinity/shouts/:username', require('./routes/furaffinity/shouts'));
-router.get('/furaffinity/journals/:username', require('./routes/furaffinity/journals'));
-router.get('/furaffinity/gallery/:username/:nsfw?', require('./routes/furaffinity/gallery'));
-router.get('/furaffinity/scraps/:username/:nsfw?', require('./routes/furaffinity/scraps'));
-router.get('/furaffinity/favorites/:username/:nsfw?', require('./routes/furaffinity/favorites'));
-router.get('/furaffinity/submission_comments/:id', require('./routes/furaffinity/submission_comments'));
-router.get('/furaffinity/journal_comments/:id', require('./routes/furaffinity/journal_comments'));
+router.get('/furaffinity/home/:type?/:nsfw?', lazyloadRouteHandler('./routes/furaffinity/home'));
+router.get('/furaffinity/browse/:nsfw?', lazyloadRouteHandler('./routes/furaffinity/browse'));
+router.get('/furaffinity/status', lazyloadRouteHandler('./routes/furaffinity/status'));
+router.get('/furaffinity/search/:keyword/:nsfw?', lazyloadRouteHandler('./routes/furaffinity/search'));
+router.get('/furaffinity/user/:username', lazyloadRouteHandler('./routes/furaffinity/user'));
+router.get('/furaffinity/watching/:username', lazyloadRouteHandler('./routes/furaffinity/watching'));
+router.get('/furaffinity/watchers/:username', lazyloadRouteHandler('./routes/furaffinity/watchers'));
+router.get('/furaffinity/commissions/:username', lazyloadRouteHandler('./routes/furaffinity/commissions'));
+router.get('/furaffinity/shouts/:username', lazyloadRouteHandler('./routes/furaffinity/shouts'));
+router.get('/furaffinity/journals/:username', lazyloadRouteHandler('./routes/furaffinity/journals'));
+router.get('/furaffinity/gallery/:username/:nsfw?', lazyloadRouteHandler('./routes/furaffinity/gallery'));
+router.get('/furaffinity/scraps/:username/:nsfw?', lazyloadRouteHandler('./routes/furaffinity/scraps'));
+router.get('/furaffinity/favorites/:username/:nsfw?', lazyloadRouteHandler('./routes/furaffinity/favorites'));
+router.get('/furaffinity/submission_comments/:id', lazyloadRouteHandler('./routes/furaffinity/submission_comments'));
+router.get('/furaffinity/journal_comments/:id', lazyloadRouteHandler('./routes/furaffinity/journal_comments'));
 
 // Logseq
-router.get('/logseq/changelog', require('./routes/logseq/changelog'));
+router.get('/logseq/changelog', lazyloadRouteHandler('./routes/logseq/changelog'));
 
 // 亿欧网
-router.get('/iyiou', require('./routes/iyiou'));
+router.get('/iyiou', lazyloadRouteHandler('./routes/iyiou'));
 
 // 香港商报
-router.get('/hkcd/pdf', require('./routes/hkcd/pdf'));
+router.get('/hkcd/pdf', lazyloadRouteHandler('./routes/hkcd/pdf'));
 
 // 博客来
-router.get('/bookscomtw/newbooks/:category', require('./routes/bookscomtw/newbooks'));
+router.get('/bookscomtw/newbooks/:category', lazyloadRouteHandler('./routes/bookscomtw/newbooks'));
 
 // Elite Babes
-router.get('/elitebabes/videos/:sort?', require('./routes/elitebabes/videos'));
-router.get('/elitebabes/search/:keyword?', require('./routes/elitebabes/search'));
-router.get('/elitebabes/:category?', require('./routes/elitebabes/index'));
+router.get('/elitebabes/videos/:sort?', lazyloadRouteHandler('./routes/elitebabes/videos'));
+router.get('/elitebabes/search/:keyword?', lazyloadRouteHandler('./routes/elitebabes/search'));
+router.get('/elitebabes/:category?', lazyloadRouteHandler('./routes/elitebabes/index'));
 
 // Trakt.tv
-router.get('/trakt/collection/:username/:type?', require('./routes/trakt/collection'));
+router.get('/trakt/collection/:username/:type?', lazyloadRouteHandler('./routes/trakt/collection'));
 
 // 全球化智库
-router.get('/ccg/:category?', require('./routes/ccg/index'));
+router.get('/ccg/:category?', lazyloadRouteHandler('./routes/ccg/index'));
 
 // 少女前线
-router.get('/gf-cn/news/:category?', require('./routes/gf-cn/news'));
+router.get('/gf-cn/news/:category?', lazyloadRouteHandler('./routes/gf-cn/news'));
 
 // Eagle
-router.get('/eagle/changelog/:language?', require('./routes/eagle/changelog'));
+router.get('/eagle/changelog/:language?', lazyloadRouteHandler('./routes/eagle/changelog'));
 
 // ezone.hk
-router.get('/ezone/:category?', require('./routes/ezone/index'));
+router.get('/ezone/:category?', lazyloadRouteHandler('./routes/ezone/index'));
 
 // 中国橡胶网
-router.get('/cria/news/:id?', require('./routes/cria/news'));
+router.get('/cria/news/:id?', lazyloadRouteHandler('./routes/cria/news'));
 
 // 灵异网
-router.get('/lingyi/:category', require('./routes/lingyi/index'));
+router.get('/lingyi/:category', lazyloadRouteHandler('./routes/lingyi/index'));
 
 // 歪脑读
-router.get('/wainao-reads/all-articles', require('./routes/wainao/index'));
+router.get('/wainao-reads/all-articles', lazyloadRouteHandler('./routes/wainao/index'));
 
 // react
-router.get('/react/react-native-weekly', require('./routes/react/react-native-weekly'));
+router.get('/react/react-native-weekly', lazyloadRouteHandler('./routes/react/react-native-weekly'));
 
 // dbaplus 社群
-router.get('/dbaplus/:tab?', require('./routes/dbaplus/tab'));
+router.get('/dbaplus/:tab?', lazyloadRouteHandler('./routes/dbaplus/tab'));
 
 // 梨园
-router.get('/liyuan-forums/threads', require('./routes/liyuan-forums/threads'));
-router.get('/liyuan-forums/threads/forum/:forum_id', require('./routes/liyuan-forums/threads'));
-router.get('/liyuan-forums/threads/topic/:topic_id', require('./routes/liyuan-forums/threads'));
-router.get('/liyuan-forums/threads/user/:user_id', require('./routes/liyuan-forums/threads'));
+router.get('/liyuan-forums/threads', lazyloadRouteHandler('./routes/liyuan-forums/threads'));
+router.get('/liyuan-forums/threads/forum/:forum_id', lazyloadRouteHandler('./routes/liyuan-forums/threads'));
+router.get('/liyuan-forums/threads/topic/:topic_id', lazyloadRouteHandler('./routes/liyuan-forums/threads'));
+router.get('/liyuan-forums/threads/user/:user_id', lazyloadRouteHandler('./routes/liyuan-forums/threads'));
 
 // 集思录
-router.get('/jisilu/reply/:user', require('./routes/jisilu/reply'));
-router.get('/jisilu/topic/:user', require('./routes/jisilu/topic'));
+router.get('/jisilu/reply/:user', lazyloadRouteHandler('./routes/jisilu/reply'));
+router.get('/jisilu/topic/:user', lazyloadRouteHandler('./routes/jisilu/topic'));
 
 // Constitutional Court of Baden-Württemberg (Germany)
-router.get('/verfghbw/press/:keyword?', require('./routes/verfghbw/press'));
+router.get('/verfghbw/press/:keyword?', lazyloadRouteHandler('./routes/verfghbw/press'));
 
 // Topbook
-router.get('/topbook/overview/:id?', require('./routes/topbook/overview'));
-router.get('/topbook/today', require('./routes/topbook/today'));
+router.get('/topbook/overview/:id?', lazyloadRouteHandler('./routes/topbook/overview'));
+router.get('/topbook/today', lazyloadRouteHandler('./routes/topbook/today'));
 
 // Melon
-router.get('/melon/chart/:category?', require('./routes/melon/chart'));
+router.get('/melon/chart/:category?', lazyloadRouteHandler('./routes/melon/chart'));
 
 // 弯弯字幕组
-router.get('/wanwansub/info/:id', require('./routes/wanwansub/info'));
-router.get('/wanwansub/:id?', require('./routes/wanwansub/index'));
+router.get('/wanwansub/info/:id', lazyloadRouteHandler('./routes/wanwansub/info'));
+router.get('/wanwansub/:id?', lazyloadRouteHandler('./routes/wanwansub/index'));
 
 // FIX 字幕侠
-router.get('/zimuxia/portfolio/:id', require('./routes/zimuxia/portfolio'));
-router.get('/zimuxia/:category?', require('./routes/zimuxia/index'));
+router.get('/zimuxia/portfolio/:id', lazyloadRouteHandler('./routes/zimuxia/portfolio'));
+router.get('/zimuxia/:category?', lazyloadRouteHandler('./routes/zimuxia/index'));
 
 // Bandcamp
-router.get('/bandcamp/tag/:tag?', require('./routes/bandcamp/tag'));
+router.get('/bandcamp/tag/:tag?', lazyloadRouteHandler('./routes/bandcamp/tag'));
 
 // Hugo 更新日志
-router.get('/hugo/releases', require('./routes/hugo/releases'));
+router.get('/hugo/releases', lazyloadRouteHandler('./routes/hugo/releases'));
 
 // 东立出版
-router.get('/tongli/news/:type', require('./routes/tongli/news'));
+router.get('/tongli/news/:type', lazyloadRouteHandler('./routes/tongli/news'));
 
 // OR
-router.get('/or/:id?', require('./routes/or'));
+router.get('/or/:id?', lazyloadRouteHandler('./routes/or'));
 
 // HKEPC
-router.get('/hkepc/:category?', require('./routes/hkepc/index'));
+router.get('/hkepc/:category?', lazyloadRouteHandler('./routes/hkepc/index'));
 
 // 海南大学
-router.get('/hainanu/ssszs', require('./routes/hainanu/ssszs'));
+router.get('/hainanu/ssszs', lazyloadRouteHandler('./routes/hainanu/ssszs'));
 
 // 游戏年轮
-router.get('/bibgame/:category?/:type?', require('./routes/bibgame/category'));
+router.get('/bibgame/:category?/:type?', lazyloadRouteHandler('./routes/bibgame/category'));
 
 // 澳門特別行政區政府各公共部門獎助貸學金服務平台
-router.get('/macau-bolsas/:lang?', require('./routes/macau-bolsas/index'));
+router.get('/macau-bolsas/:lang?', lazyloadRouteHandler('./routes/macau-bolsas/index'));
 
 // PotPlayer
-router.get('/potplayer/update/:language?', require('./routes/potplayer/update'));
+router.get('/potplayer/update/:language?', lazyloadRouteHandler('./routes/potplayer/update'));
 
 // 综艺秀
-router.get('/zyshow/:name', require('./routes/zyshow'));
+router.get('/zyshow/:name', lazyloadRouteHandler('./routes/zyshow'));
 
 // 加美财经
-router.get('/caus/:category?', require('./routes/caus'));
+router.get('/caus/:category?', lazyloadRouteHandler('./routes/caus'));
 
 // 摩点
-router.get('/modian/zhongchou/:category?/:sort?/:status?', require('./routes/modian/zhongchou'));
+router.get('/modian/zhongchou/:category?/:sort?/:status?', lazyloadRouteHandler('./routes/modian/zhongchou'));
 
 // MacWk
-router.get('/macwk/soft/:name', require('./routes/macwk/soft'));
+router.get('/macwk/soft/:name', lazyloadRouteHandler('./routes/macwk/soft'));
 
 // 世界计划 多彩舞台 feat.初音未来 (ProjectSekai)
-router.get('/pjsk/news', require('./routes/pjsk/news'));
+router.get('/pjsk/news', lazyloadRouteHandler('./routes/pjsk/news'));
 
 // 人民论坛网
-router.get('/rmlt/idea/:category?', require('./routes/rmlt/idea'));
+router.get('/rmlt/idea/:category?', lazyloadRouteHandler('./routes/rmlt/idea'));
 
 // CBNData
-router.get('/cbndata/information/:category?', require('./routes/cbndata/information'));
+router.get('/cbndata/information/:category?', lazyloadRouteHandler('./routes/cbndata/information'));
 
 // TANC 艺术新闻
-router.get('/tanchinese/:category?', require('./routes/tanchinese'));
+router.get('/tanchinese/:category?', lazyloadRouteHandler('./routes/tanchinese'));
 
 // Harvard
-router.get('/harvard/health/blog', require('./routes/universities/harvard/health/blog'));
+router.get('/harvard/health/blog', lazyloadRouteHandler('./routes/universities/harvard/health/blog'));
 
 // yuzu emulator
-router.get('/yuzu-emu/entry', require('./routes/yuzu-emu/entry'));
+router.get('/yuzu-emu/entry', lazyloadRouteHandler('./routes/yuzu-emu/entry'));
 
 // 温州大学
-router.get('/wzu/news', require('./routes/universities/wzu/news'));
+router.get('/wzu/news', lazyloadRouteHandler('./routes/universities/wzu/news'));
 
 // Resources - The Partnership on AI
-router.get('/partnershiponai/resources', require('./routes/partnershiponai/resources'));
+router.get('/partnershiponai/resources', lazyloadRouteHandler('./routes/partnershiponai/resources'));
 
 // Common App
-router.get('/commonapp/blog', require('./routes/commonapp/blog'));
+router.get('/commonapp/blog', lazyloadRouteHandler('./routes/commonapp/blog'));
 
 // Sky Sports
-router.get('/skysports/news/:team', require('./routes/skysports/news'));
+router.get('/skysports/news/:team', lazyloadRouteHandler('./routes/skysports/news'));
 
 // Europa Press
-router.get('/europapress/:category?', require('./routes/europapress'));
+router.get('/europapress/:category?', lazyloadRouteHandler('./routes/europapress'));
 
 // World Happiness Report
-router.get('/worldhappiness/blog', require('./routes/worldhappiness/blog'));
-router.get('/worldhappiness/archive', require('./routes/worldhappiness/archive'));
+router.get('/worldhappiness/blog', lazyloadRouteHandler('./routes/worldhappiness/blog'));
+router.get('/worldhappiness/archive', lazyloadRouteHandler('./routes/worldhappiness/archive'));
 
 // 中国纺织经济信息网
-router.get('/ctei/news/:id?', require('./routes/ctei/news'));
+router.get('/ctei/news/:id?', lazyloadRouteHandler('./routes/ctei/news'));
 
 // 时事一点通
-router.get('/ssydt/article/:id?', require('./routes/ssydt/article'));
+router.get('/ssydt/article/:id?', lazyloadRouteHandler('./routes/ssydt/article'));
 
 // 湖北省软件行业协会
-router.get('/gov/hubei/hbsia/:caty', require('./routes/gov/hubei/hbsia'));
+router.get('/gov/hubei/hbsia/:caty', lazyloadRouteHandler('./routes/gov/hubei/hbsia'));
 
 // 武汉东湖新技术开发区
-router.get('/gov/wuhan/wehdz/:caty', require('./routes/gov/wuhan/wehdz'));
+router.get('/gov/wuhan/wehdz/:caty', lazyloadRouteHandler('./routes/gov/wuhan/wehdz'));
 
 // 武汉市科学技术局
-router.get('/gov/wuhan/kjj/:caty', require('./routes/gov/wuhan/kjj'));
+router.get('/gov/wuhan/kjj/:caty', lazyloadRouteHandler('./routes/gov/wuhan/kjj'));
 
 // 费米实验室
-router.get('/fnal/news/:category?', require('./routes/fnal/news'));
+router.get('/fnal/news/:category?', lazyloadRouteHandler('./routes/fnal/news'));
 
 // X410
-router.get('/x410/news', require('./routes/x410/news'));
+router.get('/x410/news', lazyloadRouteHandler('./routes/x410/news'));
 
 // 恩山无线论坛
-router.get('/right/forum/:id?', require('./routes/right/forum'));
+router.get('/right/forum/:id?', lazyloadRouteHandler('./routes/right/forum'));
 
 // 生物探索
-router.get('/biodiscover/:channel?', require('./routes/biodiscover'));
+router.get('/biodiscover/:channel?', lazyloadRouteHandler('./routes/biodiscover'));
 
 module.exports = router;


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Fix #8009

## 完整路由地址 / Example for the proposed route(s)

```routes
/
/test/1145141919
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

Do not `require` any route handler on the cold start and only `require` when there is a coming request, which can improve the performance of the RSSHub cold start for *A LOT*.

> DO NOT MERGE. This change could break `@vercel/nft`. Tests needed.
