### PR TITLE
fix: 网易云音乐提供Cookie，抓取需要登陆才可见的歌单 && 中纪委、外交部网站小变动

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -617,11 +617,11 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 
 -   端传媒设置，用于获取付费内容全文：
 
-    -   `INITIUM_BEARER_TOKEN`: 端传媒 Web 版认证 token。获取方式：登陆后打开端传媒站内任意页面，打开浏览器开发者工具中 “网络”(Network) 选项卡，筛选 URL 找到任一个地址为`api.initium.com`开头的请求，点击检查其 “消息头”，在 “请求头” 中找到`Authorization`字段，将其值复制填入配置即可。你的配置应该形如`INITIUM_BEARER_TOKEN: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6JiE1NTYzNDgxNDVAcXEuY29tIiwidXNlcl9pZCI6MTM0NDIwLCJlbWFpbCI6IjE1NTYzNDgxNDVAcXEuY29tIiwiZXhwIjoxNTk0MTk5NjQ3fQ.Tqui-ORNR7d4Bh240nKy_Ldi6crfq0A78Yj2iwy2_U8'`。
+    -   `INITIUM_BEARER_TOKEN`: 端传媒 Web 版认证 token。获取方式：登陆后打开端传媒站内任意页面，打开浏览器开发者工具中 “网络”(Network) 选项卡，筛选 URL 找到任一个地址为`api.initium.com`开头的请求，点击检查其 “消息头”，在 “请求头” 中找到`Authorization`字段，将其值复制填入配置即可。你的配置应该形如`INITIUM_BEARER_TOKEN: 'Bearer eyJxxxx......xx_U8'`。使用 token 部署的好处是避免占据登陆设备数的额度，但这个 token 一般有效期为两周，因此只可作临时测试使用。
 
     -   `INITIUM_IAP_RECEIPT`: 端传媒 iOS 版内购回执认证 token。获取方式：登陆后打开端传媒 iOS app 内任意页面，打开抓包工具，筛选 URL 找到任一个地址为`api.initium.com`开头的请求，点击检查其 “消息头”，在 “请求头” 中找到`X-IAP-Receipt`字段，将其值复制填入配置即可。你的配置应该形如`INITIUM_IAP_RECEIPT: 'ef81dee9e4e2fe084a0af1ea82da2f7b16e75f756db321618a119fa62b52550e'`。
 
-    Web 版认证 token 和 iOS 内购回执认证 token 只需选择其一填入即可。如果你在进行上述操作时遇到困难，亦可选择在环境设置中填写明文的用户名和密码：
+    Web 版认证 token 和 iOS 内购回执认证 token 只需选择其一填入即可。你也可选择直接在环境设置中填写明文的用户名和密码：
 
     -   `INITIUM_USERNAME`: 端传媒用户名 （邮箱）
     -   `INITIUM_PASSWORD`: 端传媒密码
@@ -690,6 +690,10 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 
     -   `ZHIHU_COOKIES`: 知乎登录后的 cookie 值.
         1.  可以在知乎网页版的一些请求的请求头中找到，如 `GET /moments` 请求头中的 `cookie` 值.
+
+-   网易云歌单及听歌排行
+
+    -   `NCM_COOKIES`: 网易云音乐登陆后的 cookie 值.
 
 -   Wordpress
 

--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -1152,6 +1152,11 @@ JavDB 有多个备用域名，本路由以 <https://javdb7.com> 为默认域名�
 
 ## 网易云音乐
 
+::: tip 部分歌单及听歌排行信息为登陆后可见
+
+部分歌单及听歌排行信息为登陆后可见，自建时将环境变量`NCM_Cookies`设为登陆后的 Cookie 值，即可正常获取。
+:::
+
 ### 歌单歌曲
 
 <Route author="DIYgod" example="/ncm/playlist/35798529" path="/ncm/playlist/:id" :paramsDesc="['歌单 id, 可在歌单页 URL 中找到']" radar="1" />

