### PR TITLE
feat(route): add Bandcamp Upcoming Live Streams

### DIFF
--- a/docs/en/multimedia.md
+++ b/docs/en/multimedia.md
@@ -22,6 +22,10 @@ Full transcript support for better user experience.
 
 <RouteEn author="nczitzk" example="/bandcamp/tag/united-kingdom" path="/bandcamp/tag/:tag?" :paramsDesc="['Tag, can be found in URL']"/>
 
+### Upcoming Live Streams
+
+<Route author="nczitzk" example="/bandcamp/live" path="/bandcamp/live"/>
+
 ## EZTV
 
 ::: tip

--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -167,6 +167,10 @@ pageClass: routes
 
 <Route author="nczitzk" example="/bandcamp/tag/united-kingdom" path="/bandcamp/tag/:tag?" :paramsDesc="['标签，可在 URL 中找到']"/>
 
+### Upcoming Live Streams
+
+<Route author="nczitzk" example="/bandcamp/live" path="/bandcamp/live"/>
+
 ## bilibili
 
 见 [#bilibili](/social-media.html#bilibili)

--- a/lib/v2/bandcamp/live.js
+++ b/lib/v2/bandcamp/live.js
@@ -1,0 +1,41 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const rootUrl = 'https://bandcamp.com';
+    const currentUrl = `${rootUrl}/live_schedule`;
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+    });
+
+    const $ = cheerio.load(response.data);
+
+    $('.curated-wrapper').remove();
+
+    const items = $('.live-listing')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+
+            return {
+                link: item.find('.title-link').attr('href'),
+                title: item.find('.show-title').text(),
+                author: item.find('.show-artist').text(),
+                pubDate: parseDate(item.find('.show-time-container').text().trim().split(' UTC')[0]),
+                description: `<img src="${
+                    item
+                        .find('.show-thumb-image')
+                        .attr('style')
+                        .match(/background-image: url\((.*)\);/)[1]
+                }">`,
+            };
+        });
+
+    ctx.state.data = {
+        title: $('title').text(),
+        link: currentUrl,
+        item: items,
+    };
+};

--- a/lib/v2/bandcamp/maintainer.js
+++ b/lib/v2/bandcamp/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/live': ['nczitzk'],
+};

--- a/lib/v2/bandcamp/radar.js
+++ b/lib/v2/bandcamp/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'bandcamp.com': {
+        _name: 'Bandcamp',
+        '.': [
+            {
+                title: 'Upcoming Live Streams',
+                docs: 'https://docs.rsshub.app/multimedia.html#bandcamp-upcoming-live-streams',
+                source: ['/live_schedule'],
+                target: '/bandcamp/live',
+            },
+        ],
+    },
+};

--- a/lib/v2/bandcamp/router.js
+++ b/lib/v2/bandcamp/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/live', require('./live'));
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/bandcamp/live
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [x] CN
  - [x] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
