### PR TITLE
fix(route): dekudeals error due to ad

### DIFF
--- a/lib/routes/dekudeals/index.js
+++ b/lib/routes/dekudeals/index.js
@@ -12,7 +12,7 @@ module.exports = async (ctx) => {
     const $ = cheerio.load(response.data);
 
     const title = $('#search-title').text();
-    const list = $('.search-main > .item-grid2 > div');
+    const list = $('.search-main > .item-grid2 > div.cell');
 
     const out = await Promise.all(
         list


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

N/A

## 完整路由地址 / Example for the proposed route(s)

```routes
/dekudeals/most-wanted 
```

## 说明 / Note
An ad on the page causes an error when generating the feed. This changes the selector to only get the game items and ignore the ad.

Ad in middle of page:
![Screenshot_2021-09-18_10-57-26](https://user-images.githubusercontent.com/96819/133896533-9276fcb6-a7bc-42cb-a4de-c7c4fcdea67c.png)

Error:
![Screenshot_2021-09-18_10-59-16](https://user-images.githubusercontent.com/96819/133896536-228fd9b4-bfc7-4f34-bff7-6b01f58bdbcd.png)

