### PR TITLE
fix(route):解决漫画柜和镜像站没有pubDate问题

### DIFF
--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -2,6 +2,7 @@ const { resolve } = require('url');
 const cheerio = require('cheerio');
 const got = require('@/utils/got');
 const LZString = require('lz-string');
+global.pub_date = new Date();
 
 const getChapters = ($) =>
     $('.chapter-list > ul')
@@ -10,9 +11,13 @@ const getChapters = ($) =>
         .reduce((acc, curr) => acc.concat($(curr).children('li').toArray()), [])
         .map((ele) => {
             const a = $(ele).children('a');
+            let p_date = new Date('1900-01-01').toUTCString();
+            if(a.find('em').length > 0 )
+                p_date = global.pub_date;
             return {
                 link: resolve('https://www.manhuagui.com/', a.attr('href')),
                 title: a.attr('title'),
+                pub_date: p_date,
                 num: a.find('i').text(),
             };
         });
@@ -34,7 +39,7 @@ module.exports = async (ctx) => {
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
         .replace('最近于 [','').replace('] 更新至','');
-    let pub_date = new Date(pub_date_str);
+    global.pub_date = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -43,7 +48,7 @@ module.exports = async (ctx) => {
     const genResult = (chapter) => ({
         link: chapter.link,
         title: chapter.title,
-        pubDate: pub_date.toUTCString(),
+        pubDate: chapter.pub_date,
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />

--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -30,7 +30,11 @@ module.exports = async (ctx) => {
             $('#__VIEWSTATE').remove();
         }
     }
-
+    //增加了pubDate以免每次更新都十几个未读
+    const reg = new RegExp('最近于.+更新至');
+    const pub_date_str = $('.status > span').text().match(reg)[0]
+        .replace('最近于 [','').replace('] 更新至','');
+    let pub_date = new Date(pub_date_str);
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -39,6 +43,7 @@ module.exports = async (ctx) => {
     const genResult = (chapter) => ({
         link: chapter.link,
         title: chapter.title,
+        pubDate: pub_date.toUTCString(),
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -2,7 +2,6 @@ const { resolve } = require('url');
 const cheerio = require('cheerio');
 const got = require('@/utils/got');
 const LZString = require('lz-string');
-
 const getChapters = ($) =>
     $('.chapter-list > ul')
         .toArray()
@@ -30,7 +29,11 @@ module.exports = async (ctx) => {
             $('#__VIEWSTATE').remove();
         }
     }
-
+    //增加了pubDate以免每次更新都十几个未读
+    const reg = new RegExp('最近于.+更新至');
+    const pub_date_str = $('.status > span').text().match(reg)[0]
+        .replace('最近于 [','').replace('] 更新至','');
+    let pub_date = new Date(pub_date_str);
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -39,6 +42,7 @@ module.exports = async (ctx) => {
     const genResult = (chapter) => ({
         link: chapter.link,
         title: chapter.title,
+        pubDate: pub_date.toUTCString(),
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -2,6 +2,7 @@ const { resolve } = require('url');
 const cheerio = require('cheerio');
 const got = require('@/utils/got');
 const LZString = require('lz-string');
+global.pub_date = new Date();
 const getChapters = ($) =>
     $('.chapter-list > ul')
         .toArray()
@@ -9,9 +10,13 @@ const getChapters = ($) =>
         .reduce((acc, curr) => acc.concat($(curr).children('li').toArray()), [])
         .map((ele) => {
             const a = $(ele).children('a');
+            let p_date = new Date('1900-01-01').toUTCString();
+            if(a.find('em').length > 0 )
+                p_date = global.pub_date;
             return {
                 link: resolve('https://www.mhgui.com/', a.attr('href')),
                 title: a.attr('title'),
+                pub_date: p_date,
                 num: a.find('i').text(),
             };
         });
@@ -33,7 +38,7 @@ module.exports = async (ctx) => {
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
         .replace('最近于 [','').replace('] 更新至','');
-    let pub_date = new Date(pub_date_str);
+    global.pub_date = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -42,7 +47,7 @@ module.exports = async (ctx) => {
     const genResult = (chapter) => ({
         link: chapter.link,
         title: chapter.title,
-        pubDate: pub_date.toUTCString(),
+        pubDate: chapter.pub_date,
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
调整了pubDate,已解决每次检查都能获取到大量未读(实际已读)的文章