### PR TITLE
feat(route): add yahoo japan covid19 news collection 日本疫情消息汇总

### DIFF
--- a/docs/en/other.md
+++ b/docs/en/other.md
@@ -51,6 +51,12 @@ Official Website: [https://www.ssm.gov.mo/apps1/PreventWuhanInfection/en.aspx](h
 
 <RouteEn author="Gnnng" example="/coronavirus/sg-moh" path="/coronavirus/sg-moh"/>
 
+### Yahoo Japan COVID19 news collection
+
+Official Website: <https://news.yahoo.co.jp/pages/article/20200207>
+
+<RouteEn author="sgqy" example="/coronavirus/yahoo-japan" path="/coronavirus/yahoo-japan/:tdfk?" :paramsDesc="['Romaji of Todofuken. Can be got from URLs on area detail page. Example: kyoto']"/>
+
 ## Darwin Awards
 
 ### Articles

--- a/docs/other.md
+++ b/docs/other.md
@@ -870,6 +870,12 @@ type 为 all 时，category 参数不支持 cost 和 free
 
 <Route author="Gnnng" example="/coronavirus/sg-moh" path="/coronavirus/sg-moh"/>
 
+### Yahoo Japan 新型コロナウイルス感染症まとめ
+
+新闻主页：<https://news.yahoo.co.jp/pages/article/20200207>
+
+<Route author="sgqy" example="/coronavirus/yahoo-japan" path="/coronavirus/yahoo-japan/:tdfk?" :paramsDesc="['都道府県的拼音，可从地图详情页的链接中获取。例如：京都府 = kyoto']"/>
+
 ## 新趣集
 
 > 官方 Feed 地址为: <https://xinquji.com/rss>

--- a/lib/router.js
+++ b/lib/router.js
@@ -2591,6 +2591,7 @@ router.get('/coronavirus/nhc', lazyloadRouteHandler('./routes/coronavirus/nhc'))
 router.get('/coronavirus/mogov-2019ncov/:lang', lazyloadRouteHandler('./routes/coronavirus/mogov-2019ncov'));
 router.get('/coronavirus/qq/fact', lazyloadRouteHandler('./routes/tencent/factcheck'));
 router.get('/coronavirus/sg-moh', lazyloadRouteHandler('./routes/coronavirus/sg-moh'));
+router.get('/coronavirus/yahoo-japan/:tdfk?', lazyloadRouteHandler('./routes/coronavirus/yahoo-japan'));
 
 // 南京林业大学教务处
 router.get('/njfu/jwc/:category?', lazyloadRouteHandler('./routes/universities/njfu/jwc'));

--- a/lib/routes/coronavirus/yahoo-japan.js
+++ b/lib/routes/coronavirus/yahoo-japan.js
@@ -1,5 +1,6 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
+const dayjs = require('dayjs');
 
 module.exports = async (ctx) => {
     const tdfk = ctx.params.tdfk || false;
@@ -17,15 +18,25 @@ module.exports = async (ctx) => {
 
     const $ = cheerio.load(data);
 
+    const this_year = dayjs().year();
+    const this_month = dayjs().month() + 1;
+
     const art_uri = [];
     $('#layoutFooter ul.dlpThumbLink a').each((i, e) => {
         const link = $(e).attr('href');
         const text = $(e).find('.dlpThumbText span').eq(0).text();
         const author = $(e).find('.dlpQuote').text();
-        if (!link.includes('//news.yahoo.co.jp')) {
-            return; // too lazy to process `12/31(月) 23:59` format :)
+        const date = $(e).find('.dlpDate').text() + ' +9'; // explicit timezone
+
+        let date_obj = dayjs(date);
+        if (date_obj.month() + 1 > 11 && this_month < 2) {
+            // if the article is from the next year
+            date_obj = date_obj.year(this_year - 1);
+        } else {
+            date_obj = date_obj.year(this_year);
         }
-        art_uri.push({ l: link, t: text, a: author });
+
+        art_uri.push({ l: link, t: text, a: author, d: date_obj.toString() });
     });
 
     const getNews = async (uri) => {
@@ -33,9 +44,13 @@ module.exports = async (ctx) => {
             link: uri.l,
             title: uri.t,
             author: uri.a,
-            pubDate: null,
+            pubDate: uri.d,
             description: null,
         };
+
+        if (!uri.l.includes('//news.yahoo.co.jp')) {
+            return ret; // do not process uncertain pages
+        }
 
         const page_data = await ctx.cache.tryGet(uri.l, async () => {
             const resp = await got({
@@ -49,7 +64,7 @@ module.exports = async (ctx) => {
         const $doc = cheerio.load(page_data);
 
         const iso_date = $doc('meta[name="pubdate"]').attr('content');
-        ret.pubDate = new Date(iso_date).toUTCString();
+        ret.pubDate = dayjs(iso_date).toString();
         ret.description = $doc('div.article_body').html() || $doc('meta[name="description"]').attr('content');
 
         return ret;

--- a/lib/routes/coronavirus/yahoo-japan.js
+++ b/lib/routes/coronavirus/yahoo-japan.js
@@ -5,13 +5,18 @@ module.exports = async (ctx) => {
     const tdfk = ctx.params.tdfk || false;
     const uri = tdfk ? `https://news.yahoo.co.jp/pages/article/covid19${tdfk}` : `https://news.yahoo.co.jp/pages/article/20200207`;
     const req_header = { 'User-Agent': 'Mozilla/5.0 (Linux; Android 9; SM-G960F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36' };
-    const responst = await got({
-        method: 'get',
-        url: uri,
-        headers: req_header,
+
+    const data = await ctx.cache.tryGet(uri, async () => {
+        const responst = await got({
+            method: 'get',
+            url: uri,
+            headers: req_header,
+        });
+        return responst.data;
     });
 
-    const $ = cheerio.load(responst.data);
+    const $ = cheerio.load(data);
+
     const art_uri = [];
     $('#layoutFooter ul.dlpThumbLink a').each((i, e) => {
         const link = $(e).attr('href');
@@ -32,13 +37,17 @@ module.exports = async (ctx) => {
             description: null,
         };
 
-        const resp = await got({
-            method: 'get',
-            url: uri.l,
-            headers: req_header,
+        const page_data = await ctx.cache.tryGet(uri.l, async () => {
+            const resp = await got({
+                method: 'get',
+                url: uri.l,
+                headers: req_header,
+            });
+            return resp.data;
         });
 
-        const $doc = cheerio.load(resp.data);
+        const $doc = cheerio.load(page_data);
+
         const iso_date = $doc('meta[name="pubdate"]').attr('content');
         ret.pubDate = new Date(iso_date).toUTCString();
         ret.description = $doc('div.article_body').html() || $doc('meta[name="description"]').attr('content');

--- a/lib/routes/coronavirus/yahoo-japan.js
+++ b/lib/routes/coronavirus/yahoo-japan.js
@@ -28,12 +28,11 @@ module.exports = async (ctx) => {
         const author = $(e).find('.dlpQuote').text();
         const date = $(e).find('.dlpDate').text() + ' +9'; // explicit timezone
 
-        let date_obj = dayjs(date);
-        if (date_obj.month() + 1 > 11 && this_month < 2) {
-            // if the article is from the next year
+        let date_obj = dayjs(date).year(this_year);
+
+        if (date_obj.month() + 1 > this_month) {
+            // if the article is from the last year
             date_obj = date_obj.year(this_year - 1);
-        } else {
-            date_obj = date_obj.year(this_year);
         }
 
         art_uri.push({ l: link, t: text, a: author, d: date_obj.toString() });

--- a/lib/routes/coronavirus/yahoo-japan.js
+++ b/lib/routes/coronavirus/yahoo-japan.js
@@ -7,16 +7,13 @@ module.exports = async (ctx) => {
     const uri = tdfk ? `https://news.yahoo.co.jp/pages/article/covid19${tdfk}` : `https://news.yahoo.co.jp/pages/article/20200207`;
     const req_header = { 'User-Agent': 'Mozilla/5.0 (Linux; Android 9; SM-G960F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36' };
 
-    const data = await ctx.cache.tryGet(uri, async () => {
-        const responst = await got({
-            method: 'get',
-            url: uri,
-            headers: req_header,
-        });
-        return responst.data;
+    const resp = await got({
+        method: 'get',
+        url: uri,
+        headers: req_header,
     });
 
-    const $ = cheerio.load(data);
+    const $ = cheerio.load(resp.data);
 
     const this_year = dayjs().year();
     const this_month = dayjs().month() + 1;

--- a/lib/routes/coronavirus/yahoo-japan.js
+++ b/lib/routes/coronavirus/yahoo-japan.js
@@ -1,0 +1,57 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+
+module.exports = async (ctx) => {
+    const tdfk = ctx.params.tdfk || false;
+    const uri = tdfk ? `https://news.yahoo.co.jp/pages/article/covid19${tdfk}` : `https://news.yahoo.co.jp/pages/article/20200207`;
+    const req_header = { 'User-Agent': 'Mozilla/5.0 (Linux; Android 9; SM-G960F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36' };
+    const responst = await got({
+        method: 'get',
+        url: uri,
+        headers: req_header,
+    });
+
+    const $ = cheerio.load(responst.data);
+    const art_uri = [];
+    $('#layoutFooter ul.dlpThumbLink a').each((i, e) => {
+        const link = $(e).attr('href');
+        const text = $(e).find('.dlpThumbText span').eq(0).text();
+        const author = $(e).find('.dlpQuote').text();
+        if (!link.includes('//news.yahoo.co.jp')) {
+            return; // too lazy to process `12/31(月) 23:59` format :)
+        }
+        art_uri.push({ l: link, t: text, a: author });
+    });
+
+    const getNews = async (uri) => {
+        const ret = {
+            link: uri.l,
+            title: uri.t,
+            author: uri.a,
+            pubDate: null,
+            description: null,
+        };
+
+        const resp = await got({
+            method: 'get',
+            url: uri.l,
+            headers: req_header,
+        });
+
+        const $doc = cheerio.load(resp.data);
+        const iso_date = $doc('meta[name="pubdate"]').attr('content');
+        ret.pubDate = new Date(iso_date).toUTCString();
+        ret.description = $doc('div.article_body').html() || $doc('meta[name="description"]').attr('content');
+
+        return ret;
+    };
+
+    const items = await Promise.all(art_uri.map(getNews));
+
+    ctx.state.data = {
+        title: $('title').text(),
+        link: uri,
+        description: $('meta[name="description"]').attr('content'),
+        item: items,
+    };
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

新增 Yahoo 日本疫情新闻整合

## 完整路由地址 / Example for the proposed route(s)

```routes
/coronavirus/yahoo-japan/:tdfk?
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [x] CN
  - [x] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
