### PR TITLE
fix: cache next error not catch

### DIFF
--- a/lib/middleware/cache/index.js
+++ b/lib/middleware/cache/index.js
@@ -119,7 +119,7 @@ module.exports = function (app) {
             await next();
         } catch (e) {
             await globalCache.set(controlKey, '0', config.cache.requestTimeout);
-            throw new RequestInProgressError(e);
+            throw e;
         }
 
         if (ctx.response.get('Cache-Control') !== 'no-cache' && ctx.state && ctx.state.data) {

--- a/lib/middleware/cache/index.js
+++ b/lib/middleware/cache/index.js
@@ -114,7 +114,12 @@ module.exports = function (app) {
 
         // Doesn't hit the cache? We need to let others know!
         await globalCache.set(controlKey, '1', config.cache.requestTimeout);
-        await next();
+
+        try {
+            await next();
+        } catch (e) {
+            logger.error(`Error in ${ctx.request.path}: ${e}`);
+        }
 
         if (ctx.response.get('Cache-Control') !== 'no-cache' && ctx.state && ctx.state.data) {
             ctx.state.data.lastBuildDate = new Date().toUTCString();

--- a/lib/middleware/cache/index.js
+++ b/lib/middleware/cache/index.js
@@ -119,7 +119,7 @@ module.exports = function (app) {
             await next();
         } catch (e) {
             await globalCache.set(controlKey, '0', config.cache.requestTimeout);
-            throw new RequestInProgressError(`Error in ${ctx.request.path}: ${e}`);
+            throw new RequestInProgressError(e);
         }
 
         if (ctx.response.get('Cache-Control') !== 'no-cache' && ctx.state && ctx.state.data) {

--- a/lib/middleware/cache/index.js
+++ b/lib/middleware/cache/index.js
@@ -118,7 +118,8 @@ module.exports = function (app) {
         try {
             await next();
         } catch (e) {
-            logger.error(`Error in ${ctx.request.path}: ${e}`);
+            await globalCache.set(controlKey, '0', config.cache.requestTimeout);
+            throw new RequestInProgressError(`Error in ${ctx.request.path}: ${e}`);
         }
 
         if (ctx.response.get('Cache-Control') !== 'no-cache' && ctx.state && ctx.state.data) {


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

## 完整路由地址 / Example for the proposed route(s)

```routes
NOROUTE
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
当路由发生错误而没有捕获时，请求flag将不会重置，从而阻塞余下的所有请求。因上次pr格式不对，重启pr。
When a routing error occurs and is not caught, the request flag will not be reset, thus blocking all remaining requests.