### PR TITLE
fix(route): 修复小宇宙播客路由

### DIFF
--- a/lib/v2/xiaoyuzhou/maintainer.js
+++ b/lib/v2/xiaoyuzhou/maintainer.js
@@ -1,4 +1,4 @@
 module.exports = {
     '/': ['prnake', 'Maecenas'],
-    '/podcast/:id': ['hondajojo'],
+    '/podcast/:id': ['hondajojo', 'jtsang4'],
 };

--- a/lib/v2/xiaoyuzhou/podcast.js
+++ b/lib/v2/xiaoyuzhou/podcast.js
@@ -21,7 +21,7 @@ module.exports = async (ctx) => {
         link: `https://www.xiaoyuzhoufm.com/episode/${item.eid}`,
         pubDate: parseDate(item.pubDate),
         description: item.shownotes,
-        itunes_item_image: item.image.smallPicUrl,
+        itunes_item_image: (item.image || item.podcast?.image)?.smallPicUrl,
     }));
 
     ctx.state.data = {


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/xiaoyuzhou/podcast/:id
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/xiaoyuzhou/podcast/:id
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

Fix xiaoyuzhou podcast route issue: `Cannot read property 'smallPicUrl' of undefined` , caused by `image` property is not in episode.

e.g. https://rsshub.app/xiaoyuzhou/podcast/613753ef23c82a9a1ccfdf35