### PR TITLE
fix(route)(weibo/user): 无置顶微博时不遗漏第一条微博

### DIFF
--- a/lib/routes/weibo/user.js
+++ b/lib/routes/weibo/user.js
@@ -39,10 +39,22 @@ module.exports = async (ctx) => {
         },
     });
 
+    let earliestDate;
+
     const resultItem = await Promise.all(
         response.data.data.cards
-            .filter((item) => item.mblog)
+            .reverse() // reverse first to ensure the pinned card will be processed lastly
             .map(async (item) => {
+                if (!item.mblog && item.card_group && Array.isArray(item.card_group) && item.card_group.length > 0) {
+                    // w/o `mblog`, it may have a `card_group` containing only 1 card
+                    // only get the 1st card because we haven't observed that there can be multiple cards in it
+                    item = item.card_group[0];
+                }
+
+                if (!item.mblog) {
+                    return; // drop
+                }
+
                 const key = 'weibo:user:' + item.mblog.bid;
                 const data = await ctx.cache.tryGet(key, () => weiboUtils.getShowData(uid, item.mblog.bid));
 
@@ -55,6 +67,18 @@ module.exports = async (ctx) => {
                 } else {
                     item.mblog.created_at = timezone(item.mblog.created_at, +8);
                 }
+
+                // drop too old pinned weibo, otherwise preserve it
+                if (!item.mblog.title || item.mblog.title.text !== '置顶') {
+                    if (!earliestDate || (item.mblog.created_at && earliestDate > item.mblog.created_at)) {
+                        earliestDate = item.mblog.created_at;
+                    }
+                } else {
+                    if (earliestDate && item.mblog.created_at && earliestDate > item.mblog.created_at) {
+                        return;
+                    }
+                }
+
                 // 转发的长微博处理
                 const retweet = item.mblog.retweeted_status;
                 if (retweet && retweet.isLongText) {
@@ -91,6 +115,6 @@ module.exports = async (ctx) => {
         link: `http://weibo.com/${uid}/`,
         description,
         image: profileImageUrl,
-        item: resultItem,
+        item: resultItem.filter((item) => item).reverse(),
     };
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8336

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```routes
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/weibo/user/1750790343
/weibo/user/5270401459
/weibo/user/2675284423
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [x] Documentation
  - [x] CN
  - [ ] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [x] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
获取博主微博的 API `https://m.weibo.cn/api/container/getIndex?containerid=${containerid}` 返回的 `cards` 里，第一个 card 会是固定的格式，不含有 `mblog` ，与后面的不同，因此会被 filter 掉。第一个 card 会含有一个 `card_group` ，里面有且仅有一个 card，可能存放博主的置顶微博，也可能存放**博主最新的微博**（如果没有置顶微博）。这个 PR 会把这个嵌套的 card 取出来（当它不是置顶微博时），这样就不会漏掉它。

示例路由中，第一个是有置顶微博的，第二个没有。