### PR TITLE
fix(route): remove douban status url tracker

### DIFF
--- a/lib/routes/douban/people/status.js
+++ b/lib/routes/douban/people/status.js
@@ -51,6 +51,11 @@ function tryFixStatus(status) {
         }
     }
 
+    // 接口提供的URL最后有分享追踪器，要删去，否则路由无法工作
+    if (status.sharing_url) {
+        status.sharing_url = status.sharing_url.split('?')[0];
+    }
+
     if (!result.isFixSuccess) {
         status.sharing_url = 'https://www.douban.com?rsshub_failed=' + now.getTime().toString();
         if (!status.create_time) {

--- a/lib/routes/douban/topic.js
+++ b/lib/routes/douban/topic.js
@@ -28,7 +28,7 @@ module.exports = async (ctx) => {
             let link;
             let title;
             if (type === 'status') {
-                link = item.target.status.sharing_url;
+                link = item.target.status.sharing_url.split('?')[0];
                 author = item.target.status.author.name;
                 title = author + '的广播';
                 date = item.target.status.create_time;


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/douban/topic/3298608
/douban/people/62759792/status
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

最近他这个`status.sharing_url`字段返回的URL，在最后会多出形如`?_i=12345678`的随机追踪参数（自然是每次返回都不同），影响部分抓取器正常判断是否有条目。
