### PR TITLE
点击bilibili视频描述，打开app观看

### DIFF
--- a/lib/routes/bilibili/video.js
+++ b/lib/routes/bilibili/video.js
@@ -26,7 +26,7 @@ module.exports = async (ctx) => {
             data.data.list.vlist &&
             data.data.list.vlist.map((item) => ({
                 title: item.title,
-                description: `${item.description}${!disableEmbed ? `<br><br>${utils.iframe(item.aid)}` : ''}<br><img src="${item.pic}">`,
+                description: `<a href="bilibili://video/${ item.created > utils.bvidTime && item.bvid ? item.bvid : item.aid }">${item.description || item.title}</a>${!disableEmbed ? `<br><br>${utils.iframe(item.aid)}` : ''}<br><img src="${item.pic}">`,
                 pubDate: new Date(item.created * 1000).toUTCString(),
                 link: item.created > utils.bvidTime && item.bvid ? `https://www.bilibili.com/video/${item.bvid}` : `https://www.bilibili.com/video/av${item.aid}`,
                 author: name,


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

```routes
/bilibili/user/video
```

## 说明 / Note

因为ios上embed播放器没有倍速播放，所以加个跳转，打开app观看