### PR TITLE
fix(route): 字幕库新域名

### DIFF
--- a/lib/routes/zimuku/index.js
+++ b/lib/routes/zimuku/index.js
@@ -3,7 +3,7 @@ const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
     const { type = 'mv' } = ctx.params;
-    const baseUrl = 'http://www.zimuku.la';
+    const baseUrl = 'https://www.zimuku.org';
     const url = `${baseUrl}/newsubs?t=${type}`;
     const response = await got(url);
     const $ = cheerio.load(response.data);


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```
/zimuku
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
字幕库启用了新域名 `www.zimuku.org`