### PR TITLE
fix(route): Pixiv频繁refresh token

### DIFF
--- a/lib/routes/pixiv/token.js
+++ b/lib/routes/pixiv/token.js
@@ -48,11 +48,27 @@ async function tickToken() {
     }
 }
 
-module.exports = async () => {
-    if (!token) {
-        await tickToken();
+let tickTokenStarted = false;
+
+async function startTickToken() {
+    if (!tickTokenStarted) {
+        // 如果tickToken没启动
+        tickTokenStarted = true;
+        await tickToken(); // 启动tickToken
+    }
+}
+
+async function waitForToken() {
+    while (!token) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 0));
     }
     return token;
+}
+
+module.exports = async () => {
+    await startTickToken();
+    return waitForToken();
 };
 
 module.exports.tickToken = tickToken;


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8524

## 完整路由地址 / Example for the proposed route(s)

```routes
/pixiv/user/123456
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
#8524这种情况的根本原因是RSSHub刚启动时，如果在首次更新pixiv token还未完成又来了一个请求（比如用TTRSS自动更新的时候），会导致启动多个tickToken，从而造成频繁refresh token。

所以，用一个“信号量”限制tickToken的启动次数即可解决问题。