### PR TITLE
feat(route)(picuki/profile): 支持多图片/视频解析

### DIFF
--- a/lib/routes/picuki/profile.js
+++ b/lib/routes/picuki/profile.js
@@ -4,7 +4,7 @@ const chrono = require('chrono-node');
 
 module.exports = async (ctx) => {
     const id = ctx.params.id;
-    const displayVideo = ctx.params.displayVideo ? true : false;
+    const displayVideo = !!ctx.params.displayVideo;
 
     const url = `https://www.picuki.com/profile/${id}`;
 
@@ -17,27 +17,66 @@ module.exports = async (ctx) => {
 
     const list = $('ul.box-photos [data-s="media"]').get();
 
-    async function getVideo(url) {
+    async function getMedia(url) {
         const response = await got.get(url);
         const $ = cheerio.load(response.data);
-        return $('.single-photo').html();
+        // Instagram 允许最多 10 条图片/视频任意混合于一条 post，picuki 在所有情况下都会将它（们）置于 .single-photo 内
+        const media_items = $('.single-photo img,video').get();
+        let html = '';
+        media_items.forEach((item) => {
+            item = $(item);
+            html += item.toString(); // 可能是视频，也可能是图片，格式都比较友好，这里直接添加
+        });
+        return html;
+    }
+
+    function deVideo(media) {
+        const $ = cheerio.load(media);
+        const media_list = $('img,video').get();
+        let media_deVideo = '';
+        media_list.forEach((medium) => {
+            medium = $(medium);
+            const poster = medium.attr('poster');
+            // 如果有 poster 属性，表明它是视频，将它替换为它的 poster；如果不是，就原样返回
+            media_deVideo += poster ? `<img src='${poster}' alt='video poster'>` : medium.toString();
+        });
+        return media_deVideo;
     }
 
     const items = await Promise.all(
         list.map(async (post) => {
             post = $(post);
-            const isVideo = post.find('.video-icon').length !== 0 && displayVideo;
-            const post_image = post.find('.post-image').attr('src');
-            const post_description = post.find('.photo-description').text().trim();
+
             const post_link = post.find('.photo > a').attr('href');
-            const post_time = post.find('.time');
-            return {
-                title: post_description || 'Untitled',
-                author: `@${id}`,
-                description: (isVideo ? await getVideo(post_link) : `<img src="${post_image}">`) + (post_description.length > 100 ? `<p>${post_description}</p>` : ''),
-                link: post_link,
-                pubDate: post_time ? chrono.parseDate(post_time.text()) : new Date(),
-            };
+            const cache = await ctx.cache.get(post_link);
+
+            let cache_d;
+            if (cache) {
+                cache_d = JSON.parse(cache);
+            } else {
+                const post_description = post.find('.photo-description').text().trim();
+                const post_time = post.find('.time');
+                const media_displayVideo = await getMedia(post_link);
+                const media = deVideo(media_displayVideo);
+
+                cache_d = {
+                    title: post_description || 'Untitled',
+                    author: `@${id}`,
+                    media_prefix: media,
+                    media_displayVideo_prefix: media_displayVideo,
+                    description_body: post_description.length > 100 ? `<p>${post_description}</p>` : '',
+                    link: post_link,
+                    pubDate: post_time ? chrono.parseDate(post_time.text()) : new Date(),
+                };
+
+                ctx.cache.set(post_link, JSON.stringify(cache_d));
+            }
+
+            cache_d.description = (displayVideo ? cache_d.media_displayVideo_prefix : cache_d.media_prefix) + cache_d.description_body;
+            delete cache_d.media_prefix;
+            delete cache_d.media_displayVideo_prefix;
+            delete cache_d.description_body;
+            return cache_d;
         })
     );
 


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #7974

## 完整路由地址 / Example for the proposed route(s)

```routes
/picuki/profile/humansofny
/picuki/profile/humansofny/1
/picuki/profile/krisztinatina_
/picuki/profile/krisztinatina_/1
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [x] Documentation
  - [x] CN
  - [x] EN
- [x] 全文获取 fulltext **（新增）**
  - [x] Use Cache **（新增）**
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
本路由目前直接爬取 profile 页的预览图，不进入 media 页（除非设置了 `displayVideo` 则会在检测到视频时进入 media 页爬取，但如果一条含视频 post 存在多于一条媒体，则不能被检测到），导致不能爬取到多图片/视频 post。（Instagram 允许最多 10 条图片/视频任意混合于一条 post）
**这个 PR 使得本路由可以进入 media 页爬取 post 包含的所有图片/视频，并缓存爬取结果。** 由于 media 页的图片清晰度高于 profile 页的预览图，这同时也提升了爬取到的图片的清晰度。

尽管如此实现下，`displayVideo` 参数已经没有太大的存在价值，但为了不带来 breaking change，保留了这一参数，并继续保留只有它被设置时才输出视频的行为。