### PR TITLE
fix(route)(ptwxz): ptwxz add fulltext

### DIFF
--- a/lib/routes/novel/ptwxz.js
+++ b/lib/routes/novel/ptwxz.js
@@ -37,7 +37,6 @@ module.exports = async (ctx) => {
         };
     })
     .get();
-    
     const items = await Promise.all(
         chapter_item.map((item) =>
             ctx.cache.tryGet(item.link, async () => {

--- a/lib/routes/novel/ptwxz.js
+++ b/lib/routes/novel/ptwxz.js
@@ -3,6 +3,7 @@ const cheerio = require('cheerio');
 const iconv = require('iconv-lite');
 
 const baseUrl = 'https://www.ptwxz.com/bookinfo/';
+const timezone = require('@/utils/timezone');
 const { parseDate } = require('@/utils/parse-date');
 
 // 获取小说的最新章节列表

--- a/lib/routes/novel/ptwxz.js
+++ b/lib/routes/novel/ptwxz.js
@@ -3,6 +3,7 @@ const cheerio = require('cheerio');
 const iconv = require('iconv-lite');
 
 const baseUrl = 'https://www.ptwxz.com/bookinfo/';
+const { parseDate } = require('@/utils/parse-date');
 
 // 获取小说的最新章节列表
 module.exports = async (ctx) => {
@@ -24,17 +25,18 @@ module.exports = async (ctx) => {
 
     const title = $('span>h1').text();
 
-    const list = $('.grid>tbody>tr>td>li');
-
-    const chapter_item = list
-        .find('a')
-        .map((_, e) => ({
-            title: e.children[0].data,
-            link: e.attribs.href,
-            // pubDate // no date info found
-        }))
-        .get();
-
+    const chapter_item = $('#content li a')
+    .map((_, item) => {
+        item = $(item);
+        const date = item.attr('title').match(/更新时间:(.*)/)[1]; //"10-04 00:17"
+        return {
+            title: item.text(),
+            link: item.attr('href'),
+            pubDate: parseDate(date, 'MM-DD HH:mm'),
+        };
+    })
+    .get();
+    
     const items = await Promise.all(
         chapter_item.map((item) =>
             ctx.cache.tryGet(item.link, async () => {
@@ -58,6 +60,7 @@ module.exports = async (ctx) => {
                     title: item.title,
                     description,
                     link: item.link,
+                    pubDate: item.pubDate,
                 };
                 return single;
             })

--- a/lib/routes/novel/ptwxz.js
+++ b/lib/routes/novel/ptwxz.js
@@ -1,6 +1,7 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const iconv = require('iconv-lite');
+const asyncPool = require('tiny-async-pool');
 
 const baseUrl = 'https://www.ptwxz.com/bookinfo/';
 
@@ -24,24 +25,57 @@ module.exports = async (ctx) => {
 
     const title = $('span>h1').text();
 
-    const list = $('.grid>tbody>tr>td>li>a');
+    const list = $('.grid>tbody>tr>td>li');
+
+    const chapter_item = list
+        .find('a')
+        .map((_, e) => ({
+            title: e.children[0].data,
+            link: e.attribs.href,
+            // pubDate // no date info found
+        }))
+        .get();
+
+    const items = await asyncPool(3, chapter_item, async (item) => {
+        const cache = await ctx.cache.get(item.link);
+        if (cache) {
+            return Promise.resolve(JSON.parse(cache));
+        }
+
+        const response = await got({
+            method: 'get',
+            url: `https://www.ptwxz.com/${item.link}`,
+            responseType: 'buffer',
+        });
+
+        const responseHtml = iconv.decode(response.data, 'GBK');
+        const $ = cheerio.load(responseHtml);
+
+        // remove all unwanted elements
+        // TODO: cleaner solution to rip text from body
+        $('div').remove();
+        $('h1').remove();
+        $('table').remove();
+        $('center').remove();
+        $('table').remove();
+        $('script').remove();
+
+        const description = $('body').html();
+
+        const single = {
+            title: item.title,
+            description,
+            link: item.link,
+        };
+        ctx.cache.set(item.link, JSON.stringify(single));
+        return Promise.resolve(single);
+    });
+
 
     ctx.state.data = {
         title,
         link: `${baseUrl}${id}.html`,
         description: '',
-        item:
-            list &&
-            list
-                .map((index, item) => {
-                    item = $(item);
-
-                    return {
-                        title: item[0].children[0].data,
-                        description: '',
-                        link: item.attr('href'),
-                    };
-                })
-                .get(),
+        item: items,
     };
 };

--- a/lib/routes/novel/ptwxz.js
+++ b/lib/routes/novel/ptwxz.js
@@ -1,7 +1,6 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const iconv = require('iconv-lite');
-const asyncPool = require('tiny-async-pool');
 
 const baseUrl = 'https://www.ptwxz.com/bookinfo/';
 
@@ -36,41 +35,34 @@ module.exports = async (ctx) => {
         }))
         .get();
 
-    const items = await asyncPool(3, chapter_item, async (item) => {
-        const cache = await ctx.cache.get(item.link);
-        if (cache) {
-            return Promise.resolve(JSON.parse(cache));
-        }
-
-        const response = await got({
-            method: 'get',
-            url: `https://www.ptwxz.com/${item.link}`,
-            responseType: 'buffer',
-        });
-
-        const responseHtml = iconv.decode(response.data, 'GBK');
-        const $ = cheerio.load(responseHtml);
-
-        // remove all unwanted elements
-        // TODO: cleaner solution to rip text from body
-        $('div').remove();
-        $('h1').remove();
-        $('table').remove();
-        $('center').remove();
-        $('table').remove();
-        $('script').remove();
-
-        const description = $('body').html();
-
-        const single = {
-            title: item.title,
-            description,
-            link: item.link,
-        };
-        ctx.cache.set(item.link, JSON.stringify(single));
-        return Promise.resolve(single);
-    });
-
+    const items = await Promise.all(
+        chapter_item.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const response = await got({
+                    method: 'get',
+                    url: `https://www.ptwxz.com/${item.link}`,
+                    responseType: 'buffer',
+                });
+                const responseHtml = iconv.decode(response.data, 'GBK');
+                const $ = cheerio.load(responseHtml);
+                // remove all unwanted elements
+                // TODO: cleaner solution to rip text from body
+                $('div').remove();
+                $('h1').remove();
+                $('table').remove();
+                $('center').remove();
+                $('table').remove();
+                $('script').remove();
+                const description = $('body').html();
+                const single = {
+                    title: item.title,
+                    description,
+                    link: item.link,
+                };
+                return single;
+            })
+        )
+    );
 
     ctx.state.data = {
         title,

--- a/lib/routes/novel/ptwxz.js
+++ b/lib/routes/novel/ptwxz.js
@@ -33,7 +33,7 @@ module.exports = async (ctx) => {
         return {
             title: item.text(),
             link: item.attr('href'),
-            pubDate: parseDate(date, 'MM-DD HH:mm'),
+            pubDate: timezone(parseDate(date, 'MM-DD HH:mm'), +8),
         };
     })
     .get();

--- a/lib/routes/novel/ptwxz.js
+++ b/lib/routes/novel/ptwxz.js
@@ -29,7 +29,7 @@ module.exports = async (ctx) => {
     const chapter_item = $('#content li a')
     .map((_, item) => {
         item = $(item);
-        const date = item.attr('title').match(/更新时间:(.*)/)[1]; //"10-04 00:17"
+        const date = item.attr('title').match(/更新时间:(.*)/)[1]; // "10-04 00:17"
         return {
             title: item.text(),
             link: item.attr('href'),


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

No reletaed issue

## 完整路由地址 / Example for the proposed route(s)

```routes
/novel/ptwxz
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [x] 全文获取 fulltext
  - [] Use Cache: not sure
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed: cant be found
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

* original route does not show full text for each link/new chapter
* now it will return the latest 9 chapters of a novel
* use async and cheerio to get content
* inspired by [biquge.js](https://github.com/DIYgod/RSSHub/blob/436197e685bf746c320ecee9c70118db0e83ed30/lib/routes/novel/biquge.js)
