### PR TITLE
refactor: add no-implicit-coercion rule for ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,15 @@
         "no-multi-str": 2,
         "comma-spacing": 2,
         "comma-style": 2,
+        "no-implicit-coercion": [
+            "error",
+            {
+                "boolean": false,
+                "number": false,
+                "string": false,
+                "disallowTemplateShorthand": true
+            }
+        ],
         "func-call-spacing": 2,
         "keyword-spacing": 2,
         "linebreak-style": 2,

--- a/assets/radar-rules.js
+++ b/assets/radar-rules.js
@@ -2183,7 +2183,7 @@
                 docs: 'https://docs.rsshub.app/multimedia.html#onejav',
                 source: ['/:type', '/:type/:key', '/:type/:key/:morekey'],
                 target: (params, url, document) => {
-                    const itype = params.morekey === undefined ? `${params.type}` : params.type === 'tag' ? 'tag' : 'day';
+                    const itype = params.morekey === undefined ? params.type : params.type === 'tag' ? 'tag' : 'day';
                     let ikey = `${itype === 'day' ? params.type : ''}${params.key || ''}${itype === 'tag' && params.morekey !== undefined ? '%2F' : ''}${params.morekey || ''}`;
                     if (ikey === '' && itype === 'tag') {
                         ikey = document.querySelector('div.thumbnail.is-inline > a').getAttribute('href').replace('/tag/', '').replace('/', '%2F');
@@ -2221,7 +2221,7 @@
                 docs: 'https://docs.rsshub.app/multimedia.html#141jav',
                 source: ['/:type', '/:type/:key', '/:type/:key/:morekey'],
                 target: (params, url, document) => {
-                    const itype = params.morekey === undefined ? `${params.type}` : params.type === 'tag' ? 'tag' : 'day';
+                    const itype = params.morekey === undefined ? params.type : params.type === 'tag' ? 'tag' : 'day';
                     let ikey = `${itype === 'day' ? params.type : ''}${params.key || ''}${itype === 'tag' && params.morekey !== undefined ? '%2F' : ''}${params.morekey || ''}`;
                     if (ikey === '' && itype === 'tag') {
                         ikey = document.querySelector('div.thumbnail.is-inline > a').getAttribute('href').replace('/tag/', '').replace('/', '%2F');
@@ -2259,7 +2259,7 @@
                 docs: 'https://docs.rsshub.app/multimedia.html#141ppv',
                 source: ['/:type', '/:type/:key', '/:type/:key/:morekey'],
                 target: (params, url, document) => {
-                    const itype = params.morekey === undefined ? `${params.type}` : params.type === 'tag' ? 'tag' : 'day';
+                    const itype = params.morekey === undefined ? params.type : params.type === 'tag' ? 'tag' : 'day';
                     let ikey = `${itype === 'day' ? params.type : ''}${params.key || ''}${itype === 'tag' && params.morekey !== undefined ? '%2F' : ''}${params.morekey || ''}`;
                     if (ikey === '' && itype === 'tag') {
                         ikey = document.querySelector('div.thumbnail.is-inline > a').getAttribute('href').replace('/tag/', '').replace('/', '%2F');

--- a/docs/en/joinus/quick-start.md
+++ b/docs/en/joinus/quick-start.md
@@ -141,7 +141,7 @@ Create a new js script in [/lib/routes/](https://github.com/DIYgod/RSSHub/tree/m
             list
                 .map((index, item) => {
                     item = $(item);
-                    itemPicUrl = String(item.find('a.cover').attr('style')).replace('background-image:url(', '').replace(')', '');
+                    itemPicUrl = item.find('a.cover').attr('style').replace('background-image:url(', '').replace(')', '');
                     return {
                         title: item.find('.title a').first().text(),
                         description: `作者：${item.find('.usr-pic a').last().text()}<br>描述：${item.find('.content p').text()}<br><img src="${itemPicUrl}">`,

--- a/docs/en/joinus/quick-start.md
+++ b/docs/en/joinus/quick-start.md
@@ -141,7 +141,7 @@ Create a new js script in [/lib/routes/](https://github.com/DIYgod/RSSHub/tree/m
             list
                 .map((index, item) => {
                     item = $(item);
-                    itemPicUrl = `${item.find('a.cover').attr('style')}`.replace('background-image:url(', '').replace(')', '');
+                    itemPicUrl = String(item.find('a.cover').attr('style')).replace('background-image:url(', '').replace(')', '');
                     return {
                         title: item.find('.title a').first().text(),
                         description: `作者：${item.find('.usr-pic a').last().text()}<br>描述：${item.find('.content p').text()}<br><img src="${itemPicUrl}">`,

--- a/docs/joinus/quick-start.md
+++ b/docs/joinus/quick-start.md
@@ -142,7 +142,7 @@ sidebar: auto
             list
                 .map((index, item) => {
                     item = $(item);
-                    itemPicUrl = `${item.find('a.cover').attr('style')}`.replace('background-image:url(', '').replace(')', '');
+                    itemPicUrl = String(item.find('a.cover').attr('style')).replace('background-image:url(', '').replace(')', '');
                     return {
                         title: item.find('.title a').first().text(),
                         description: `作者：${item.find('.usr-pic a').last().text()}<br>描述：${item.find('.content p').text()}<br><img src="${itemPicUrl}">`,

--- a/docs/joinus/quick-start.md
+++ b/docs/joinus/quick-start.md
@@ -142,7 +142,7 @@ sidebar: auto
             list
                 .map((index, item) => {
                     item = $(item);
-                    itemPicUrl = String(item.find('a.cover').attr('style')).replace('background-image:url(', '').replace(')', '');
+                    itemPicUrl = item.find('a.cover').attr('style').replace('background-image:url(', '').replace(')', '');
                     return {
                         title: item.find('.title a').first().text(),
                         description: `作者：${item.find('.usr-pic a').last().text()}<br>描述：${item.find('.content p').text()}<br><img src="${itemPicUrl}">`,

--- a/lib/middleware/header.js
+++ b/lib/middleware/header.js
@@ -15,7 +15,7 @@ module.exports = async (ctx, next) => {
     logger.info(`${ctx.url}, user IP: ${ctx.ips[0] || ctx.ip}`);
     ctx.set(headers);
     ctx.set({
-        'Access-Control-Allow-Origin': `${config.allowOrigin || ctx.host}`,
+        'Access-Control-Allow-Origin': config.allowOrigin || ctx.host,
     });
 
     await next();

--- a/lib/routes/1point3acres/post.js
+++ b/lib/routes/1point3acres/post.js
@@ -22,7 +22,7 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         data.map(async (item) => {
             const result = {
-                title: `${item.subject}`,
+                title: item.subject,
                 description: `${item.summary}...<br><br><small>作者 ${item.author} · 回复 ${item.replies} · 查看 ${item.views}</small>`,
                 link: `https://instant.1point3acres.com/thread/${item.tid}`,
             };

--- a/lib/routes/36kr/motif.js
+++ b/lib/routes/36kr/motif.js
@@ -30,6 +30,6 @@ module.exports = async (ctx) => {
                 })
             )
         ),
-        description: `${motifInfo.categoryTitle}`,
+        description: motifInfo.categoryTitle,
     };
 };

--- a/lib/routes/aliyun/developer/group.js
+++ b/lib/routes/aliyun/developer/group.js
@@ -28,7 +28,7 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `阿里云开发者社区-${title}`,
         link,
-        description: `${desc}`,
+        description: desc,
         item:
             list &&
             list

--- a/lib/routes/asahi/index.js
+++ b/lib/routes/asahi/index.js
@@ -29,7 +29,20 @@ module.exports = async (ctx) => {
     const category = ctx.params.category || '';
 
     const rootUrl = 'https://www.asahi.com';
-    const currentUrl = `${rootUrl}${genre ? `${category ? `${category in categories ? categories[category] : `/${genre}/list/${category}.html`}` : `/${genre}`}` : '/news/history.html'}`;
+    let currentUrl;
+    if (genre) {
+        if (category) {
+            if (category in categories) {
+                currentUrl = `${rootUrl}${categories[category]}`;
+            } else {
+                currentUrl = `${rootUrl}/${genre}/list/${category}.html`;
+            }
+        } else {
+            currentUrl = `${rootUrl}/${genre}`;
+        }
+    } else {
+        currentUrl = `${rootUrl}${'/news/history.html'}`;
+    }
 
     const response = await got({
         method: 'get',

--- a/lib/routes/av01/actor.js
+++ b/lib/routes/av01/actor.js
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
             list
                 .map((index, item) => {
                     item = $(item);
-                    const itemPicUrl = `${item.find('img').attr('data-src')}`;
+                    const itemPicUrl = item.find('img').attr('data-src');
                     return {
                         title: item.find('span.video-title.title-truncate.m-t-5').text(),
                         description: `翻译${item.find('div.video-added.title-truncate').text()}<br><img src="${itemPicUrl}">`,

--- a/lib/routes/av01/tag.js
+++ b/lib/routes/av01/tag.js
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
             list
                 .map((index, item) => {
                     item = $(item);
-                    const itemPicUrl = `${item.find('img').attr('data-src')}`;
+                    const itemPicUrl = String(item.find('img')).attr('data-src');
                     return {
                         title: item.find('span.video-title.title-truncate.m-t-5').text(),
                         description: `翻译${item.find('div.video-added.title-truncate').text()}<br><img src="${itemPicUrl}">`,

--- a/lib/routes/av01/tag.js
+++ b/lib/routes/av01/tag.js
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
             list
                 .map((index, item) => {
                     item = $(item);
-                    const itemPicUrl = String(item.find('img')).attr('data-src');
+                    const itemPicUrl = item.find('img').attr('data-src');
                     return {
                         title: item.find('span.video-title.title-truncate.m-t-5').text(),
                         description: `翻译${item.find('div.video-added.title-truncate').text()}<br><img src="${itemPicUrl}">`,

--- a/lib/routes/avgle/videos.js
+++ b/lib/routes/avgle/videos.js
@@ -28,7 +28,7 @@ module.exports = async (ctx) => {
     });
     const returnData = response.data.response.videos;
 
-    const compact_number = (number) => `${Intl.NumberFormat('en-US', { notation: 'compact', compactDisplay: 'short' }).format(number)}`;
+    const compact_number = (number) => String(Intl.NumberFormat('en-US', { notation: 'compact', compactDisplay: 'short' }).format(number));
     const like = (item) => `[${Math.round((item.likes / (item.likes + item.dislikes)) * 100)}%/${compact_number(item.likes + item.dislikes)}/${compact_number(item.viewnumber)}]`;
 
     ctx.state.data = {
@@ -37,7 +37,7 @@ module.exports = async (ctx) => {
         description: `Avgle ${order}/${time}`,
         item: returnData.map((item) => ({
             title: like(item) + item.title,
-            description: `${item.preview_video_url ? `<video controls loop ${item.preview_url ? `poster="${item.preview_url}"` : ''} src="${item.preview_video_url}" />` : ''}`,
+            description: item.preview_video_url ? `<video controls loop ${item.preview_url ? `poster="${item.preview_url}"` : ''} src="${item.preview_video_url}" />` : '',
             pubDate: new Date(item.addtime * 1000).toUTCString(),
             link: item.video_url,
             category: item.keyword.split(' '),

--- a/lib/routes/axis-studios/work.js
+++ b/lib/routes/axis-studios/work.js
@@ -73,9 +73,9 @@ module.exports = async (ctx) => {
                 video = `<iframe id="ytplayer" type="text/html" width="640" height="360" src='https://youtube.com/embed/${articledata[index].youtube}' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe><br>`;
             }
             return {
-                title: `${articledata[index].title}`,
+                title: articledata[index].title,
                 description: `${video}+${articledata[index].describe}`,
-                link: `${articledata[index].link}`,
+                link: articledata[index].link,
             };
         }),
     };

--- a/lib/routes/bangumi/calendar/today.js
+++ b/lib/routes/bangumi/calendar/today.js
@@ -13,7 +13,7 @@ module.exports = async (ctx) => {
 
     const todayList = list.filter((l) => l.weekday.id % 7 === day)[0];
 
-    const todayBgmId = todayList.items.map((t) => `${t.id}`);
+    const todayBgmId = todayList.items.map((t) => t.id);
     const images = todayList.items.reduce((p, c) => {
         p[c.id] = (c.images || {}).large;
         return p;

--- a/lib/routes/bangumi/group/topic.js
+++ b/lib/routes/bangumi/group/topic.js
@@ -12,7 +12,7 @@ module.exports = async (ctx) => {
     const title = 'Bangumi - ' + $('.SecondaryNavTitle').text();
 
     ctx.state.data = {
-        title: `${title}`,
+        title,
         link,
         item: $('.topic_list .topic')
             .map((_, elem) => ({

--- a/lib/routes/bangumi/subject/ep.js
+++ b/lib/routes/bangumi/subject/ep.js
@@ -12,7 +12,7 @@ module.exports = async (subjectID) => {
     });
 
     return {
-        title: `${epsInfo.name_cn}`,
+        title: epsInfo.name_cn,
         link: `https://bgm.tv/subject/${subjectID}`,
         description: epsInfo.summary,
         item: activeEps.reverse().map((e) => ({

--- a/lib/routes/behance/index.js
+++ b/lib/routes/behance/index.js
@@ -42,15 +42,15 @@ module.exports = async (ctx) => {
     );
     ctx.state.data = {
         title: `${data.profile.owner.first_name} ${data.profile.owner.last_name}'s Work`,
-        link: `${data.profile.owner.url}`,
+        link: data.profile.owner.url,
         item: list.map((item, index) => {
             if (type !== 'projects') {
                 item = item.project;
             }
             return {
-                title: `${item.name}`,
-                description: `${articledata[index].content}`,
-                link: `${item.url}`,
+                title: item.name,
+                description: articledata[index].content,
+                link: item.url,
                 pubDate: dayjs.unix(item.published_on).format(),
             };
         }),

--- a/lib/routes/bilibili/blackboard.js
+++ b/lib/routes/bilibili/blackboard.js
@@ -22,10 +22,10 @@ module.exports = async (ctx) => {
                     !index || item.name !== array[index - 1].name
             )
             .map((item) => ({
-                title: `${item.name}`,
+                title: item.name,
                 description: `${item.name}<br> ${item.desc}`,
                 pubDate: new Date(item.ctime.replace(' ', 'T') + '+08:00').toUTCString(),
-                link: `${item.pc_url}`,
+                link: item.pc_url,
             })),
     };
 };

--- a/lib/routes/bilibili/dynamic.js
+++ b/lib/routes/bilibili/dynamic.js
@@ -190,10 +190,14 @@ module.exports = async (ctx) => {
 
             return {
                 title: getTitle(data),
-                description: `${data_content || getDes(data)}${
-                    origin && getOriginName(origin) ? `<br><br>//转发自: @${getOriginName(origin)}: ${getOriginTitle(origin.item || origin)}${getDes(origin.item || origin)}` : `${getOriginDes(origin)}`
-                }<br>${getUrl(data)}${getUrl(origin)}${getIframe(data)}${getIframe(origin)}${imgHTML ? `<br>${imgHTML}` : ''}${videoHTML ? `<br>${videoHTML}` : ''}`,
-                pubDate: new Date(item.desc.timestamp * 1000).toUTCString(),
+                description: (() => {
+                    const description = data_content || getDes(data);
+                    const originName = origin && getOriginName(origin) ? `<br><br>//转发自: @${getOriginName(origin)}: ${getOriginTitle(origin.item || origin)}${getDes(origin.item || origin)}` : getOriginDes(origin);
+                    const imgHTMLSource = imgHTML ? `<br>${imgHTML}` : '';
+                    const videoHTMLSource = videoHTML ? `<br>${videoHTML}` : '';
+                    return `${description}${originName}<br>${getUrl(data)}${getUrl(origin)}${getIframe(data)}${getIframe(origin)}${imgHTMLSource}${videoHTMLSource}`;
+                })(),
+                pubDate: new Date(item.desc.timestamp * 1000),
                 link,
             };
         }),

--- a/lib/routes/bilibili/followings_dynamic.js
+++ b/lib/routes/bilibili/followings_dynamic.js
@@ -121,9 +121,14 @@ module.exports = async (ctx) => {
             return {
                 title: getTitle(data),
                 author,
-                description: `${parsed.new_desc || data_content || getDes(data)}${
-                    origin && getOriginName(origin) ? `<br><br>//转发自: @${getOriginName(origin)}: ${getOriginTitle(origin.item || origin)}${getDes(origin.item || origin)}` : `${getOriginDes(origin)}`
-                }${getIframe(data)}${getIframe(origin)}${imgHTML ? `<br>${imgHTML}` : ''}${videoHTML ? `<br>${videoHTML}` : ''}`,
+                description: (() => {
+                    const description = parsed.new_desc || data_content || getDes(data);
+                    const originName = origin && getOriginName(origin) ? `<br><br>//转发自: @${getOriginName(origin)}: ${getOriginTitle(origin.item || origin)}${getDes(origin.item || origin)}` : getOriginDes(origin);
+                    const imgHTMLSource = imgHTML ? `<br>${imgHTML}` : '';
+                    const videoHTMLSource = videoHTML ? `<br>${videoHTML}` : '';
+
+                    return `${description}${originName}${getIframe(data)}${getIframe(origin)}${imgHTMLSource}${videoHTMLSource}`;
+                })(),
                 pubDate: new Date(item.desc.timestamp * 1000).toUTCString(),
                 link,
             };

--- a/lib/routes/bilibili/liveArea.js
+++ b/lib/routes/bilibili/liveArea.js
@@ -61,7 +61,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `哔哩哔哩直播-${parentTitle}·${areaTitle}分区-${orderTitle}`,
-        link: `${areaLink}`,
+        link: areaLink,
         description: `哔哩哔哩直播-${parentTitle}·${areaTitle}分区-${orderTitle}`,
         item: data.map((item) => ({
             title: `${item.uname} ${item.title}`,

--- a/lib/routes/bilibili/partion-ranking.js
+++ b/lib/routes/bilibili/partion-ranking.js
@@ -41,7 +41,7 @@ module.exports = async (ctx) => {
         let item = hotlist[i];
 
         item = {
-            title: `${item.title}`,
+            title: item.title,
             description: `${item.description}${!disableEmbed ? `<br><br>${utils.iframe(item.id)}` : ''}<br><img src="https:${item.pic}"><br/>Tags:${item.tag}`,
             pubDate: new Date(item.pubdate).toUTCString(),
             link: item.pubdate > utils.bvidTime && item.bvid ? `https://www.bilibili.com/video/${item.bvid}` : `https://www.bilibili.com/video/av${item.id}`,

--- a/lib/routes/bilibili/partion.js
+++ b/lib/routes/bilibili/partion.js
@@ -26,7 +26,7 @@ module.exports = async (ctx) => {
         item:
             list &&
             list.map((item) => ({
-                title: `${item.title}`,
+                title: item.title,
                 description: `${item.desc}${!disableEmbed ? `<br><br>${utils.iframe(item.aid)}` : ''}<br><img src="${item.pic}">`,
                 pubDate: new Date(item.pubdate * 1000).toUTCString(),
                 link: item.pubdate > utils.bvidTime && item.bvid ? `https://www.bilibili.com/video/${item.bvid}` : `https://www.bilibili.com/video/av${item.aid}`,

--- a/lib/routes/bilibili/weekly_recommend.js
+++ b/lib/routes/bilibili/weekly_recommend.js
@@ -29,7 +29,12 @@ module.exports = async (ctx) => {
         description: 'B站每周必看',
         item: data.map((item) => ({
             title: item.title,
-            description: `${weekly_name} ${item.title}<br>${item.rcmd_reason}<br>${!disableEmbed ? `${utils.iframe(item.param)}` : ''}<img src="${item.cover}">`,
+            // description: `${weekly_name} ${item.title}<br>${item.rcmd_reason}<br>${!disableEmbed ? `${utils.iframe(item.param)}` : ''}<img src="${item.cover}">`,
+            description: `
+                ${weekly_name} ${item.title}<br>
+                ${item.rcmd_reason}<br>
+                ${!disableEmbed ? utils.iframe(item.param) : ''}<img src="${item.cover}">
+            `,
             link: weekly_number > 60 && item.bvid ? `https://www.bilibili.com/video/${item.bvid}` : `https://www.bilibili.com/video/av${item.param}`,
         })),
     };

--- a/lib/routes/bjnews/epaper.js
+++ b/lib/routes/bjnews/epaper.js
@@ -72,9 +72,9 @@ module.exports = async (ctx) => {
         title: `新京报电子报|${cat}叠`,
         link: `http://epaper.bjnews.com.cn/html/${year}-${month}/${day}/node_1.htm`,
         item: list.map((item, index) => ({
-            title: `${articledata[index].title}`,
-            description: `${articledata[index].description}`,
-            link: `${articledata[index].link}`,
+            title: articledata[index].title,
+            description: articledata[index].description,
+            link: articledata[index].link,
         })),
     };
 };

--- a/lib/routes/blow-studio/work.js
+++ b/lib/routes/blow-studio/work.js
@@ -53,7 +53,7 @@ module.exports = async (ctx) => {
             const imgstyle = `style="max-width: 650px; height: auto; object-fit: contain; flex: 0 0 auto;"`;
 
             content += `<iframe ${videostyle} src='https://player.vimeo.com/video/${articledata[index].mainvideo}' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe><br>`;
-            content += `${articledata[index].describe}`;
+            content += articledata[index].describe;
 
             if (articledata[index].images) {
                 for (let p = 0; p < articledata[index].images.length; p++) {
@@ -62,9 +62,9 @@ module.exports = async (ctx) => {
             }
 
             return {
-                title: `${articledata[index].title}`,
-                description: `${content}`,
-                link: `${articledata[index].link}`,
+                title: articledata[index].title,
+                description: content,
+                link: articledata[index].link,
             };
         }),
     };

--- a/lib/routes/blur-studio/index.js
+++ b/lib/routes/blur-studio/index.js
@@ -72,9 +72,9 @@ module.exports = async (ctx) => {
             }
 
             return {
-                title: `${articledata[index].title}`,
-                description: `${content}`,
-                link: `${articledata[index].link}`,
+                title: articledata[index].title,
+                description: content,
+                link: articledata[index].link,
             };
         }),
     };

--- a/lib/routes/chinafile/index.js
+++ b/lib/routes/chinafile/index.js
@@ -40,7 +40,7 @@ module.exports = async (ctx) => {
 
                 url = $('link[rel="canonical"]').attr('href');
 
-                const pubDate = dayjs(`${item.pubDate.replace(' - ', ' ').replace('am', ' am').replace('pm', ' pm')}`).toISOString();
+                const pubDate = dayjs(item.pubDate.replace(' - ', ' ').replace('am', ' am').replace('pm', ' pm'));
 
                 return {
                     title: item.title,

--- a/lib/routes/coolapk/dyh.js
+++ b/lib/routes/coolapk/dyh.js
@@ -35,7 +35,7 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `酷安看看号-${targetTitle}`,
         link: `https://www.coolapk.com/dyh/${dyhId}`,
-        description: `${feedDescription}`,
+        description: feedDescription,
         item: out,
     };
 };

--- a/lib/routes/coolapk/tuwen.js
+++ b/lib/routes/coolapk/tuwen.js
@@ -25,9 +25,9 @@ module.exports = async (ctx) => {
     const out = await Promise.all(data.map((item) => utils.parseDynamic(item, ctx)));
 
     ctx.state.data = {
-        title: `${feedTitle}`,
+        title: feedTitle,
         link: 'https://www.coolapk.com/',
-        description: `${feedTitle}`,
+        description: feedTitle,
         item: out,
     };
 };

--- a/lib/routes/coronavirus/sg-moh.js
+++ b/lib/routes/coronavirus/sg-moh.js
@@ -19,7 +19,7 @@ module.exports = async (ctx) => {
         })
         .map((_, item) => {
             item = $(item);
-            const title = `${item.find('a').first().text()}`;
+            const title = item.find('a').first().text();
             const dateRaw = item.find('td:first-child').text().trim();
             const pubDate = Date.parse(dateRaw) && dateRaw;
             const link = item.find('a').attr('href');

--- a/lib/routes/digic-pictures/index.js
+++ b/lib/routes/digic-pictures/index.js
@@ -62,10 +62,10 @@ module.exports = async (ctx) => {
                 }
             }
             return {
-                title: `${articledata[index].title}`,
+                title: articledata[index].title,
                 description: content,
-                link: `${articledata[index].link}`,
-                pubDate: `${articledata[index].time}`,
+                link: articledata[index].link,
+                pubDate: new Date(articledata[index].time),
             };
         }),
     };

--- a/lib/routes/digitaling/article.js
+++ b/lib/routes/digitaling/article.js
@@ -30,7 +30,7 @@ module.exports = async (ctx) => {
     let link = `https://www.digitaling.com/articles/${category}/`;
     // 二级子分类
     if (subcate !== undefined) {
-        link = link + `${subcate}`;
+        link = link + subcate;
         title = title + '/' + categoryTitle.get(category).type[subcate];
     }
     const res = await got.get(link);

--- a/lib/routes/douban/channel/subject.js
+++ b/lib/routes/douban/channel/subject.js
@@ -22,7 +22,7 @@ module.exports = async (ctx) => {
     });
 
     const channel_name = channel_info_response.data.title;
-    const data = response.data.modules[`${nav}`].payload.subjects;
+    const data = response.data.modules[nav].payload.subjects;
     let nav_name = '';
 
     switch (nav) {
@@ -46,7 +46,7 @@ module.exports = async (ctx) => {
         description: `豆瓣${channel_name}频道书影音下的${nav_name}推荐`,
 
         item: data.map(({ title, extra, cover_img, url }) => {
-            const rate = `${extra.rating_group.rating}` ? `${extra.rating_group.rating.value.toFixed(1)}分` : `${extra.rating_group.null_rating_reason}`;
+            const rate = extra.rating_group.rating ? `${extra.rating_group.rating.value.toFixed(1)}分` : extra.rating_group.null_rating_reason;
 
             const description = `标题：${title} <br> 信息：${extra.short_info} <br> 评分：${rate} <br> <img src="${cover_img.url}">`;
 

--- a/lib/routes/douban/channel/topic.js
+++ b/lib/routes/douban/channel/topic.js
@@ -48,10 +48,10 @@ module.exports = async (ctx) => {
                     const description = `作者：${item.author.name} | ${item.create_time} <br><br> ${item.abstract}">`;
 
                     return {
-                        title: `${item.title}`,
+                        title: item.title,
                         description,
-                        pubDate: `${item.create_time}`,
-                        link: `${item.url}`,
+                        pubDate: new Date(item.create_time),
+                        link: item.url,
                     };
                 } else {
                     return null;

--- a/lib/routes/douban/explore.js
+++ b/lib/routes/douban/explore.js
@@ -21,7 +21,7 @@ module.exports = async (ctx) => {
             list
                 .map((index, item) => {
                     item = $(item);
-                    itemPicUrl = `${item.find('a.cover').attr('style')}`.replace('background-image:url(', '').replace(')', '');
+                    itemPicUrl = item.find('a.cover').attr('style').replace('background-image:url(', '').replace(')', '');
                     return {
                         title: item.find('.title a').first().text(),
                         description: `作者：${item.find('.usr-pic a').last().text()}<br>描述：${item.find('.content p').text()}<br><img src="${itemPicUrl}">`,

--- a/lib/routes/douban/people/status.js
+++ b/lib/routes/douban/people/status.js
@@ -260,7 +260,16 @@ function getContentByActivity(ctx, item, params = {}, picsPrefixes = []) {
         }
         const videoCover = status.video_info.cover_url;
         const videoSrc = status.video_info.video_url;
-        description += `${videoSrc ? `<video src="${videoSrc}" ${videoCover ? `poster="${videoCover}"` : ''}></video>` : ''}`;
+        if (videoSrc) {
+            description = `
+                ${description}
+                <video
+                    src="${videoSrc}"
+                    ${videoCover ? `poster="${videoCover}"` : ''}
+                >
+                </video>
+            `;
+        }
     }
 
     if (status.parent_status) {

--- a/lib/routes/douban/people/wish.js
+++ b/lib/routes/douban/people/wish.js
@@ -35,7 +35,7 @@ module.exports = async (ctx) => {
                     return Promise.all(
                         list.get().map(async (item) => {
                             item = $(item);
-                            const itemPicUrl = `${item.find('.pic a img').attr('src')}`;
+                            const itemPicUrl = item.find('.pic a img').attr('src');
                             const info = item.find('.info');
                             const title = info.find('ul li.title a').text();
                             const url = info.find('ul li.title a').attr('href');

--- a/lib/routes/dxy/vaccine.js
+++ b/lib/routes/dxy/vaccine.js
@@ -4,7 +4,16 @@ module.exports = async (ctx) => {
     const province = ctx.params.province || '';
     const city = ctx.params.city || '';
     const location = ctx.params.location || '';
-    const fullLocation = `${province ? `${province}${city ? `/${city}${location ? `/${location}` : ''}` : ''}` : ''}`;
+    let fullLocation = '';
+    if (province) {
+        fullLocation += `/${province}`;
+        if (city) {
+            fullLocation += `/${city}`;
+            if (location) {
+                fullLocation += `/${location}`;
+            }
+        }
+    }
 
     const rootUrl = 'https://mama.dxy.com';
     const currentUrl = `${rootUrl}/client/vaccine/new-crown-vaccine`;

--- a/lib/routes/fanbox/conv.js
+++ b/lib/routes/fanbox/conv.js
@@ -188,7 +188,7 @@ async function conv_article(i) {
     }
 
     if (!i.body) {
-        ret += `${i.excerpt}`;
+        ret += i.excerpt;
         return ret;
     }
 

--- a/lib/routes/galgame/hhgal.js
+++ b/lib/routes/galgame/hhgal.js
@@ -54,13 +54,13 @@ module.exports = async (ctx) => {
                 .slice(1)
                 .map((index, item) => {
                     item = $(item);
-                    const time = `${item.find('.tag-article .label.label-zan').text()}`;
+                    const time = item.find('.tag-article .label.label-zan').text();
                     const math = /\d{4}-\d{2}-\d{2}/.exec(time);
                     const pubDate = new Date(math[0]);
 
                     return {
                         title: item.find('h1').text(),
-                        description: `${item.find('.info p').text()}`,
+                        description: item.find('.info p').text(),
                         pubDate,
                         link: item.find('h1 a').attr('href'),
                     };

--- a/lib/routes/github/starred_repos.js
+++ b/lib/routes/github/starred_repos.js
@@ -56,8 +56,8 @@ module.exports = async (ctx) => {
             description: `${repo.node.description === null ? 'no description' : repo.node.description} <br> primary language: ${
                 repo.node.primaryLanguage === null ? 'no primary language' : repo.node.primaryLanguage.name
             } <br> stargazers: ${repo.node.stargazers.totalCount} <br> <img sytle="width:50px;" src='${repo.node.openGraphImageUrl}'>`,
-            pubDate: new Date(`${repo.starredAt}`).toUTCString(),
-            link: `${repo.node.url}`,
+            pubDate: new Date(repo.starredAt),
+            link: repo.node.url,
         })),
     };
 };

--- a/lib/routes/github/topic.js
+++ b/lib/routes/github/topic.js
@@ -15,7 +15,7 @@ module.exports = async (ctx) => {
 
                 const title = $(item.find('h1 a').get(1)).attr('href').slice(1);
                 const author = title.split('/')[0];
-                const description = `${item.find('div.border-bottom > div > p + div').text()}`;
+                const description = item.find('div.border-bottom > div > p + div').text();
                 const link = `https://github.com/${title}`;
 
                 return { title, author, description, link };

--- a/lib/routes/gov/moa/sjzxfb.js
+++ b/lib/routes/gov/moa/sjzxfb.js
@@ -11,10 +11,10 @@ module.exports = async (ctx) => {
         title: '中华人民共和国农业农村部 - 数据 - 最新发布',
         link: `http://zdscxx.moa.gov.cn:8080/nyb/pc/index.jsp`,
         item: data.map((item) => ({
-            title: `${item.title}`,
-            description: `${item.content}`,
+            title: item.title,
+            description: item.content,
             link: `http://zdscxx.moa.gov.cn:8080/misportal/public/agricultureMessageViewDC.jsp?page=1&channel=%E6%9C%80%E6%96%B0%E5%8F%91%E5%B8%83&id=${item._id}`,
-            pubDate: `${item.publishTime}`,
+            pubDate: new Date(item.publishTime),
         })),
     };
 };

--- a/lib/routes/gov/province/jiangsu/getContent.js
+++ b/lib/routes/gov/province/jiangsu/getContent.js
@@ -58,8 +58,7 @@ async function extract(homePage, cid, uid, page = 1) {
         const description = $aTag.attr('title');
         let pubDate = $item.find('span').text();
         pubDate = new Date(pubDate).toUTCString();
-        let link = $aTag.attr('href');
-        link = `${link}`;
+        const link = $aTag.attr('href');
 
         return { title, description, pubDate, link };
     });

--- a/lib/routes/gov/taiwan/mnd.js
+++ b/lib/routes/gov/taiwan/mnd.js
@@ -48,7 +48,7 @@ module.exports = async (ctx) => {
                 const content = cheerio.load(detailResponse.data);
 
                 item.description = content('div.thisPages').html();
-                item.link = content('form[name="aspnetForm"]').attr('action').replace('.', `${rootUrl}`);
+                item.link = String(content('form[name="aspnetForm"]').attr('action')).replace('.', rootUrl);
 
                 return item;
             })

--- a/lib/routes/gov/taiwan/mnd.js
+++ b/lib/routes/gov/taiwan/mnd.js
@@ -48,7 +48,7 @@ module.exports = async (ctx) => {
                 const content = cheerio.load(detailResponse.data);
 
                 item.description = content('div.thisPages').html();
-                item.link = String(content('form[name="aspnetForm"]').attr('action')).replace('.', rootUrl);
+                item.link = content('form[name="aspnetForm"]').attr('action').replace('.', rootUrl);
 
                 return item;
             })

--- a/lib/routes/gracg/user.js
+++ b/lib/routes/gracg/user.js
@@ -5,7 +5,7 @@ module.exports = async (ctx) => {
     const url = ctx.params.love ? `https://www.gracg.com/${ctx.params.user}/love` : `https://www.gracg.com/${ctx.params.user}`;
     const response = await got({
         method: 'get',
-        url: `${url}`,
+        url,
     });
     const html = response.body;
     const $ = cheerio.load(html);

--- a/lib/routes/guancha/index.js
+++ b/lib/routes/guancha/index.js
@@ -44,7 +44,7 @@ module.exports = async (ctx) => {
                     const link = item.attr('href');
                     return {
                         title: item.text(),
-                        link: `${(link.indexOf('http') === 0 ? '' : rootUrl) + link}`,
+                        link: (link.indexOf('http') === 0 ? '' : rootUrl) + link,
                     };
                 })
                 .get();

--- a/lib/routes/guancha/personalpage.js
+++ b/lib/routes/guancha/personalpage.js
@@ -63,7 +63,7 @@ module.exports = async (ctx) => {
         description: `${user_nick} 的个人主页`,
         item: list.map((item) => ({
             title: item.title,
-            description: `${item.summary}`,
+            description: item.summary,
             pubDate: getpass_at(item.pass_at),
             link: `https://user.guancha.cn/main/content?id=${item.id}`,
             author: item.user_nick,

--- a/lib/routes/hinatazaka46/blog.js
+++ b/lib/routes/hinatazaka46/blog.js
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
             list
                 .map((index, item) => {
                     item = $(item);
-                    itemPicUrl = `${item.find('div.c-blog__image').attr('style')}`.replace('background-image:url(', '').replace(');', '');
+                    itemPicUrl = item.find('div.c-blog__image').attr('style').replace('background-image:url(', '').replace(');', '');
                     return {
                         title: item.find('p.c-blog-top__title').text().trim(),
                         link: item.find('a').first().attr('href'),

--- a/lib/routes/hkepc/index.js
+++ b/lib/routes/hkepc/index.js
@@ -92,7 +92,7 @@ module.exports = async (ctx) => {
             method: 'get',
             url: link,
             headers: {
-                Referer: `${baseUrl}`,
+                Referer: baseUrl,
             },
         });
         return cheerio.load(resp.data)('#article').html();

--- a/lib/routes/hket/index.js
+++ b/lib/routes/hket/index.js
@@ -45,10 +45,10 @@ module.exports = async (ctx) => {
     const category = ctx.params.category || 'sran001';
     const cat = categories[category];
 
-    const response = await ctx.cache.tryGet(`${cat.link}`, async () => {
+    const response = await ctx.cache.tryGet(cat.link, async () => {
         const resp = await got({
             method: 'get',
-            url: `${cat.link}`,
+            url: cat.link,
             header: {
                 Referer: `https://www.hket.com/`,
             },
@@ -79,7 +79,7 @@ module.exports = async (ctx) => {
                         method: 'get',
                         url: item.link,
                         header: {
-                            Referer: `${cat.link}`,
+                            Referer: cat.link,
                         },
                     });
                     const content = cheerio.load(article.data);
@@ -121,7 +121,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `${cat.title}新聞RSS - 香港經濟日報 hket.com`,
-        link: `${cat.link}`,
+        link: cat.link,
         description: `訂閱${cat.title}新聞RSS，獲取最新${cat.description} - RSS - 香港經濟日報 hket.com`,
         item: items,
         language: 'zh-hk',

--- a/lib/routes/huxiu/collection.js
+++ b/lib/routes/huxiu/collection.js
@@ -25,7 +25,7 @@ module.exports = async (ctx) => {
     const items = await utils.ProcessFeed(list, ctx.cache);
 
     const info = `虎嗅 - ${$('h1').text()}`;
-    const description = `${$('p').text()}`;
+    const description = $('p').text();
     ctx.state.data = {
         title: info,
         link,

--- a/lib/routes/ieee/author.js
+++ b/lib/routes/ieee/author.js
@@ -17,7 +17,7 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `${author.preferredName} on IEEE Xplore`,
         link: `https://ieeexplore.ieee.org/author/${aid}`,
-        description: `${author.bioParagraphs.join('<br/>')}`,
+        description: author.bioParagraphs.join('<br/>'),
         item: papers.records.map((item) => ({
             title: item.articleTitle,
             author: item.authors.map((author) => author.preferredName).join(', '),

--- a/lib/routes/imaijia/category.js
+++ b/lib/routes/imaijia/category.js
@@ -14,7 +14,7 @@ module.exports = async (ctx) => {
         url: api_url,
         form: {
             pageNo: 1,
-            catid: `${category}`,
+            catid: category,
         },
     });
 

--- a/lib/routes/jandan/pic.js
+++ b/lib/routes/jandan/pic.js
@@ -97,9 +97,9 @@ module.exports = async (ctx) => {
     }
 
     ctx.state.data = {
-        title: `${rss_title}`,
+        title: rss_title,
         link: `${baseUrl}${sub_model}/`,
-        description: `${description}`,
+        description,
         item: items,
     };
 };

--- a/lib/routes/japanpost/track.js
+++ b/lib/routes/japanpost/track.js
@@ -63,7 +63,7 @@ module.exports = async (ctx) => {
                 itemDescription += packageTrackRecord ? `${packageTrackRecord}<br>` : '';
                 itemDescription += packageOfficeZipCode ? `${packageOfficeZipCode} ` : '';
                 itemDescription += packageOffice ? `${packageOffice} ` : '';
-                itemDescription += `${packageRegion}`;
+                itemDescription += packageRegion;
 
                 if (index === 0) {
                     if (officeList.length) {

--- a/lib/routes/jike/user.js
+++ b/lib/routes/jike/user.js
@@ -103,7 +103,7 @@ module.exports = async (ctx) => {
                 title: `${typeMap[item.type]}了: ${shortenTitle}`,
                 description: `${content}${linkTemplate}${imgTemplate}`,
                 pubDate: new Date(item.createdAt).toUTCString(),
-                link: `${linkMap[item.type]}`,
+                link: linkMap[item.type],
             };
 
             if (id === 'wenhao1996' && item.topic.id === '553870e8e4b0cafb0a1bef68') {

--- a/lib/routes/jinritoutiao/keyword.js
+++ b/lib/routes/jinritoutiao/keyword.js
@@ -16,12 +16,12 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `今日头条: ${keyword}`,
         link: `https://www.toutiao.com/search/?keyword=${keyword}`,
-        description: `${keyword}`,
+        description: keyword,
         item: data.map((item) => ({
             title: `${item.media_name}: ${item.title}`,
-            description: `${item.abstract}`,
-            pubDate: `${new Date(parseInt(item.create_time) * 1000)}`,
-            link: `${item.article_url}`,
+            description: item.abstract,
+            pubDate: new Date(parseInt(item.create_time) * 1000),
+            link: item.article_url,
         })),
     };
 };

--- a/lib/routes/juejin/utils.js
+++ b/lib/routes/juejin/utils.js
@@ -29,7 +29,7 @@ const ProcessFeed = (list, caches) =>
             // 列表上提取到的信息
             const single = {
                 title: item.article_info.title,
-                description: `${(item.article_info.brief_content || '无描述').replace(/[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f]/g, '')}`,
+                description: (item.article_info.brief_content || '无描述').replace(/[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f]/g, ''),
                 pubDate,
                 author: item.author_user_info.user_name,
                 link,

--- a/lib/routes/keyakizaka46/blog.js
+++ b/lib/routes/keyakizaka46/blog.js
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
             list
                 .map((index, item) => {
                     item = $(item);
-                    itemPicUrl = `${item.find('img.js-replaceImage').attr('src')}`;
+                    itemPicUrl = item.find('img.js-replaceImage').attr('src');
                     return {
                         title: item.find('p.ttl').text().trim(),
                         link: item.find('a').first().attr('href'),

--- a/lib/routes/kongfz/people.js
+++ b/lib/routes/kongfz/people.js
@@ -41,6 +41,6 @@ module.exports = async (ctx) => {
         title: `孔夫子旧书网 - ${userInfo.nickname}`,
         link: userInfo.shareUrl,
         item: list,
-        description: `${userInfo.sign}`,
+        description: userInfo.sign,
     };
 };

--- a/lib/routes/latepost/index.js
+++ b/lib/routes/latepost/index.js
@@ -41,7 +41,7 @@ module.exports = async (ctx) => {
         const $ = cheerio.load(first.data);
         const firstItem = {};
         firstItem.title = $('.headlines-title a').text();
-        firstItem.detail_url = `${$('.headlines-title a').attr('href')}`;
+        firstItem.detail_url = $('.headlines-title a').attr('href');
         data = [firstItem].concat(response.data.data || []);
     } else {
         const apiUrl = `${rootUrl}/news/get-news-data`;

--- a/lib/routes/leetcode/check-us.js
+++ b/lib/routes/leetcode/check-us.js
@@ -6,7 +6,7 @@ module.exports = async (ctx) => {
     const url = 'https://leetcode.com/';
     const response = await got({
         method: 'get',
-        url: url + `${user}`,
+        url: `${url}${user}`,
         headers: {
             Referer: url,
         },

--- a/lib/routes/lfsyd/index.js
+++ b/lib/routes/lfsyd/index.js
@@ -44,7 +44,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `旅法师营地 - ${ctx.params.typecode === '1' ? '首页资讯' : feeds['0'].feed.seedTitle}`,
-        link: `${url}`,
+        link: url,
         item: items,
     };
 };

--- a/lib/routes/lizhi/user.js
+++ b/lib/routes/lizhi/user.js
@@ -41,6 +41,6 @@ module.exports = async (ctx) => {
                 })
             )
         ),
-        description: `${$('div.isAll').text()}`,
+        description: $('div.isAll').text(),
     };
 };

--- a/lib/routes/mastodon/account_id.js
+++ b/lib/routes/mastodon/account_id.js
@@ -9,8 +9,8 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `${account_data.display_name} (@${account_data.acct})`,
-        link: `${account_data.url}`,
-        description: `${account_data.note}`,
+        link: account_data.url,
+        description: account_data.note,
         item: utils.parseStatuses(data),
         allowEmpty: true,
     };

--- a/lib/routes/mastodon/acct.js
+++ b/lib/routes/mastodon/acct.js
@@ -10,8 +10,8 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `${account_data.display_name} (@${account_data.acct})`,
-        link: `${account_data.url}`,
-        description: `${account_data.note}`,
+        link: account_data.url,
+        description: account_data.note,
         item: utils.parseStatuses(data),
         allowEmpty: true,
     };

--- a/lib/routes/matataki/site/posts/favorite.js
+++ b/lib/routes/matataki/site/posts/favorite.js
@@ -14,7 +14,7 @@ module.exports = async (ctx) => {
                 const ipfsHtmlHash = await matatakiUtils.getPostIpfsHtmlHash(item.pid);
 
                 return {
-                    title: `${item.title}`,
+                    title: item.title,
                     description: item.short_content,
                     link: `${matatakiUtils.IPFS_GATEWAY_URL}/ipfs/${ipfsHtmlHash}`,
                     pubDate: item.create_time,
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
         );
     } else {
         items = response.data.data.list.map((item) => ({
-            title: `${item.title}`,
+            title: item.title,
             description: item.short_content,
             link: `https://www.matataki.io/p/${item.pid}`,
             pubDate: item.create_time,

--- a/lib/routes/matataki/utils/matataki-utils.js
+++ b/lib/routes/matataki/utils/matataki-utils.js
@@ -38,7 +38,7 @@ function get(path) {
 async function getUserNickname(userId) {
     try {
         const userInfoResponse = await get(`/user/${userId}`);
-        return `${userInfoResponse.data.data.nickname || userInfoResponse.data.data.username}`;
+        return userInfoResponse.data.data.nickname || userInfoResponse.data.data.username;
     } catch (err) {
         return '';
     }
@@ -52,7 +52,7 @@ async function getUserNickname(userId) {
 async function getTokenName(tokenId) {
     try {
         const tokenInfoResponse = await get(`/minetoken/${tokenId}`);
-        return `${tokenInfoResponse.data.data.token.name}`;
+        return tokenInfoResponse.data.data.token.name;
     } catch (err) {
         return '';
     }
@@ -65,7 +65,7 @@ async function getTokenName(tokenId) {
  */
 async function getPostIpfsHtmlHash(postId) {
     const ipfsInfoResponse = await get(`/p/${postId}/ipfs`);
-    return `${ipfsInfoResponse.data.data[0].htmlHash}`;
+    return ipfsInfoResponse.data.data[0].htmlHash;
 }
 
 /**

--- a/lib/routes/meipai/user.js
+++ b/lib/routes/meipai/user.js
@@ -30,7 +30,7 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `${name}又有更新了`,
         link: `https://www.meipai.com/user/${uid}/`,
-        description: `${name}`,
+        description: name,
         item: result,
     };
 };

--- a/lib/routes/method-studios/index.js
+++ b/lib/routes/method-studios/index.js
@@ -52,9 +52,9 @@ module.exports = async (ctx) => {
         link: 'https://www.methodstudios.com/',
         description: $('description').text(),
         item: list.map((item, index) => ({
-            title: `${articledata[index].title}`,
-            description: `${articledata[index].describe}`,
-            link: `${articledata[index].link}`,
+            title: articledata[index].title,
+            description: articledata[index].describe,
+            link: articledata[index].link,
         })),
     };
 };

--- a/lib/routes/mi/golden.js
+++ b/lib/routes/mi/golden.js
@@ -17,6 +17,6 @@ module.exports = async (ctx) => {
         title: `金米奖 - 小米应用商店`,
         link,
         item: list,
-        description: `${response.data.description}`,
+        description: response.data.description,
     };
 };

--- a/lib/routes/miniflux/get_entries.js
+++ b/lib/routes/miniflux/get_entries.js
@@ -94,9 +94,9 @@ module.exports = async (ctx) => {
     const setMark = [];
     const setFeedName = [];
 
-    const feeds = `${ctx.params.feeds}`;
+    const feeds = ctx.params.feeds;
 
-    let parameters = `${ctx.params.parameters}`;
+    let parameters = ctx.params.parameters;
     // Set default direction
     if (parameters.search('direction=') === -1) {
         parameters += '&direction=desc';
@@ -195,7 +195,7 @@ module.exports = async (ctx) => {
 
         ctx.state.data = {
             title: agTitle,
-            link: `${instance}`,
+            link: instance,
             description: agInfo,
             item: articles,
             allowEmpty: true,
@@ -240,7 +240,7 @@ module.exports = async (ctx) => {
 
         ctx.state.data = {
             title: `MiniFlux | All`,
-            link: `${instance}`,
+            link: instance,
             description: `All feeds on ${instance} powered by MiniFlux`,
             item: articles,
             allowEmpty: true,

--- a/lib/routes/miniflux/get_feeds.js
+++ b/lib/routes/miniflux/get_feeds.js
@@ -45,7 +45,7 @@ module.exports = async (ctx) => {
     const feeds = [];
     const feedsList = response.data;
 
-    const parameters = `${ctx.params.parameters}`
+    const parameters = ctx.params.parameters
         .split('&')
         .map((parameter) => set(parameter))
         .join('');
@@ -82,7 +82,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `MiniFlux | Subscription List`,
-        link: `${instance}`,
+        link: instance,
         description: `A subscription tracking feed.`,
         item: subscription,
         allowEmpty: true,

--- a/lib/routes/mp4ba/index.js
+++ b/lib/routes/mp4ba/index.js
@@ -59,7 +59,7 @@ async function buildRss($, paramType, ctx) {
                 selectorPath2 = 'a';
                 break;
             case ParamType.paramType.search:
-                desc = `${typeString}`;
+                desc = typeString;
                 selectorPath1 = '.search .search_content .sousuo';
                 selectorPath2 = 'b a';
                 break;

--- a/lib/routes/mp4er/index.js
+++ b/lib/routes/mp4er/index.js
@@ -59,7 +59,14 @@ module.exports = async (ctx) => {
 
                 const torrents = content('#torrent-list .list');
 
-                item.description = content('.info0').html() + `<div><b>下载地址：</b>${downloadLinks}</div>` + `${torrents.html() ? `<div><b>种子列表：</b>${torrents.html()}</div>` : ''}`;
+                item.description = `
+                    ${content('.info0').html()}
+                    <div>
+                        <b>下载地址：</b>
+                        ${downloadLinks}
+                    </div>
+                    ${torrents.html() ? `<div><b>种子列表：</b>${torrents.html()}</div>` : ''}
+                `;
                 item.enclosure_url = torrents.html() ? `${rootUrl}${torrents.find('a.header').last().attr('href')}` : downloadResponse.data.pop().url;
                 item.enclosure_type = 'application/x-bittorrent';
 

--- a/lib/routes/mp4er/index.js
+++ b/lib/routes/mp4er/index.js
@@ -66,7 +66,7 @@ module.exports = async (ctx) => {
                         ${downloadLinks}
                     </div>
                     ${torrents.html() ? `<div><b>种子列表：</b>${torrents.html()}</div>` : ''}
-                `;
+                `.replace(/\n +/gm, ''); // Minify the string.
                 item.enclosure_url = torrents.html() ? `${rootUrl}${torrents.find('a.header').last().attr('href')}` : downloadResponse.data.pop().url;
                 item.enclosure_type = 'application/x-bittorrent';
 

--- a/lib/routes/mpaypass/news.js
+++ b/lib/routes/mpaypass/news.js
@@ -17,7 +17,7 @@ module.exports = async (ctx) => {
                     const title = $a.text();
                     const date = $el.find('.newsbodylist-title span').text().split('|')[1];
 
-                    const key = `${href}`;
+                    const key = href;
                     let description;
                     const value = await ctx.cache.get(key);
 

--- a/lib/routes/natgeo/natgeo.js
+++ b/lib/routes/natgeo/natgeo.js
@@ -41,7 +41,7 @@ async function load(link) {
 }
 
 module.exports = async (ctx) => {
-    const type = `${ctx.params.type || ''}`;
+    const type = ctx.params.type || '';
     const url = `https://www.natgeomedia.com/${ctx.params.cat}/${type}`;
     const res = await got.get(url);
     const $ = cheerio.load(res.data);

--- a/lib/routes/neea/index.js
+++ b/lib/routes/neea/index.js
@@ -20,7 +20,7 @@ function load(link, ctx) {
 
 module.exports = async (ctx) => {
     const type = ctx.params.type;
-    const host = `http://${type}.neea.edu.cn${typeDic[`${type}`].url}`;
+    const host = `http://${type}.neea.edu.cn${typeDic[type].url}`;
     const response = await got({
         method: 'get',
         url: host,
@@ -48,9 +48,9 @@ module.exports = async (ctx) => {
         })
     );
     ctx.state.data = {
-        title: `${typeDic[`${type}`].title}动态`,
+        title: `${typeDic[String(type)].title}动态`,
         link: host,
-        description: `${typeDic[`${type}`].title}动态 `,
+        description: `${typeDic[String(type)].title}动态 `,
         item: process,
     };
 };

--- a/lib/routes/notefolio/index.js
+++ b/lib/routes/notefolio/index.js
@@ -60,7 +60,7 @@ module.exports = async (ctx) => {
     );
 
     ctx.state.data = {
-        title: `${$('title').text()}`,
+        title: $('title').text(),
         link: rootUrl,
         item: items,
     };

--- a/lib/routes/novel/ptwxz.js
+++ b/lib/routes/novel/ptwxz.js
@@ -27,7 +27,7 @@ module.exports = async (ctx) => {
     const list = $('.grid>tbody>tr>td>li>a');
 
     ctx.state.data = {
-        title: `${title}`,
+        title,
         link: `${baseUrl}${id}.html`,
         description: '',
         item:

--- a/lib/routes/novel/wenxuemi.js
+++ b/lib/routes/novel/wenxuemi.js
@@ -54,7 +54,7 @@ module.exports = async (ctx) => {
     );
 
     ctx.state.data = {
-        title: `${title}`,
+        title,
         link: `${baseUrl}/files/article/html${id}/`,
         image: cover_url,
         description,

--- a/lib/routes/parcel/hermesuk.js
+++ b/lib/routes/parcel/hermesuk.js
@@ -22,7 +22,7 @@ module.exports = async (ctx) => {
             parcel = parcel[0];
 
             if (parcel.point) {
-                message += `${parcel.point.description}`;
+                message += parcel.point.description;
             }
 
             if (parcel.location) {

--- a/lib/routes/pcr/news-cn.js
+++ b/lib/routes/pcr/news-cn.js
@@ -13,10 +13,10 @@ module.exports = async (ctx) => {
             ? await Promise.all(
                   data.data.map(async (item) => ({
                       title: item.title,
-                      description: `${await ctx.cache.tryGet(`pcrcn_${item.id}`, async () => {
+                      description: await ctx.cache.tryGet(`pcrcn_${item.id}`, async () => {
                           const resp = await got({ method: 'get', url: `https://api.biligame.com/news/${item.id}` });
                           return resp.data.data.content;
-                      })}`,
+                      }),
                       link: `https://game.bilibili.com/pcr/news.html#detail=${item.id}`,
                       pubDate: item.ctime ? item.ctime : item.createTime,
                   }))

--- a/lib/routes/pediy/topic.js
+++ b/lib/routes/pediy/topic.js
@@ -101,7 +101,7 @@ module.exports = async (ctx) => {
                       return Promise.resolve({
                           title: subject.text(),
                           link,
-                          pubDate: `${pubDate}`,
+                          pubDate: new Date(pubDate),
                           description,
                       });
                   })
@@ -110,7 +110,7 @@ module.exports = async (ctx) => {
     );
 
     ctx.state.data = {
-        title: `${title}`,
+        title,
         link: baseUrl + path,
         item: resultItem,
     };

--- a/lib/routes/pgyer/app.js
+++ b/lib/routes/pgyer/app.js
@@ -51,19 +51,19 @@ module.exports = async (ctx) => {
                 });
             });
         });
-    const appName = $(`${indexOfEle[pageTemplate].appName}`).text();
-    const appIntro = $(`${indexOfEle[pageTemplate].appIntro}`).text();
-    const version = $(`${indexOfEle[pageTemplate].version}`).children('li').eq(0).text();
-    const appSize = $(`${indexOfEle[pageTemplate].appSize}`).children('li').eq(1).text().slice(3);
-    const appImg = $(`${indexOfEle[pageTemplate].appImg}`)
+    const appName = $(indexOfEle[pageTemplate].appName).text();
+    const appIntro = $(indexOfEle[pageTemplate].appIntro).text();
+    const version = $(indexOfEle[pageTemplate].version).children('li').eq(0).text();
+    const appSize = $(indexOfEle[pageTemplate].appSize).children('li').eq(1).text().slice(3);
+    const appImg = $(indexOfEle[pageTemplate].appImg)
         .toArray()
         .reduce((acc, curr) => (acc += `<img src='${$(curr).children().find('img').attr('src')}'  style="margin: 0 auto;">`), '');
-    let appStatus = $(`${indexOfEle[pageTemplate].appStatus}`).text().trim();
+    let appStatus = $(indexOfEle[pageTemplate].appStatus).text().trim();
     if (appStatus === '点击安装') {
         appStatus = '可下载安装';
     }
 
-    let updateIntro = $(`${indexOfEle[pageTemplate].updateIntro}`).text().trim().slice(4);
+    let updateIntro = $(indexOfEle[pageTemplate].updateIntro).text().trim().slice(4);
     if (updateIntro === '') {
         updateIntro = '暂无更新内容';
     }
@@ -84,7 +84,7 @@ module.exports = async (ctx) => {
             {
                 link,
                 title: `${appName}-${version}`,
-                description: `${description}`,
+                description,
             },
         ],
     };

--- a/lib/routes/pianyuan/app.js
+++ b/lib/routes/pianyuan/app.js
@@ -35,7 +35,7 @@ module.exports = async (ctx) => {
 
         items.push({
             title: `[${size}] ${description_simple}`,
-            description: `${description}`,
+            description,
             link: link_base + link,
         });
     });

--- a/lib/routes/pixiv/bookmarks.js
+++ b/lib/routes/pixiv/bookmarks.js
@@ -34,7 +34,7 @@ module.exports = async (ctx) => {
                 }
             }
             return {
-                title: `${illust.title}`,
+                title: illust.title,
                 author: illust.user.name,
                 pubDate: new Date(illust.create_date).toUTCString(),
                 description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p>${images.join('')}`,

--- a/lib/routes/pixiv/ranking.js
+++ b/lib/routes/pixiv/ranking.js
@@ -84,7 +84,7 @@ module.exports = async (ctx) => {
                 pubDate: new Date(illust.create_date).toUTCString(),
                 description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p><br>${images.join('')}`,
                 link: `https://www.pixiv.net/artworks/${illust.id}`,
-                author: `${illust.user.name}`,
+                author: illust.user.name,
             };
         }),
     };

--- a/lib/routes/popiask/tapechat_questions.js
+++ b/lib/routes/popiask/tapechat_questions.js
@@ -30,8 +30,8 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `${nickname} 的 Tape 提问箱`,
         link: `https://www.tapechat.net/${sharecode}`,
-        image: `${avatar}`,
-        description: `${production}`,
+        image: avatar,
+        description: production,
         item: data.map((item) => ({
             title: item.title,
             description: `${item.title}<br>(${item.createdAt})<br><br><b>答：</b><br>${item.answer.txtContent}<br>(${new Date(item.answerAt * 1000).toLocaleString()})`,

--- a/lib/routes/ps/product.js
+++ b/lib/routes/ps/product.js
@@ -73,7 +73,7 @@ module.exports = async (ctx) => {
         url: `https://store.playstation.com/valkyrie-api/${langurl}/999/resolve/${gridName}?depth=2`,
     });
     const data = response.data;
-    const item = data.included?.filter((item) => item.id === gridName);
+    const item = data.included?.filter((item) => item.id === gridName) ?? [];
     ctx.state.data = {
         title: `PlayStation Store - ${item?.[0]?.attributes?.name ?? 'Unknown Name'}`,
         link: `https://store.playstation.com/${ctx.params.lang}/product/${gridName}`,

--- a/lib/routes/ps/product.js
+++ b/lib/routes/ps/product.js
@@ -75,7 +75,7 @@ module.exports = async (ctx) => {
     const data = response.data;
     const item = data.included?.filter((item) => item.id === gridName);
     ctx.state.data = {
-        title: `PlayStation Store - ${item?.[0]?.attributes?.name}`,
+        title: `PlayStation Store - ${item?.[0]?.attributes?.name ?? 'Unknown Name'}`,
         link: `https://store.playstation.com/${ctx.params.lang}/product/${gridName}`,
         item: item.map((item) => {
             let discount = '';

--- a/lib/routes/ps/product.js
+++ b/lib/routes/ps/product.js
@@ -75,7 +75,7 @@ module.exports = async (ctx) => {
     const data = response.data;
     const item = data.included?.filter((item) => item.id === gridName);
     ctx.state.data = {
-        title: `PlayStation Store - ${item[0].attributes.name}`,
+        title: `PlayStation Store - ${item[0]?.attributes?.name}`,
         link: `https://store.playstation.com/${ctx.params.lang}/product/${gridName}`,
         item: item.map((item) => {
             let discount = '';

--- a/lib/routes/ps/product.js
+++ b/lib/routes/ps/product.js
@@ -73,7 +73,7 @@ module.exports = async (ctx) => {
         url: `https://store.playstation.com/valkyrie-api/${langurl}/999/resolve/${gridName}?depth=2`,
     });
     const data = response.data;
-    const item = data.included && data.included.filter((item) => item.id === `${gridName}`);
+    const item = data.included?.filter((item) => item.id === gridName);
     ctx.state.data = {
         title: `PlayStation Store - ${item[0].attributes.name}`,
         link: `https://store.playstation.com/${ctx.params.lang}/product/${gridName}`,
@@ -100,7 +100,7 @@ module.exports = async (ctx) => {
                 (item.attributes['badge-info']['plus-user'] && item.attributes['badge-info']['plus-user']['discount-percentage'] === 100) ||
                 (item.attributes['badge-info']['plus-user'] && item.attributes['badge-info']['plus-user']['discount-percentage'] === 0)
             ) {
-                pdiscount = `${textshow.tplusfree}`;
+                pdiscount = textshow.tplusfree;
             }
 
             // 优惠时限&判断

--- a/lib/routes/ps/product.js
+++ b/lib/routes/ps/product.js
@@ -75,7 +75,7 @@ module.exports = async (ctx) => {
     const data = response.data;
     const item = data.included?.filter((item) => item.id === gridName);
     ctx.state.data = {
-        title: `PlayStation Store - ${item[0]?.attributes?.name}`,
+        title: `PlayStation Store - ${item?.[0]?.attributes?.name}`,
         link: `https://store.playstation.com/${ctx.params.lang}/product/${gridName}`,
         item: item.map((item) => {
             let discount = '';

--- a/lib/routes/ps/product.js
+++ b/lib/routes/ps/product.js
@@ -75,7 +75,7 @@ module.exports = async (ctx) => {
     const data = response.data;
     const item = data.included?.filter((item) => item.id === gridName) ?? [];
     ctx.state.data = {
-        title: `PlayStation Store - ${item?.[0]?.attributes?.name ?? 'Unknown Name'}`,
+        title: `PlayStation Store - ${item[0].attributes?.name ?? 'Unknown Name'}`,
         link: `https://store.playstation.com/${ctx.params.lang}/product/${gridName}`,
         item: item.map((item) => {
             let discount = '';

--- a/lib/routes/sakurazaka46/blog.js
+++ b/lib/routes/sakurazaka46/blog.js
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
             list
                 .map((index, item) => {
                     item = $(item);
-                    itemPicUrl = `${item.find('div.wrap-bg span.img').attr('style')}`.replace('background-image: url(', '').replace(');', '');
+                    itemPicUrl = item.find('div.wrap-bg span.img').attr('style').replace('background-image: url(', '').replace(');', '');
                     return {
                         title: item.find('div.date-title h3.title').text().trim(),
                         link: item.find('a').first().attr('href'),

--- a/lib/routes/showroom/room.js
+++ b/lib/routes/showroom/room.js
@@ -14,8 +14,8 @@ module.exports = async (ctx) => {
     if (data.is_onlive) {
         item = [
             {
-                title: `${data.room_name}`,
-                pubDate: new Date(data.current_live_started_at * 1000).toUTCString(),
+                title: data.room_name,
+                pubDate: new Date(data.current_live_started_at * 1000),
                 guid: new Date(data.current_live_started_at * 1000).toUTCString(),
                 link: data.share_url_live,
             },

--- a/lib/routes/shuhui/comics.js
+++ b/lib/routes/shuhui/comics.js
@@ -75,11 +75,11 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         // 源标题
-        title: `${rssData.name}`,
+        title: rssData.name,
         // 源链接
         link: `https://www.ishuhui.com/comics/anime/${id}`,
         // 源说明
-        description: `${rssData.desc}`,
+        description: rssData.desc,
         // 遍历此前获取的数据
         item: data.map((item) => ({
             // 文章标题

--- a/lib/routes/siren/index.js
+++ b/lib/routes/siren/index.js
@@ -25,7 +25,7 @@ module.exports = async (ctx) => {
             // 文章正文
             description: `${item.title}<br>${item.date}`,
             // 文章发布时间
-            pubDate: parseDate(`${item.date}`),
+            pubDate: parseDate(item.date),
             // 文章链接
             link: `https://monster-siren.hypergryph.com/info/${item.cid}`,
         })),

--- a/lib/routes/sketch/updates.js
+++ b/lib/routes/sketch/updates.js
@@ -26,13 +26,13 @@ module.exports = async (ctx) => {
                     const pubyear = item.find('section.update-highlights time').attr('datetime').substr(-4);
                     const pubdateString = pubmonth + `-` + pubday + `-` + pubyear;
                     return {
-                        title: `${item.find('h2.update-version-title').first().text().trim()}`,
+                        title: item.find('h2.update-version-title').first().text().trim(),
                         description: `${item.find('section.update-highlights .lead').html()}<br>
                         ${item.find('section.update-highlights footer').html()}<br>
                         ${item.find('aside.update-details .mask').html()}`,
                         link: `https://www.sketch.com/updates/${item.find('.update-version-title a').attr('href')}`,
-                        pubDate: new Date(pubdateString).toLocaleDateString(),
-                        guid: `${item.find('h2.update-version-title').first().text().trim()}`,
+                        pubDate: new Date(pubdateString),
+                        guid: item.find('h2.update-version-title').first().text().trim(),
                     };
                 })
                 .get(),

--- a/lib/routes/smzdm/keyword.js
+++ b/lib/routes/smzdm/keyword.js
@@ -31,7 +31,7 @@ module.exports = async (ctx) => {
                         title: `${item.find('.feed-block-title a').eq(0).text().trim()} - ${item.find('.feed-block-title a').eq(1).text().trim()}`,
                         description: `${item.find('.feed-block-descripe').contents().eq(2).text().trim()}<br>${item.find('.feed-block-extras span').text().trim()}<br><img src="http:${item.find('.z-feed-img img').attr('src')}">`,
                         pubDate: timezone(parseDate(item.find('.feed-block-extras').contents().eq(0).text().trim(), 'H:mm'), +8),
-                        link: `${item.find('.feed-block-title a').attr('href')}`,
+                        link: String(item.find('.feed-block-title a').attr('href')),
                     };
                 })
                 .get(),

--- a/lib/routes/soul/hot.js
+++ b/lib/routes/soul/hot.js
@@ -37,7 +37,7 @@ module.exports = async (ctx) => {
         let items = response.data.data.posts;
 
         items = items.map((item) => {
-            const pureContent = `${item.content}`;
+            const pureContent = item.content;
             let content = pureContent.replace(/\n/, '<br />');
 
             if (item.attachments) {

--- a/lib/routes/soul/index.js
+++ b/lib/routes/soul/index.js
@@ -47,7 +47,7 @@ module.exports = async (ctx) => {
     }
 
     items = items.map((item) => {
-        const pureContent = `${item.content}`;
+        const pureContent = item.content;
         let content = pureContent.replace(/\n/, '<br />');
 
         if (item.attachments) {

--- a/lib/routes/ssmh/category.js
+++ b/lib/routes/ssmh/category.js
@@ -37,8 +37,8 @@ module.exports = async (ctx) => {
         item: list
             .map((index, item) => {
                 item = $(item);
-                const thumbnail_url = 'https:' + `${item.find('a > img').attr('src') ? item.find('a > img').attr('src') : item.find('a > img').attr('data-original')}`;
-                const link_url = 'https://wnacg.org' + `${item.find('a').attr('href')}`;
+                const thumbnail_url = 'https:' + item.find('a > img').attr('src') ? item.find('a > img').attr('src') : item.find('a > img').attr('data-original');
+                const link_url = 'https://wnacg.org' + item.find('a').attr('href');
                 return {
                     title: item.find('a').attr('title'),
                     description: `<img src=${thumbnail_url} referrerpolicy="no-referrer">`,

--- a/lib/routes/ssmh/category.js
+++ b/lib/routes/ssmh/category.js
@@ -37,7 +37,7 @@ module.exports = async (ctx) => {
         item: list
             .map((index, item) => {
                 item = $(item);
-                const thumbnail_url = 'https:' + item.find('a > img').attr('src') ? item.find('a > img').attr('src') : item.find('a > img').attr('data-original');
+                const thumbnail_url = 'https:' + (item.find('a > img').attr('src') ? item.find('a > img').attr('src') : item.find('a > img').attr('data-original'));
                 const link_url = 'https://wnacg.org' + item.find('a').attr('href');
                 return {
                     title: item.find('a').attr('title'),

--- a/lib/routes/ssmh/index.js
+++ b/lib/routes/ssmh/index.js
@@ -19,8 +19,8 @@ module.exports = async (ctx) => {
         item: list
             .map((index, item) => {
                 item = $(item);
-                thumbnail_url = 'https:' + `${item.find('a > img').attr('src') ? item.find('a > img').attr('src') : item.find('a > img').attr('data-original')}`;
-                link_url = 'https://wnacg.org' + `${item.find('a').attr('href')}`;
+                thumbnail_url = `https:${item.find('a > img').attr('src') ?? item.find('a > img').attr('data-original')}`;
+                link_url = `https://wnacg.org${item.find('a').attr('href')}`;
                 return {
                     title: item.find('a').attr('title'),
                     description: `<img src=${thumbnail_url} referrerpolicy="no-referrer">`,

--- a/lib/routes/sspai/activity.js
+++ b/lib/routes/sspai/activity.js
@@ -56,18 +56,18 @@ module.exports = async (ctx) => {
                     break;
                 case 'comment_article':
                     item_title = `${item.author.nickname}${item.action}：${content_data.article_title}`;
-                    item_desc = `${content_data.comment}`;
+                    item_desc = content_data.comment;
                     item_url = `https://sspai.com/post/${content_data.article_id}`;
                     break;
                 case 'release_article':
                     item_title = `${item.author.nickname}${item.action}：${content_data.title}`;
-                    item_desc = `${content_data.summary}`;
+                    item_desc = content_data.summary;
                     item_url = `https://sspai.com/post/${content_data.id}`;
                     break;
                 case 'chosen_comment':
                     item_title = `${item.author.nickname}在文章「${content_data.article_title}」下的${item.action}`;
-                    item_desc = `${content_data.comment}`;
-                    item_url = `${content_data.comment}`;
+                    item_desc = content_data.comment;
+                    item_url = content_data.comment;
                     break;
             }
 

--- a/lib/routes/szse/inquire.js
+++ b/lib/routes/szse/inquire.js
@@ -81,7 +81,7 @@ module.exports = async (ctx) => {
                 `</td></tr>
             </table>`,
             pubDate: new Date(item.fhrq).toUTCString(),
-            link: `http://reportdocs.static.szse.cn` + getUrl(`${item.ck}`),
+            link: `http://reportdocs.static.szse.cn${getUrl(item.ck)}`,
         })),
     };
 };

--- a/lib/routes/taptap/changelog.js
+++ b/lib/routes/taptap/changelog.js
@@ -30,7 +30,7 @@ module.exports = async (ctx) => {
         image: app_img,
         item: list.map((item) => ({
             title: item.version_label,
-            description: `${item.whatsnew.text}`,
+            description: item.whatsnew.text,
             pubDate: new Date(item.update_date),
             link: url,
             guid: item.version_label,

--- a/lib/routes/tencent/video/playlist.js
+++ b/lib/routes/tencent/video/playlist.js
@@ -10,7 +10,7 @@ module.exports = async (ctx) => {
     let vtype = 4;
     // 支持地址 https://v.qq.com/detail/8/84842.html
     let items = null;
-    if (`${id[0]}` === '8') {
+    if (id[0] === '8') {
         vtype = 1;
         const episodes = await got.get(`https://s.video.qq.com/get_playsource?id=${id}&plat=2&type=${vtype}&data_type=2&video_type=3&range=1&plname=qq&otype=json&num_mod_cnt=20&callback=a&_t=${Date.now()}`);
         const playList = JSON.parse(episodes.data.slice(2, -1)).playlist[0].videoPlayList;

--- a/lib/routes/tencent/wechat/csm.js
+++ b/lib/routes/tencent/wechat/csm.js
@@ -16,7 +16,7 @@ module.exports = async (ctx) => {
             .slice(0, 10)
             .get()
             .map(async (e) => {
-                const pubDate = date(`${$(e).find('.timestamp').text().trim()}`, 8);
+                const pubDate = date($(e).find('.timestamp').text().trim(), 8);
 
                 const link = `https://chuansongme.com${$(e).find('.question_link').attr('href')}`;
 

--- a/lib/routes/tencent/wechat/feeds.js
+++ b/lib/routes/tencent/wechat/feeds.js
@@ -39,7 +39,7 @@ module.exports = async (ctx) => {
     );
 
     ctx.state.data = {
-        title: `${feed.title}`,
+        title: feed.title,
         link,
         description: feed.description,
         item: items,

--- a/lib/routes/tencent/wechat/miniprogram/devtools.js
+++ b/lib/routes/tencent/wechat/miniprogram/devtools.js
@@ -14,7 +14,7 @@ module.exports = async (ctx) => {
         .replace(/[\s|#]/g, '');
 
     ctx.state.data = {
-        title: `${name}`,
+        title: name,
         link,
         item: $('#docContent .content h3')
             .map((_, item) => {
@@ -33,6 +33,6 @@ module.exports = async (ctx) => {
                 };
             })
             .get(),
-        description: `${name}`,
+        description: name,
     };
 };

--- a/lib/routes/tencent/wechat/miniprogram/framework.js
+++ b/lib/routes/tencent/wechat/miniprogram/framework.js
@@ -14,7 +14,7 @@ module.exports = async (ctx) => {
         .replace(/[\s|#]/g, '');
 
     ctx.state.data = {
-        title: `${name}`,
+        title: name,
         link,
         item: $('#docContent .content h3')
             .map((_, item) => {
@@ -28,6 +28,6 @@ module.exports = async (ctx) => {
                 };
             })
             .get(),
-        description: `${name}`,
+        description: name,
     };
 };

--- a/lib/routes/tencent/wechat/miniprogram/wxcloud.js
+++ b/lib/routes/tencent/wechat/miniprogram/wxcloud.js
@@ -12,7 +12,7 @@ module.exports = async (ctx) => {
     const name = $('#docContent .content h2').text();
 
     ctx.state.data = {
-        title: `${name}`,
+        title: name,
         link,
         item: ctx.params.caty
             ? $('#docContent .content h3')
@@ -42,6 +42,6 @@ module.exports = async (ctx) => {
                       };
                   })
                   .get(),
-        description: `${name}`,
+        description: name,
     };
 };

--- a/lib/routes/tencent/wechat/mp.js
+++ b/lib/routes/tencent/wechat/mp.js
@@ -56,14 +56,21 @@ module.exports = async (ctx) => {
     );
     ctx.state.data = {
         // 源标题，差一个cid相关的标题！
-        title: `${mptitle}`,
+        title: mptitle,
         link: `https://mp.weixin.qq.com/mp/homepage?__biz=${biz}${hidurl}${cidurl}`,
         item: list.map((item, index) => ({
-            title: `${item.title}`,
-            description: `${item.digest}<br>   
-<img style="max-width: 650px; height: auto; object-fit: contain; width: 100%;" src="${item.cover}"><br><br>${articledata[index].content}`,
-            link: `${item.link}`,
-            author: `${articledata[index].author}`,
+            title: item.title,
+            description: `
+                ${item.digest}<br>
+                <img
+                    style="max-width: 650px; height: auto; object-fit: contain; width: 100%;"
+                    src="${item.cover}"
+                ><br>
+                <br>
+                ${articledata[index].content}
+            `,
+            link: item.link,
+            author: articledata[index].author,
             pubDate: dayjs.unix(item.sendtime).format(),
         })),
     };

--- a/lib/routes/tencent/wechat/msgalbum.js
+++ b/lib/routes/tencent/wechat/msgalbum.js
@@ -46,13 +46,13 @@ module.exports = async (ctx) => {
         })
     );
     ctx.state.data = {
-        title: `${mptitle}`,
+        title: mptitle,
         link: `https://mp.weixin.qq.com/mp/appmsgalbum?__biz=${biz}&action=getalbum${aidurl}`,
         item: list.map((item, index) => ({
-            title: `${articledata[index].title}`,
+            title: articledata[index].title,
             description: $(item).find('.album__item-img').html() + `<br><br>${articledata[index].content}`,
-            link: `${articledata[index].link}`,
-            author: `${articledata[index].author}`,
+            link: articledata[index].link,
+            author: articledata[index].author,
             pubDate: dayjs.unix($(item).find('.js_article_create_time').text()).format(),
         })),
     };

--- a/lib/routes/tencent/wechat/wechat-open/community/question.js
+++ b/lib/routes/tencent/wechat/wechat-open/community/question.js
@@ -27,7 +27,7 @@ module.exports = async (ctx) => {
             // 文章标题
             title: item.Title,
             // 文章正文
-            description: `${item.Content}`,
+            description: item.Content,
             // 文章发布时间
             pubDate: new Date(item.CreateTime * 1000).toUTCString(),
             // 文章链接

--- a/lib/routes/thepaper/839studio/category.js
+++ b/lib/routes/thepaper/839studio/category.js
@@ -23,7 +23,7 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `澎湃美数课作品集-${category}`,
         link,
-        description: `${desc}`,
+        description: desc,
         item:
             list &&
             list

--- a/lib/routes/tieba/post.js
+++ b/lib/routes/tieba/post.js
@@ -51,13 +51,13 @@ module.exports = async (ctx) => {
                         .get();
                     return {
                         title: `${author.user_name}回复了帖子《${title}》`,
-                        description: [
-                            `<p>${content.content}</p>`,
-                            `作者：${author.user_name}`,
-                            `楼层：${num}`,
-                            `${from}`
-                        ].join('<br />'), // prettier-ignore
-                        pubDate: new Date(time).toUTCString(),
+                        description: `
+                            <p>${content.content}</p><br>
+                            作者：${author.user_name}<br>
+                            楼层：${num}<br>
+                            ${from}
+                        `, // prettier-ignore
+                        pubDate: new Date(time),
                         link: `https://tieba.baidu.com/p/${id}?pid=${content.post_id}#${content.post_id}`,
                     };
                 })

--- a/lib/routes/tingshuitz/dalian.js
+++ b/lib/routes/tingshuitz/dalian.js
@@ -26,7 +26,7 @@ module.exports = async (ctx) => {
                         title: item.find('a').text(),
                         description: `大连市停水通知：${item.find('a').text()}`,
                         pubDate: new Date(item.find('span').text()).toUTCString(),
-                        link: `${item.find('a').attr('href')}`,
+                        link: item.find('a').attr('href'),
                     };
                 })
                 .get(),

--- a/lib/routes/tingshuitz/wuhan.js
+++ b/lib/routes/tingshuitz/wuhan.js
@@ -26,7 +26,7 @@ module.exports = async (ctx) => {
                         title: item.find('a').text(),
                         description: `武汉市停水通知：${item.find('a').text()}`,
                         pubDate: new Date(item.find('span').text()).toUTCString(),
-                        link: `${url.resolve(baseUrl, item.find('a').attr('href'))}`,
+                        link: url.resolve(baseUrl, item.find('a').attr('href')),
                     };
                 })
                 .get(),

--- a/lib/routes/tuicool/mags.js
+++ b/lib/routes/tuicool/mags.js
@@ -33,7 +33,7 @@ module.exports = async (ctx) => {
                         title: item.find('.title').text(),
                         description: `推酷：${item.find('.title').text()}`,
                         pubDate: new Date($('.period-title sub').text().substring(1, 11)).toUTCString(),
-                        link: `${item.find('a').attr('href')}`,
+                        link: String(item.find('a').attr('href')),
                     };
                 })
                 .get(),

--- a/lib/routes/uisdc/zt.js
+++ b/lib/routes/uisdc/zt.js
@@ -43,7 +43,7 @@ module.exports = async (ctx) => {
 
                 if (title === '' || title === 'hot') {
                     item.title = content('.block-main h2').text();
-                    item.description = `${content('.block-main p').text()}`;
+                    item.description = content('.block-main p').text();
                     item.pubDate = new Date(content('.time').eq(0).text()).toUTCString();
                 } else {
                     item.title = content('#post_title').text();

--- a/lib/routes/unit-image/films.js
+++ b/lib/routes/unit-image/films.js
@@ -129,10 +129,10 @@ module.exports = async (ctx) => {
                 content += `Compare:<br><video width="100%" controls="controls" ${videostyle}><source src="${articledata[index].compare.compare0.url}" type="video/mp4"></video><br><video width="100%" controls="controls" ${videostyle}><source src="${articledata[index].compare.compare1.url}" type="video/mp4"></video><br>`;
             }
             return {
-                title: `${item.title}`,
-                description: `${content}`,
+                title: item.title,
+                description: content,
                 link: `https://www.unit-image.fr${item.href}`,
-                pubDate: `${item.preview.mp4.date}`,
+                pubDate: item.preview.mp4.date,
             };
         }),
     };

--- a/lib/routes/universities/bjtu/gs/index.js
+++ b/lib/routes/universities/bjtu/gs/index.js
@@ -110,7 +110,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: struct[type].name,
-        link: `${url}`,
+        link: url,
         description: '北京交通大学研究生院',
         item:
             list &&

--- a/lib/routes/universities/bupt/yz.js
+++ b/lib/routes/universities/bupt/yz.js
@@ -148,8 +148,8 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `${name}又有更新了`,
-        link: `${url}`,
-        description: `${name}`,
+        link: url,
+        description: name,
         item: result,
     };
 };

--- a/lib/routes/universities/hbut/cs.js
+++ b/lib/routes/universities/hbut/cs.js
@@ -34,7 +34,7 @@ module.exports = async (ctx) => {
             .map((_, elem) => ({
                 link: resolve_url(link, $('a', elem).attr('href')),
                 title: $('a', elem).text(),
-                pubDate: new Date(`${$('font:nth-child(3)', elem).text()}`).toString(),
+                pubDate: new Date($('font:nth-child(3)', elem).text()),
             }))
             .get(),
     };

--- a/lib/routes/universities/hbut/news.js
+++ b/lib/routes/universities/hbut/news.js
@@ -35,7 +35,7 @@ module.exports = async (ctx) => {
             .map((_, elem) => ({
                 link: resolve_url(link, $('span.news_title>a', elem).attr('href')),
                 title: $('a', elem).text(),
-                pubDate: new Date(`${$('span.news_meta', elem).text()}`).toString(),
+                pubDate: new Date($('span.news_meta', elem).text()),
             }))
             .get(),
     };

--- a/lib/routes/universities/jnu/yw/index.js
+++ b/lib/routes/universities/jnu/yw/index.js
@@ -12,7 +12,7 @@ module.exports = async (ctx) => {
         headers: {
             'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36',
         },
-        url: `${ywUrl}`,
+        url: ywUrl,
     });
 
     const $ = cheerio.load(response.data);
@@ -35,7 +35,7 @@ module.exports = async (ctx) => {
         ctx.state.data = {
             title: desc,
             description: desc,
-            link: `${ywUrl}`,
+            link: ywUrl,
             item: list,
         };
     } else {
@@ -74,7 +74,7 @@ module.exports = async (ctx) => {
         ctx.state.data = {
             title: desc,
             description: desc,
-            link: `${ywUrl}`,
+            link: ywUrl,
             item: out,
         };
     }

--- a/lib/routes/universities/nku/jwc/index.js
+++ b/lib/routes/universities/nku/jwc/index.js
@@ -39,7 +39,7 @@ module.exports = async (ctx) => {
                         title: $(item.find('a')).text(),
                         pubDate: $(item.find('.Article_PublishDate')).text(),
                         description: `发布日期：${$(item.find('.Article_PublishDate')).text()}`,
-                        link: `${dirname + $(item.find('a')).attr('href')}`,
+                        link: `${dirname}${$(item.find('a')).attr('href')}`,
                     };
                 })
                 .get(),

--- a/lib/routes/universities/sctu/jwc/index.js
+++ b/lib/routes/universities/sctu/jwc/index.js
@@ -38,7 +38,7 @@ module.exports = async (ctx) => {
                         title: $(item.find('a')).text(),
                         pubDate: $(item.find('dl')).text(),
                         description: `发布日期：${$(item.find('dl')).text()}`,
-                        link: `${dirname + $(item.find('a')).attr('href')}`,
+                        link: dirname + $(item.find('a')).attr('href'),
                     };
                 })
                 .get(),

--- a/lib/routes/universities/sustech/newshub-zh.js
+++ b/lib/routes/universities/sustech/newshub-zh.js
@@ -21,7 +21,7 @@ module.exports = async (ctx) => {
             list
                 .map((index, item) => {
                     item = $(item);
-                    const itemPicUrl = `${item.find('a > div.u-pic').attr('style')}`.replace('background-image:url(', 'https://newshub.sustech.edu.cn/').replace(');', '');
+                    const itemPicUrl = String(item.find('a > div.u-pic').attr('style')).replace('background-image:url(', 'https://newshub.sustech.edu.cn/').replace(');', '');
                     const itemPubdate = item.find('a > div.u-date').text();
                     return {
                         pubDate: itemPubdate,

--- a/lib/routes/universities/szu/yz/index.js
+++ b/lib/routes/universities/szu/yz/index.js
@@ -44,8 +44,8 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: map.get(type).title,
-        link: `${url}`,
-        description: `${name}`,
+        link: url,
+        description: name,
         item: result,
     };
 };

--- a/lib/routes/universities/ustc/jwc/index.js
+++ b/lib/routes/universities/ustc/jwc/index.js
@@ -16,12 +16,12 @@ module.exports = async (ctx) => {
     });
 
     const $ = cheerio.load(response.data);
-    const list = $(`${type === '' ? 'ul[class="article-list with-tag"] > li' : 'ul[class=article-list] > li'}`)
+    const list = $(type === '' ? 'ul[class="article-list with-tag"] > li' : 'ul[class=article-list] > li')
         .map(function () {
             const child = $(this).children();
             const info = {
-                title: `${type === '' ? $(child[0]).find('a').text() + ' - ' + $(child[1]).find('a').text() : $(child[0]).find('a').text()}`,
-                link: `${type === '' ? $(child[1]).find('a').attr('href') : $(child[0]).find('a').attr('href')}`,
+                title: type === '' ? $(child[0]).find('a').text() + ' - ' + $(child[1]).find('a').text() : $(child[0]).find('a').text(),
+                link: type === '' ? $(child[1]).find('a').attr('href') : $(child[0]).find('a').attr('href'),
             };
             return info;
         })

--- a/lib/routes/universities/wtu/index.js
+++ b/lib/routes/universities/wtu/index.js
@@ -16,19 +16,19 @@ module.exports = async (ctx) => {
     const type = map.get(typein).type;
     const res = await got({
         method: 'get',
-        url: apiUrl + `${columnId}`,
+        url: `${apiUrl}${columnId}`,
     });
     const res_json = res.data.bulletinList;
 
     ctx.state.data = {
         title: `${title} - 武汉纺织大学信息门户`,
-        link: listUrl + `${type}`,
+        link: `${listUrl}${type}`,
         description: `${title} - 武汉纺织大学信息门户`,
         item: res_json.map((item) => ({
             title: item.TITLE,
             description: item.TITLE,
             pubDate: new Date(item.CREATE_TIME).toUTCString(),
-            link: psgUrl + `type=` + `${type}` + `?bulletinId=` + item.WID,
+            link: `${psgUrl}type=${type}?bulletinId=${item.WID}`,
         })),
     };
 };

--- a/lib/routes/universities/zju/career/index.js
+++ b/lib/routes/universities/zju/career/index.js
@@ -14,7 +14,7 @@ module.exports = async (ctx) => {
     const id = map.get(type).id;
     const res = await got({
         method: 'get',
-        url: host + `${id}`,
+        url: `${host}${id}`,
     });
 
     const $ = cheerio.load(res.data);
@@ -36,7 +36,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: map.get(type).title,
-        link: host + `${id}`,
+        link: `${host}${id}`,
         item: items,
     };
 };

--- a/lib/routes/universities/zju/grs/index.js
+++ b/lib/routes/universities/zju/grs/index.js
@@ -16,7 +16,7 @@ module.exports = async (ctx) => {
     const tag = map.get(type).tag;
     const res = await got({
         method: 'get',
-        url: host + `${tag}`,
+        url: `${host}${tag}`,
     });
 
     const $ = cheerio.load(res.data);
@@ -38,7 +38,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: map.get(type).title,
-        link: host + `${tag}`,
+        link: `${host}${tag}`,
         item: items,
     };
 };

--- a/lib/routes/universities/zju/physics/index.js
+++ b/lib/routes/universities/zju/physics/index.js
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
     const id = map.get(type).id;
     const res = await got({
         method: 'get',
-        url: host + `${id}`,
+        url: `${host}${id}`,
         responseType: 'buffer',
     });
 
@@ -49,7 +49,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: map.get(type).title,
-        link: host + `${id}`,
+        link: `${host}${id}`,
         item: items,
     };
 };

--- a/lib/routes/universities/zzuli/campus/index.js
+++ b/lib/routes/universities/zzuli/campus/index.js
@@ -18,7 +18,7 @@ module.exports = async (ctx) => {
     const id = map.get(type).link;
     const res = await got({
         method: 'get',
-        url: `${id}`,
+        url: id,
         responseType: 'buffer',
     });
 

--- a/lib/routes/universities/zzuli/yjsc/index.js
+++ b/lib/routes/universities/zzuli/yjsc/index.js
@@ -14,7 +14,7 @@ module.exports = async (ctx) => {
     const id = map.get(type).link;
     const res = await got({
         method: 'get',
-        url: `${id}`,
+        url: id,
         responseType: 'buffer',
     });
 

--- a/lib/routes/vol/lastupdate.js
+++ b/lib/routes/vol/lastupdate.js
@@ -23,7 +23,9 @@ module.exports = async (ctx) => {
             const title = $el.find('a').last().text();
             const imgEL = $el.find('a').first();
             const link = imgEL.attr('href');
-            const imgSrc = `${imgEL.find('.img_book').attr('style')}`.replace(/.*\s?url\(['"]?/, '').replace(/['"]?\).*/, '');
+            const imgSrc = String(imgEL.find('.img_book').attr('style'))
+                .replace(/.*\s?url\(['"]?/, '')
+                .replace(/['"]?\).*/, '');
             const match = $el.text().match(/\[[\s\S]*?\]/g);
             const detail = $el.find('.pagefoot').text();
             const date = $el.find('.filesize').text();

--- a/lib/routes/weatheralarm/index.js
+++ b/lib/routes/weatheralarm/index.js
@@ -17,9 +17,9 @@ module.exports = async (ctx) => {
             const title = item.title;
             const url = item.url;
             return {
-                title: `${title}`,
+                title,
                 link: `http://www.nmc.cn${url}`,
-                pubDate: `${item.issuetime}`,
+                pubDate: item.issuetime,
             };
         }),
     };

--- a/lib/routes/weibo/timeline.js
+++ b/lib/routes/weibo/timeline.js
@@ -72,7 +72,7 @@ module.exports = async (ctx) => {
                         res.forEach((content, index) => {
                             const emotion = [];
                             content.replace(/(\[.*?\])/g, (s, value) => {
-                                emotion.push(`${value}`);
+                                emotion.push(value);
                             });
 
                             if (content.length > 0) {
@@ -138,10 +138,10 @@ module.exports = async (ctx) => {
                     });
                 }
                 return {
-                    description: `${description
+                    description: description
                         .replace(/\b(url|href|src)\b=(['|"])http:/g, '$1=$2https:')
                         .replace('http://t.cn/', 'https://t.cn/')
-                        .replace('http://m.weibo.', 'https://m.weibo.')}`,
+                        .replace('http://m.weibo.', 'https://m.weibo.'),
                     link: item.link,
                     pubDate: item.date,
                     title: item.title,

--- a/lib/routes/wukong/user.js
+++ b/lib/routes/wukong/user.js
@@ -65,7 +65,7 @@ module.exports = async (ctx) => {
             }
             case 'answers': {
                 return {
-                    title: `${item.question.title}`,
+                    title: item.question.title,
                     link: `https://www.wukong.com/answer/${item.ans_list[0].ansid}`,
                     description: item.ans_list[0].content,
                     pubDate: new Date(item.ans_list[0].create_time * 1000).toUTCString(),
@@ -73,7 +73,7 @@ module.exports = async (ctx) => {
             }
             case 'questions': {
                 return {
-                    title: `${item.title}`,
+                    title: item.title,
                     link: `https://www.wukong.com/question/${item.qid}`,
                     description: item.content.text,
                     pubDate: new Date(item.create_time * 1000).toUTCString(),
@@ -88,6 +88,6 @@ module.exports = async (ctx) => {
         title: `悟空问答 - ${userResponse.data.other_user_info.uname}`,
         link: `https://www.wukong.com/user/?uid=${ctx.params.id}&type=${number}`,
         item: list,
-        description: `${userResponse.data.other_user_info.description}`,
+        description: userResponse.data.other_user_info.description,
     };
 };

--- a/lib/routes/xiaohongshu/board.js
+++ b/lib/routes/xiaohongshu/board.js
@@ -8,12 +8,12 @@ module.exports = async (ctx) => {
     const main = JSON.parse(match[1]).Main;
 
     const albumInfo = main.albumInfo;
-    const title = `${albumInfo.name}`;
-    const description = `${albumInfo.desc}`;
+    const title = albumInfo.name;
+    const description = albumInfo.desc;
 
     const list = main.notesDetail;
     const resultItem = list.map((item) => ({
-        title: `${item.title}`,
+        title: item.title,
         link: `https://www.xiaohongshu.com/discovery/item/${item.id}`,
         description: `<img src ="${item.cover.url}"><br>${item.title}`,
     }));

--- a/lib/routes/xiaohongshu/user.js
+++ b/lib/routes/xiaohongshu/user.js
@@ -17,7 +17,7 @@ module.exports = async (ctx) => {
     if (category === 'notes') {
         const list = main.notesDetail;
         const resultItem = list.map((item) => ({
-            title: `${item.title}`,
+            title: item.title,
             link: `https://www.xiaohongshu.com/discovery/item/${item.id}`,
             description: `<img src ="${item.cover.url}"><br>${item.title}`,
         }));
@@ -32,7 +32,7 @@ module.exports = async (ctx) => {
     } else if (category === 'album') {
         const list = main.albumDetail;
         const resultItem = list.map((item) => ({
-            title: `${item.title}`,
+            title: item.title,
             link: `https://www.xiaohongshu.com/board/${item.id}`,
             description: item.images.map((it) => `<img src ="${it}">`).join(`<br />`),
         }));

--- a/lib/routes/ximalaya/album.js
+++ b/lib/routes/ximalaya/album.js
@@ -211,8 +211,8 @@ module.exports = async (ctx) => {
     });
 
     ctx.state.data = {
-        title: `${albumTitle}`,
-        link: `${baseUrl + albumUrl}`,
+        title: albumTitle,
+        link: baseUrl + albumUrl,
         description: albumIntro,
         image: albumCover,
         itunes_author: author,

--- a/lib/routes/xuangubao/subject.js
+++ b/lib/routes/xuangubao/subject.js
@@ -41,7 +41,7 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `${subject_title} - 主题 - 选股宝`,
         link: `https://xuangubao.cn/subject/${subject_id}`,
-        description: `${subject_desc}`,
+        description: subject_desc,
         item: out,
     };
 };

--- a/lib/routes/yande.re/post_popular_recent.js
+++ b/lib/routes/yande.re/post_popular_recent.js
@@ -31,7 +31,7 @@ module.exports = async (ctx) => {
         title: `${title} - yande.re`,
         link: `https://yande.re/post/popular_recent?period=${period}`,
         item: posts.map((post) => ({
-            title: `${post.tags}`,
+            title: post.tags,
             id: `${ctx.path}#${post.id}`,
             guid: `${ctx.path}#${post.id}`,
             link: `https://yande.re/post/show/${post.id}`,

--- a/lib/routes/zfrontier/board_postlist.js
+++ b/lib/routes/zfrontier/board_postlist.js
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
                 .map((index, item) => {
                     item = $(item);
                     return {
-                        title: `${item.find('.post-title h2').text()}`,
+                        title: item.find('.post-title h2').text(),
                         description: `${item.find('.ellipsis').html()}<br/>${item.find('.imgs-wrap').html()}`,
                         link: `https://www.zfrontier.com${item.find('.post-title').attr('href')}`,
                         author: item.find('.author a').text(),

--- a/lib/routes/zfrontier/postlist.js
+++ b/lib/routes/zfrontier/postlist.js
@@ -21,7 +21,7 @@ module.exports = async (ctx) => {
                 .map((index, item) => {
                     item = $(item);
                     return {
-                        title: `${item.find('.post-title h2').text()}`,
+                        title: item.find('.post-title h2').text(),
                         description: `${item.find('.ellipsis').html()}<br/>${item.find('.imgs-wrap').html()}`,
                         link: `https://www.zfrontier.com${item.find('.post-title').attr('href')}`,
                         author: item.find('.author a').text(),

--- a/lib/routes/zhihu/collection.js
+++ b/lib/routes/zhihu/collection.js
@@ -33,18 +33,18 @@ module.exports = async (ctx) => {
 
     const generateDataPin = (item) => generateData([item.content])[0];
     ctx.state.data = {
-        title: `${collection_title}`,
+        title: collection_title,
         link: `https://www.zhihu.com/collection/${id}`,
-        description: `${collection_description}`,
+        description: collection_description,
         item:
             list &&
             list.map((item) =>
                 item.content.type === 'pin'
                     ? generateDataPin(item)
                     : {
-                          title: `${item.content.type === 'article' ? item.content.title : item.content.question.title}`,
-                          link: `${item.content.url}`,
-                          description: `${item.content.content}`,
+                          title: item.content.type === 'article' ? item.content.title : item.content.question.title,
+                          link: item.content.url,
+                          description: item.content.content,
                           pubDate: new Date((item.content.type === 'article' ? item.content.updated : item.content.updated_time) * 1000).toUTCString(),
                       }
             ),

--- a/lib/routes/zhihu/posts.js
+++ b/lib/routes/zhihu/posts.js
@@ -31,13 +31,13 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: `${authorname}的知乎文章`,
         link: `https://www.zhihu.com/${usertype}/${id}/posts`,
-        description: `${authordescription}`,
+        description: authordescription,
         item:
             list.length > 0 &&
             list.map((item) => ({
                 title: String(item.title),
-                description: `${item.content}`,
-                link: `${item.url}`,
+                description: item.content,
+                link: item.url,
                 pubDate: new Date(item.updated).toUTCString(),
             })),
     };

--- a/lib/routes/zyshow/index.js
+++ b/lib/routes/zyshow/index.js
@@ -35,7 +35,7 @@ module.exports = async (ctx) => {
         .get();
 
     ctx.state.data = {
-        title: `${$('title').text()}`,
+        title: $('title').text(),
         link: currentUrl,
         item: list,
     };

--- a/lib/utils/dateParser.js
+++ b/lib/utils/dateParser.js
@@ -59,7 +59,7 @@ const tStringParser = (html, customFormat = undefined, lang = 'en', htmlOffset =
     Object.values(dayjs.Ls).forEach((k) => {
         ['weekdays', 'weekdaysShort'].forEach((x) => {
             if (k.hasOwnProperty(x)) {
-                const a = k[x].map((z) => `${z}`);
+                const a = k[x].map((z) => z);
                 removeStr = removeStr.concat(...a);
             }
         });

--- a/lib/utils/torrent.js
+++ b/lib/utils/torrent.js
@@ -48,7 +48,7 @@ class HDHome extends TorrentProvider {
         return this.parser.parseURL(url).then((feed) =>
             feed.items.map((t) => ({
                 provider: this.name,
-                title: `${t.title}`,
+                title: t.title,
                 time: t.pubDate,
                 seeds: 1000,
                 peers: 1000,


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

无

## 完整路由地址 / Example for the proposed route(s)

```routes
/1point3acres/post/hot
/36kr/motif/452
/aliyun/developer/group/alitech
/asahi
/av01/actor/七沢みあ
/av01/tag/中出し
/avgle/videos
/axis-studios/work/full-service-cg-production 
/bangumi/calendar/today
/bangumi/group/boring 
/bangumi/subject/240038
/behance/mishapetrick 
/bilibili/blackboard
/bilibili/user/dynamic/2267573
/bilibili/user/followings/2267573
/bilibili/link/news/live
/bilibili/partion/ranking/171/3
/bilibili/partion/33
/bilibili/weekly
/bjnews/epaper/A 
/blow-studio
/blur-studio
/chinafile/all
/coolapk/dyh/1524
/coolapk/tuwen
/coronavirus/sg-moh
/digic-pictures/works/real-time-engine
/digitaling/articles/latest
/douban/channel/30168934/subject/0
/douban/topic/48823
/douban/explore
/douban/people/62759792/status
/douban/people/exherb/wish/torrentProvider=1337x
/dxy/vaccine/北京
/fanbox/otomeoto
/hhgal
/github/starred_repos/DIYgod
/github/topics/framework
/gov/moa/sjzxfb
/gov/province/jiangsu/important-news
/gov/taiwan/mnd
/gracg/user11968EIcqS3
/guancha
/guancha/personalpage/243983
/hinatazaka46/blog
/hkepc/news
/hket/sran001
/huxiu/collection/212
/ieee/author/37283006000/newest/10
/imaijia/category/xls
/jandan/pic
/japanpost/track/EJ123456789JP/ja
/jike/user/3EE02BC9-C5B3-4209-8750-4ED1EE0F67BB
/jinritoutiao/keyword/AI
/juejin/category/frontend
/juejin/tag/架构
/juejin/trending/ios/monthly
/juejin/books
/juejin/pins/6824710202487472141
/juejin/posts/3051900006845944
/juejin/collections/1697301682482439
/juejin/collection/6845243180586123271
/juejin/shares/56852b2460b2a099cdc1d133
/keyakizaka46/blog
/kongfz/people/5032170
/latepost
/leetcode/submission/us/nathandai
/lfsyd/1
/lizhi/user/27151442948222380
/mastodon/account_id/mastodon.social/23634/statuses/only_media
/mastodon/acct/CatWhitney@mastodon.social/statuses
/matataki/posts/hot
/matataki/posts/latest/ipfs
/matataki/users/9/posts
/matataki/tokens/22/posts/3
/matataki/tags/150/区块链/posts
/matataki/users/3017/favorites/155/posts
/meipai/user/56537299
/method-studios/games
/mi/golden
/miniflux/subscription/categories=科技,影音
/miniflux/feeds=1&2&3/mark=read&limit=7&status=unread
/mp4ba/6
/mp4er
/mpaypass/news
/natgeo/environment/article
/neea/gaokao
/notefolio
/novel/ptwxz/10/10272
/novel/wenxuemi/6/6144
/parcel/hermesuk/[tracking number]
/pcr/news-cn
/pediy/topic/android/digest
/pgyer/kz-test
/pianyuan
/pixiv/user/bookmarks/15288095
/pixiv/ranking/week
/popiask/popi6666
/ps/product/UP9000-CUSA00552_00-THELASTOFUS00000
/sakurazaka46/blog
/showroom/room/93401
/shuhui/comics/1
/siren/news
/sketch/updates
/smzdm/keyword/女装
/soul/posts/hot/NXJiSlM5V21kamJWVlgvZUh1NEExdz09
/soul/Y2w2aTNWQVBLOU09
/ssmh
/ssmh/category/6
/sspai/activity/d0u947vr
/cninfo/announcement/szse/000002/gssz0000002/category_ndbg_szsh
/taptap/changelog/142793
/tencentvideo/playlist/jx7g4sm320sqm7i
/wechat/csm/huxiu_com
/wechat/feeds/MzIwMzAwMzQxNw==
/weixin/miniprogram/devtools
/weixin/miniprogram/framework
/weixin/miniprogram/wxcloud/cloud-sdk
/wechat/mp/homepage/MzA3MDM3NjE5NQ==/16
/wechat/mp/msgalbum/MzA3MDM3NjE5NQ==/1375870284640911361
/wechat-open/community/xyx-question/0
/wechat-open/community/xcx-question/new
/thepaper/839studio/2
/tieba/post/5853240586
/tingshuitz/dalian
/tingshuitz/wuhan
/tuicool/mags/tech
/uisdc/zt/design-history
/unit-image/films/vfx
/bjtu/gs/all
/bupt/yz/int
/hbut/cs/xwdt
/hbut/news/tzgg
/jnu/yw/tt
/nku/jwc/1
/sctu/jwc/13
/sustech/newshub-zh
/szu/yz/1
/ustc/jwc/info
/wtu/2
/zju/career/1
/zju/grs/1
/zju/physics/1
/zzuli/campus/0
/zzuli/yjsc/0
/voa/cantonese/zprtie-ttp 
weatheralarm/广东省
/weibo/timeline/3306934123
/wukong/user/5826687196
/xiaohongshu/board/5db6f79200000000020032df
/xiaohongshu/user/593032945e87e77791e03696/album
/xiaohongshu/user/593032945e87e77791e03696/notes
/xuangubao/subject/41
/yande.re/post/popular_recent
/zfrontier/board/56
/zfrontier/postlist/:byReplyTime
/zhihu/collection/26444956
/zhihu/posts/people/frederchen
/zyshow/chongchongchong
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

### 消除无意义的模板字符串格式

添加ESLint规则no-implicit-coercion，并配置`"disallowTemplateShorthand": true`，可自动检查和修改无意义的模板字符串。

本PR未使用`eslint --fix`，因为自动修改会把所有有问题的模板字符串用`String()`包括起来，多数情况不使用`String()`已经可以得到字符串，所以采用手动改写的方式。

个人脑容量有限，遇到一些可读性不是那么高的代码（比如多层三元运算符嵌套）我进行了一下重构，使得可读性好一点点。