### PR TITLE
fix(route): university - 哈尔滨工程大学 /heu/uae/*

### DIFF
--- a/lib/routes/universities/heu/job.js
+++ b/lib/routes/universities/heu/job.js
@@ -64,7 +64,7 @@ module.exports = async (ctx) => {
                 const single = {
                     title: titleList[index],
                     link: itemUrl,
-                    description: '此链接为文件，请点击下载',
+                    description: '本文需跳转，请点击标题后阅读',
                     pubDate: dateList[index],
                 };
                 return Promise.resolve(single);

--- a/lib/routes/universities/heu/news.js
+++ b/lib/routes/universities/heu/news.js
@@ -64,7 +64,7 @@ module.exports = async (ctx) => {
                 const single = {
                     title: titleList[index],
                     link: itemUrl,
-                    description: '此链接为跳转，点击标题查看',
+                    description: '本文需跳转，请点击标题后阅读',
                     pubDate: dateList[index],
                 };
                 return Promise.resolve(single);

--- a/lib/routes/universities/heu/uae.js
+++ b/lib/routes/universities/heu/uae.js
@@ -56,10 +56,7 @@ module.exports = async (ctx) => {
                     title: titleList[index],
                     link: itemUrl,
                     description: $('.wp_articlecontent')
-                        .html()
-                        .replace(/src="\//g, `src="${url.resolve(baseUrl, '.')}`)
-                        .replace(/href="\//g, `href="${url.resolve(baseUrl, '.')}`)
-                        .trim(),
+                        .html(),
                     pubDate: dateList[index],
                 };
                 ctx.cache.set(itemUrl, JSON.stringify(single));
@@ -68,7 +65,7 @@ module.exports = async (ctx) => {
                 const single = {
                     title: titleList[index],
                     link: itemUrl,
-                    description: '此链接为文件，请点击下载',
+                    description: '本文需跳转，点击标题跳转',
                     pubDate: dateList[index],
                 };
                 return Promise.resolve(single);

--- a/lib/routes/universities/heu/uae.js
+++ b/lib/routes/universities/heu/uae.js
@@ -65,7 +65,7 @@ module.exports = async (ctx) => {
                 const single = {
                     title: titleList[index],
                     link: itemUrl,
-                    description: '本文需跳转，点击标题跳转',
+                    description: '本文需跳转，请点击标题后阅读',
                     pubDate: dateList[index],
                 };
                 return Promise.resolve(single);

--- a/lib/routes/universities/heu/yjsy.js
+++ b/lib/routes/universities/heu/yjsy.js
@@ -76,7 +76,7 @@ module.exports = async (ctx) => {
                 const single = {
                     title: titleList[index],
                     link: itemUrl,
-                    description: '此链接为文件，请点击下载',
+                    description: '本文需跳转，请点击标题后阅读',
                     pubDate: dateList[index],
                 };
                 return Promise.resolve(single);


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/heu/uae/xwdt
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

### fix(route): university - 哈尔滨工程大学

删除了`/lib/routes/heu/uae.js`中`line 60 - 62`代码——该部分用于格式化`html`，主要是为了去除空行以及转换链接。

原代码中使用`.replace()`与`.trim()`会报如下错误：
```
Route requested: /heu/uae/xwdt
Error message: TypeError: Cannot read property 'replace' of null
    at Promise.all.urlList.map (/home/RSSHub/lib/routes/universities/heu/uae.js:67:29)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

在调试过程(修改`require`路径、`async`部分，直接使用`node`命令：`node /RSSHub/lib/routes/universities/heu/uae.js`查看各部分输出)中发现，[line 60](https://github.com/DIYgod/RSSHub/blob/a7635464d29003bf9d14e27ad43734db79598fe1/lib/routes/universities/heu/uae.js#L60)中的`.replace()`可以成功运行(对比了结果，替换内容正确)，

而使用`yarn dev`调试时，仍旧报错，因为无法定位到错误提示中的`null`，所以删除该部分语句，恢复`/heu/uae/xwdt`基本功能。
