### PR TITLE
fix(cache): next error not catch

### DIFF
--- a/lib/middleware/cache/index.js
+++ b/lib/middleware/cache/index.js
@@ -114,7 +114,12 @@ module.exports = function (app) {
 
         // Doesn't hit the cache? We need to let others know!
         await globalCache.set(controlKey, '1', config.cache.requestTimeout);
-        await next();
+
+        try {
+            await next();
+        } catch (e) {
+            logger.error(`Error in ${ctx.request.path}: ${e}`);
+        }
 
         if (ctx.response.get('Cache-Control') !== 'no-cache' && ctx.state && ctx.state.data) {
             ctx.state.data.lastBuildDate = new Date().toUTCString();


### PR DESCRIPTION
NOROUTE

## 说明 / Note
当路由发生错误而没有捕获时，请求flag将不会重置，从而阻塞余下的所有请求。
When a routing error occurs and is not caught, the request flag will not be reset, thus blocking all remaining requests.