### PR TITLE
Add 'restrict' parameter to Pixiv illustfollows

### DIFF
--- a/lib/routes/pixiv/api/getIllustFollows.js
+++ b/lib/routes/pixiv/api/getIllustFollows.js
@@ -7,7 +7,7 @@ const queryString = require('query-string');
  * @param {string} token pixiv oauth token
  * @returns {Promise<got.AxiosResponse<{illusts: illust[]}>>}
  */
-module.exports = function getUserIllustFollows(token) {
+module.exports = function getUserIllustFollows(token, restrict) {
     return got({
         method: 'get',
         url: 'https://app-api.pixiv.net/v2/illust/follow',
@@ -16,7 +16,7 @@ module.exports = function getUserIllustFollows(token) {
             Authorization: 'Bearer ' + token,
         },
         searchParams: queryString.stringify({
-            restrict: 'public',
+            restrict: restrict ? 'private' : 'public',
         }),
     });
 };

--- a/lib/routes/pixiv/illustfollow.js
+++ b/lib/routes/pixiv/illustfollow.js
@@ -8,12 +8,14 @@ module.exports = async (ctx) => {
         throw 'pixiv RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#%E9%83%A8%E5%88%86-rss-%E6%A8%A1%E5%9D%97%E9%85%8D%E7%BD%AE">relevant config</a>';
     }
 
+    const restrict = (ctx.params.restrict === 'private');
+
     const token = await getToken();
     if (!(await getToken())) {
         throw 'pixiv not login';
     }
 
-    const response = await getIllustFollows(token);
+    const response = await getIllustFollows(token, restrict);
     const illusts = response.data.illusts;
     ctx.state.data = {
         title: `Pixiv关注的新作品`,


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

The pixiv illustfollows route is hardcoded to fetch the public feed (`restrict` parameter set to `public`).

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/pixiv/user/illustfollows
/pixiv/user/illustfollows?restrict=private
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [ ] CN
  - [x] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

This PR adds the capability to choose whether to use the private or public feed.