### PR TITLE
feat(config): support URL prefix

### DIFF
--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -435,6 +435,10 @@ RSSHub supports access control via access key/code, whitelisting and blacklistin
 
 White/blacklisting support IP, route and UA as values, fuzzy matching. Use `,` as the delimiter to separate multiple values, eg: `WHITELIST=1.1.1.1,2.2.2.2,/qdaily/column/59`
 
+#### URL Prefix
+
+`PREFIX`: The prefix of URL, default is an empty string. eg: `/prefix`, then the URL become <https://rsshub.app/prefix/qdaily/column/59>
+
 #### Access Key/Code
 
 -   `ACCESS_KEY`: the access key. When set, access via the key directly or the access code described above

--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -435,9 +435,9 @@ RSSHub supports access control via access key/code, whitelisting and blacklistin
 
 White/blacklisting support IP, route and UA as values, fuzzy matching. Use `,` as the delimiter to separate multiple values, eg: `WHITELIST=1.1.1.1,2.2.2.2,/qdaily/column/59`
 
-#### URL Prefix
+#### URL Path Prefix
 
-`PREFIX`: The prefix of URL, default is an empty string. eg: `/prefix`, then the URL become <https://rsshub.app/prefix/qdaily/column/59>
+`PATHPREFIX`: The prefix of URL path, default is an empty string. eg: `/pathprefix`, then the URL become <https://rsshub.app/pathprefix/qdaily/column/59>
 
 #### Access Key/Code
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -438,6 +438,10 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 
 黑白名单支持 IP、路由和 UA，模糊匹配，设置多项时用英文逗号 `,` 隔开，例如 `WHITELIST=1.1.1.1,2.2.2.2,/qdaily/column/59`
 
+#### 路径前缀
+
+`PREFIX`: URL 的路径前缀，默认为空字符串。如设置为 `/prefix`，则需要使用 <https://rsshub.app/prefix/qdaily/column/59>
+
 #### 访问密钥 / 码
 
 -   `ACCESS_KEY`: 访问密钥，用于直接访问所有路由或者生成访问码

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -440,7 +440,7 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 
 #### 路径前缀
 
-`PREFIX`: URL 的路径前缀，默认为空字符串。如设置为 `/prefix`，则需要使用 <https://rsshub.app/prefix/qdaily/column/59>
+`PATHPREFIX`: URL 路径的前缀，默认为空字符串。如设置为 `/pathprefix`，则需要使用 <https://rsshub.app/pathprefix/qdaily/column/59>
 
 #### 访问密钥 / 码
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -74,7 +74,7 @@ app.use(antiHotlink);
 app.use(parameter);
 
 // No Cache routes
-app.use(mount(`${config.prefix}/`, core_router.routes())).use(core_router.allowedMethods());
+app.use(mount(config.prefix || '/', core_router.routes())).use(core_router.allowedMethods());
 // API router
 app.use(mount(`${config.prefix}/api`, api_router.routes())).use(api_router.allowedMethods());
 
@@ -85,7 +85,7 @@ app.use(cache(app));
 app.use(loadOnDemand(app));
 
 // router
-app.use(mount(`${config.prefix}/`, router.routes())).use(router.allowedMethods());
+app.use(mount(config.prefix || '/', router.routes())).use(router.allowedMethods());
 
 // routes the require authentication
 app.use(mount(`${config.prefix}/protected`, protected_router.routes())).use(protected_router.allowedMethods());

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,3 +1,4 @@
+const config = require('./config').value;
 const moduleAlias = require('module-alias');
 moduleAlias.addAlias('@', () => __dirname);
 
@@ -73,9 +74,9 @@ app.use(antiHotlink);
 app.use(parameter);
 
 // No Cache routes
-app.use(mount('/', core_router.routes())).use(core_router.allowedMethods());
+app.use(mount(`${config.prefix}/`, core_router.routes())).use(core_router.allowedMethods());
 // API router
-app.use(mount('/api', api_router.routes())).use(api_router.allowedMethods());
+app.use(mount(`${config.prefix}/api`, api_router.routes())).use(api_router.allowedMethods());
 
 // 2 cache
 app.use(cache(app));
@@ -84,9 +85,9 @@ app.use(cache(app));
 app.use(loadOnDemand(app));
 
 // router
-app.use(mount('/', router.routes())).use(router.allowedMethods());
+app.use(mount(`${config.prefix}/`, router.routes())).use(router.allowedMethods());
 
 // routes the require authentication
-app.use(mount('/protected', protected_router.routes())).use(protected_router.allowedMethods());
+app.use(mount(`${config.prefix}/protected`, protected_router.routes())).use(protected_router.allowedMethods());
 
 module.exports = app;

--- a/lib/app.js
+++ b/lib/app.js
@@ -74,9 +74,9 @@ app.use(antiHotlink);
 app.use(parameter);
 
 // No Cache routes
