### PR TITLE
fix(route): allow preLoginFlow of instagram to fail

### DIFF
--- a/lib/routes/instagram/utils.js
+++ b/lib/routes/instagram/utils.js
@@ -8,7 +8,11 @@ async function login(ig) {
     if (process.env.IG_USERNAME && process.env.IG_PASSWORD) {
         try {
             ig.state.generateDevice(process.env.IG_USERNAME);
-            await ig.simulate.preLoginFlow();
+            try {
+              await ig.simulate.preLoginFlow();
+            } catch (error) {
+              logger.info('Instagram preLoginFlow fail: ' + error);
+            }
             await ig.account.login(process.env.IG_USERNAME, process.env.IG_PASSWORD);
             process.nextTick(() => ig.simulate.postLoginFlow());
             logger.info('Instagram login success.');


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #7289

## 完整路由地址 / Example for the proposed route(s)

```routes
/instagram/user
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

Fix Instagram login failures.

Based on discussion in instragram-private-api repo, we do not need
the preLoginFlow function for login.

See:
https://github.com/dilame/instagram-private-api/issues/1411
https://github.com/dilame/instagram-private-api/issues/1417
