### PR TITLE
fix(route): touhougarakuta

### DIFF
--- a/lib/routes/touhougarakuta/index.js
+++ b/lib/routes/touhougarakuta/index.js
@@ -16,7 +16,7 @@ module.exports = async (ctx) => {
 
     const response = await got({
         method: 'get',
-        url: `${baseUrl}/page-data/${type}/page-data.json`,
+        url: `${baseUrl}/page-data/${type === 'interviews' ? 'tags/interviews' : type}/page-data.json`,
     });
 
     ctx.state.data = {
@@ -33,6 +33,7 @@ module.exports = async (ctx) => {
             try {
                 switch (article.type) {
                     case 'index_interview':
+                    case 'column':
                         result.description = j2h.indexInterview(article, language);
                         break;
                     case 'index_comic':
@@ -42,6 +43,7 @@ module.exports = async (ctx) => {
                         result.description = j2h.indexNovel(article, language);
                         break;
                     case 'interview':
+                    case 'report':
                         result.description = j2h.interview(article, language);
                         break;
                     case 'novel':
@@ -54,7 +56,7 @@ module.exports = async (ctx) => {
                         result.description = j2h.uncategorized(article);
                 }
             } catch (error) {
-                error.message += ` (at article ${i}: ${article.title})`;
+                error.message += `(at article ${i}: ${article.title})`;
                 throw error;
             }
             return result;

--- a/lib/routes/touhougarakuta/json2html.js
+++ b/lib/routes/touhougarakuta/json2html.js
@@ -84,9 +84,9 @@ const ogpImage = (article) => `<img src="${article.ogpSettings.ogp.image.sourceU
  * 处理 linkToIndex
  */
 const linkToIndex = (article, language) => {
-    if (article.hasOwnProperty('linkToIndex') && article.linkToIndex.linktoindex == null) {
+    if (article.hasOwnProperty('linkToIndex') && article.linkToIndex.linktoindex === null) {
         const index = article.linkToIndex.linktoindex;
-        return index ? `<p>Index：${href(index.title, index.url, language)}</p>` : '';
+        return `<p>Index：${href(index.title, index.url, language)}</p>`;
     }
     return '';
 };

--- a/lib/routes/touhougarakuta/json2html.js
+++ b/lib/routes/touhougarakuta/json2html.js
@@ -1,17 +1,26 @@
-const indexInterview = (article, language) => ogpImage(article) + article.index.about + index(article, language);
+const indexInterview = (article, language) => {
+    if (article.hasOwnProperty('index')) {
+        return ogpImage(article) + article.ogpSettings.ogp.description + index(article, language);
+    }
+    return ogpImage(article);
+};
 
 const indexComic = (article, language) => ogpImage(article) + article.index.about + authors(article.index.authors) + `<img src="${article.indexCover.cover.sourceUrl}">` + index(article, language);
 
 const indexNovel = (article, language) => ogpImage(article) + article.index.about + authors(article.index.authors) + `<img src="${article.indexCover.cover.sourceUrl}">` + index(article, language);
 
 const interview = (article, language) => {
-    const leading = article.interviewContents.leading;
+    if (article.hasOwnProperty('interviewContents')) {
+        const leading = article.interviewContents.leading;
 
-    let result = ogpImage(article) + linkToIndex(article, language) + '<hr/>' + (leading ? leading : '');
-    for (const block of article.interviewContents.block) {
-        result += `<h2 style="text-align: center;">${block.head}</h2>` + block.content;
+        let result = ogpImage(article) + linkToIndex(article, language) + '<hr/>' + (leading ? leading : '');
+        for (const block of article.interviewContents.block) {
+            result += `<h2 style="text-align: center;">${block.head}</h2>` + block.content;
+        }
+        return result;
     }
-    return result;
+
+    return ogpImage(article) + linkToIndex(article, language);
 };
 
 const novel = (article, language) =>
@@ -38,9 +47,9 @@ const comic = (article, language) => {
 const uncategorized = (article, language) => ogpImage(article) + linkToIndex(article, language) + '<hr/>' + article.contents.texts;
 
 /**
- * 生成超链接，并将 edit 替换为对应语言
+ * 生成超链接，并将 edit 替换为对应语言; 从 article.index.item 会有带 edit 的 url 进来
  */
-const href = (text, url, language) => `<a href="${url.replace(/\/\/edit/, `//${language}`)}">${text}</a>`;
+const href = (text, url, language) => `<a href="${url.replace(/\/\/edit/, `//${language === 'ja' ? '' : language}`)}">${text}</a>`;
 
 /**
  * 处理 authors
@@ -75,8 +84,11 @@ const ogpImage = (article) => `<img src="${article.ogpSettings.ogp.image.sourceU
  * 处理 linkToIndex
  */
 const linkToIndex = (article, language) => {
-    const index = article.linkToIndex.linktoindex;
-    return index ? `<p>Index：${href(index.title, index.url, language)}</p>` : '';
+    if (article.hasOwnProperty('linkToIndex') && article.linkToIndex.linktoindex == null) {
+        const index = article.linkToIndex.linktoindex;
+        return index ? `<p>Index：${href(index.title, index.url, language)}</p>` : '';
+    }
+    return '';
 };
 
 /**

--- a/lib/routes/touhougarakuta/json2html.js
+++ b/lib/routes/touhougarakuta/json2html.js
@@ -84,7 +84,7 @@ const ogpImage = (article) => `<img src="${article.ogpSettings.ogp.image.sourceU
  * 处理 linkToIndex
  */
 const linkToIndex = (article, language) => {
-    if (article.hasOwnProperty('linkToIndex') && article.linkToIndex.linktoindex === null) {
+    if (article.hasOwnProperty('linkToIndex') && article.linkToIndex.linktoindex !== null) {
         const index = article.linkToIndex.linktoindex;
         return `<p>Index：${href(index.title, index.url, language)}</p>`;
     }


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #9271

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

源站点的 interviews 迁移到了 tags/interviews
/touhougarakuta/ja/index 有部分文章 type 为 column/report，返回数据跟已有的类型大同小异
/touhougarakuta/cn/interviews 有部分文章不存在 interviewContents/linkToIndex