### PR TITLE
feat(core): caching enhancements

### DIFF
--- a/docs/en/joinus/quick-start.md
+++ b/docs/en/joinus/quick-start.md
@@ -291,7 +291,7 @@ const description = await ctx.cache.tryGet(link, async () => {
 });
 ```
 
-The implementation of tryGet can be seen [here](https://github.com/DIYgod/RSSHub/blob/master/lib/middleware/cache/index.js#L58). The first parameter is the cache key, the second parameter is the cache data acquisition method, and the third parameter is the cache time, it should not be passed in normally. The cache time defaults to [CACHE_CONTENT_EXPIRE](/en/install/#cache-configurations), and each time accessing the cache will recalculate the expiration time
+The implementation of tryGet can be seen [here](https://github.com/DIYgod/RSSHub/blob/master/lib/middleware/cache/index.js#L58). The 1st parameter is the cache key; the 2nd parameter is the cache data acquisition method (executed when cache miss); the 3rd parameter is the cache time, it should not be passed in normally and defaults to [CACHE_CONTENT_EXPIRE](/en/install/#cache-configurations); the 4th parameter determines whether to recalculate the expiration time ("renew" the cache) when the current attempt cache hits, `true` is on, `false` is off, default is on
 
 ---
 

--- a/docs/joinus/quick-start.md
+++ b/docs/joinus/quick-start.md
@@ -292,7 +292,7 @@ const description = await ctx.cache.tryGet(link, async () => {
 });
 ```
 
-tryGet 的实现可以看[这里](https://github.com/DIYgod/RSSHub/blob/master/lib/middleware/cache/index.js#L58)，第一个参数为缓存的 key，第二个参数为缓存数据获取方法，第三个参数为缓存时间，正常情况不应该传入，缓存时间默认为 [CACHE_CONTENT_EXPIRE](/install/#缓存配置)，且每次访问缓存会重新计算过期时间
+tryGet 的实现可以看[这里](https://github.com/DIYgod/RSSHub/blob/master/lib/middleware/cache/index.js#L58)。第一个参数为缓存的 key；第二个参数为缓存未命中时的数据获取方法；第三个参数为缓存时间，正常情况不应该传入，缓存时间默认为 [CACHE_CONTENT_EXPIRE](/install/#缓存配置)；第四个参数为控制本次尝试缓存命中时是否需要重新计算过期时间（给缓存「续期」）的开关，`true` 为打开，`false` 为关闭，默认为打开
 
 * * *
 

--- a/lib/middleware/cache/index.js
+++ b/lib/middleware/cache/index.js
@@ -55,8 +55,8 @@ module.exports = function (app) {
     const { get, set, status } = cacheModule;
     app.context.cache = {
         ...cacheModule,
-        tryGet: async (key, getValueFunc, maxAge = config.cache.contentExpire) => {
-            let v = await get(key);
+        tryGet: async (key, getValueFunc, maxAge = config.cache.contentExpire, refresh = true) => {
+            let v = await get(key, refresh);
             if (!v) {
                 v = await getValueFunc();
                 set(key, v, maxAge);

--- a/lib/middleware/cache/redis.js
+++ b/lib/middleware/cache/redis.js
@@ -18,12 +18,26 @@ redisClient.on('connect', () => {
     logger.info('Redis connected.');
 });
 
+const getCacheTtlKey = (key) => {
+    if (key.startsWith('cacheTtl:')) {
+        throw Error('"cacheTtl:" prefix is reserved for the internal usage, please change your cache key'); // blocking any attempt to get/set the cacheTtl
+    }
+    return `cacheTtl:${key}`;
+};
+
 module.exports = {
     get: async (key, refresh = true) => {
         if (key && status.available) {
-            let value = await redisClient.get(key);
+            const cacheTtlKey = getCacheTtlKey(key);
+            let [value, cacheTtl] = await redisClient.mget(key, cacheTtlKey);
             if (value && refresh) {
-                redisClient.expire(key, config.cache.contentExpire);
+                if (!cacheTtl) {
+                    cacheTtl = config.cache.contentExpire;
+                    redisClient.set(cacheTtlKey, cacheTtl, 'EX', cacheTtl);
+                } else {
+                    redisClient.expire(cacheTtlKey, cacheTtl);
+                }
+                redisClient.expire(key, cacheTtl);
                 value = value + '';
             }
             return value;
@@ -40,6 +54,7 @@ module.exports = {
             value = JSON.stringify(value);
         }
         if (key) {
+            redisClient.set(getCacheTtlKey(key), maxAge, 'EX', maxAge);
             return redisClient.set(key, value, 'EX', maxAge); // setMode: https://redis.io/commands/set
         }
     },


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

https://github.com/DIYgod/RSSHub/pull/9213#discussion_r816462771

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
Redis cache ignores `maxAge` when refreshing TTL. Fixed this by writing the `maxAge` into Redis too. (while memory cache does not have such a problem.)
`cache.tryGet()` always enforce refreshing the TTL of cache entries. Added an optional parameter `refresh` to let routes get control of it.