### PR TITLE
fix(route): migrate initium routes to new timezone

### DIFF
--- a/lib/routes/initium/full.js
+++ b/lib/routes/initium/full.js
@@ -2,6 +2,7 @@ const got = require('@/utils/got');
 const config = require('@/config').value;
 const cheerio = require('cheerio');
 const resolve_url = require('url').resolve;
+const timezone = require('@/utils/timezone');
 
 module.exports = async (ctx) => {
     // model是channel/tag/etc.，而type是latest/feature/quest-academy这些一级栏目/标签/作者名的slug名。如果是追踪的话，那就是model是follow，type是articles。
@@ -95,11 +96,6 @@ module.exports = async (ctx) => {
     // 如果model=author，那就是avatar；否则都是cover，要么就没封面
     const image = response.data[model] && (response.data[model].cover || response.data[model].avatar);
 
-    function fixDate(date) {
-        // The date is mistakenly declared as UTC, but actually it's UTC+08:00
-        return date.replace(/Z$/, '+08:00');
-    }
-
     const getFullText = async (slug) => {
         let content = await ctx.cache.get(slug + language);
         if (content) {
@@ -166,6 +162,8 @@ module.exports = async (ctx) => {
             .filter((a) => a.article)
             .slice(0, token === 'Basic YW5vbnltb3VzOkdpQ2VMRWp4bnFCY1ZwbnA2Y0xzVXZKaWV2dlJRY0FYTHY=' && key.iapReceipt === undefined ? 10 : articles.length)
             .map(async (item) => {
+                item.article.date = timezone(item.article.date, +8);
+                item.article.updated = timezone(item.article.updated, +8);
                 const description = await getFullText(item.article.slug);
                 return {
                     title: item.article.headline,
@@ -173,8 +171,8 @@ module.exports = async (ctx) => {
                     category: item.article.channels.filter((x) => !x.homepage).map((x) => x.name),
                     description,
                     link: resolve_url('https://theinitium.com', item.article.url),
-                    pubDate: new Date(fixDate(item.article.date)),
-                    updated: new Date(fixDate(item.article.updated)),
+                    pubDate: item.article.date,
+                    updated: item.article.updated,
                     // 如果遇到编辑部漏录入情况，则给uuid做个手脚，以便阅读器到时重抓。
                     guid: description.endsWith('内容为空，请稍后再来') ? item.article.uuid + '-I-am-empty' : item.article.uuid,
                 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

#6795

## 完整路由地址 / Example for the proposed route(s)

```
/initium/latest/zh-hans
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

不过解析出来的时间似乎本身就有一些问题，比如 https://theinitium.com/article/20210901-opinion-govern-fanquan/ 这一篇解析出来的时间是 "datePublished" datetime="2021-09-01T18:57:00+08:00"