### PR TITLE
perf: lazy require dependencies

### DIFF
--- a/lib/middleware/cache.js
+++ b/lib/middleware/cache.js
@@ -1,8 +1,9 @@
-const Redis = require('ioredis');
 const Lru = require('lru-cache');
 const md5 = require('@/utils/md5');
 const config = require('@/config').value;
 const logger = require('@/utils/logger');
+
+let Redis;
 
 module.exports = function (app) {
     let available = false;
@@ -12,6 +13,7 @@ module.exports = function (app) {
     };
 
     if (config.cache.type === 'redis') {
+        Redis = Redis || require('ioredis');
         const redisClient = new Redis(config.redis.url);
 
         redisClient.on('error', (error) => {

--- a/lib/middleware/parameter.js
+++ b/lib/middleware/parameter.js
@@ -1,9 +1,10 @@
 const entities = require('entities');
-const mercury_parser = require('@postlight/mercury-parser');
 const cheerio = require('cheerio');
 const { simplecc } = require('simplecc-wasm');
 const got = require('@/utils/got');
 const config = require('@/config').value;
+
+let mercury_parser;
 
 module.exports = async (ctx, next) => {
     await next();
@@ -204,6 +205,8 @@ module.exports = async (ctx, next) => {
                     const parsed_result = await ctx.cache.tryGet(`mercury-cache-${link}`, async () => {
                         // if parser failed, return default description and not report error
                         try {
+                            mercury_parser = mercury_parser || require('@postlight/mercury-parser');
+
                             const res = await got(link);
                             const $ = cheerio.load(res.data);
                             const result = await mercury_parser.parse(link, {

--- a/lib/utils/request-wrapper.js
+++ b/lib/utils/request-wrapper.js
@@ -1,17 +1,20 @@
 const config = require('@/config').value;
-const HttpsProxyAgent = require('https-proxy-agent');
-const SocksProxyAgent = require('socks-proxy-agent');
-const tunnel = require('tunnel');
 const logger = require('./logger');
 const http = require('http');
 const https = require('https');
+
+let tunnel;
+let HttpsProxyAgent;
+let SocksProxyAgent;
 
 let agent = null;
 if (config.proxyUri && typeof config.proxyUri === 'string') {
     let proxy = null;
     if (config.proxyUri.startsWith('http')) {
+        HttpsProxyAgent = HttpsProxyAgent || require('https-proxy-agent');
         proxy = new HttpsProxyAgent(config.proxyUri);
     } else if (config.proxyUri.startsWith('socks')) {
+        SocksProxyAgent = SocksProxyAgent || require('socks-proxy-agent');
         proxy = new SocksProxyAgent(config.proxyUri);
     } else {
         throw 'Unknown proxy-uri format';
@@ -27,10 +30,12 @@ if (config.proxyUri && typeof config.proxyUri === 'string') {
 
     switch (config.proxy.protocol) {
         case 'socks':
+            SocksProxyAgent = SocksProxyAgent || require('socks-proxy-agent');
             agent.http = new SocksProxyAgent(proxyUrl);
             agent.https = new SocksProxyAgent(proxyUrl);
             break;
         case 'http':
+            tunnel = tunnel || require('tunnel');
             process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
             agent.http = tunnel.httpOverHttp({
                 proxy: {
@@ -46,6 +51,7 @@ if (config.proxyUri && typeof config.proxyUri === 'string') {
             });
             break;
         case 'https':
+            tunnel = tunnel || require('tunnel');
             agent.http = tunnel.httpOverHttps({
                 proxy: {
                     host: config.proxy.host,


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

## 完整路由地址 / Example for the proposed route(s)

```routes
NOROUTE
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

Only require proxyagent, `ioredis` when explicitly enabled in the config, and only require `mecuri_parser` on the first `fulltext` mode request. This improve RSSHub cold start performance by another 35%.