### PR TITLE
fix(route)(weibo/user): 无置顶微博时不遗漏第一条微博

### DIFF
--- a/lib/routes/weibo/user.js
+++ b/lib/routes/weibo/user.js
@@ -39,51 +39,65 @@ module.exports = async (ctx) => {
         },
     });
 
+    const filteredCards = response.data.data.cards
+        .map((item) => {
+            if (item.mblog) {
+                // w/ `mblog`, it is a mblog card
+                return item;
+            } else if (item.card_group) {
+                // w/o `mblog`, it may have a `card_group` containing only 1 card
+                // we should drop pinned mblogs
+                item = item.card_group[0];
+                return (item.mblog && !item.mblog.title) || item.mblog.title.text !== '置顶' ? item : null;
+            } else {
+                return null;
+            }
+        })
+        .filter((item) => item);
+
     const resultItem = await Promise.all(
-        response.data.data.cards
-            .filter((item) => item.mblog)
-            .map(async (item) => {
-                const key = 'weibo:user:' + item.mblog.bid;
-                const data = await ctx.cache.tryGet(key, () => weiboUtils.getShowData(uid, item.mblog.bid));
+        filteredCards.map(async (item) => {
+            const key = 'weibo:user:' + item.mblog.bid;
+            const data = await ctx.cache.tryGet(key, () => weiboUtils.getShowData(uid, item.mblog.bid));
 
-                if (data && data.text) {
-                    item.mblog.text = data.text;
-                    item.mblog.created_at = parseDate(data.created_at);
-                    if (item.mblog.retweeted_status && data.retweeted_status) {
-                        item.mblog.retweeted_status.created_at = data.retweeted_status.created_at;
-                    }
-                } else {
-                    item.mblog.created_at = timezone(item.mblog.created_at, +8);
+            if (data && data.text) {
+                item.mblog.text = data.text;
+                item.mblog.created_at = parseDate(data.created_at);
+                if (item.mblog.retweeted_status && data.retweeted_status) {
+                    item.mblog.retweeted_status.created_at = data.retweeted_status.created_at;
                 }
-                // 转发的长微博处理
-                const retweet = item.mblog.retweeted_status;
-                if (retweet && retweet.isLongText) {
-                    const retweetData = await weiboUtils.getShowData(retweet.user.id, retweet.bid);
-                    if (retweetData !== undefined && retweetData.text) {
-                        item.mblog.retweeted_status.text = retweetData.text;
-                    }
+            } else {
+                item.mblog.created_at = timezone(item.mblog.created_at, +8);
+            }
+            // 转发的长微博处理
+            const retweet = item.mblog.retweeted_status;
+            if (retweet && retweet.isLongText) {
+                const retweetData = await weiboUtils.getShowData(retweet.user.id, retweet.bid);
+                if (retweetData !== undefined && retweetData.text) {
+                    item.mblog.retweeted_status.text = retweetData.text;
                 }
+            }
 
-                const link = `https://weibo.com/${uid}/${item.mblog.bid}`;
-                const formatExtended = weiboUtils.formatExtended(ctx, item.mblog);
-                let description = formatExtended.description;
-                const formattedTitle = formatExtended.title;
-                const title = formattedTitle;
-                const pubDate = item.mblog.created_at;
+            const link = `https://weibo.com/${uid}/${item.mblog.bid}`;
+            const formatExtended = weiboUtils.formatExtended(ctx, item.mblog);
+            let description = formatExtended.description;
+            const formattedTitle = formatExtended.title;
+            const title = formattedTitle;
+            const pubDate = item.mblog.created_at;
 
-                // 视频的处理
-                if (displayVideo === '1') {
-                    description = weiboUtils.formatVideo(description, item.mblog);
-                }
+            // 视频的处理
+            if (displayVideo === '1') {
+                description = weiboUtils.formatVideo(description, item.mblog);
+            }
 
-                return {
-                    title,
-                    description,
-                    link,
-                    pubDate,
-                    author: item.mblog.user.screen_name,
-                };
-            })
+            return {
+                title,
+                description,
+                link,
+                pubDate,
+                author: item.mblog.user.screen_name,
+            };
+        })
     );
 
     ctx.state.data = {


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8336

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```routes
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/weibo/user/1750790343
/weibo/user/5270401459
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
获取博主微博的 API `https://m.weibo.cn/api/container/getIndex?containerid=${containerid}` 返回的 `cards` 里，第一个 card 会是固定的格式，不含有 `mblog` ，与后面的不同，因此会被 filter 掉。第一个 card 会含有一个 `card_group` ，里面有且仅有一个 card，可能存放博主的置顶微博，也可能存放**博主最新的微博**（如果没有置顶微博）。这个 PR 会把这个嵌套的 card 取出来（当它不是置顶微博时），这样就不会漏掉它。

示例路由中，第一个是有置顶微博的，第二个没有。