### PR TITLE
WIP: fix segmentfault user router

### DIFF
--- a/lib/routes/segmentfault/user.js
+++ b/lib/routes/segmentfault/user.js
@@ -1,7 +1,7 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const url = require('url');
-const date = require('@/utils/date');
+const {parseDate} = require('@/utils/parse-date');
 
 const host = 'https://segmentfault.com';
 
@@ -12,20 +12,20 @@ module.exports = async (ctx) => {
     const response = await got.get(link);
     const $ = cheerio.load(response.data);
 
-    const channel_name = $('h2.profile__heading--name').text().trim().split(' ')[0];
+    const channel_name = $('h3.text-center').text().trim().split(' ')[0];
 
-    const list = $('ul.profile-mine__content li')
+    const list = $('ul.list-group li')
         .slice(0, 10)
         .map(function () {
             const info = {
-                link: $(this).find('a.profile-mine__content--title').attr('href'),
-                title: $(this).find('a.profile-mine__content--title').text(),
+                link: $(this).find('a.text-body').attr('href'),
+                title: $(this).find('a.text-body').text(),
                 author: channel_name,
             };
             return info;
         })
         .get();
-
+    
     const out = await Promise.all(
         list.map(async (info) => {
             const title = info.title;
@@ -66,8 +66,8 @@ module.exports = async (ctx) => {
                     .html()
                     .replace(/data-src="/g, 'src="https://segmentfault.com')
                     .trim();
-                const date_v = $('div.article__authorright > span').text().trim().replace(' ', '');
-                date_value = date_v.substring(0, date_v.length - 2);
+                const date_v = $('time.text-secondary').attr('datetime')
+                pubDate = parseDate(date_v, 'YYYY-MM-DDTHH:mm:ss.SSS')
             }
 
             const single = {
@@ -75,7 +75,7 @@ module.exports = async (ctx) => {
                 link: itemUrl,
                 author,
                 description,
-                pubDate: date(date_value, 8),
+                pubDate
             };
             ctx.cache.set(itemUrl, JSON.stringify(single));
             return Promise.resolve(single);


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

#6795 

## 完整路由地址 / Example for the proposed route(s)

```routes
/segmentfault/user/yunqishequ_5aa899aad5395
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
https://segmentfault.com/u/yunqishequ_5aa899aad5395/articles
网站升级导致原路由 broken
原路由中存在两个逻辑分支，分享和原创。
原创分支已经修复完毕，时间解析也迁移到了 `utils/parse-date` @NeverBehave 
由于不是思否用户，并没有找到任何要走分享逻辑分支的user ，希望有人可以给一个分享的 case 出来，从而修复分享的逻辑分支。cc [原作者](https://github.com/DIYgod/RSSHub/pull/5465 ) @leyuuu 