### PR TITLE
fix(route): lazyloadRouteHandler

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -1821,9 +1821,7 @@ router.get('/aqicn/:city/:pollution?', lazyloadRouteHandler('./routes/aqicn/inde
 // 猫眼电影
 router.get('/maoyan/hot', lazyloadRouteHandler('./routes/maoyan/hot'));
 router.get('/maoyan/upcoming', lazyloadRouteHandler('./routes/maoyan/upcoming'));
-router.get('/maoyan/hot', require('./routes/maoyan/hot'));
-router.get('/maoyan/upcoming', require('./routes/maoyan/upcoming'));
-router.get('/maoyan/hotComplete/:orderby?/:ascOrDesc?/:top?', require('./routes/maoyan/hotComplete'));
+router.get('/maoyan/hotComplete/:orderby?/:ascOrDesc?/:top?', lazyloadRouteHandler('./routes/maoyan/hotComplete'));
 
 // cnBeta
 router.get('/cnbeta', lazyloadRouteHandler('./routes/cnbeta/home'));
@@ -4254,6 +4252,9 @@ router.get('/rss3/blog', lazyloadRouteHandler('./routes/rss3/blog'));
 
 // 星球日报
 router.get('/odaily/activity', lazyloadRouteHandler('./routes/odaily/activity'));
+router.get('/odaily/newsflash', lazyloadRouteHandler('./routes/odaily/newsflash'));
+router.get('/odaily/user/:id', lazyloadRouteHandler('./routes/odaily/user'));
+router.get('/odaily/:id?', lazyloadRouteHandler('./routes/odaily/post'));
 
 // Fashion Network
 router.get('/fashionnetwork/news/:sectors?/:categories?/:language?', lazyloadRouteHandler('./routes/fashionnetwork/news.js'));
@@ -4265,12 +4266,7 @@ router.get('/dykszx/news/:type?', lazyloadRouteHandler('./routes/dykszx/news'));
 router.get('/secrss/category/:category?', lazyloadRouteHandler('./routes/secrss/category'));
 router.get('/secrss/author/:author?', lazyloadRouteHandler('./routes/secrss/author'));
 
-// 星球日报
-router.get('/odaily/newsflash', require('./routes/odaily/newsflash'));
-router.get('/odaily/user/:id', require('./routes/odaily/user'));
-router.get('/odaily/:id?', require('./routes/odaily/post'));
-
 // Fashion Network
-router.get('/fashionnetwork/headline/:country?', require('./routes/fashionnetwork/headline.js'));
+router.get('/fashionnetwork/headline/:country?', lazyloadRouteHandler('./routes/fashionnetwork/headline.js'));
 
 module.exports = router;

--- a/lib/router.js
+++ b/lib/router.js
@@ -4239,8 +4239,6 @@ router.get('/sbs/chinese/:category?/:id?/:dialect?/:language?', lazyloadRouteHan
 // Asian to lick
 router.get('/asiantolick/:category?/:keyword?', lazyloadRouteHandler('./routes/asiantolick'));
 
-// Deprecated: DO NOT ADD ROUTE HERE
-
 // Research Gate
 router.get('/researchgate/publications/:id', lazyloadRouteHandler('./routes/researchgate/publications'));
 
@@ -4268,5 +4266,7 @@ router.get('/secrss/author/:author?', lazyloadRouteHandler('./routes/secrss/auth
 
 // Fashion Network
 router.get('/fashionnetwork/headline/:country?', lazyloadRouteHandler('./routes/fashionnetwork/headline.js'));
+
+// Deprecated: DO NOT ADD ROUTE HERE
 
 module.exports = router;


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```routes
/some/route
/some/other/route
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

This should fix `build assets` workflow failure from multiple PR merges.

- Duplicated route entries in https://github.com/DIYgod/RSSHub/pull/8587 by @song-zhou
- https://github.com/DIYgod/RSSHub/pull/7638 by @nczitzk
- https://github.com/DIYgod/RSSHub/pull/7666
- https://github.com/DIYgod/RSSHub/pull/7603

Also moved the route v1 deprecation warning back to the end of the file.