### PR TITLE
feat(route): add 上下游 News&Market

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -2028,6 +2028,22 @@ column 为 third 时可选的 category:
 
 <Route author="nczitzk" example="/ruancan/search/ColorOS" path="/ruancan/search/:keyword?" :paramsDesc="['关键字，默认为空']"/>
 
+## 上下游 News&Market
+
+### 分類
+
+<Route author="nczitzk" example="/newsmarket" path="/newsmarket/:category?" :paramsDesc="['分类，见下表，默认为首页']">
+
+| 時事。政策  | 食安        | 新知      | 愛地方       | 種好田       | 好吃。好玩    |
+| ----------- | ----------- | --------- | ------------ | ------------ | ------------- |
+| news-policy | food-safety | knowledge | country-life | good-farming | good-food-fun |
+
+| 食農教育       | 人物               | 漁業。畜牧           | 綠生活。國際        | 評論    |
+| -------------- | ------------------ | -------------------- | ------------------- | ------- |
+| food-education | people-and-history | raising-and-breeding | living-green-travel | opinion |
+
+</Route>
+
 ## 少数派 sspai
 
 ### 最新上架付费专栏

--- a/lib/v2/newsmarket/index.js
+++ b/lib/v2/newsmarket/index.js
@@ -16,7 +16,7 @@ module.exports = async (ctx) => {
     const $ = cheerio.load(response.data);
 
     const list = $('.title a')
-        .slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 50)
+        .slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 20)
         .map((_, item) => {
             item = $(item);
 

--- a/lib/v2/newsmarket/index.js
+++ b/lib/v2/newsmarket/index.js
@@ -16,6 +16,7 @@ module.exports = async (ctx) => {
     const $ = cheerio.load(response.data);
 
     const list = $('.title a')
+        .slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 50)
         .map((_, item) => {
             item = $(item);
 

--- a/lib/v2/newsmarket/index.js
+++ b/lib/v2/newsmarket/index.js
@@ -1,0 +1,62 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const category = ctx.params.category ?? '';
+
+    const rootUrl = 'https://www.newsmarket.com.tw';
+    const currentUrl = `${rootUrl}${category ? `/blog/category/${category}` : ''}`;
+
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+    });
+
+    const $ = cheerio.load(response.data);
+
+    const list = $('.title a')
+        .map((_, item) => {
+            item = $(item);
+
+            return {
+                title: item.text(),
+                link: item.attr('href'),
+                pubDate: parseDate(),
+            };
+        })
+        .get();
+
+    const items = await Promise.all(
+        list.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const detailResponse = await got({
+                    method: 'get',
+                    url: item.link,
+                });
+
+                const content = cheerio.load(detailResponse.data);
+
+                content('figure img').each(function () {
+                    content(this)
+                        .parent()
+                        .html(`<img src="${content(this).attr('data-src')}">`);
+                });
+
+                content('.inline-post').remove();
+
+                item.author = content('.author-name').text();
+                item.description = content('.entry-content').html();
+                item.pubDate = parseDate(detailResponse.data.match(/"datePublished":"(.*)","dateModified"/)[1]);
+
+                return item;
+            })
+        )
+    );
+
+    ctx.state.data = {
+        title: $('title').text(),
+        link: currentUrl,
+        item: items,
+    };
+};

--- a/lib/v2/newsmarket/maintainer.js
+++ b/lib/v2/newsmarket/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/:category?': ['nczitzk'],
+};

--- a/lib/v2/newsmarket/radar.js
+++ b/lib/v2/newsmarket/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'newsmarket.com.tw': {
+        _name: '上下游News&amp;Market',
+        '.': [
+            {
+                title: '分類',
+                docs: 'https://docs.rsshub.app/new-media.html#shang-xia-you-news-market',
+                source: ['/blog/category/:category', '/'],
+                target: '/newsmarket/:category?',
+            },
+        ],
+    },
+};

--- a/lib/v2/newsmarket/router.js
+++ b/lib/v2/newsmarket/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/:category?', require('./index'));
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8320

## 完整路由地址 / Example for the proposed route(s)

```routes
/newsmarket/news-policy
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [x] CN
  - [ ] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
