### PR TITLE
feat: /spotify/*

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,6 +26,9 @@
         "SPOTIFY_API_SECRET": {
             "required": false
         },
+        "SPOTIFY_REFRESHTOKEN": {
+            "required": false
+        },
         "TWITTER_CONSUMER_KEY": {
             "required": false
         },

--- a/app.json
+++ b/app.json
@@ -20,10 +20,10 @@
         "DISQUS_API_KEY": {
             "required": false
         },
-        "SPOTIFY_API_KEY": {
+        "SPOTIFY_CLIENT_ID": {
             "required": false
         },
-        "SPOTIFY_API_SECRET": {
+        "SPOTIFY_CLIENT_SECRET": {
             "required": false
         },
         "SPOTIFY_REFRESHTOKEN": {

--- a/app.json
+++ b/app.json
@@ -20,6 +20,12 @@
         "DISQUS_API_KEY": {
             "required": false
         },
+        "SPOTIFY_API_KEY": {
+            "required": false
+        },
+        "SPOTIFY_API_SECRET": {
+            "required": false
+        },
         "TWITTER_CONSUMER_KEY": {
             "required": false
         },

--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -538,6 +538,16 @@ See docs of the specified route and `lib/config.js` for detailed information.
 
     -   `GITHUB_ACCESS_TOKEN`: GitHub Access Token
 
+-   spotify: [API key registration](https://developer.spotify.com)
+
+    -   `SPOTIFY_API_KEY`：Client ID of the application
+
+    -   `SPOTIFY_API_SECRET`：Client secret of the application
+
+-   spotify (user data related routes):
+
+    -   `SPOTIFY_REFRESHTOKEN`：The refresh token of the user f the Spotify application. Check [this gist](https://gist.github.com/outloudvi/d1bbeb5e989db5385384a223a7263744) for detailed information.
+
 -   Instagram:
 
     -   `IG_USERNAME`: Your Instagram username

--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -540,9 +540,9 @@ See docs of the specified route and `lib/config.js` for detailed information.
 
 -   spotify: [API key registration](https://developer.spotify.com)
 
-    -   `SPOTIFY_API_KEY`：Client ID of the application
+    -   `SPOTIFY_CLIENT_ID`：Client ID of the application
 
-    -   `SPOTIFY_API_SECRET`：Client secret of the application
+    -   `SPOTIFY_CLIENT_SECRET`：Client secret of the application
 
 -   spotify (user data related routes):
 

--- a/docs/en/multimedia.md
+++ b/docs/en/multimedia.md
@@ -150,6 +150,30 @@ Refer to [Pornhub F.A.Qs](https://help.pornhub.com/hc/en-us/articles/36004432703
 
 <RouteEn author="fallenhh" example="/soundcloud/tracks/angeart" path="/soundcloud/tracks/:user" :paramsDesc="['User name']" />
 
+## Spotify
+
+
+### Artist Albums
+
+<RouteEn author="outloudvi" example="/spotify/artist/6k9TBCxyr4bXwZ8Y21Kwn1" path="/spotify/artist/:id" :paramsDesc="['Artist ID']" />
+
+### Playlist
+
+<RouteEn author="outloudvi" example="/spotify/playlist/4UBVy1LttvodwivPUuwJk2" path="/spotify/playlist/:id" :paramsDesc="['Playlist ID']" />
+
+### Personal Saved Tracks
+
+<RouteEn author="outloudvi" example="/spotify/saved/50" path="/spotify/saved/:limit?" :paramsDesc="['Track count, 50 by default']" />
+
+### Personal Top Tracks
+
+<RouteEn author="outloudvi" example="/spotify/top/tracks" path="/spotify/top/tracks" />
+
+### Personal Top Artists
+
+<RouteEn author="outloudvi" example="/spotify/top/artists" path="/spotify/top/artists" />
+
+
 ## Trakt.tv
 
 ### User Collection

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -550,9 +550,9 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 
 -   spotify 全部路由： [注册地址](https://developer.spotify.com)
 
-    -   `SPOTIFY_API_KEY`：Spotify 应用的 client ID
+    -   `SPOTIFY_CLIENT_ID`：Spotify 应用的 client ID
 
-    -   `SPOTIFY_API_SECRET`：Spotify 应用的 client secret
+    -   `SPOTIFY_CLIENT_SECRET`：Spotify 应用的 client secret
 
 -   spotify 用户相关路由
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -548,6 +548,16 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
         3.  点击 dynamic_new 请求，找到 Cookie
         4.  视频和专栏只要求 `SESSDATA` 字段，动态需复制整段 Cookie
 
+-   spotify 全部路由： [注册地址](https://developer.spotify.com)
+
+    -   `SPOTIFY_API_KEY`：Spotify 应用的 client ID
+
+    -   `SPOTIFY_API_SECRET`：Spotify 应用的 client secret
+
+-   spotify 用户相关路由
+
+    -   `SPOTIFY_REFRESHTOKEN`：用户在此 Spotify 应用的 refresh token。可以利用 [此 gist](https://gist.github.com/outloudvi/d1bbeb5e989db5385384a223a7263744) 获取。
+
 -   语雀 全部路由：[注册地址](https://www.yuque.com/register)
 
     -   `YUQUE_TOKEN`: 语雀 Token，[获取地址](https://www.yuque.com/settings/tokens)。语雀接口做了访问频率限制，为保证正常访问建议配置 Token，详见 [语雀开发者文档](https://www.yuque.com/yuque/developer/api#5b3a1535)。

--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -826,6 +826,28 @@ JavDB 有多个备用域名，本路由以 <https://javdb7.com> 为默认域名�
 
 <Route author="fallenhh" example="/soundcloud/tracks/angeart" path="/soundcloud/tracks/:user" :paramsDesc="['用户名']" />
 
+## Spotify
+
+### 艺术家专辑
+
+<Route author="outloudvi" example="/spotify/artist/6k9TBCxyr4bXwZ8Y21Kwn1" path="/spotify/artist/:id" :paramsDesc="['艺术家 ID']" />
+
+### 播放列表
+
+<Route author="outloudvi" example="/spotify/playlist/4UBVy1LttvodwivPUuwJk2" path="/spotify/playlist/:id" :paramsDesc="['播放列表 ID']" />
+
+### 个人 Saved Tracks
+
+<Route author="outloudvi" example="/spotify/saved/50" path="/spotify/saved/:limit?" :paramsDesc="['歌曲数量，默认为 50']" />
+
+### 个人 Top Tracks
+
+<Route author="outloudvi" example="/spotify/top/tracks" path="/spotify/top/tracks" />
+
+### 个人 Top Artists
+
+<Route author="outloudvi" example="/spotify/top/artists" path="/spotify/top/artists" />
+
 ## Sub HD
 
 ### 字幕

--- a/lib/config.js
+++ b/lib/config.js
@@ -63,6 +63,10 @@ const calculateValue = () => {
         disqus: {
             api_key: envs.DISQUS_API_KEY,
         },
+        spotify: {
+            apiKey: envs.SPOTIFY_API_KEY,
+            apiSecret: envs.SPOTIFY_API_SECRET,
+        },
         twitter: {
             consumer_key: envs.TWITTER_CONSUMER_KEY,
             consumer_secret: envs.TWITTER_CONSUMER_SECRET,

--- a/lib/config.js
+++ b/lib/config.js
@@ -64,8 +64,8 @@ const calculateValue = () => {
             api_key: envs.DISQUS_API_KEY,
         },
         spotify: {
-            apiKey: envs.SPOTIFY_API_KEY,
-            apiSecret: envs.SPOTIFY_API_SECRET,
+            clientId: envs.SPOTIFY_CLIENT_ID,
+            clientSecret: envs.SPOTIFY_CLIENT_SECRET,
             refreshToken: envs.SPOTIFY_REFRESHTOKEN,
         },
         twitter: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -66,6 +66,7 @@ const calculateValue = () => {
         spotify: {
             apiKey: envs.SPOTIFY_API_KEY,
             apiSecret: envs.SPOTIFY_API_SECRET,
+            refreshToken: envs.SPOTIFY_REFRESHTOKEN,
         },
         twitter: {
             consumer_key: envs.TWITTER_CONSUMER_KEY,

--- a/lib/v2/spotify/artist.js
+++ b/lib/v2/spotify/artist.js
@@ -34,4 +34,8 @@ module.exports = async (ctx) => {
             link: x.external_urls.spotify,
         })),
     };
+
+    if (meta.images.length) {
+        ctx.state.data.image = meta.images[0].url;
+    }
 };

--- a/lib/v2/spotify/artist.js
+++ b/lib/v2/spotify/artist.js
@@ -1,0 +1,37 @@
+const utils = require('./utils');
+const got = require('@/utils/got');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const token = await utils.getPublicToken();
+    const { id } = ctx.params;
+    const meta = await got
+        .get(`https://api.spotify.com/v1/artists/${id}`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+        .json();
+
+    const itemsResponse = await got
+        .get(`https://api.spotify.com/v1/artists/${id}/albums`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+        .json();
+    const albums = itemsResponse.items;
+
+    ctx.state.data = {
+        title: `Albums of ${meta.name}`,
+        link: meta.external_urls.spotify,
+        allowEmpty: true,
+        item: albums.map((x) => ({
+            title: x.name,
+            author: x.artists.map((a) => a.name).join(', '),
+            description: `"${x.name}" by ${x.artists.map((a) => a.name).join(', ')}, released at ${x.release_date} with ${x.total_tracks} tracks.`,
+            pubDate: parseDate(x.release_date),
+            link: x.external_urls.spotify,
+        })),
+    };
+};

--- a/lib/v2/spotify/maintainer.js
+++ b/lib/v2/spotify/maintainer.js
@@ -1,3 +1,4 @@
 module.exports = {
+    '/artist/:id': ['outloudvi'],
     '/playlist/:id': ['outloudvi'],
 };

--- a/lib/v2/spotify/maintainer.js
+++ b/lib/v2/spotify/maintainer.js
@@ -1,4 +1,7 @@
 module.exports = {
     '/artist/:id': ['outloudvi'],
     '/playlist/:id': ['outloudvi'],
+    '/saved/:limit?': ['outloudvi'],
+    '/top/tracks': ['outloudvi'],
+    '/top/artists': ['outloudvi'],
 };

--- a/lib/v2/spotify/maintainer.js
+++ b/lib/v2/spotify/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/playlist/:id': ['outloudvi'],
+};

--- a/lib/v2/spotify/playlist.js
+++ b/lib/v2/spotify/playlist.js
@@ -24,4 +24,8 @@ module.exports = async (ctx) => {
             pubDate: parseDate(x.added_at),
         })),
     };
+
+    if (meta.images.length) {
+        ctx.state.data.image = meta.images[0].url;
+    }
 };

--- a/lib/v2/spotify/playlist.js
+++ b/lib/v2/spotify/playlist.js
@@ -1,0 +1,38 @@
+const utils = require('./utils');
+const got = require('@/utils/got');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const token = await utils.getPublicToken();
+    const { id } = ctx.params;
+    const meta = await got
+        .get(`https://api.spotify.com/v1/playlists/${id}`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+        .json();
+
+    const itemsResponse = await got
+        .get(`https://api.spotify.com/v1/playlists/${id}/tracks`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+        .json();
+    const tracks = itemsResponse.items;
+
+    ctx.state.data = {
+        title: meta.name,
+        link: meta.external_urls.spotify,
+        description: meta.description,
+        allowEmpty: true,
+        item: tracks.map((x) => ({
+            title: x.track.name,
+            author: x.track.artists.map((a) => a.name).join(', '),
+            description: `"${x.track.name}" by ${x.track.artists.map((a) => a.name).join(', ')} from the album "${x.track.album.name}"`,
+            pubDate: parseDate(x.added_at),
+            link: x.track.external_urls.spotify,
+        })),
+    };
+};

--- a/lib/v2/spotify/playlist.js
+++ b/lib/v2/spotify/playlist.js
@@ -12,15 +12,7 @@ module.exports = async (ctx) => {
             },
         })
         .json();
-
-    const itemsResponse = await got
-        .get(`https://api.spotify.com/v1/playlists/${id}/tracks`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        })
-        .json();
-    const tracks = itemsResponse.items;
+    const tracks = meta.tracks.items;
 
     ctx.state.data = {
         title: meta.name,
@@ -28,11 +20,8 @@ module.exports = async (ctx) => {
         description: meta.description,
         allowEmpty: true,
         item: tracks.map((x) => ({
-            title: x.track.name,
-            author: x.track.artists.map((a) => a.name).join(', '),
-            description: `"${x.track.name}" by ${x.track.artists.map((a) => a.name).join(', ')} from the album "${x.track.album.name}"`,
+            ...utils.parseTrack(x.track),
             pubDate: parseDate(x.added_at),
-            link: x.track.external_urls.spotify,
         })),
     };
 };

--- a/lib/v2/spotify/radar.js
+++ b/lib/v2/spotify/radar.js
@@ -16,6 +16,27 @@ module.exports = {
                 source: ['/artist/:id'],
                 target: '/spotify/artist/:id',
             },
+            {
+                title: '用户喜爱歌曲',
+                // TODO: update docs link
+                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                source: ['/collection/tracks'],
+                target: '/spotify/saved',
+            },
+            {
+                title: '用户 Top Tracks',
+                // TODO: update docs link
+                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                source: ['/'],
+                target: '/spotify/top/tracks',
+            },
+            {
+                title: '用户 Top Artists',
+                // TODO: update docs link
+                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                source: ['/'],
+                target: '/spotify/top/artists',
+            },
         ],
     },
 };

--- a/lib/v2/spotify/radar.js
+++ b/lib/v2/spotify/radar.js
@@ -1,13 +1,20 @@
 module.exports = {
-    'open.spotify.com': {
+    'spotify.com': {
         _name: 'Spotify',
-        '.': [
+        open: [
             {
                 title: '播放列表',
                 // TODO: update docs link
                 docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
                 source: ['/playlist/:id'],
                 target: '/spotify/playlist/:id',
+            },
+            {
+                title: '歌手专辑',
+                // TODO: update docs link
+                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                source: ['/artist/:id'],
+                target: '/spotify/artist/:id',
             },
         ],
     },

--- a/lib/v2/spotify/radar.js
+++ b/lib/v2/spotify/radar.js
@@ -4,36 +4,31 @@ module.exports = {
         open: [
             {
                 title: '播放列表',
-                // TODO: update docs link
-                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                docs: 'https://docs.rsshub.app/multimedia.html#spotify',
                 source: ['/playlist/:id'],
                 target: '/spotify/playlist/:id',
             },
             {
                 title: '歌手专辑',
-                // TODO: update docs link
-                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                docs: 'https://docs.rsshub.app/multimedia.html#spotify',
                 source: ['/artist/:id'],
                 target: '/spotify/artist/:id',
             },
             {
-                title: '用户喜爱歌曲',
-                // TODO: update docs link
-                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                title: '用户 Saved Tracks',
+                docs: 'https://docs.rsshub.app/multimedia.html#spotify',
                 source: ['/collection/tracks'],
                 target: '/spotify/saved',
             },
             {
                 title: '用户 Top Tracks',
-                // TODO: update docs link
-                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                docs: 'https://docs.rsshub.app/multimedia.html#spotify',
                 source: ['/'],
                 target: '/spotify/top/tracks',
             },
             {
                 title: '用户 Top Artists',
-                // TODO: update docs link
-                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                docs: 'https://docs.rsshub.app/multimedia.html#spotify',
                 source: ['/'],
                 target: '/spotify/top/artists',
             },

--- a/lib/v2/spotify/radar.js
+++ b/lib/v2/spotify/radar.js
@@ -1,0 +1,14 @@
+module.exports = {
+    'open.spotify.com': {
+        _name: 'Spotify',
+        '.': [
+            {
+                title: '播放列表',
+                // TODO: update docs link
+                docs: 'https://docs.rsshub.app/shopping.html#furstar-zui-xin-shou-mai-jiao-se-lie-biao',
+                source: ['/playlist/:id'],
+                target: '/spotify/playlist/:id',
+            },
+        ],
+    },
+};

--- a/lib/v2/spotify/router.js
+++ b/lib/v2/spotify/router.js
@@ -2,4 +2,6 @@ module.exports = function (router) {
     router.get('/artist/:id', require('./artist'));
     router.get('/playlist/:id', require('./playlist'));
     router.get('/saved/:limit?', require('./saved'));
+    router.get('/top/tracks', require('./top')('tracks'));
+    router.get('/top/artists', require('./top')('artists'));
 };

--- a/lib/v2/spotify/router.js
+++ b/lib/v2/spotify/router.js
@@ -1,3 +1,4 @@
 module.exports = function (router) {
+    router.get('/artist/:id', require('./artist'));
     router.get('/playlist/:id', require('./playlist'));
 };

--- a/lib/v2/spotify/router.js
+++ b/lib/v2/spotify/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/playlist/:id', require('./playlist'));
+};

--- a/lib/v2/spotify/router.js
+++ b/lib/v2/spotify/router.js
@@ -1,4 +1,5 @@
 module.exports = function (router) {
     router.get('/artist/:id', require('./artist'));
     router.get('/playlist/:id', require('./playlist'));
+    router.get('/saved/:limit?', require('./saved'));
 };

--- a/lib/v2/spotify/saved.js
+++ b/lib/v2/spotify/saved.js
@@ -1,0 +1,33 @@
+const utils = require('./utils');
+const got = require('@/utils/got');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const token = await utils.getPrivateToken();
+
+    const { limit } = ctx.params;
+    const pageSize = !isNaN(parseInt(limit)) ? parseInt(limit) : 50;
+
+    const itemsResponse = await got
+        .get(`https://api.spotify.com/v1/me/tracks?limit=${pageSize}`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+        .json();
+    const tracks = itemsResponse.items;
+
+    ctx.state.data = {
+        title: 'Spotify: My Saved Tracks',
+        link: 'https://open.spotify.com/collection/tracks',
+        description: `Latest ${pageSize} saved tracks on Spotify.`,
+        allowEmpty: true,
+        item: tracks.map((x) => ({
+            title: x.track.name,
+            author: x.track.artists.map((a) => a.name).join(', '),
+            description: `"${x.track.name}" by ${x.track.artists.map((a) => a.name).join(', ')} from the album "${x.track.album.name}"`,
+            pubDate: parseDate(x.added_at),
+            link: x.track.external_urls.spotify,
+        })),
+    };
+};

--- a/lib/v2/spotify/saved.js
+++ b/lib/v2/spotify/saved.js
@@ -23,11 +23,8 @@ module.exports = async (ctx) => {
         description: `Latest ${pageSize} saved tracks on Spotify.`,
         allowEmpty: true,
         item: tracks.map((x) => ({
-            title: x.track.name,
-            author: x.track.artists.map((a) => a.name).join(', '),
-            description: `"${x.track.name}" by ${x.track.artists.map((a) => a.name).join(', ')} from the album "${x.track.album.name}"`,
+            ...utils.parseTrack(x.track),
             pubDate: parseDate(x.added_at),
-            link: x.track.external_urls.spotify,
         })),
     };
 };

--- a/lib/v2/spotify/top.js
+++ b/lib/v2/spotify/top.js
@@ -1,0 +1,24 @@
+const utils = require('./utils');
+const got = require('@/utils/got');
+
+module.exports = (type) => async (ctx) => {
+    if (type !== 'tracks' && type !== 'artists') {
+        throw `Invalid type: ${type}`;
+    }
+
+    const token = await utils.getPrivateToken();
+    const itemsResponse = await got
+        .get(`https://api.spotify.com/v1/me/top/${type}`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+        .json();
+    const items = itemsResponse.items;
+
+    ctx.state.data = {
+        title: `Spotify: My Top ${type[0].toUpperCase() + type.slice(1)}`,
+        allowEmpty: true,
+        item: type === 'tracks' ? items.map(utils.parseTrack) : items.map(utils.parseArtist),
+    };
+};

--- a/lib/v2/spotify/utils.js
+++ b/lib/v2/spotify/utils.js
@@ -3,16 +3,16 @@ const got = require('@/utils/got');
 
 // Token used to retrieve public information.
 async function getPublicToken() {
-    if (!config.spotify || !config.spotify.apiKey || !config.spotify.apiSecret) {
+    if (!config.spotify || !config.spotify.clientId || !config.spotify.clientSecret) {
         throw 'Spotify public RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#pei-zhi-bu-fen-rss-mo-kuai-pei-zhi">relevant config</a>';
     }
 
-    const { apiKey, apiSecret } = config.spotify;
+    const { clientId, clientSecret } = config.spotify;
 
     const tokenResponse = await got
         .post('https://accounts.spotify.com/api/token', {
             headers: {
-                Authorization: `Basic ${Buffer.from(`${apiKey}:${apiSecret}`).toString('base64')}`,
+                Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
             },
             form: {
                 grant_type: 'client_credentials',
@@ -25,16 +25,16 @@ async function getPublicToken() {
 // Token used to retrieve user-specific information.
 // Note that we don't use PKCE since the client secret shall be safe on the server.
 async function getPrivateToken() {
-    if (!config.spotify || !config.spotify.apiKey || !config.spotify.apiSecret || !config.spotify.refreshToken) {
+    if (!config.spotify || !config.spotify.clientId || !config.spotify.clientSecret || !config.spotify.refreshToken) {
         throw 'Spotify private RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#pei-zhi-bu-fen-rss-mo-kuai-pei-zhi">relevant config</a>';
     }
 
-    const { apiKey, apiSecret, refreshToken } = config.spotify;
+    const { clientId, clientSecret, refreshToken } = config.spotify;
 
     const tokenResponse = await got
         .post('https://accounts.spotify.com/api/token', {
             headers: {
-                Authorization: `Basic ${Buffer.from(`${apiKey}:${apiSecret}`).toString('base64')}`,
+                Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
             },
             form: {
                 grant_type: 'refresh_token',

--- a/lib/v2/spotify/utils.js
+++ b/lib/v2/spotify/utils.js
@@ -47,7 +47,22 @@ async function getPrivateToken() {
     return tokenResponse.access_token;
 }
 
+const parseTrack = (x) => ({
+    title: x.name,
+    author: x.artists.map((a) => a.name).join(', '),
+    description: `"${x.name}" by ${x.artists.map((a) => a.name).join(', ')} from the album "${x.album.name}"`,
+    link: x.external_urls.spotify,
+});
+
+const parseArtist = (x) => ({
+    title: x.name,
+    description: `"${x.name}" with the genres of ${x.genres.join(', ')}`,
+    link: x.external_urls.spotify,
+});
+
 module.exports = {
     getPublicToken,
     getPrivateToken,
+    parseTrack,
+    parseArtist,
 };

--- a/lib/v2/spotify/utils.js
+++ b/lib/v2/spotify/utils.js
@@ -4,8 +4,7 @@ const got = require('@/utils/got');
 // Token used to retrieve public information.
 async function getPublicToken() {
     if (!config.spotify || !config.spotify.apiKey || !config.spotify.apiSecret) {
-        // TODO: link
-        throw 'Spotify public RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#%E9%83%A8%E5%88%86-rss-%E6%A8%A1%E5%9D%97%E9%85%8D%E7%BD%AE">relevant config</a>';
+        throw 'Spotify public RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#pei-zhi-bu-fen-rss-mo-kuai-pei-zhi">relevant config</a>';
     }
 
     const { apiKey, apiSecret } = config.spotify;
@@ -27,8 +26,7 @@ async function getPublicToken() {
 // Note that we don't use PKCE since the client secret shall be safe on the server.
 async function getPrivateToken() {
     if (!config.spotify || !config.spotify.apiKey || !config.spotify.apiSecret || !config.spotify.refreshToken) {
-        // TODO: link
-        throw 'Spotify private RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#%E9%83%A8%E5%88%86-rss-%E6%A8%A1%E5%9D%97%E9%85%8D%E7%BD%AE">relevant config</a>';
+        throw 'Spotify private RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#pei-zhi-bu-fen-rss-mo-kuai-pei-zhi">relevant config</a>';
     }
 
     const { apiKey, apiSecret, refreshToken } = config.spotify;

--- a/lib/v2/spotify/utils.js
+++ b/lib/v2/spotify/utils.js
@@ -1,0 +1,26 @@
+const config = require('@/config').value;
+const got = require('@/utils/got');
+
+// Token used to retrieve public information.
+async function getPublicToken() {
+    if (!config.spotify || !config.spotify.apiKey || !config.spotify.apiSecret) {
+        // TODO: link
+        throw 'Spotify public RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#%E9%83%A8%E5%88%86-rss-%E6%A8%A1%E5%9D%97%E9%85%8D%E7%BD%AE">relevant config</a>';
+    }
+
+    const tokenResponse = await got
+        .post('https://accounts.spotify.com/api/token', {
+            headers: {
+                Authorization: `Basic ${Buffer.from(`${config.spotify.apiKey}:${config.spotify.apiSecret}`).toString('base64')}`,
+            },
+            form: {
+                grant_type: 'client_credentials',
+            },
+        })
+        .json();
+    return tokenResponse.access_token;
+}
+
+module.exports = {
+    getPublicToken,
+};

--- a/lib/v2/spotify/utils.js
+++ b/lib/v2/spotify/utils.js
@@ -8,10 +8,12 @@ async function getPublicToken() {
         throw 'Spotify public RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#%E9%83%A8%E5%88%86-rss-%E6%A8%A1%E5%9D%97%E9%85%8D%E7%BD%AE">relevant config</a>';
     }
 
+    const { apiKey, apiSecret } = config.spotify;
+
     const tokenResponse = await got
         .post('https://accounts.spotify.com/api/token', {
             headers: {
-                Authorization: `Basic ${Buffer.from(`${config.spotify.apiKey}:${config.spotify.apiSecret}`).toString('base64')}`,
+                Authorization: `Basic ${Buffer.from(`${apiKey}:${apiSecret}`).toString('base64')}`,
             },
             form: {
                 grant_type: 'client_credentials',
@@ -21,6 +23,31 @@ async function getPublicToken() {
     return tokenResponse.access_token;
 }
 
+// Token used to retrieve user-specific information.
+// Note that we don't use PKCE since the client secret shall be safe on the server.
+async function getPrivateToken() {
+    if (!config.spotify || !config.spotify.apiKey || !config.spotify.apiSecret || !config.spotify.refreshToken) {
+        // TODO: link
+        throw 'Spotify private RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#%E9%83%A8%E5%88%86-rss-%E6%A8%A1%E5%9D%97%E9%85%8D%E7%BD%AE">relevant config</a>';
+    }
+
+    const { apiKey, apiSecret, refreshToken } = config.spotify;
+
+    const tokenResponse = await got
+        .post('https://accounts.spotify.com/api/token', {
+            headers: {
+                Authorization: `Basic ${Buffer.from(`${apiKey}:${apiSecret}`).toString('base64')}`,
+            },
+            form: {
+                grant_type: 'refresh_token',
+                refresh_token: refreshToken,
+            },
+        })
+        .json();
+    return tokenResponse.access_token;
+}
+
 module.exports = {
     getPublicToken,
+    getPrivateToken,
 };

--- a/lib/v2/spotify/utils.js
+++ b/lib/v2/spotify/utils.js
@@ -52,11 +52,7 @@ const parseTrack = (x) => ({
     link: x.external_urls.spotify,
 });
 
-const parseArtist = (x) => ({
-    title: x.name,
-    description: `"${x.name}" with the genres of ${x.genres.join(', ')}`,
-    link: x.external_urls.spotify,
-});
+const parseArtist = (x) => ({ title: x.name, description: `${x.name}, with ${x.followers.total} followers`, link: x.external_urls.spotify });
 
 module.exports = {
     getPublicToken,


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

fixes #6601

## 完整路由地址 / Example for the proposed route(s)

```routes
/spotify/playlist/4UBVy1LttvodwivPUuwJk2
/spotify/artist/31zCA3lKnObwtGBbDNnNAt
/spotify/saved/25
/spotify/top/tracks
/spotify/top/artists
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [x] CN
  - [x] EN
- [ ] 全文获取 fulltext
  - [ ] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note

* Spotify 的 API 需要 token，因此 GHA 的测试应该会失败。生成这些 token 需要 clientId/clientSecret，但不一定需要用户登录。
* Spotify 专辑的 `release_date` 只能精确至日、月或年。 [src](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-track)
* 对于与用户相关的端点，可能需要让用户填入 `refresh_token` 来获取。其它端点只需要 clientId/clientSecret。 [src](https://developer.spotify.com/documentation/general/guides/authorization/code-flow/)
* [Spotify Developer Terms](https://developer.spotify.com/terms/).