### PR TITLE
fix(zimuxia-portfollo): `$.reverse` is removed

### DIFF
--- a/lib/routes/zimuxia/portfolio.js
+++ b/lib/routes/zimuxia/portfolio.js
@@ -1,6 +1,5 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
-const fs = require('fs/promises');
 
 module.exports = async (ctx) => {
     const id = ctx.params.id;

--- a/lib/routes/zimuxia/portfolio.js
+++ b/lib/routes/zimuxia/portfolio.js
@@ -6,7 +6,6 @@ module.exports = async (ctx) => {
 
     const rootUrl = 'http://zimuxia.cn';
     const currentUrl = `${rootUrl}/portfolio/${id}`;
-
     const response = await got({
         method: 'get',
         url: currentUrl,

--- a/lib/routes/zimuxia/portfolio.js
+++ b/lib/routes/zimuxia/portfolio.js
@@ -17,7 +17,7 @@ module.exports = async (ctx) => {
         .filter(function () {
             return $(this).attr('href').substr(0, 7) === 'magnet:';
         })
-        .get()
+        .toArray()
         .reverse()
         .map((item) => {
             item = $(item);

--- a/lib/routes/zimuxia/portfolio.js
+++ b/lib/routes/zimuxia/portfolio.js
@@ -1,24 +1,25 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
+const fs = require('fs/promises');
 
 module.exports = async (ctx) => {
     const id = ctx.params.id;
-
     const rootUrl = 'http://zimuxia.cn';
     const currentUrl = `${rootUrl}/portfolio/${id}`;
+
     const response = await got({
         method: 'get',
         url: currentUrl,
     });
-
     const $ = cheerio.load(response.data);
 
-    const items = $('a')
-        .filter(function () {
+    const items = Array.from(
+        $('a').filter(function () {
             return $(this).attr('href').substr(0, 7) === 'magnet:';
         })
+    )
         .reverse()
-        .map((_, item) => {
+        .map((item) => {
             item = $(item);
 
             return {
@@ -28,8 +29,7 @@ module.exports = async (ctx) => {
                 enclosure_url: item.attr('href'),
                 enclosure_type: 'application/x-bittorrent',
             };
-        })
-        .get();
+        });
 
     ctx.state.data = {
         title: `${$('.content-page-title').text()} - FIX字幕侠`,

--- a/lib/routes/zimuxia/portfolio.js
+++ b/lib/routes/zimuxia/portfolio.js
@@ -13,11 +13,11 @@ module.exports = async (ctx) => {
 
     const $ = cheerio.load(response.data);
 
-    const items = Array.from(
-        $('a').filter(function () {
+    const items = $('a')
+        .filter(function () {
             return $(this).attr('href').substr(0, 7) === 'magnet:';
         })
-    )
+        .get()
         .reverse()
         .map((item) => {
             item = $(item);

--- a/lib/routes/zimuxia/portfolio.js
+++ b/lib/routes/zimuxia/portfolio.js
@@ -3,6 +3,7 @@ const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
     const id = ctx.params.id;
+
     const rootUrl = 'http://zimuxia.cn';
     const currentUrl = `${rootUrl}/portfolio/${id}`;
 
@@ -10,6 +11,7 @@ module.exports = async (ctx) => {
         method: 'get',
         url: currentUrl,
     });
+
     const $ = cheerio.load(response.data);
 
     const items = Array.from(


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

好像是cheerio的api发生了变化？`$.reverse()` 被移除了

## 完整路由地址 / Example for the proposed route(s)

```routes
/zimuxia/portfolio/假如marvel
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
