### PR TITLE
fix(ci): `pr-deploy-route-test` workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,9 +14,10 @@ Close #
 如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。
 
 Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
-```routes
+```route
 /some/route
 /some/other/route
+```
 如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
 If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
 -->

--- a/scripts/workflow/test-route/identify.js
+++ b/scripts/workflow/test-route/identify.js
@@ -9,7 +9,7 @@ module.exports = async ({ github, context, core }, body, number) => {
     let res = null;
 
     const removeLabel = () =>
-        github.issues
+        github.rest.issues
             .removeLabel({
                 issue_number: number,
                 owner: context.repo.owner,
@@ -23,7 +23,7 @@ module.exports = async ({ github, context, core }, body, number) => {
     if (whiteListedUser.includes(context.payload.sender.login)) {
         core.info('PR created by a whitelisted user, passing');
         await removeLabel();
-        await github.issues
+        await github.rest.issues
             .addLabels({
                 issue_number: number,
                 owner: context.repo.owner,
@@ -45,7 +45,7 @@ module.exports = async ({ github, context, core }, body, number) => {
         if (res.length > 0 && res[0] === 'NOROUTE') {
             core.info('PR stated no route, passing');
             await removeLabel();
-            await github.issues
+            await github.rest.issues
                 .addLabels({
                     issue_number: number,
                     owner: context.repo.owner,
@@ -66,7 +66,7 @@ module.exports = async ({ github, context, core }, body, number) => {
 
     core.warning('seems no route found, failing');
 
-    await github.issues
+    await github.rest.issues
         .addLabels({
             issue_number: number,
             owner: context.repo.owner,
@@ -76,7 +76,7 @@ module.exports = async ({ github, context, core }, body, number) => {
         .catch((e) => {
             core.warning(e);
         });
-    await github.issues
+    await github.rest.issues
         .createComment({
             issue_number: number,
             owner: context.repo.owner,
@@ -87,7 +87,7 @@ Auto Route test failed, please check your PR body format and reopen pull request
         .catch((e) => {
             core.warning(e);
         });
-    await github.pulls
+    await github.rest.pulls
         .update({
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/scripts/workflow/test-route/test.js
+++ b/scripts/workflow/test-route/test.js
@@ -42,7 +42,7 @@ module.exports = async ({ github, context, core }, baseUrl, routes, number) => {
 `;
         }
     }
-    github.issues
+    github.rest.issues
         .addLabels({
             issue_number: number,
             owner: context.repo.owner,
@@ -52,7 +52,7 @@ module.exports = async ({ github, context, core }, baseUrl, routes, number) => {
         .catch((e) => {
             core.warning(e);
         });
-    github.issues
+    github.rest.issues
         .createComment({
             issue_number: number,
             owner: context.repo.owner,


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

- Fix `pr-deploy-route-test` workflow not working due to https://github.com/DIYgod/RSSHub/pull/8602
  - `github.issues.*` becomes `github.rest.issues.*`
  - More info on <https://github.com/actions/github-script#breaking-changes-in-v5>

- Fix `/scripts/workflow/test-route/identify.js` not identifying correct route(s) due to https://github.com/DIYgod/RSSHub/pull/8379 ~~introduced by @SukkaW~~