### PR TITLE
fix(route): JavDB Domain

### DIFF
--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -441,9 +441,9 @@ BT 之家的域名会变更，本路由以 <https://www.btbtt20.com> 为默认�
 
 ::: tip 提示
 
-JavDB 有多个备用域名，本路由以 <https://javdb7.com> 为默认域名，若该域名无法访问，可以通过在路由后方加上 `?domain=<域名>` 指定路由访问的域名。如指定域名为 <https://javdb.com>，则在所有 JavDB 路由后加上 `?domain=javdb.com` 即可，此时路由为 [`/javdb?domain=javdb.com`](https://rsshub.app/javdb?domain=javdb.com)
+JavDB 有多个备用域名，本路由默认使用永久域名 <https://javdb.com> ，若该域名无法访问，可以通过在路由最后加上 `?domain=<域名>` 指定路由访问的域名。如指定备用域名为 <https://javdb36.com>，则在所有 JavDB 路由最后加上 `?domain=javdb36.com` 即可，此时路由为 [`/javdb?domain=javdb36.com`](https://rsshub.app/javdb?domain=javdb36.com)
 
-如果加入了 **分類** 参数，直接在分類参数后加入 `?domain=<域名>` 即可。如指定分類 URL 为 <https://javdb.com/tags?c2=5&c10=1> 并指定域名为 <https://javdb.com>，即在 `/javdb/tags/c2=5&c10=1` 后加上 `?domain=javdb.com`，此时路由为 [`/javdb/tags/c2=5&c10=1?domain=javdb.com`](https://rsshub.app/javdb/tags/c2=5&c10=1?domain=javdb.com)
+如果加入了 **分類** 参数，直接在分類参数后加入 `?domain=<域名>` 即可。如指定分類 URL 为 <https://javdb.com/tags?c2=5&c10=1> 并指定备用域名为 <https://javdb36.com>，即在 `/javdb/tags/c2=5&c10=1` 最后加上 `?domain=javdb36.com`，此时路由为 [`/javdb/tags/c2=5&c10=1?domain=javdb36.com`](https://rsshub.app/javdb/tags/c2=5&c10=1?domain=javdb36.com)
 
 **排行榜**、**搜索**、**演員**、**片商** 参数同适用于 **分類** 参数的上述规则
 

--- a/lib/v2/javdb/utils.js
+++ b/lib/v2/javdb/utils.js
@@ -4,7 +4,7 @@ const { parseDate } = require('@/utils/parse-date');
 
 module.exports = {
     ProcessItems: async (ctx, currentUrl, title) => {
-        const domain = ctx.query.domain ?? 'javdb36.com';
+        const domain = ctx.query.domain ?? 'javdb.com';
         const rootUrl = `https://${domain}`;
 
         const response = await got({

--- a/lib/v2/javdb/utils.js
+++ b/lib/v2/javdb/utils.js
@@ -4,7 +4,7 @@ const { parseDate } = require('@/utils/parse-date');
 
 module.exports = {
     ProcessItems: async (ctx, currentUrl, title) => {
-        const domain = ctx.query.domain ?? 'javdb7.com';
+        const domain = ctx.query.domain ?? 'javdb36.com';
         const rootUrl = `https://${domain}`;
 
         const response = await got({


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #9083

## 完整路由地址 / Example for the proposed route(s)

```routes
/javdb/censored/2/2
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [x] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
javdb7.com域名失效，更换为javdb36.com