### PR TITLE
feat(router): ccac 澳门廉政公署

### DIFF
--- a/docs/en/government.md
+++ b/docs/en/government.md
@@ -20,7 +20,18 @@ pageClass: routes
 
 ### Press Releases
 
-<Route author="linbuxiao" example="/icac/news/sc" path="/icac/news/:lang?" :paramsDesc="['Language, default to `sc`. Supprot `en`(English), `sc`(Simplified Chinese) and `tc`(Traditional Chinese)']">
+<RouteEn author="linbuxiao" example="/icac/news/sc" path="/icac/news/:lang?" :paramsDesc="['Language, default to `sc`. Supprot `en`(English), `sc`(Simplified Chinese) and `tc`(Traditional Chinese)']"/>
+
+## Macau Independent Commission Against Corruption
+
+### Latest News
+
+<RouteEn author="linbuxiao" example="/ccac/news/all" path="/ccac/news/:type/:lang?" :paramsDesc="['Category', 'Language, default to `sc`. Supprot `en`(English), `sc`(Simplified Chinese), `tc`(Traditional Chinese) and `pt`(Portuguese)']"/>
+Category
+
+| All  | Detected Cases | Investigation Reports or Recommendations  | Annual Reports | CCAC's Updates |
+| ---- | -------------- | ----------------------------------------- | -------------- | -------------- |
+| all  | case           | Persuasion                                | AnnualReport   | PCANews        |
 
 ## Ministry of Foreign Affairs of Japan
 

--- a/docs/en/government.md
+++ b/docs/en/government.md
@@ -26,12 +26,14 @@ pageClass: routes
 
 ### Latest News
 
-<RouteEn author="linbuxiao" example="/ccac/news/all" path="/ccac/news/:type/:lang?" :paramsDesc="['Category', 'Language, default to `sc`. Supprot `en`(English), `sc`(Simplified Chinese), `tc`(Traditional Chinese) and `pt`(Portuguese)']"/>
+<RouteEn author="linbuxiao" example="/ccac/news/all" path="/ccac/news/:type/:lang?" :paramsDesc="['Category', 'Language, default to `sc`. Supprot `en`(English), `sc`(Simplified Chinese), `tc`(Traditional Chinese) and `pt`(Portuguese)']">
 Category
 
 | All  | Detected Cases | Investigation Reports or Recommendations  | Annual Reports | CCAC's Updates |
 | ---- | -------------- | ----------------------------------------- | -------------- | -------------- |
 | all  | case           | Persuasion                                | AnnualReport   | PCANews        |
+
+</RouteEn>
 
 ## Ministry of Foreign Affairs of Japan
 

--- a/docs/government.md
+++ b/docs/government.md
@@ -238,7 +238,17 @@ pageClass: routes
 
 ### 新闻公布
 
-<Route author="linbuxiao" example="/icac/news/sc" path="/icac/news/:lang?" :paramsDesc="['语言，留空为`sc`，支持`sc`（简中），`tc`（繁中），`en`（英文）']">
+<Route author="linbuxiao" example="/icac/news/sc" path="/icac/news/:lang?" :paramsDesc="['语言，留空为`sc`，支持`sc`（简中），`tc`（繁中），`en`（英文）']"/>
+
+## 澳门廉政公署
+
+### 最新消息
+
+<Route author="linbuxiao" example="/ccac/news/all" path="/ccac/news/:type/:lang?" :paramsDesc="['类别', '语言，留空为`sc`，支持`sc`（简中），`tc`（繁中），`en`（英文）'，`pt`（葡萄牙文）]"/>
+
+| 全部  | 案件发布 | 调查报告或勘喻  | 年度报告        | 公署消息    |
+| ---- | ------- | ------------ | -------------  | --------- |
+| all  | case    | Persuasion   | AnnualReport   | PCANews   |
 
 ## 中国工业和信息化部
 

--- a/docs/government.md
+++ b/docs/government.md
@@ -244,7 +244,7 @@ pageClass: routes
 
 ### 最新消息
 
-<Route author="linbuxiao" example="/ccac/news/all" path="/ccac/news/:type/:lang?" :paramsDesc="['类别', '语言，留空为`sc`，支持`sc`（简中），`tc`（繁中），`en`（英文）'，`pt`（葡萄牙文）]"/>
+<Route author="linbuxiao" example="/ccac/news/all" path="/ccac/news/:type/:lang?" :paramsDesc="['类别', '语言，留空为`sc`，支持`sc`（简中），`tc`（繁中），`en`（英文），`pt`（葡萄牙文）']"/>
 
 | 全部  | 案件发布 | 调查报告或勘喻  | 年度报告        | 公署消息    |
 | ---- | ------- | ------------ | -------------  | --------- |

--- a/docs/government.md
+++ b/docs/government.md
@@ -244,11 +244,13 @@ pageClass: routes
 
 ### 最新消息
 
