### PR TITLE
Add `illust.type` for pixiv

### DIFF
--- a/lib/routes/pixiv/bookmarks.js
+++ b/lib/routes/pixiv/bookmarks.js
@@ -31,7 +31,7 @@ module.exports = async (ctx) => {
                 title: illust.title,
                 author: illust.user.name,
                 pubDate: new Date(illust.create_date).toUTCString(),
-                description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p>${images.join('')}`,
+                description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks} - 类型：${illust.type}</p>${images.join('')}`,
                 link: `https://www.pixiv.net/artworks/${illust.id}`,
             };
         }),

--- a/lib/routes/pixiv/illustfollow.js
+++ b/lib/routes/pixiv/illustfollow.js
@@ -25,7 +25,7 @@ module.exports = async (ctx) => {
                 title: illust.title,
                 author: illust.user.name,
                 pubDate: new Date(illust.create_date).toUTCString(),
-                description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p>${images.join('')}`,
+                description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks} - 类型：${illust.type}</p>${images.join('')}`,
                 link: `https://www.pixiv.net/artworks/${illust.id}`,
             };
         }),

--- a/lib/routes/pixiv/ranking.js
+++ b/lib/routes/pixiv/ranking.js
@@ -76,7 +76,7 @@ module.exports = async (ctx) => {
             return {
                 title: `#${index + 1} ${illust.title}`,
                 pubDate: new Date(illust.create_date).toUTCString(),
-                description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p><br>${images.join('')}`,
+                description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks} - 类型：${illust.type}</p>${images.join('')}`,
                 link: `https://www.pixiv.net/artworks/${illust.id}`,
                 author: illust.user.name,
             };

--- a/lib/routes/pixiv/search.js
+++ b/lib/routes/pixiv/search.js
@@ -41,7 +41,7 @@ module.exports = async (ctx) => {
                 title: illust.title,
                 author: illust.user.name,
                 pubDate: new Date(illust.create_date).toUTCString(),
-                description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p>${images.join('')}`,
+                description: `<p>画师：${illust.user.name} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks} - 类型：${illust.type}</p>${images.join('')}`,
                 link: `https://www.pixiv.net/artworks/${illust.id}`,
             };
         }),

--- a/lib/routes/pixiv/user.js
+++ b/lib/routes/pixiv/user.js
@@ -29,7 +29,7 @@ module.exports = async (ctx) => {
                 title: illust.title,
                 author: username,
                 pubDate: new Date(illust.create_date).toUTCString(),
-                description: `<p>画师：${username} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks}</p>${images.join('')}`,
+                description: `<p>画师：${username} - 阅览数：${illust.total_view} - 收藏数：${illust.total_bookmarks} - 类型：${illust.type}</p>${images.join('')}`,
                 link: `https://www.pixiv.net/artworks/${illust.id}`,
             };
         }),


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

```routes
pixiv/ranking
pixiv/search
pixiv/user
pixiv/user/bookmarks
pixiv/user/illustfollows
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
往 description 中添加了作品类型的信息，效果如：`- 类型：ugoira`
