### PR TITLE
fix(core): fix fulltext

### DIFF
--- a/lib/middleware/parameter.js
+++ b/lib/middleware/parameter.js
@@ -209,9 +209,7 @@ module.exports = async (ctx, next) => {
 
                             const res = await got(link);
                             const $ = cheerio.load(res.data, {
-                                xml: {
-                                    xmlMode: false,
-                                },
+                                xmlMode: true,
                             });
                             const result = await mercury_parser.parse(link, {
                                 html: $.html(),

--- a/lib/middleware/parameter.js
+++ b/lib/middleware/parameter.js
@@ -208,7 +208,11 @@ module.exports = async (ctx, next) => {
                             mercury_parser = mercury_parser || require('@postlight/mercury-parser');
 
                             const res = await got(link);
-                            const $ = cheerio.load(res.data);
+                            const $ = cheerio.load(res.data, {
+                                xml: {
+                                    xmlMode: false,
+                                },
+                            });
                             const result = await mercury_parser.parse(link, {
                                 html: $.html(),
                             });


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #8946

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/bilibili/user/article/334958638?mode=fulltext
/weatherAlarm?mode=fulltext
```

## 说明 / Note

This is possibly caused by a breaking change of cheerio in `1.0.0-rc.4` in efa0018b3fe1a2426c804a4fa12dcc381eda2252.

cheerio will now return U+FFFD

<details>

<summary>bad html entities</summary>

```xml
<item>
<title>
<![CDATA[ 陕西省延安市洛川县气象台发布大雾黄色预警信号 ]]>
</title>
<description>
<![CDATA[ <div><div id="alarmtext"><p>&#x77F;a&#xFFFD;2022t0127&#xFFFD;21&#xFFFD;40&#xFFFD;&apos;&#xFFFD;&#xFFFD;r&#xFFFD;f&#xFFFD;&#xFFFD;&#xFFFD;&#xFFFD;*e12&#xFFFD;&#xFFFD;&#xFFFD;&#xFFFD;$G&#xFFFD;4G&#xFFFD;G&#xFFFD;G&#xFFFD;&#xFFFD;G&#xFFFD;WS8aG&#xFFFD;G&#xFFFD;&#xFFFD;G&#xFFFD;&#xFFFD;&#xFFFD;&#xFFFD;&#xFFFD;&#xFFFD;500s&#xFFFD;&#xFFFD;&#xFFFD;&#xFFFD;2</p></div><div id="alarmtext"><p><strong>2&#xFFFD;W</strong></p> 1.s&#xFFFD;&#xFFFD;UMgL#Z}2&#xFFFD;&#xFFFD;&#xFFFD;\ 2.::&#xFFFD;l&#xFFFD;n!4IUM&#xFFFD;:&#xFFFD;&#xFFFD;&#x75C;&#xFFFD;h 3.~v&#xFFFD;X&#xFFFD;&#xFFFD;&#xFFFD;&#xFFFD;&#xFFFD;~v <p>4.7;&#xFFFD;&#xFFFD;&#xFFFD;h </p></div></div> ]]>
</description>
<pubDate>Thu, 27 Jan 2022 21:43:00 GMT</pubDate>
<guid isPermaLink="false">http://www.nmc.cn/publish/alarm/61062941600000_20220127214313.html</guid>
<link>http://www.nmc.cn/publish/alarm/61062941600000_20220127214313.html</link>
</item>
```
</details>

compare with Vercel's

<details>

<summary>decodable output</summary>

```xml
<item>
            <title><![CDATA[陕西省延安市洛川县气象台发布道路结冰黄色预警信号]]></title>
            <description><![CDATA[<div><div id="alarmtext"><p>&#x6D1B;&#x5DDD;&#x53BF;&#x6C14;&#x8C61;&#x53F0;2022&#x5E74;01&#x6708;27&#x65E5;21&#x65F6;30&#x5206;&#x7EE7;&#x7EED;&#x53D1;&#x5E03;&#x9053;&#x8DEF;&#x7ED3;&#x51B0;&#x9EC4;&#x8272;&#x9884;&#x8B66;&#x4FE1;&#x53F7;&#xFF1A;&#x53D7;&#x964D;&#x96EA;&#x548C;&#x4F4E;&#x6E29;&#x5F71;&#x54CD;&#xFF0C;&#x9884;&#x8BA1;&#x672A;&#x6765;12&#x5C0F;&#x65F6;&#x5185;&#xFF0C;&#x6211;&#x53BF;&#x65E7;&#x53BF;&#x9547;&#x3001;&#x83E9;&#x5824;&#x9547;&#x3001;&#x77F3;&#x5934;&#x9547;&#x3001;&#x571F;&#x57FA;&#x9547;&#x3001;&#x8001;&#x5E99;&#x9547;&#x3001;&#x69D0;&#x67CF;&#x9547;&#x3001;&#x51E4;&#x6816;&#x8857;&#x9053;&#x3001;&#x6C38;&#x4E61;&#x9547;&#x3001;&#x4EA4;&#x53E3;&#x6CB3;&#x9547;&#x4ECD;&#x6709;&#x5BF9;&#x4EA4;&#x901A;&#x6709;&#x5F71;&#x54CD;&#x7684;&#x9053;&#x8DEF;&#x7ED3;&#x51B0;&#xFF0C;&#x8BF7;&#x6709;&#x5173;&#x5355;&#x4F4D;&#x548C;&#x4EBA;&#x5458;&#x505A;&#x597D;&#x9632;&#x8303;&#x51C6;&#x5907;&#xFF01;</p></div><div id="alarmtext"><p><strong>&#x9632;&#x5FA1;&#x6307;&#x5357;&#xFF1A;</strong></p> 1.&#x4EA4;&#x901A;&#x3001;&#x516C;&#x5B89;&#x7B49;&#x90E8;&#x95E8;&#x8981;&#x6309;&#x7167;&#x804C;&#x8D23;&#x505A;&#x597D;&#x9053;&#x8DEF;&#x7ED3;&#x51B0;&#x5E94;&#x5BF9;&#x51C6;&#x5907;&#x5DE5;&#x4F5C;&#xFF1B; 2.&#x9A7E;&#x9A76;&#x4EBA;&#x5458;&#x5E94;&#x5F53;&#x6CE8;&#x610F;&#x8DEF;&#x51B5;&#xFF0C;&#x5B89;&#x5168;&#x884C;&#x9A76;&#xFF1B; <p>3.&#x884C;&#x4EBA;&#x5916;&#x51FA;&#x5C3D;&#x91CF;&#x5C11;&#x9A91;&#x81EA;&#x884C;&#x8F66;&#xFF0C;&#x6CE8;&#x610F;&#x9632;&#x6ED1;&#x3002; </p></div></div>]]></description>
            <pubDate>Thu, 27 Jan 2022 21:33:00 GMT</pubDate>
            <guid isPermaLink="false">http://www.nmc.cn/publish/alarm/61062941600000_20220127213314.html</guid>
            <link>http://www.nmc.cn/publish/alarm/61062941600000_20220127213314.html</link>
```
</details>

Adding xmMode to cheerio.load() will switch to htmlparser2 instead of the new default parse5 starting from 1.0.0-rc.4

---
Alternative option:

revert back to `cheerio@1.0.0-rc.3`