### PR TITLE
fix华尔街见闻快讯的title

### DIFF
--- a/lib/routes/wallstreetcn/live.js
+++ b/lib/routes/wallstreetcn/live.js
@@ -21,11 +21,8 @@ module.exports = async (ctx) => {
     });
 
     const items = response.data.data.items.map((item) => {
-        let title;
-        const match = item.content_text.match(/【(.*)】/);
-        if (match !== null) {
-            title = match[1];
-        } else {
+        let title = item.title;
+        if (title == '') {
             title = item.content_text;
         }
         return {

--- a/lib/routes/wallstreetcn/live.js
+++ b/lib/routes/wallstreetcn/live.js
@@ -21,12 +21,8 @@ module.exports = async (ctx) => {
     });
 
     const items = response.data.data.items.map((item) => {
-        let title = item.title;
-        if (title == '') {
-            title = item.content_text;
-        }
         return {
-            title,
+            title: item.title || item.content_text,
             link: `https://wallstreetcn.com/livenews/${item.id}`,
             pubDate: new Date(item.display_time * 1000).toUTCString(),
             description: item.content,


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

```routes
/wallstreetcn/live
```

## 说明 / Note

用api中返回的item.title填充title
