### PR TITLE
fix(route): incorrect source links in yuzu emulator

### DIFF
--- a/lib/routes/yuzu-emu/entry.js
+++ b/lib/routes/yuzu-emu/entry.js
@@ -30,7 +30,7 @@ module.exports = async (ctx) => {
                     method: 'get',
                     url: item.link,
                 });
-                const content = cheerio.load(detailResponse.data);
+                const content = cheerio.load(detailResponse.data.replace(/<source src="\.\//g, `<source src="${item.link}`));
 
                 const meta = content('.h3').text().trim().split(' on ');
 


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8107

## 完整路由地址 / Example for the proposed route(s)

```routes
/yuzu-emu/entry
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
