### PR TITLE
fix: bilibili bvid in followings_video.

### DIFF
--- a/lib/routes/bilibili/followings_video.js
+++ b/lib/routes/bilibili/followings_video.js
@@ -33,7 +33,7 @@ module.exports = async (ctx) => {
             title: card_data.title,
             description: `${card_data.desc}${!disableEmbed ? `<br><br>${utils.iframe(card_data.aid)}` : ''}<br><img src="${card_data.pic}">`,
             pubDate: new Date(card_data.pubdate * 1000).toUTCString(),
-            link: card_data.pubdate > utils.bvidTime && card_data.bvid ? `https://www.bilibili.com/video/${card_data.bvid}` : `https://www.bilibili.com/video/av${card_data.aid}`,
+            link: card_data.pubdate > utils.bvidTime && card.desc.bvid ? `https://www.bilibili.com/video/${card.desc.bvid}` : `https://www.bilibili.com/video/av${card_data.aid}`,
             author: card.desc.user_profile.info.uname,
         };
     });


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```
/bilibili/followings/video/2267573
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
`bvid` now becomes a member of `card.desc` instead of `card.card`