### PR TITLE
fix(route): hket Missing `url` property

### DIFF
--- a/lib/routes/hket/index.js
+++ b/lib/routes/hket/index.js
@@ -73,7 +73,7 @@ module.exports = async (ctx) => {
 
     const items = await Promise.all(
         list &&
-            list.map((_, item) =>
+            list.map((item) =>
                 ctx.cache.tryGet(item.link, async () => {
                     const article = await got({
                         method: 'get',


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/hket
/hket/sran001
/hket/sran008
/hket/sran010
/hket/sran011
/hket/srac002
/hket/srat006
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [x] Documentation
  - [x] CN
  - [ ] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
Fix 
```bash
...Missing url property...
```
in https://github.com/DIYgod/RSSHub/pull/8050