### PR TITLE
fix(route): App Center Release

### DIFF
--- a/lib/v2/app-center/release.js
+++ b/lib/v2/app-center/release.js
@@ -13,13 +13,9 @@ module.exports = async (ctx) => {
     const apiUrl = `${baseUrl}/${user}/${app}/distribution_groups/${distribution_group}`;
     const releasesListUrl = `${apiUrl}/public_releases?scope=tester`;
     // const releaseUrl = `${apiUrl}/releases/${release_id}?is_install_page=true`;
+    const link = `https://install.appcenter.ms/users/${user}/apps/${app}/distribution_groups/${distribution_group}`;
 
     const response = await got(releasesListUrl);
-
-    let title;
-    const link = `https://install.appcenter.ms/users/${user}/apps/${app}/distribution_groups/${distribution_group}`;
-    let icon;
-
     let items = response.data.map((item) => ({
         // item:
         // {
@@ -69,17 +65,17 @@ module.exports = async (ctx) => {
                 const installUrl = releaseInfo.install_url;
                 const fileExtension = releaseInfo.fileExtension;
 
-                if (!(title && icon)) {
-                    const appName = releaseInfo.app_display_name;
-                    const distributionGroupId = releaseInfo.distribution_group_id;
-                    const distributionGroupName = releaseInfo.distribution_groups.filter((group) => group.id === distributionGroupId)[0].display_name;
-                    title = `${appName} (${distributionGroupName}) for ${appOS} by ${userName} - App Center Releases`;
-                    icon = releaseInfo.app_icon_url;
-                }
+                // workaround: cache feed title and icon
+                const appName = releaseInfo.app_display_name;
+                const distributionGroupId = releaseInfo.distribution_group_id;
+                const distributionGroupName = releaseInfo.distribution_groups.filter((group) => group.id === distributionGroupId)[0].display_name;
+                item._feed_title = `${appName} (${distributionGroupName}) for ${appOS} by ${userName} - App Center Releases`;
+                item._feed_icon = releaseInfo.app_icon_url;
 
                 const version = shortVersion && versionCode ? `${shortVersion} (${versionCode})` : shortVersion || versionCode;
 
                 item.title =
+                    `${appName}: ` +
                     (isMandatoryUpdate ? '[Mandatory]' : '') +
                     // + (isLatest ? "[Latest]" : "")
                     (isExternalBuild ? '[External Build]' : '') +
@@ -110,6 +106,9 @@ module.exports = async (ctx) => {
             })
         )
     );
+
+    const icon = items && items[0]._feed_icon; // if it is an empty feed, would not raise an error here
+    const title = items && items[0]._feed_title;
 
     ctx.state.data = {
         title,


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/app-center/release/gameonline/baitomobile/baito
/app-center/release/cloudflare/1.1.1.1-windows/beta
/app-center/release/rdmacios-k2vy/microsoft-remote-desktop-for-mac/all-users-of-microsoft-remote-desktop-for-mac
/app-center/release/rafalense-70ux/plus-release/public
```

## 新RSS检查列表 / New RSS Script Checklist
  
- [x] New Route
- [x] Documentation
  - [x] CN
  - [x] EN
- [x] 全文获取 fulltext
  - [x] Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] 日期和时间 date and time
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added 
- [ ] `Puppeteer`

## 说明 / Note
Fixed this bug:

<table>
<tr>
	<td>
	<td>route cache miss
<tr>
	<td>content cache miss
	<td>feed title, description and icon are correct 😀
<tr>
	<td>content cache hit
	<td>feed title, description and icon are missing 🥵
</table>

A suggestion: maybe the route test workflow should cover this if the route support caching?