### PR TITLE
feat(route)(weibo): 720P video, video fallback

### DIFF
--- a/lib/routes/weibo/utils.js
+++ b/lib/routes/weibo/utils.js
@@ -204,11 +204,37 @@ const weiboUtils = {
         const pageInfo = status.page_info;
         if (pageInfo && pageInfo.type === 'video') {
             const pagePic = pageInfo.page_pic;
-            const mediaInfo = pageInfo.media_info;
             const posterUrl = pagePic ? pagePic.url : '';
-            const videoUrl = mediaInfo ? mediaInfo.stream_url_hd || mediaInfo.stream_url || mediaInfo.mp4_hd_url || mediaInfo.mp4_sd_url || mediaInfo.mp4_720p_mp4 : '';
-            if (videoUrl) {
-                const video = `<br clear="both" /><div style="clear: both"></div><video src="${videoUrl}"  controls="controls" poster="${posterUrl}" style="width: 100%"></video>`;
+            const pageUrl = pageInfo.page_url; // video page url
+            const mediaInfo = pageInfo.media_info || {}; // stream_url, stream_url_hd; deprecated: mp4_720p_mp4, mp4_hd_url, mp4_sd_url
+            const urls = pageInfo.urls || {}; // mp4_720p_mp4, mp4_hd_mp4, hevc_mp4_hd, mp4_ld_mp4
+
+            const video720p = urls.mp4_720p_mp4 || mediaInfo.mp4_720p_mp4 || '';
+            const videoHd = urls.mp4_hd_mp4 || mediaInfo.mp4_hd_url || mediaInfo.stream_url_hd || '';
+            const videoHdHevc = urls.hevc_mp4_hd || '';
+            const videoLd = urls.mp4_ld_mp4 || mediaInfo.mp4_sd_url || mediaInfo.stream_url || '';
+
+            const hasVideo = video720p || videoHd || videoHdHevc || videoLd;
+
+            if (hasVideo) {
+                let video = '<br clear="both" /><div style="clear: both"></div>';
+                video += `<video controls="controls" poster="${posterUrl}" style="width: 100%">`;
+                if (video720p) {
+                    video += `<source src="${video720p}">`;
+                }
+                if (videoHd) {
+                    video += `<source src="${videoHd}">`;
+                }
+                if (videoHdHevc) {
+                    video += `<source src="${videoHdHevc}">`;
+                }
+                if (videoLd) {
+                    video += `<source src="${videoLd}">`;
+                }
+                if (pageUrl) {
+                    video += `<p>视频无法显示，请前往<a href="${pageUrl}" target="_blank" rel="noopener noreferrer">微博视频</a>观看。</p>`;
+                }
+                video += '</video>';
                 itemDesc += video;
             }
         }


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/weibo/user/5347795977/1
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
* 原本的匹配已经过时，不能再匹配到 720P 视频，更新匹配后，能够取得 720P 视频。
* 增加视频的回落，高画质无法播放时可回落至低画质。若视频过期（从微博的 API 获得的视频 URL 有时间限制），则可显示一段提示（取决于阅读器如何渲染 <video> tag）。