### PR TITLE
feat: /dockerhub/tags/:owner/:image

### DIFF
--- a/docs/program-update.md
+++ b/docs/program-update.md
@@ -158,6 +158,16 @@ pageClass: routes
 
 :::
 
+### 镜像有新 Tag
+
+<Route author="outloudvi" example="/dockerhub/tag/library/mariadb" path="/dockerhub/tag/:owner/:image" :paramsDesc="['镜像作者', '镜像名称']" radar="1" rssbud="1"/>
+
+::: warning 注意
+
+官方镜像的 owner 填写 library, 如: <https://rsshub.app/dockerhub/tag/library/mysql>
+
+:::
+
 ## Eagle
 
 ### 更新日志

--- a/lib/v2/dockerhub/maintainer.js
+++ b/lib/v2/dockerhub/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/tag/:owner/:image': ['outloudvi'],
+};

--- a/lib/v2/dockerhub/radar.js
+++ b/lib/v2/dockerhub/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'hub.docker.com': {
+        _name: 'Docker Hub',
+        '.': [
+            {
+                title: '镜像有新 Tag',
+                docs: 'https://docs.rsshub.app/shopping.html#docker-hub-jing-xiang-you-xin-tag',
+                source: ['/r/:owner/:image', '/r/:owner/:image/tags', '/_/:image'],
+                target: (params) => `/dockerhub/tag/${params.owner ? params.owner : 'library'}/${params.image}`,
+            },
+        ],
+    },
+};

--- a/lib/v2/dockerhub/router.js
+++ b/lib/v2/dockerhub/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/tag/:owner/:image', require('./tag'));
+};

--- a/lib/v2/dockerhub/tag.js
+++ b/lib/v2/dockerhub/tag.js
@@ -1,0 +1,29 @@
+const got = require('@/utils/got');
+
+module.exports = async (ctx) => {
+    const { owner, image } = ctx.params;
+
+    const namespace = `${owner}/${image}`;
+
+    const link = `https://hub.docker.com/r/${namespace}`;
+
+    const data = await got.get(`https://hub.docker.com/v2/repositories/${namespace}/tags/`);
+    const metadata = await got.get(`https://hub.docker.com/v2/repositories/${namespace}/`);
+
+    const tags = data.data.results;
+
+    ctx.state.data = {
+        title: `${namespace} tags`,
+        description: metadata.data.description,
+        link,
+        language: 'en',
+        item: tags.map((item) => ({
+            title: `${namespace}:${item.name} was updated`,
+            description: `${namespace}:${item.name} was updated, supporting the architectures of ${item.images.map((img) => `${img.os}/${img.architecture}`).join(', ')}`,
+            link: `https://hub.docker.com/layers/${owner === 'library' ? `${image}/` : ''}${namespace}/${item.name}/images/${item.images[0].digest.replace(':', '-')}`,
+            author: owner,
+            pubDate: new Date(item.tag_last_pushed).toUTCString(),
+            guid: item.tag_last_pushed,
+        })),
+    };
+};


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #6916

## 完整路由地址 / Example for the proposed route(s)

```route
/dockerhub/tag/library/mariadb
/dockerhub/tag/rustembedded/cross
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [x] CN
  - [ ] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

将来也许可以将 architecture 作为过滤参数。