-<Route author="linbuxiao" example="/ccac/news/all" path="/ccac/news/:type/:lang?" :paramsDesc="['类别', '语言，留空为`sc`，支持`sc`（简中），`tc`（繁中），`en`（英文），`pt`（葡萄牙文）']"/>
+<Route author="linbuxiao" example="/ccac/news/all" path="/ccac/news/:type/:lang?" :paramsDesc="['类别', '语言，留空为`sc`，支持`sc`（简中），`tc`（繁中），`en`（英文），`pt`（葡萄牙文）']">
 
 | 全部  | 案件发布 | 调查报告或勘喻  | 年度报告        | 公署消息    |
 | ---- | ------- | ------------ | -------------  | --------- |
 | all  | case    | Persuasion   | AnnualReport   | PCANews   |
+
+</Route>
 
 ## 中国工业和信息化部
 

--- a/lib/v2/ccac/maintainer.js
+++ b/lib/v2/ccac/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/news/:type/:lang?': ['linbuxiao'],
+};

--- a/lib/v2/ccac/news.js
+++ b/lib/v2/ccac/news.js
@@ -3,32 +3,25 @@ const { parseDate } = require('@/utils/parse-date');
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 
-const TYPE = {
-    case: '案件發佈',
-    Persuasion: '調查報告或勸喻',
-    AnnualReport: '年度報告',
-    PCANews: '公署消息',
-};
-
 module.exports = async (ctx) => {
     const browser = await require('@/utils/puppeteer')();
     const lang = ctx.params.lang || 'sc';
-    const type = TYPE[ctx.params.type];
+    const type = utils.TYPE[ctx.params.type];
 
     const BASE = utils.langBase(lang);
     const page = await browser.newPage();
     await page.goto(BASE);
     const articles = await page.evaluate(() => window.articles);
-    const list = articles
-        .filter((item) => item.tags.some((tag) => tag.name === TYPE[ctx.params.type]))
+
+    const list = utils
+        .typeFilter(articles, type)
         .slice(0, 11)
         .map((item) => ({
             title: item.name,
-            category: item.tags.join(','),
+            category: item.tags.map((tag) => tag.name).join(','),
             link: utils.BASE_URL + item.url,
-            pubDate: parseDate(item.time, 'YYYY-DD-MM'),
+            pubDate: parseDate(item.time, 'YYYY-MM-DD'),
         }));
-
     const items = await Promise.all(
         list.map((item) =>
             ctx.cache.tryGet(item.link, async () => {
@@ -38,11 +31,12 @@ module.exports = async (ctx) => {
                 });
 
                 const $ = cheerio.load(detailResponse.data);
+                $('.article_details_body > *').removeAttr('style');
                 item.description = $('.article_details_body').html();
+                return item;
             })
         )
     );
-
     ctx.state.data = {
         title: `CCAC ${type}`,
         link: BASE,

--- a/lib/v2/ccac/news.js
+++ b/lib/v2/ccac/news.js
@@ -1,0 +1,53 @@
+const utils = require('./utils');
+const { parseDate } = require('@/utils/parse-date');
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+
+const TYPE = {
+    case: '案件發佈',
+    Persuasion: '調查報告或勸喻',
+    AnnualReport: '年度報告',
+    PCANews: '公署消息',
+};
+
+module.exports = async (ctx) => {
+    const browser = await require('@/utils/puppeteer')();
+    const lang = ctx.params.lang || 'sc';
+    const type = TYPE[ctx.params.type];
+
+    const BASE = utils.langBase(lang);
+    const page = await browser.newPage();
+    await page.goto(BASE);
+    const articles = await page.evaluate(() => window.articles);
+    const list = articles
+        .filter((item) => item.tags.some((tag) => tag.name === TYPE[ctx.params.type]))
+        .slice(0, 11)
+        .map((item) => ({
+            title: item.name,
+            category: item.tags.join(','),
+            link: utils.BASE_URL + item.url,
+            pubDate: parseDate(item.time, 'YYYY-DD-MM'),
+        }));
+
+    const items = await Promise.all(
+        list.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const detailResponse = await got({
+                    method: 'get',
+                    url: item.link,
+                });
+
+                const $ = cheerio.load(detailResponse.data);
+                item.description = $('.article_details_body').html();
+            })
+        )
+    );
+
+    ctx.state.data = {
+        title: `CCAC ${type}`,
+        link: BASE,
+        description: `CCAC ${type}`,
+        language: ctx.params.lang ? utils.LANG_TYPE[ctx.params.lang] : utils.LANG_TYPE.sc,
+        item: items,
+    };
+};

--- a/lib/v2/ccac/news.js
+++ b/lib/v2/ccac/news.js
@@ -5,7 +5,7 @@ const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
     const browser = await require('@/utils/puppeteer')();
-    const lang = ctx.params.lang || 'sc';
+    const lang = ctx.params.lang ?? 'sc';
     const type = utils.TYPE[ctx.params.type];
 
     const BASE = utils.langBase(lang);

