### PR TITLE
fix(route): 修复IMAP邮箱环境变量命名

### DIFF
--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -519,8 +519,8 @@ See docs of specified route and `lib/config.js` for detail information.
 -   mail:
 
     -   `EMAIL_CONFIG_{email}`: Mail setting, replace `{email}` with the email account, replace `@` in email account with `.`, eg. `EMAIL_CONFIG_xxx.gmail.com`. The value is in the format of `password=password&host=server&port=port`, eg:
-        -   Linux env: `EMAIL_CONFIG_xxx.qq.com="password=123456&host=imap.qq.com&port=993"`
-        -   docker env: `EMAIL_CONFIG_xxx.qq.com=password=123456&host=imap.qq.com&port=993`, please do not include quotations `'`,`"`
+        -   Linux env: `EMAIL_CONFIG_xxx_qq_com="password=123456&host=imap.qq.com&port=993"`
+        -   docker env: `EMAIL_CONFIG_xxx_qq_com=password=123456&host=imap.qq.com&port=993`, please do not include quotations `'`,`"`
 
 -   nhentai torrent: [Registration](https://nhentai.net/register/)
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -551,8 +551,8 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 -   邮箱 邮件列表路由：
 
     -   `EMAIL_CONFIG_{email}`: 邮箱设置，替换 `{email}` 为 邮箱账号，邮件账户的 `@` 替换为 `.`，例如 `EMAIL_CONFIG_xxx.qq.com`。Linux 内容格式为 `password=密码&host=服务器&port=端口`，docker 内容格式为 `password=密码\&host=服务器\&port=端口`，例如：
-        -   Linux 环境变量：`EMAIL_CONFIG_xxx.qq.com="password=123456&host=imap.qq.com&port=993"`
-        -   docker 环境变量：`EMAIL_CONFIG_xxx.qq.com=password=123456\&host=imap.qq.com\&port=993`，请勿添加引号 `'`，`"`。
+        -   Linux 环境变量：`EMAIL_CONFIG_xxx_qq_com="password=123456&host=imap.qq.com&port=993"`
+        -   docker 环境变量：`EMAIL_CONFIG_xxx_qq_com=password=123456\&host=imap.qq.com\&port=993`，请勿添加引号 `'`，`"`。
 
 -   吹牛部落 栏目更新
 

--- a/lib/routes/mail/imap.js
+++ b/lib/routes/mail/imap.js
@@ -13,7 +13,7 @@ module.exports = async (ctx) => {
             host: '',
             port: 993,
         },
-        queryString.parse(config.email.config[email.replace('@', '.')])
+        queryString.parse(config.email.config[email.replaceAll(/[@.]/g, '_')])
     );
 
     if (!mailConfig.username || !mailConfig.password || !mailConfig.host || !mailConfig.port) {

--- a/lib/routes/mail/imap.js
+++ b/lib/routes/mail/imap.js
@@ -13,7 +13,7 @@ module.exports = async (ctx) => {
             host: '',
             port: 993,
         },
-        queryString.parse(config.email.config[email.replaceAll(/[@.]/g, '_')])
+        queryString.parse(config.email.config[email.replace(/[@.]/g, '_')])
     );
 
     if (!mailConfig.username || !mailConfig.password || !mailConfig.host || !mailConfig.port) {


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8064 

## 完整路由地址 / Example for the proposed route(s)

```routes
/mail/imap/:email
```

## 说明 / Note
将环境变量命名中出现的 `.` 都替换成 `_`，避免 docker-compose 部署时无法获取环境变量。
本地测试通过。