### PR TITLE
feat(router): third-party

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -13,6 +13,7 @@ const cache = require('./middleware/cache');
 const parameter = require('./middleware/parameter');
 const template = require('./middleware/template');
 const favicon = require('koa-favicon');
+const bodyparser = require('koa-bodyparser');
 const debug = require('./middleware/debug');
 const accessControl = require('./middleware/access-control');
 const antiHotlink = require('./middleware/anti-hotlink');
@@ -37,6 +38,8 @@ app.proxy = true;
 
 // favicon
 app.use(favicon(__dirname + '/favicon.png'));
+
+app.use(bodyparser());
 
 // global error handing
 app.use(onerror);

--- a/lib/v2/third-party/index.js
+++ b/lib/v2/third-party/index.js
@@ -1,0 +1,5 @@
+module.exports = (ctx) => {
+    // 接收一个post请求。格式为raw/json
+    // koa-bodyparser会解析为对象，直接返回即可
+    ctx.state.data = ctx.request.body;
+};

--- a/lib/v2/third-party/router.js
+++ b/lib/v2/third-party/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.post('/', require('./index'));
+};

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "json5": "2.2.0",
     "koa": "2.13.1",
     "koa-basic-auth": "4.0.0",
+    "koa-bodyparser": "^4.3.0",
     "koa-favicon": "2.1.0",
     "koa-mount": "4.0.0",
     "lru-cache": "6.0.0",


### PR DESCRIPTION
#8236 

path: `/third-party`
method: `POST`
content-type: `application/json`
`dep`: `koa-bodyparser` 解析`post`请求体

目前想法是第三方路由的支持并不包含解析部分。只暴露一个接口，将抛来的对象转化为`xml`返回。

优点在于：
1. 与目前的路由不冲突，作为功能性路由与其他路由同级存在。
2. 分离`parse`步骤。页面格式复杂，使用`get url ---> return xml`的形式建立内容不太现实？

