### PR TITLE
 fix(route):解决漫画柜和镜像站没有pubDate问题 

### DIFF
--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -2,6 +2,7 @@ const { resolve } = require('url');
 const cheerio = require('cheerio');
 const got = require('@/utils/got');
 const LZString = require('lz-string');
+global.pub_date = new Date();
 
 const getChapters = ($) =>
     $('.chapter-list > ul')
@@ -10,9 +11,13 @@ const getChapters = ($) =>
         .reduce((acc, curr) => acc.concat($(curr).children('li').toArray()), [])
         .map((ele) => {
             const a = $(ele).children('a');
+            let p_date = new Date('1900-01-01').toUTCString();
+            if(a.find('em').length > 0 )
+                p_date = global.pub_date;
             return {
                 link: resolve('https://www.manhuagui.com/', a.attr('href')),
                 title: a.attr('title'),
+                pub_date: p_date,
                 num: a.find('i').text(),
             };
         });
@@ -34,7 +39,7 @@ module.exports = async (ctx) => {
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
         .replace('最近于 [','').replace('] 更新至','');
-    let pub_date = new Date(pub_date_str);
+    global.pub_date = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -43,7 +48,7 @@ module.exports = async (ctx) => {
     const genResult = (chapter) => ({
         link: chapter.link,
         title: chapter.title,
-        pubDate: pub_date.toUTCString(),
+        pubDate: chapter.pub_date,
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />

--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -11,7 +11,7 @@ const getChapters = ($) =>
         .map((ele) => {
             const a = $(ele).children('a');
             //增加了GUID
-            let pDate = pDate = $.pubDate;
+            let pDate = $.pubDate;
             const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
             return {
                 link: resolve('https://www.manhuagui.com/', a.attr('href')),

--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -12,8 +12,6 @@ const getChapters = ($) =>
             const a = $(ele).children('a');
             //增加了GUID
             let pDate = new Date('1900-01-01').toUTCString();
-            if(a.find('em').length > 0 )
-                pDate = $.pubDate;
             const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
             return {
                 link: resolve('https://www.manhuagui.com/', a.attr('href')),

--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -11,7 +11,7 @@ const getChapters = ($) =>
         .map((ele) => {
             const a = $(ele).children('a');
             //增加了GUID
-            let pDate = new Date('1900-01-01').toUTCString();
+            let pDate = pDate = $.pubDate;
             const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
             return {
                 link: resolve('https://www.manhuagui.com/', a.attr('href')),

--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -37,7 +37,7 @@ module.exports = async (ctx) => {
     // 对最新更新的章节增加了pubDate
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
-        .replace('最近于 [','').replace('] 更新至', '');
+        .replace('最近于 [', '').replace('] 更新至', '');
     // 为了能在闭包内访问到这个日期而不是每次需要处理这个最近更新日期
     $.pubDate = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();

--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -10,15 +10,14 @@ const getChapters = ($) =>
         .reduce((acc, curr) => acc.concat($(curr).children('li').toArray()), [])
         .map((ele) => {
             const a = $(ele).children('a');
-            //增加了GUID
-            let pDate = $.pubDate;
-            const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
+            // 增加了GUID
+            const pDate = $.pubDate;
             return {
                 link: resolve('https://www.manhuagui.com/', a.attr('href')),
                 title: a.attr('title'),
                 pub_date: pDate,
                 num: a.find('i').text(),
-                guid: guid
+                guid: resolve('https://www.manhuagui.com/', a.attr('href'))
             };
         });
 
@@ -35,11 +34,11 @@ module.exports = async (ctx) => {
             $('#__VIEWSTATE').remove();
         }
     }
-    //对最新更新的章节增加了pubDate
+    // 对最新更新的章节增加了pubDate
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
-        .replace('最近于 [','').replace('] 更新至','');
-    //为了能在闭包内访问到这个日期而不是每次需要处理这个最近更新日期
+        .replace('最近于 [','').replace('] 更新至', '');
+    // 为了能在闭包内访问到这个日期而不是每次需要处理这个最近更新日期
     $.pubDate = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();

--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -30,7 +30,11 @@ module.exports = async (ctx) => {
             $('#__VIEWSTATE').remove();
         }
     }
-
+    //增加了pubDate以免每次更新都十几个未读
+    const reg = new RegExp('最近于.+更新至');
+    const pub_date_str = $('.status > span').text().match(reg)[0]
+        .replace('最近于 [','').replace('] 更新至','');
+    let pub_date = new Date(pub_date_str);
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -39,6 +43,7 @@ module.exports = async (ctx) => {
     const genResult = (chapter) => ({
         link: chapter.link,
         title: chapter.title,
+        pubDate: pub_date.toUTCString(),
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />

--- a/lib/routes/manhuagui/comic.js
+++ b/lib/routes/manhuagui/comic.js
@@ -2,7 +2,6 @@ const { resolve } = require('url');
 const cheerio = require('cheerio');
 const got = require('@/utils/got');
 const LZString = require('lz-string');
-global.pub_date = new Date();
 
 const getChapters = ($) =>
     $('.chapter-list > ul')
@@ -11,14 +10,17 @@ const getChapters = ($) =>
         .reduce((acc, curr) => acc.concat($(curr).children('li').toArray()), [])
         .map((ele) => {
             const a = $(ele).children('a');
-            let p_date = new Date('1900-01-01').toUTCString();
+            //增加了GUID
+            let pDate = new Date('1900-01-01').toUTCString();
             if(a.find('em').length > 0 )
-                p_date = global.pub_date;
+                pDate = $.pubDate;
+            const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
             return {
                 link: resolve('https://www.manhuagui.com/', a.attr('href')),
                 title: a.attr('title'),
-                pub_date: p_date,
+                pub_date: pDate,
                 num: a.find('i').text(),
+                guid: guid
             };
         });
 
@@ -35,11 +37,12 @@ module.exports = async (ctx) => {
             $('#__VIEWSTATE').remove();
         }
     }
-    //增加了pubDate以免每次更新都十几个未读
+    //对最新更新的章节增加了pubDate
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
         .replace('最近于 [','').replace('] 更新至','');
-    global.pub_date = new Date(pub_date_str).toUTCString();
+    //为了能在闭包内访问到这个日期而不是每次需要处理这个最近更新日期
+    $.pubDate = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -49,6 +52,7 @@ module.exports = async (ctx) => {
         link: chapter.link,
         title: chapter.title,
         pubDate: chapter.pub_date,
+        guid: chapter.guid,
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -2,7 +2,6 @@ const { resolve } = require('url');
 const cheerio = require('cheerio');
 const got = require('@/utils/got');
 const LZString = require('lz-string');
-
 const getChapters = ($) =>
     $('.chapter-list > ul')
         .toArray()
@@ -30,7 +29,11 @@ module.exports = async (ctx) => {
             $('#__VIEWSTATE').remove();
         }
     }
-
+    //增加了pubDate以免每次更新都十几个未读
+    const reg = new RegExp('最近于.+更新至');
+    const pub_date_str = $('.status > span').text().match(reg)[0]
+        .replace('最近于 [','').replace('] 更新至','');
+    let pub_date = new Date(pub_date_str);
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -39,6 +42,7 @@ module.exports = async (ctx) => {
     const genResult = (chapter) => ({
         link: chapter.link,
         title: chapter.title,
+        pubDate: pub_date.toUTCString(),
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -11,7 +11,7 @@ const getChapters = ($) =>
         .map((ele) => {
             const a = $(ele).children('a');
             //增加了GUID
-            let pDate = pDate = $.pubDate;
+            let pDate = $.pubDate;
             const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
             return {
                 link: resolve('https://www.mhgui.com/', a.attr('href')),

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -37,7 +37,7 @@ module.exports = async (ctx) => {
     // 对最新更新的章节增加了pubDate
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
-        .replace('最近于 [','').replace('] 更新至', '');
+        .replace('最近于 [', '').replace('] 更新至', '');
     // 为了能在闭包内访问到这个日期而不是每次需要处理这个最近更新日期
     $.pubDate = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -11,7 +11,7 @@ const getChapters = ($) =>
         .map((ele) => {
             const a = $(ele).children('a');
             //增加了GUID
-            let pDate = new Date('1900-01-01').toUTCString();
+            let pDate = pDate = $.pubDate;
             const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
             return {
                 link: resolve('https://www.mhgui.com/', a.attr('href')),

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -2,7 +2,7 @@ const { resolve } = require('url');
 const cheerio = require('cheerio');
 const got = require('@/utils/got');
 const LZString = require('lz-string');
-global.pub_date = new Date();
+
 const getChapters = ($) =>
     $('.chapter-list > ul')
         .toArray()
@@ -10,14 +10,17 @@ const getChapters = ($) =>
         .reduce((acc, curr) => acc.concat($(curr).children('li').toArray()), [])
         .map((ele) => {
             const a = $(ele).children('a');
-            let p_date = new Date('1900-01-01').toUTCString();
+            //增加了GUID
+            let pDate = new Date('1900-01-01').toUTCString();
             if(a.find('em').length > 0 )
-                p_date = global.pub_date;
+                pDate = $.pubDate;
+            const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
             return {
                 link: resolve('https://www.mhgui.com/', a.attr('href')),
                 title: a.attr('title'),
-                pub_date: p_date,
+                pub_date: pDate,
                 num: a.find('i').text(),
+                guid: guid
             };
         });
 
@@ -34,11 +37,12 @@ module.exports = async (ctx) => {
             $('#__VIEWSTATE').remove();
         }
     }
-    //增加了pubDate以免每次更新都十几个未读
+    //对最新更新的章节增加了pubDate
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
         .replace('最近于 [','').replace('] 更新至','');
-    global.pub_date = new Date(pub_date_str).toUTCString();
+    //为了能在闭包内访问到这个日期而不是每次需要处理这个最近更新日期
+    $.pubDate = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -48,6 +52,7 @@ module.exports = async (ctx) => {
         link: chapter.link,
         title: chapter.title,
         pubDate: chapter.pub_date,
+        guid: chapter.guid,
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -2,6 +2,7 @@ const { resolve } = require('url');
 const cheerio = require('cheerio');
 const got = require('@/utils/got');
 const LZString = require('lz-string');
+global.pub_date = new Date();
 const getChapters = ($) =>
     $('.chapter-list > ul')
         .toArray()
@@ -9,9 +10,13 @@ const getChapters = ($) =>
         .reduce((acc, curr) => acc.concat($(curr).children('li').toArray()), [])
         .map((ele) => {
             const a = $(ele).children('a');
+            let p_date = new Date('1900-01-01').toUTCString();
+            if(a.find('em').length > 0 )
+                p_date = global.pub_date;
             return {
                 link: resolve('https://www.mhgui.com/', a.attr('href')),
                 title: a.attr('title'),
+                pub_date: p_date,
                 num: a.find('i').text(),
             };
         });
@@ -33,7 +38,7 @@ module.exports = async (ctx) => {
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
         .replace('最近于 [','').replace('] 更新至','');
-    let pub_date = new Date(pub_date_str);
+    global.pub_date = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();
     const coverImgSrc = $('.book-cover img').attr('src');
@@ -42,7 +47,7 @@ module.exports = async (ctx) => {
     const genResult = (chapter) => ({
         link: chapter.link,
         title: chapter.title,
-        pubDate: pub_date.toUTCString(),
+        pubDate: chapter.pub_date,
         description: `
             <h1>${chapter.num}</h1>
             <img src="${coverImgSrc}" />

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -10,15 +10,14 @@ const getChapters = ($) =>
         .reduce((acc, curr) => acc.concat($(curr).children('li').toArray()), [])
         .map((ele) => {
             const a = $(ele).children('a');
-            //增加了GUID
-            let pDate = $.pubDate;
-            const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
+            // 增加了GUID
+            const pDate = $.pubDate;
             return {
                 link: resolve('https://www.mhgui.com/', a.attr('href')),
                 title: a.attr('title'),
                 pub_date: pDate,
                 num: a.find('i').text(),
-                guid: guid
+                guid: resolve('https://www.mhgui.com/', a.attr('href'))
             };
         });
 
@@ -35,11 +34,11 @@ module.exports = async (ctx) => {
             $('#__VIEWSTATE').remove();
         }
     }
-    //对最新更新的章节增加了pubDate
+    // 对最新更新的章节增加了pubDate
     const reg = new RegExp('最近于.+更新至');
     const pub_date_str = $('.status > span').text().match(reg)[0]
-        .replace('最近于 [','').replace('] 更新至','');
-    //为了能在闭包内访问到这个日期而不是每次需要处理这个最近更新日期
+        .replace('最近于 [','').replace('] 更新至', '');
+    // 为了能在闭包内访问到这个日期而不是每次需要处理这个最近更新日期
     $.pubDate = new Date(pub_date_str).toUTCString();
     const bookTitle = $('.book-title > h1').text();
     const bookIntro = $('#intro-all').text();

--- a/lib/routes/mhgui/comic.js
+++ b/lib/routes/mhgui/comic.js
@@ -12,8 +12,6 @@ const getChapters = ($) =>
             const a = $(ele).children('a');
             //增加了GUID
             let pDate = new Date('1900-01-01').toUTCString();
-            if(a.find('em').length > 0 )
-                pDate = $.pubDate;
             const guid = a.attr('href').replace(a.attr('href').match('/.+/')[0],'').replace('\.','');
             return {
                 link: resolve('https://www.mhgui.com/', a.attr('href')),


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

无

## 完整路由地址 / Example for the proposed route(s)

```routes
/mhgui/comic/:id
/manhuagui/comic/:id
```


## 说明 / Note
添加了pubDate,并且通过添加GUID的方式解决每次检查都能获取到大量未读(实际已读)的文章