### PR TITLE
fix(route): 公众号 (feeddd 来源)

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -3071,7 +3071,7 @@ column 为 third 时可选的 category:
 
 ### 公众号 (feeddd 来源)
 
-<Route author="TonyRL" example="/wechat/feeddd/6131e1441269c358aa0e2141" path="/wechat/feeddd/:id" :paramsDesc="['公众号 id, 打开 `https://feeddd.org/feeds` 或 `https://cdn.jsdelivr.net/gh/feeddd/feeds/feeds_all_rss.txt`, 在 URL 中找到 id']"/>
+<Route author="TonyRL Rongronggg9" example="/wechat/feeddd/6131e1441269c358aa0e2141" path="/wechat/feeddd/:id" :paramsDesc="['公众号 id, 打开 `https://feeddd.org/feeds` 或 `https://cdn.jsdelivr.net/gh/feeddd/feeds/feeds_all_rss.txt`, 在 URL 中找到 id; 注意不是公众号页的 id, 而是订阅的 id']"/>
 
 ### 公众号栏目 (非推送 & 历史消息)
 

--- a/lib/v2/wechat/feeddd.js
+++ b/lib/v2/wechat/feeddd.js
@@ -12,15 +12,10 @@ module.exports = async (ctx) => {
 
     const response = await got(apiUrl);
 
-    if (response.data.items.length === 0) {
-        throw Error('Empty feed');
-    }
-
     let items = response.data.items.map((item) => ({
         title: item.title,
         pubDate: parseDate(item.date_modified),
         link: item.url,
-        author: item.title,
         guid: item.id,
     }));
 
@@ -51,6 +46,18 @@ module.exports = async (ctx) => {
                     desc: $('#js_content').html(),
                 });
 
+                item.author = $('meta[name=author]').attr('content');
+
+                // another way to get publish timestamp:
+                // const publish_time_script = $('script[nonce][type="text/javascript"]:contains("var ct")').html();
+                // const publish_time_match = publish_time_script && publish_time_script.match(/var ct *= *"(\d{10})"/);
+                const publish_time_script = $('script[nonce][type="text/javascript"]:contains("publish_time")').html();
+                const publish_time_match = publish_time_script && publish_time_script.match(/var.*[ ,]n *= *"(\d{10})"/);
+                const publish_timestamp = publish_time_match && publish_time_match[1];
+                if (publish_timestamp) {
+                    item.pubDate = parseDate(publish_timestamp * 1000);
+                }
+
                 return item;
             })
         )
@@ -61,6 +68,7 @@ module.exports = async (ctx) => {
         link: response.data.feed_url,
         description: response.data.title,
         item: items,
+        allowEmpty: true,
     };
 
     ctx.state.json = {

--- a/lib/v2/wechat/maintainer.js
+++ b/lib/v2/wechat/maintainer.js
@@ -1,3 +1,3 @@
 module.exports = {
-    '/feeddd/:id': ['TonyRL'],
+    '/feeddd/:id': ['TonyRL', 'Rongronggg9'],
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/wechat/feeddd/6131e1441269c358aa0e2141
/wechat/feeddd/61512ab61269c358aa13b69c
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [x] Documentation
  - [x] CN
  - [ ] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
* `author`
	* 文章标题 -> 文章作者（从文章页元数据提取，可为空）
* `pubDate`
	* feeddd 提供的 `pubDate`（抓取时间，晚于文章实际发布时间） -> 文章实际发布时间（从文章页提取，提取失败则为 feeddd 抓取时间）
* 允许 empty feed
	* feeddd 收录公众号后就会产生一个 empty feed, 抓取到文章后才会填充内容。我们应当允许一个 empty feed, 这样就不必等到 feed 被填充才能订阅
* 文档中增加选取正确的 id 的提示
	* > 在 URL 中找到 id; 注意不是公众号页的 id, 而是订阅的 id