### PR TITLE
fix(route)(weibo): title, icon, regex

### DIFF
--- a/lib/routes/weibo/utils.js
+++ b/lib/routes/weibo/utils.js
@@ -50,12 +50,12 @@ const weiboUtils = {
         let htmlNewLineUnreplaced = (status.longText && status.longText.longTextContent) || status.text || '';
         // 表情图标转换为文字
         if (!showEmojiInDescription) {
-            htmlNewLineUnreplaced = htmlNewLineUnreplaced.replace(/<span class="url-icon"><img.*?alt="?(.*?)"? [\s\S]*?\/><\/span>/g, '$1');
+            htmlNewLineUnreplaced = htmlNewLineUnreplaced.replace(/<span class=["']url-icon["']><img\s[^>]*?alt=["']?([^>]+?)["']?\s[^>]*?\/><\/span>/g, '$1');
         }
-        // 去掉外部链接的图标，保留 a 标签链接
-        htmlNewLineUnreplaced = htmlNewLineUnreplaced.replace(/<span class=["|']url-icon["|']>.*?(<a.*?>).*?<\/span><span class="surl-text">(.*?)<\/span>/g, '$1$2</a>');
-        // 去掉乱七八糟的图标
-        // htmlNewLineUnreplaced = htmlNewLineUnreplaced.replace(/<span class=["|']url-icon["|']>(.*?)<\/span>/g, '');
+        // 去掉外部链接的图标，保留 a 标签链接  // 不能去掉，否则像超话这样的有意义的图标也会被去掉
+        // htmlNewLineUnreplaced = htmlNewLineUnreplaced.replace(/(<a\s[^>]*>)<span class=["']url-icon["']><img\s[^>]*><\/span>[^<>]*?<span class="surl-text">([^<>]*?)<\/span><\/a>/g, '$1$2</a>');
+        // 去掉乱七八糟的图标  // 不能去掉，否则像超话这样的有意义的图标也会被去掉
+        // htmlNewLineUnreplaced = htmlNewLineUnreplaced.replace(/<span class=["']url-icon["']>(<img\s[^>]*?>)<\/span>/g, '');
         // 去掉全文
         htmlNewLineUnreplaced = htmlNewLineUnreplaced.replace(/全文<br>/g, '<br>');
         htmlNewLineUnreplaced = htmlNewLineUnreplaced.replace(/<a href="(.*?)">全文<\/a>/g, '');
@@ -174,6 +174,8 @@ const weiboUtils = {
         }
         if (!status.retweeted_status || showRetweetTextInTitle) {
             title += htmlNewLineUnreplaced
+                .replace(/<span class=["']url-icon["']><img\s[^>]*?alt=["']?([^>]+?)["']?\s[^>]*?\/><\/span>/g, '$1') // 表情转换
+                .replace(/<span class=["']url-icon["']>(<img\s[^>]*?>)<\/span>/g, '') // 去掉所有图标
                 .replace(/<img[\s\S]*?>/g, '[图片]')
                 .replace(/<.*?>/g, '')
                 .replace('\n', '');
@@ -181,6 +183,8 @@ const weiboUtils = {
         if (status.retweeted_status) {
             title += showEmojiForRetweet ? '🔁 ' : ' - 转发 ';
             title += retweeted
+                .replace(/<span class=["']url-icon["']><img\s[^>]*?alt=["']?([^>]+?)["']?\s[^>]*?\/><\/span>/g, '$1') // 表情转换
+                .replace(/<span class=["']url-icon["']>(<img\s[^>]*?>)<\/span>/g, '') // 去掉所有图标
                 .replace(/<img[\s\S]*?>/g, '[图片]')
                 .replace(/<.*?>/g, '')
                 .replace('\n', '');


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

#7827 破坏了标题，让所有图标和表情都变成 `[图片]` 加入到标题里，这显然是不对的。

#9117 破坏了链接图标的清理，我不能观察到任何链接以该格式呈现。
原先 (e44064d) 的 regex 只能在已经完成微博表情转换的前提下正常工作，而 #7827 把这个 prereq 破坏了，导致微博表情和链接图标连续出现时，微博表情和链接都会被去掉。
然而 #9117 对这个问题的修复实在令人哭笑不得，恐怕根本没有仔细观察，竟然创造了一个在微博表情和链接图标连续出现时才能匹配成功的 regex，破坏了链接图标的清理。
我修正了所有不安全的 regex，但也把链接图标清理注释掉了，因为这会清理掉所有链接的图标，包括超话等有意义的图标，这也不合适。反正链接图标清理已经被破坏这么久了，也没人觉得不合适来提 issue。

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/weibo/user/6228221165
/weibo/user/2214257545
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