--- a/lib/v2/ccac/radar.js
+++ b/lib/v2/ccac/radar.js
@@ -4,7 +4,7 @@ module.exports = {
         '.': [
             {
                 title: '最新消息',
-                docs: 'https://docs.rsshub.app/government.html#xiang-gang-lian-zheng-gong-shu',
+                docs: 'https://docs.rsshub.app/government.html#ao-men-lian-zheng-gong-shu',
                 source: ['/:lang/news.html'],
                 target: '/ccac/news/all/:lang',
             },

--- a/lib/v2/ccac/radar.js
+++ b/lib/v2/ccac/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'ccac.org.mo': {
+        _name: '澳门廉政公署',
+        '.': [
+            {
+                title: '最新消息',
+                docs: 'https://docs.rsshub.app/government.html#xiang-gang-lian-zheng-gong-shu',
+                source: ['/:lang/news.html'],
+                target: '/ccac/news/all/:lang',
+            },
+        ],
+    },
+};

--- a/lib/v2/ccac/router.js
+++ b/lib/v2/ccac/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/news/:type/:lang?', require('./news'));
+};

--- a/lib/v2/ccac/utils.js
+++ b/lib/v2/ccac/utils.js
@@ -1,4 +1,4 @@
-const BASE_URL = 'https://www.icac.org.hk';
+const BASE_URL = 'https://www.ccac.org.mo';
 
 const LANG_TYPE = {
     en: 'en-US',
@@ -7,11 +7,11 @@ const LANG_TYPE = {
 };
 
 function langBase(lang) {
-    return lang ? `${BASE_URL}/${lang}` : `https://www.icac.org.hk/sc`;
+    return `${BASE_URL}/${lang}/news.html`;
 }
 
 module.exports = {
-    LANG_TYPE,
     BASE_URL,
+    LANG_TYPE,
     langBase,
 };

--- a/lib/v2/ccac/utils.js
+++ b/lib/v2/ccac/utils.js
@@ -1,17 +1,32 @@
 const BASE_URL = 'https://www.ccac.org.mo';
 
 const LANG_TYPE = {
-    en: 'en-US',
-    sc: 'zh-CN',
-    tc: 'zh-HK',
+    en: 'en-us',
+    sc: 'zh-cn',
+    tc: 'zh-hk',
+    pt: 'pt',
+};
+
+const TYPE = {
+    all: '全部',
+    case: '案件發佈',
+    Persuasion: '調查報告或勸喻',
+    AnnualReport: '年度報告',
+    PCANews: '公署消息',
 };
 
 function langBase(lang) {
     return `${BASE_URL}/${lang}/news.html`;
 }
 
+function typeFilter(list, type) {
+    return type === '全部' ? list : list.filter((item) => item.tags.some((tag) => tag.name === type));
+}
+
 module.exports = {
+    TYPE,
     BASE_URL,
     LANG_TYPE,
     langBase,
+    typeFilter,
 };

--- a/lib/v2/icac/news.js
+++ b/lib/v2/icac/news.js
@@ -11,8 +11,8 @@ module.exports = async (ctx) => {
     const list = $('.pressItem.clearfix')
         .map((_, e) => {
             const c = cheerio.load(e);
-
             return {
+                title: c('.hd a').text(),
                 link: `${utils.BASE_URL}${c('.hd a').attr('href')}`,
             };
         })
@@ -30,7 +30,6 @@ module.exports = async (ctx) => {
                 c('.col-3-wrap.clearfix.pressPhoto div').removeAttr('class');
                 const des = c('.pressContent.full').html();
                 const thumbs = c('.col-3-wrap.clearfix.pressPhoto').html() ?? '';
-                item.title = c('h2').text().trim();
                 item.pubDate = parseDate(decodeURI(c('.date').text().trim()), ['YYYY年MM月DD日', 'YYYY年MM月D日', 'YYYY年M月DD日', 'YYYY年M月D日'], true);
                 item.description = des + thumbs;
                 return item;

--- a/lib/v2/icac/news.js
+++ b/lib/v2/icac/news.js
@@ -39,7 +39,7 @@ module.exports = async (ctx) => {
     );
     ctx.state.data = {
         title: 'ICAC 新闻公布',
-        link: 'https://www.icac.org.hk/tc/press/index.html',
+        link: `${BASE_WITH_LANG}/press/index.html`,
         description: 'ICAC 新闻公布',
         language: ctx.params.lang ? utils.LANG_TYPE[ctx.params.lang] : utils.LANG_TYPE.sc,
         item: items,

--- a/lib/v2/icac/utils.js
+++ b/lib/v2/icac/utils.js
@@ -1,9 +1,9 @@
 const BASE_URL = 'https://www.icac.org.hk';
 
 const LANG_TYPE = {
-    en: 'en-US',
-    sc: 'zh-CN',
-    tc: 'zh-HK',
+    en: 'en-us',
+    sc: 'zh-cn',
+    tc: 'zh-hk',
 };
 
 function langBase(lang) {


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8251

## 完整路由地址 / Example for the proposed route(s)

```routes
/ccac/news/all
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [x] CN
  - [x] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [x] `Puppeteer`

## 说明 / Note
1. Added Macau ICAC `router`. Since the page data is stored directly in `js` and the specific category cannot be determined by `url`. Use `puppeteer` to get the data of the list, and then parse the article details by `cheerio`.
2. Fixed the documentation content of `/icac/news/:lang?`router. And cleaned up the way to get `title` for this route. Thanks to @TonyRL .