### PR TITLE
fix: update minify-docker.js for newer @vercel/nft

### DIFF
--- a/scripts/docker/minify-docker.js
+++ b/scripts/docker/minify-docker.js
@@ -7,9 +7,10 @@ const resultFolder = 'app-minimal';
 
 (async () => {
     console.log('Start analyizing...');
-    const { fileList } = await nodeFileTrace(files, {
+    const { fileList: fileSet } = await nodeFileTrace(files, {
         base: path.resolve(path.join(__dirname, '../..')),
     });
+    const fileList = Array.from(fileSet);
     console.log('Total files need to be copy: ' + fileList.length);
     return Promise.all(fileList.map((e) => fs.copy(e, path.resolve(path.join(resultFolder, e)))));
 })();


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

N/A

## 完整路由地址 / Example for the proposed route(s)

```routes
NOROUTE
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

In commit ad1a09597f19db6adecd6d04f6e8ceaed5dd0026, @vercel/nft is
updated to 0.17.0, and in this version fileList from nft is a set
instead of an array [1].

[1] https://github.com/vercel/nft/pull/240
