### PR TITLE
fix: instagram logo url error due to upstream change

### DIFF
--- a/lib/routes/instagram/index.js
+++ b/lib/routes/instagram/index.js
@@ -23,7 +23,7 @@ async function loadContent(category, nameOrId) {
             }
 
             description = userInfo.biography;
-            logo = userInfo.hd_profile_pic_url_info.url;
+            logo = userInfo.profile_pic_url;
             const fullName = userInfo.full_name;
             title = `${fullName} (@${username}) - Instagram`;
             link = `https://www.instagram.com/${username}`;


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/instagram/user/jolin_cai
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

The upstream changes the api property naming. This PR does so accordingly.