### PR TITLE
feat(router): timednews 时刻新闻

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -2703,3 +2703,18 @@ QueryString:
 |          | zh-hk    | zh-tw    |
 
 </Route>
+
+## 时刻新闻
+
+### 新闻
+
+<Route author="linbuxiao" example="/timednews/news" path="/timednews/news/:type?" :paramsDesc="['子分类，见下表，默认为全部']">
+
+子分类
+
+| 全部 | 时政            | 财经    | 科技        | 社会   | 体娱   | 国际           | 美国 | 中国 | 欧洲    | 评论     |
+|-----|----------------|---------|------------|-------|--------|---------------|-----|-----|--------|----------|
+| all | currentAffairs | finance | technology | social| sports | international | usa | cn  | europe | comments |
+
+</Route>
+

--- a/lib/v2/timednews/maintainer.js
+++ b/lib/v2/timednews/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/news/:type?': ['linbuxiao'],
+};

--- a/lib/v2/timednews/news.js
+++ b/lib/v2/timednews/news.js
@@ -1,0 +1,106 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+
+const BASE = 'https://www.timednews.com/topic';
+
+const PATH_LIST = {
+    all: {
+        name: '全部',
+        path: 'cat/1.html',
+    },
+    currentAffairs: {
+        name: '时政',
+        path: 'subcat/1.html',
+    },
+    finance: {
+        name: '财经',
+        path: 'subcat/2.html',
+    },
+    technology: {
+        name: '科技',
+        path: 'subcat/3.html',
+    },
+    social: {
+        name: '社会',
+        path: 'subcat/4.html',
+    },
+    sports: {
+        name: '体娱',
+        path: 'subcat/5.html',
+    },
+    international: {
+        name: '国际',
+        path: 'subcat/6.html',
+    },
+    usa: {
+        name: '美国',
+        path: 'subcat/7.html',
+    },
+    cn: {
+        name: '中国',
+        path: 'subcat/8.html',
+    },
+    europe: {
+        name: '欧洲',
+        path: 'subcat/9.html',
+    },
+    comments: {
+        name: '评论',
+        path: 'subcat/14.html',
+    },
+};
+
+module.exports = async (ctx) => {
+    const type = ctx.params.type ?? 'all';
+    const url = `${BASE}/${PATH_LIST[type].path}`;
+    const res = await got({
+        method: 'get',
+        url,
+    });
+
+    const $ = cheerio.load(res.data);
+
+    const list = $('#content li')
+        .map((i, e) => {
+            const c = cheerio.load(e);
+            return {
+                title: c('a').text().trim(),
+                link: c('a').attr('href'),
+            };
+        })
+        .get();
+
+    const items = await Promise.all(
+        list.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const detailResponse = await got({
+                    method: 'get',
+                    url: item.link,
+                });
+
+                const c = cheerio.load(detailResponse.data, { decodeEntities: false });
+                c('.event .twitter').remove();
+                item.pubDate = parseDate(c('.datetime #publishdate').text(), 'YYYY-MM-DD');
+                item.author = c('.datetime #author').text();
+                item.description = c('.event').html();
+
+                return item;
+            })
+        )
+    );
+
+    ctx.state.data = {
+        title: '时刻新闻',
+        link: url,
+        description: `时刻新闻 ${PATH_LIST[type].name}`,
+        item: items,
+    };
+
+    ctx.state.json = {
+        title: '时刻新闻',
+        link: url,
+        description: `时刻新闻 ${PATH_LIST[type].name}`,
+        item: items,
+    };
+};

--- a/lib/v2/timednews/radar.js
+++ b/lib/v2/timednews/radar.js
@@ -1,0 +1,57 @@
+module.exports = {
+    'timednews.com': {
+        _name: '时刻新闻',
+        '.': [
+            {
+                title: '新闻',
+                docs: 'https://docs.rsshub.app/new-media.html#shi-ke-xin-wen',
+                source: ['/topic/:type/:id'],
+                target: ({ type, id }) => {
+                    let name = '';
+                    if (type === 'cat') {
+                        if (id === '1') {
+                            name = 'all';
+                        }
+                    } else if (type === 'subcat') {
+                        switch (id) {
+                            case '1':
+                                name = 'currentAffairs';
+                                break;
+                            case '2':
+                                name = 'finance';
+                                break;
+                            case '3':
+                                name = 'technology';
+                                break;
+                            case '4':
+                                name = 'social';
+                                break;
+                            case '5':
+                                name = 'sports';
+                                break;
+                            case '6':
+                                name = 'international';
+                                break;
+                            case '7':
+                                name = 'usa';
+                                break;
+                            case '8':
+                                name = 'cn';
+                                break;
+                            case '9':
+                                name = 'europe';
+                                break;
+                            case '14':
+                                name = 'comments';
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
+                    return `/news/${name}`;
+                },
+            },
+        ],
+    },
+};

--- a/lib/v2/timednews/radar.js
+++ b/lib/v2/timednews/radar.js
@@ -49,7 +49,7 @@ module.exports = {
                         }
                     }
 
-                    return `/news/${name}`;
+                    return `/timednews/news/${name}`;
                 },
             },
         ],

--- a/lib/v2/timednews/router.js
+++ b/lib/v2/timednews/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/news/:type?', require('./news'));
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8271

## 完整路由地址 / Example for the proposed route(s)

```routes
/timednews/news
/timednews/news/all
/timednews/news/currentAffairs
/timednews/news/finance
/timednews/news/technology
/timednews/news/social
/timednews/news/sports
/timednews/news/international
/timednews/news/usa
/timednews/news/cn
/timednews/news/europe
/timednews/news/comments
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [x] CN
  - [ ] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
时刻新闻 - 新闻
支持子分类