### PR TITLE
ci: ignore route test on forks

### DIFF
--- a/.github/workflows/pr-deploy-route-test.yml
+++ b/.github/workflows/pr-deploy-route-test.yml
@@ -9,7 +9,7 @@ jobs:
   testRoute:
     name: Vercel Preview
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'DIYgod'
+    if: github.actor != github.repository_owner
     steps:
       - uses: actions/checkout@v3
       - name: Fetch affected routes

--- a/.github/workflows/pr-deploy-route-test.yml
+++ b/.github/workflows/pr-deploy-route-test.yml
@@ -9,6 +9,7 @@ jobs:
   testRoute:
     name: Vercel Preview
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'DIYgod'
     steps:
       - uses: actions/checkout@v3
       - name: Fetch affected routes


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)
```routes
noroute
```
## 说明 / Note
Automated pull requests to forks like liyishuai/RSSHub#1007 are closed because `routes` was unspecified. No need to check this on forks.