--- a/lib/config.js
+++ b/lib/config.js
@@ -92,6 +92,9 @@ const calculateValue = () => {
         zhihu: {
             cookies: envs.ZHIHU_COOKIES,
         },
+        ncm: {
+            cookies: envs.NCM_COOKIES || '',
+        },
         puppeteerWSEndpoint: envs.PUPPETEER_WS_ENDPOINT,
         loggerLevel: envs.LOGGER_LEVEL || 'info',
         proxyUri: envs.PROXY_URI,

--- a/lib/routes/ccdi/scdc.js
+++ b/lib/routes/ccdi/scdc.js
@@ -3,7 +3,7 @@ const got = require('@/utils/got');
 const { resolve } = require('url');
 
 module.exports = async (ctx) => {
-    const url = 'http://www.ccdi.gov.cn/scdc/';
+    const url = 'https://www.ccdi.gov.cn/scdcn/';
     const res = await got.get(url);
     const $ = cheerio.load(res.data);
 
@@ -27,11 +27,15 @@ module.exports = async (ctx) => {
                 if (value) {
                     item.description = value;
                 } else {
-                    const response = await got.get(item.link);
-                    const data = response.data;
-                    const $ = cheerio.load(data);
-                    item.description = $('div.TRS_Editor').html();
-                    ctx.cache.set(key, item.description);
+                    try {
+                        const response = await got.get(item.link);
+                        const data = response.data;
+                        const $ = cheerio.load(data);
+                        item.description = $('div.TRS_Editor').html();
+                        ctx.cache.set(key, item.description);
+                    } catch (error) {
+                        item.description = '';
+                    }
                 }
 
                 return item;

--- a/lib/routes/douban/people/status.js
+++ b/lib/routes/douban/people/status.js
@@ -448,11 +448,16 @@ async function getFullTextItems(ctx, items) {
             if (cache) {
                 item.status.reshared_status.text = cache;
             } else if (tryFixStatus(item.status.reshared_status).isFixSuccess) {
-                const {
-                    data: { text },
-                } = await got({ url, headers });
-                ctx.cache.set(url, text);
-                item.status.reshared_status.text = text;
+                try {
+                    // 存在reshared_status字段正常，但尝试获取时返回403的情况。比如原po被炸号就可能这样。
+                    const {
+                        data: { text },
+                    } = await got({ url, headers });
+                    ctx.cache.set(url, text);
+                    item.status.reshared_status.text = text;
+                } catch (err) {
+                    item.status.reshared_status.text += '\n[获取原动态失败]';
+                }
             }
         })
     );

--- a/lib/routes/gov/fmprc/fyrbt.js
+++ b/lib/routes/gov/fmprc/fyrbt.js
@@ -11,7 +11,7 @@ module.exports = async (ctx) => {
 
     const $ = cheerio.load(response.data);
 
-    const list = $('.rebox_news ul li').get();
+    const list = $('.newsBd ul li').get();
 
     const result = await util.ProcessFeed(list, ctx.cache);
 

--- a/lib/routes/ncm/playlist.js
+++ b/lib/routes/ncm/playlist.js
@@ -1,4 +1,5 @@
 const got = require('@/utils/got');
+const config = require('@/config').value;
 
 module.exports = async (ctx) => {
     const id = ctx.params.id;
@@ -8,6 +9,7 @@ module.exports = async (ctx) => {
         url: 'https://music.163.com/api/v3/playlist/detail',
         headers: {
             Referer: 'https://music.163.com/',
+            Cookie: config.ncm.cookies,
         },
         form: {
             id,

--- a/lib/routes/ncm/userplayrecords.js
+++ b/lib/routes/ncm/userplayrecords.js
@@ -1,6 +1,10 @@
 const got = require('@/utils/got');
+const config = require('@/config').value;
 
-const headers = { Referer: 'https://music.163.com/' };
+const headers = {
+    cookie: config.ncm.cookies,
+    Referer: 'https://music.163.com/',
+};
 
 function getItem(records) {
     if (!records || records.length === 0) {
@@ -37,7 +41,7 @@ function getItem(records) {
 
 module.exports = async (ctx) => {
     const uid = ctx.params.uid;
-    const type = ctx.params.type || 0;
+    const type = parseInt(ctx.params.type) || 0;
 
     const url = `http://music.163.com/api/v1/play/record?uid=${uid}&type=${type}`;
     const response = await got({ url, headers });


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/ncm/playlist/390676073
/ccdi/scdc
/gov/fmprc/fyrbt
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [x] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

1. 网易云部分歌单需要登陆后才能查看，故允许用户在部署时提供Cookie。
2. 中纪委网站更新迁移至新路径 `/scdcn`，原 `/scdc` 不再更新；同时该站反爬严格，并发抓取全文基本都会返回420异常，为了让路由仍然工作所以mute了异常。
3. 外交部发言人表态网页小变动