### PR TITLE
fix: exclude datanews to prevent `pubDate` error (`/caixin/latest`)

### DIFF
--- a/lib/routes/caixin/latest.js
+++ b/lib/routes/caixin/latest.js
@@ -4,7 +4,7 @@ const cheerio = require('cheerio');
 module.exports = async (ctx) => {
     const li_r = await got({
         method: 'get',
-        url: 'http://finance.caixin.com/2020-11-03/101622309.html',
+        url: 'https://www.caixin.com/2021-08-22/101758426.html',
     });
 
     const $ = cheerio.load(li_r.data);
@@ -13,7 +13,7 @@ module.exports = async (ctx) => {
     const tasks = [];
 
     list.map((_index, li) => $(li).find('a').first().attr('href'))
-        .filter((_index, link) => link.indexOf('fm.caixin.com') === -1 && link.indexOf('video.caixin.com') === -1) // content filter
+        .filter((_index, link) => link.indexOf('fm.caixin.com') === -1 && link.indexOf('video.caixin.com') === -1 && link.indexOf('datanews.caixin.com') === -1) // content filter
         .each((_index, link) => {
             const entry = ctx.cache.tryGet(link, async () => {
                 const entry_r = await got.get(link);

--- a/lib/routes/caixin/latest.js
+++ b/lib/routes/caixin/latest.js
@@ -16,7 +16,7 @@ module.exports = async (ctx) => {
     const tasks = [];
 
     list.map((_index, li) => $(li).find('a').first().attr('href'))
-        .filter((_index, link) => link.indexOf('fm.caixin.com') === -1 && link.indexOf('video.caixin.com') === -1 && link.indexOf('datanews.caixin.com') === -1) // content filter
+        .filter((_index, link) => !link.includes('fm.caixin.com') && !link.includes('video.caixin.com') && !link.includes('datanews.caixin.com')) // content filter
         .each((_index, link) => {
             const entry = ctx.cache.tryGet(link, async () => {
                 const entry_r = await got.get(link);
@@ -49,14 +49,16 @@ module.exports = async (ctx) => {
                     desc = `<blockquote><p>${subhead}</p></blockquote><img src="${pic_url}" alt="${pic_alt}">${content}`;
                 }
                 // time
+                /*
                 const [, year, month, day, hour, minute] = $('div#artInfo.artInfo')
                     .text()
                     .match(/(\d+)年(\d+)月(\d+)日 *(\d+):(\d+)/);
+                */
 
                 return {
                     title: h1,
                     description: desc,
-                    pubDate: timezone(parseDate(`${year}-${month}-${day} ${hour}:${minute}`), +8),
+                    pubDate: timezone(parseDate($('div#artInfo.artInfo').text(), 'YYYY年MM月DD日 HH:mm'), +8),
                     link,
                 };
             });

--- a/lib/routes/caixin/latest.js
+++ b/lib/routes/caixin/latest.js
@@ -1,6 +1,9 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 
+const { parseDate } = require('@/utils/parse-date');
+const timezone = require('@/utils/timezone');
+
 module.exports = async (ctx) => {
     const li_r = await got({
         method: 'get',
@@ -49,12 +52,11 @@ module.exports = async (ctx) => {
                 const [, year, month, day, hour, minute] = $('div#artInfo.artInfo')
                     .text()
                     .match(/(\d+)年(\d+)月(\d+)日 *(\d+):(\d+)/);
-                const time = new Date(`${year}-${month}-${day}T${hour}:${minute}:00+0800`).toUTCString();
 
                 return {
                     title: h1,
                     description: desc,
-                    pubDate: time,
+                    pubDate: timezone(parseDate(`${year}-${month}-${day} ${hour}:${minute}`), +8),
                     link,
                 };
             });


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/caixin/latest
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [x] Documentation
  - [x] CN
  - [ ] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
