### PR TITLE
fix(docs): change en comma to cn in journal.md(cn); fix(route): /heu/job/list/tzgg

### DIFF
--- a/docs/en/journal.md
+++ b/docs/en/journal.md
@@ -112,13 +112,13 @@ The parameter id in the route is the id in the URL of the user's Google Scholar 
 
 ### Latest Research
 
-<RouteEn author="Derekmini auto-bot-ty" example="/ieee/70/latest/vol" path="/:journal/latest/vol/:sortType?" :paramsDesc="['Journal Name, get it from punumber of the URL','Sort Type, default: `vol-only-seq`, get it from sortType of the URL']" radar="1" rssbud="1">
+<RouteEn author="Derekmini auto-bot-ty" example="/ieee/70/latest/vol" path="/ieee/:journal/latest/vol/:sortType?" :paramsDesc="['Journal Name, get it from punumber of the URL','Sort Type, default: `vol-only-seq`, get it from sortType of the URL']" radar="1" rssbud="1">
 
 </RouteEn>
 
 ### Latest Research (Last 2 month)
 
-<RouteEn author="Derekmini auto-bot-ty" example="/ieee/78/latest/date" path="/:journal/latest/date/:sortType?" :paramsDesc="['Journal Name, get it from punumber of the URL','Sort Type, default: `vol-only-seq`, get it from sortType of the URL']" radar="1" rssbud="1">
+<RouteEn author="Derekmini auto-bot-ty" example="/ieee/78/latest/date" path="/ieee/:journal/latest/date/:sortType?" :paramsDesc="['Journal Name, get it from punumber of the URL','Sort Type, default: `vol-only-seq`, get it from sortType of the URL']" radar="1" rssbud="1">
 
 New items may always at the end of the list, when the number of paper entries is too large. So we only filtered those articles published in the current month and the previous month.
 

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -90,7 +90,7 @@ pageClass: routes
 
 ### 指定卷中的文章
 
-<Route author="Derekmini sunwolf-swb" example="/elsevier/signal-processing/vol/192" path="/elsevier/:journal/vol/:id" :paramsDesc="['期刊名称，复制 URL 中 tocSection 部分','卷号 (如果 `Issue` 存在, 使用 `Volume-Issue`, e.g., `/elsevier/aace-clinical-case-reports/vol/7-6`)']" radar="1" rssbud="1">
+<Route author="Derekmini sunwolf-swb" example="/elsevier/signal-processing/vol/192" path="/elsevier/:journal/vol/:id" :paramsDesc="['期刊名称，复制 URL 中 tocSection 部分','卷号 (如果 `Issue` 存在，使用 `Volume-Issue`, e.g., `/elsevier/aace-clinical-case-reports/vol/7-6`)']" radar="1" rssbud="1">
 
 </Route>
 

--- a/lib/v2/heu/job/list.js
+++ b/lib/v2/heu/job/list.js
@@ -33,7 +33,7 @@ module.exports = async (ctx) => {
     const list = $('li.list_item.i1')
         .map((_, item) => {
             let link = $(item).find('a').attr('href');
-            if (link.indexOf('.shtml') !== -1) {
+            if (link.indexOf('HrbeuJY') !== -1) {
                 link = rootUrl.concat(link);
             }
             return {
@@ -47,7 +47,7 @@ module.exports = async (ctx) => {
     await Promise.all(
         list.map((item) =>
             ctx.cache.tryGet(item.link, async () => {
-                if (item.link.indexOf('.shtml') !== -1) {
+                if (item.link.indexOf('HrbeuJY') !== -1) {
                     const detailResponse = await got({
                         method: 'get',
                         url: item.link,


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```routes
/some/route
/some/other/route
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/heu/job/list/tzgg
/heu/job/list/rdxw
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

`/heu/job/list/tzgg`中有一个链接也是以`.shtml`结尾的，但是该链接所指其他单位网页，故不适用于`tryGet`获取缓存，故导致路由出现错误。通过替换关键词，解决该问题。