### PR TITLE
fix(route): fixes "this route is empty" for copymanga

### DIFF
--- a/docs/anime.md
+++ b/docs/anime.md
@@ -443,7 +443,7 @@ Sources
 
 ### 漫画更新
 
-<Route author="btdwv" path="/copymanga/comic/:id/:chapterCnt?" example="/copymanga/comic/zaiyishijiemigongkaihougong/5" :paramsDesc="['漫画ID','返回章节的数量，默认为0，返回所有章节']" radar="1" rssbud="1"/>
+<Route author="btdwv yan12125" path="/copymanga/comic/:id/:chapterCnt?" example="/copymanga/comic/zaiyishijiemigongkaihougong/5" :paramsDesc="['漫画ID','返回章节的数量，默认为0，返回所有章节']" radar="1" rssbud="1"/>
 
 ## 漫画 DB
 

--- a/docs/anime.md
+++ b/docs/anime.md
@@ -443,7 +443,7 @@ Sources
 
 ### 漫画更新
 
-<Route author="btdwv yan12125" path="/copymanga/comic/:id/:chapterCnt?" example="/copymanga/comic/zaiyishijiemigongkaihougong/5" :paramsDesc="['漫画ID','返回章节的数量，默认为0，返回所有章节']" radar="1" rssbud="1"/>
+<Route author="btdwv marvolo666 yan12125" path="/copymanga/comic/:id/:chapterCnt?" example="/copymanga/comic/zaiyishijiemigongkaihougong/5" :paramsDesc="['漫画ID','返回章节的数量，默认为0，返回所有章节']" radar="1" rssbud="1"/>
 
 ## 漫画 DB
 

--- a/lib/routes/copymanga/comic.js
+++ b/lib/routes/copymanga/comic.js
@@ -59,10 +59,16 @@ module.exports = async (ctx) => {
         `.trim(),
     });
 
+    let itemsLen = chapterArray.length;
+
+    if (chapterCnt > 0) {
+        itemsLen = chapterCnt;
+    }
+
     ctx.state.data = {
         title: `拷贝漫画 - ${bookTitle}`,
         link: `https://copymanga.com/comic/${id}`,
         description: bookIntro,
-        item: chapterArray.map(genResult).slice(0, chapterCnt),
+        item: chapterArray.map(genResult).slice(0, itemsLen),
     };
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/copymanga/comic/woliyubaiwanshengmingzhishang/5
/copymanga/comic/woliyubaiwanshengmingzhishang/0
/copymanga/comic/woliyubaiwanshengmingzhishang
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [ ] New Route
- [ ] Documentation
  - [ ] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 日期和时间 date and time
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

This fix mirrors manhuagui logic updated in [1] - returns all items
when chapterCnt is 0 or not specified.

/cc @marvolo666

[1] https://github.com/DIYgod/RSSHub/pull/8670