### PR TITLE
feat(route): add 台灣衛生福利部即時新聞澄清

### DIFF
--- a/docs/government.md
+++ b/docs/government.md
@@ -210,6 +210,12 @@ pageClass: routes
 
 <Route author="EsuRt" example="/gov/suzhou/doc" path="/gov/suzhou/doc"/>
 
+## 台灣衛生福利部
+
+### 即時新聞澄清
+
+<Route author="nczitzk" example="/mohw/clarification" path="/mohw/clarification"/>
+
 ## 武汉东湖新技术开发区
 
 ### 新闻中心

--- a/lib/router.js
+++ b/lib/router.js
@@ -4249,4 +4249,8 @@ router.get('/hket/:category?', lazyloadRouteHandler('./routes/hket/index'));
 // s-hentai
 router.get('/s-hentai/:id?', lazyloadRouteHandler('./routes/s-hentai'));
 
+// 台灣衛生福利部
+router.get('/mohw/clarification', lazyloadRouteHandler('./routes/gov/taiwan/mohw'));
+router.get('/mohw', lazyloadRouteHandler('./routes/gov/taiwan/mohw'));
+
 module.exports = router;

--- a/lib/routes/gov/taiwan/mohw.js
+++ b/lib/routes/gov/taiwan/mohw.js
@@ -1,0 +1,50 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const rootUrl = 'https://www.mohw.gov.tw';
+    const currentUrl = `${rootUrl}/lp-17-1.html`;
+
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+    });
+
+    const $ = cheerio.load(response.data);
+
+    const list = $('.list01 a[title]')
+        .map((_, item) => {
+            item = $(item);
+
+            return {
+                title: item.text(),
+                link: item.attr('href'),
+            };
+        })
+        .get();
+
+    const items = await Promise.all(
+        list.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const detailResponse = await got({
+                    method: 'get',
+                    url: item.link,
+                });
+
+                const content = cheerio.load(detailResponse.data);
+
+                item.description = content('article').html();
+                item.pubDate = parseDate(content('meta[name="DC.Date"]').attr('datetime'));
+
+                return item;
+            })
+        )
+    );
+
+    ctx.state.data = {
+        title: '即時新聞澄清 - 台灣衛生福利部',
+        link: currentUrl,
+        item: items,
+    };
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8203

## 完整路由地址 / Example for the proposed route(s)

```routes
/mohw/clarification
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [x] CN
  - [ ] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