-app.use(mount(config.prefix || '/', core_router.routes())).use(core_router.allowedMethods());
+app.use(mount(config.pathPrefix || '/', core_router.routes())).use(core_router.allowedMethods());
 // API router
-app.use(mount(`${config.prefix}/api`, api_router.routes())).use(api_router.allowedMethods());
+app.use(mount(`${config.pathPrefix}/api`, api_router.routes())).use(api_router.allowedMethods());
 
 // 2 cache
 app.use(cache(app));
@@ -85,9 +85,9 @@ app.use(cache(app));
 app.use(loadOnDemand(app));
 
 // router
-app.use(mount(config.prefix || '/', router.routes())).use(router.allowedMethods());
+app.use(mount(config.pathPrefix || '/', router.routes())).use(router.allowedMethods());
 
 // routes the require authentication
-app.use(mount(`${config.prefix}/protected`, protected_router.routes())).use(protected_router.allowedMethods());
+app.use(mount(`${config.pathPrefix}/protected`, protected_router.routes())).use(protected_router.allowedMethods());
 
 module.exports = app;

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,7 @@ const calculateValue = () => {
     }
 
     value = {
+        prefix: envs.PREFIX || '', // URL 路径前缀，如 '/prefix'
         isPackage: envs.IS_PACKAGE,
         noLogfiles: envs.NO_LOGFILES,
         connect: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,7 +25,7 @@ const calculateValue = () => {
     }
 
     value = {
-        prefix: envs.PREFIX || '', // URL 路径前缀，如 '/prefix'
+        pathPrefix: envs.PATHPREFIX || '', // URL 路径前缀，如 '/pathprefix'
         isPackage: envs.IS_PACKAGE,
         noLogfiles: envs.NO_LOGFILES,
         connect: {

--- a/lib/middleware/load-on-demand.js
+++ b/lib/middleware/load-on-demand.js
@@ -1,3 +1,4 @@
+const config = require('../config').value;
 const mount = require('koa-mount');
 const Router = require('@koa/router');
 const routes = require('../v2router');
@@ -5,7 +6,7 @@ const loadedRoutes = new Set();
 
 module.exports = function (app) {
     return async function (ctx, next) {
-        const p = ctx.request.path.split('/').filter(Boolean);
+        const p = ctx.request.path.slice(config.prefix.length).split('/').filter(Boolean);
         let modName = null;
         let mounted = false;
 
@@ -19,7 +20,7 @@ module.exports = function (app) {
                     loadedRoutes.add(modName);
                     const router = new Router();
                     mod(router);
-                    app.use(mount(`/${modName}`, router.routes())).use(router.allowedMethods());
+                    app.use(mount(`${config.prefix}/${modName}`, router.routes())).use(router.allowedMethods());
                 }
             } else {
                 mounted = true;
@@ -30,7 +31,7 @@ module.exports = function (app) {
 
         // We should only add it when koa router matched
         if (mounted && ctx._matchedRoute) {
-            ctx._matchedRoute = `/${modName}${ctx._matchedRoute}`;
+            ctx._matchedRoute = `${config.prefix}/${modName}${ctx._matchedRoute}`;
         }
     };
 };

--- a/lib/middleware/load-on-demand.js
+++ b/lib/middleware/load-on-demand.js
@@ -6,7 +6,7 @@ const loadedRoutes = new Set();
 
 module.exports = function (app) {
     return async function (ctx, next) {
-        const p = ctx.request.path.slice(config.prefix.length).split('/').filter(Boolean);
+        const p = ctx.request.path.slice(config.pathPrefix.length).split('/').filter(Boolean);
         let modName = null;
         let mounted = false;
 
@@ -20,7 +20,7 @@ module.exports = function (app) {
                     loadedRoutes.add(modName);
                     const router = new Router();
                     mod(router);
-                    app.use(mount(`${config.prefix}/${modName}`, router.routes())).use(router.allowedMethods());
+                    app.use(mount(`${config.pathPrefix}/${modName}`, router.routes())).use(router.allowedMethods());
                 }
             } else {
                 mounted = true;
@@ -31,7 +31,7 @@ module.exports = function (app) {
 
         // We should only add it when koa router matched
         if (mounted && ctx._matchedRoute) {
-            ctx._matchedRoute = `${config.prefix}/${modName}${ctx._matchedRoute}`;
+            ctx._matchedRoute = `${config.pathPrefix}/${modName}${ctx._matchedRoute}`;
         }
     };
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
NOROUTE
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [x] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

添加了对 URL 路径前缀的支持，通过环境变量 `PREFIX` 设置。默认值为空字符串。

例如设置 `PREFIX=/prefix` 将需要使用 <https://rsshub.app/prefix/qdaily/column/59> 进行访问。

这个功能使得 RSSHub 可以部署（藏）在某些网站 URL 后面。