### PR TITLE
feat(route): add Nikkei Asia

### DIFF
--- a/docs/en/traditional-media.md
+++ b/docs/en/traditional-media.md
@@ -207,6 +207,10 @@ Only `s00017` is in English.
 
 <RouteEn author="Andiedie" example="/nhk/news_web_easy" path="/nhk/news_web_easy"/>
 
+## Nikkei Asia
+
+<Route author="rainrdx" example="/nikkei-asia" path="/nikkei-asia"/>
+
 ## Phoronix
 
 ### News & Reviews

--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -212,6 +212,10 @@ pageClass: routes
 
 <Route author="Andiedie" example="/nhk/news_web_easy" path="/nhk/news_web_easy"/>
 
+## Nikkei Asia
+
+<Route author="rainrdx" example="/nikkei-asia" path="/nikkei-asia"/>
+
 ## Now 新聞
 
 ### 新聞

--- a/lib/v2/nikkei-asia/index.js
+++ b/lib/v2/nikkei-asia/index.js
@@ -1,0 +1,41 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+
+
+module.exports = async (ctx) => {
+
+    const currentUrl = `https://main-asianreview-nikkei.content.pugpig.com/editionfeed/4519/pugpig_atom_contents.json`;
+
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+    });
+
+
+    const stories = response.data.stories;
+
+    items = await Promise.all(
+        stories.map((item) =>
+            ctx.cache.tryGet(item.url, async () => {
+                const fulltext = await got({
+                    method: 'get',
+                    url: `https://main-asianreview-nikkei.content.pugpig.com/editionfeed/4519/${item.url}`,
+                });
+
+                item.pubDate = parseDate(item.published);
+		item.link = item.shareurl;
+
+		const fulltextcontent = cheerio.load(fulltext.data);
+		item.description = fulltextcontent('section[class="pp-article__body"]').html().replace(/\.\.\/\.\.\/\.\.\/\.\.\//g, 'https://main-asianreview-nikkei.content.pugpig.com/');
+                return item;
+            })
+        )
+    );
+
+    ctx.state.data = {
+        title: `Nikkei Asia`,
+        link: `https://asia.nikkei.com`,
+        item: items,
+    };
+};

--- a/lib/v2/nikkei-asia/maintainer.js
+++ b/lib/v2/nikkei-asia/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/nikkei-asia': ['rainrdx'],
+};

--- a/lib/v2/nikkei-asia/radar.js
+++ b/lib/v2/nikkei-asia/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'asia.nikkei.com': {
+        _name: 'Nikkei Asia',
+        '.': [
+            {
+                title: 'Nikkei Asia',
+                docs: 'https://docs.rsshub.app/traditional-media.html#nikkei-asia',
+                source: '/',
+                target: '/nikkei-asia/',
+            },
+        ],
+    },
+};

--- a/lib/v2/nikkei-asia/router.js
+++ b/lib/v2/nikkei-asia/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/', require('./index'));
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/nikkei-asia
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [X] New Route
- [X] Documentation
  - [X] CN
  - [X] EN
- [X] 全文获取 fulltext
  - [X] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [X] 日期和时间 date and time
  - [X] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
Full text rss for https://asia.nikkei.com