### PR TITLE
fix: 网易号（通用）

### DIFF
--- a/lib/routes/netease/dy2.js
+++ b/lib/routes/netease/dy2.js
@@ -31,31 +31,16 @@ module.exports = async (ctx) => {
 
     const items = await Promise.all(
         list.map(async (item) => {
-            let content;
-            if (item.link.startsWith('https://www.163.com')) {
-                const itemData = await ctx.cache.tryGet(item.link, async () =>
-                    iconv.decode(
-                        (
-                            await got.get(item.link, {
-                                responseType: 'buffer',
-                            })
-                        ).data,
-                        charset
-                    )
-                );
-                content = cheerio.load(itemData, { decodeEntities: false });
-            } else {
-                const itemData = await ctx.cache.tryGet(
-                    item.link,
-                    async () =>
-                        (
-                            await got.get(item.link, {
-                                responseType: 'buffer',
-                            })
-                        ).data
-                );
-                content = cheerio.load(itemData, { decodeEntities: false });
-            }
+            const itemData = await ctx.cache.tryGet(
+                item.link,
+                async () =>
+                    (
+                        await got.get(item.link, {
+                            responseType: 'buffer',
+                        })
+                    ).data
+            );
+            const content = cheerio.load(itemData, { decodeEntities: false });
 
             const eDescription = content('.post_body').html();
 


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/netease/dy2/T1555591616739
/netease/dy2/T1482377048407
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
163网页改版，全部采用`utf-8`编码，故无需再判断三级域名并从`gbk`和`utf-8`中选择。
本地测试无误。