### PR TITLE
chore(route): refactor the usage of pixiv token

### DIFF
--- a/lib/routes/pixiv/bookmarks.js
+++ b/lib/routes/pixiv/bookmarks.js
@@ -10,11 +10,12 @@ module.exports = async (ctx) => {
 
     const id = ctx.params.id;
 
-    if (!getToken()) {
+    const token = await getToken();
+    if (!token) {
         throw 'pixiv not login';
     }
 
-    const [bookmarksResponse, userDetailResponse] = await Promise.all([getBookmarks(id, getToken()), getUserDetail(id, getToken())]);
+    const [bookmarksResponse, userDetailResponse] = await Promise.all([getBookmarks(id, token), getUserDetail(id, token)]);
 
     const illusts = bookmarksResponse.data.illusts;
     const username = userDetailResponse.data.user.name;
@@ -26,10 +27,10 @@ module.exports = async (ctx) => {
         item: illusts.map((illust) => {
             const images = [];
             if (illust.page_count === 1) {
-                images.push(`<p><img src="https://pixiv.cat/${illust.id}.jpg"/></p>`);
+                images.push(`<p><img src='https://pixiv.cat/${illust.id}.jpg'/></p>`);
             } else {
                 for (let i = 0; i < illust.page_count; i++) {
-                    images.push(`<p><img src="https://pixiv.cat/${illust.id}-${i + 1}.jpg"/></p>`);
+                    images.push(`<p><img src='https://pixiv.cat/${illust.id}-${i + 1}.jpg'/></p>`);
                 }
             }
             return {

--- a/lib/routes/pixiv/illustfollow.js
+++ b/lib/routes/pixiv/illustfollow.js
@@ -5,10 +5,13 @@ module.exports = async (ctx) => {
     if (!config.pixiv || !config.pixiv.refreshToken) {
         throw 'pixiv RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#%E9%83%A8%E5%88%86-rss-%E6%A8%A1%E5%9D%97%E9%85%8D%E7%BD%AE">relevant config</a>';
     }
-    if (!getToken()) {
+
+    const token = await getToken();
+    if (!(await getToken())) {
         throw 'pixiv not login';
     }
-    const response = await getIllustFollows(getToken());
+
+    const response = await getIllustFollows(token);
     const illusts = response.data.illusts;
     ctx.state.data = {
         title: `Pixiv关注的新作品`,
@@ -17,10 +20,10 @@ module.exports = async (ctx) => {
         item: illusts.map((illust) => {
             const images = [];
             if (illust.page_count === 1) {
-                images.push(`<p><img src="https://pixiv.cat/${illust.id}.jpg"/></p>`);
+                images.push(`<p><img src='https://pixiv.cat/${illust.id}.jpg'/></p>`);
             } else {
                 for (let i = 0; i < illust.page_count; i++) {
-                    images.push(`<p><img src="https://pixiv.cat/${illust.id}-${i + 1}.jpg"/></p>`);
+                    images.push(`<p><img src='https://pixiv.cat/${illust.id}-${i + 1}.jpg'/></p>`);
                 }
             }
             return {

--- a/lib/routes/pixiv/ranking.js
+++ b/lib/routes/pixiv/ranking.js
@@ -55,11 +55,12 @@ module.exports = async (ctx) => {
     const mode = alias[ctx.params.mode] ? alias[ctx.params.mode] : ctx.params.mode;
     const date = ctx.params.date ? new Date(ctx.params.date) : new Date();
 
-    if (!getToken()) {
+    const token = await getToken();
+    if (!token) {
         throw 'pixiv not login';
     }
 
-    const response = await getRanking(mode, ctx.params.date && date, getToken());
+    const response = await getRanking(mode, ctx.params.date && date, token);
 
     const illusts = response.data.illusts;
 

--- a/lib/routes/pixiv/search.js
+++ b/lib/routes/pixiv/search.js
@@ -12,15 +12,16 @@ module.exports = async (ctx) => {
     const order = ctx.params.order || 'date';
     const mode = ctx.params.mode;
 
-    if (!getToken()) {
+    const token = await getToken();
+    if (!token) {
         throw 'pixiv not login';
     }
 
     let response;
     if (order === 'popular') {
-        response = await searchPopularIllust(keyword, getToken());
+        response = await searchPopularIllust(keyword, token);
     } else {
-        response = await searchIllust(keyword, getToken());
+        response = await searchIllust(keyword, token);
     }
 
     let illusts = response.data.illusts;

--- a/lib/routes/pixiv/token.js
+++ b/lib/routes/pixiv/token.js
@@ -42,7 +42,10 @@ async function tickToken() {
         expireTime = 30;
         logger.error(`Pixiv refresh token failed, retry in ${expireTime} seconds.`);
     }
-    setTimeout(tickToken, expireTime);
+    // If is package, the mock server should be closed after request, needn't to refresh
+    if (!config.isPackage) {
+        setTimeout(tickToken, expireTime);
+    }
 }
 
 module.exports = async () => {
@@ -52,4 +55,4 @@ module.exports = async () => {
     return token;
 };
 
-module.exports.refreshToken = refreshToken;
+module.exports.tickToken = tickToken;

--- a/lib/routes/pixiv/token.js
+++ b/lib/routes/pixiv/token.js
@@ -1,6 +1,5 @@
 const config = require('@/config').value;
 const logger = require('@/utils/logger');
-const wait = require('@/utils/wait');
 const got = require('./pixiv-got');
 const { maskHeader } = require('./constants');
 
@@ -12,8 +11,8 @@ const authorizationInfo = {
     hash_secret: '28c1fdd170a5204386cb1313c7077b34f83e4aaf4aa829ce78c231e05b0bae2c',
 };
 
-async function refreshToken() {
-    const response = await got({
+const refreshToken = () =>
+    got({
         method: 'post',
         url: 'https://oauth.secure.pixiv.net/auth/token',
         form: {
@@ -31,37 +30,25 @@ async function refreshToken() {
         logger.error('Pixiv refresh token failed.');
         logger.debug(e);
     });
-    return response;
-}
 
-async function tokenLoop() {
-    const res = await refreshToken();
-    if (res && res.access_token) {
-        logger.info('Pixiv login success.');
-        token = res.access_token;
-        let expires_in = res.expires_in * 0.9;
-        /* eslint-disable no-constant-condition, no-await-in-loop */
-        while (true) {
-            await wait(expires_in * 1000);
-            const refresh_res = await refreshToken();
-            if (refresh_res && refresh_res.access_token) {
-                logger.debug('Pixiv refresh token success.');
-                token = refresh_res.access_token;
-                expires_in = refresh_res.expires_in * 0.9;
-            } else {
-                expires_in = 30;
-                logger.error(`Pixiv refresh token failed, retry in ${expires_in} seconds.`);
-            }
-        }
-        /* eslint-enable no-await-in-loop */
+async function tickToken() {
+    const result = await refreshToken();
+    let expireTime;
+    if (result && result.access_token) {
+        logger.debug('Pixiv refresh token success.');
+        token = result.access_token;
+        expireTime = result.expires_in;
+    } else {
+        expireTime = 30;
+        logger.error(`Pixiv refresh token failed, retry in ${expireTime} seconds.`);
     }
+    setTimeout(tickToken, expireTime);
 }
 
-if (config.pixiv && config.pixiv.refreshToken) {
-    tokenLoop();
-}
-
-module.exports = function getToken() {
+module.exports = async () => {
+    if (!token) {
+        await tickToken();
+    }
     return token;
 };
 

--- a/lib/routes/pixiv/user.js
+++ b/lib/routes/pixiv/user.js
@@ -8,12 +8,12 @@ module.exports = async (ctx) => {
     }
 
     const id = ctx.params.id;
-
-    if (!getToken()) {
+    const token = await getToken();
+    if (!token) {
         throw 'pixiv not login';
     }
 
-    const response = await getIllusts(id, getToken());
+    const response = await getIllusts(id, token);
 
     const illusts = response.data.illusts;
     const username = illusts[0].user.name;
@@ -25,10 +25,10 @@ module.exports = async (ctx) => {
         item: illusts.map((illust) => {
             const images = [];
             if (illust.page_count === 1) {
-                images.push(`<p><img src="https://pixiv.cat/${illust.id}.jpg"/></p>`);
+                images.push(`<p><img src='https://pixiv.cat/${illust.id}.jpg'/></p>`);
             } else {
                 for (let i = 0; i < illust.page_count; i++) {
-                    images.push(`<p><img src="https://pixiv.cat/${illust.id}-${i + 1}.jpg"/></p>`);
+                    images.push(`<p><img src='https://pixiv.cat/${illust.id}-${i + 1}.jpg'/></p>`);
                 }
             }
             return {


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

## 完整路由地址 / Example for the proposed route(s)

```routes
/pixiv/user/bookmarks/15288095
/pixiv/user/11
/pixiv/ranking/week
/pixiv/search/麻衣/popular/2
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
之前的 token 使用有些奇怪，不等拿到第一个 token 就直接返回了，造成垃圾报错

Signed-off-by: SettingDust <settingdust@gmail.com>