### PR TITLE
fix(core): MEMORY_MAX should be an integer.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -50,7 +50,7 @@ const calculateValue = () => {
             contentExpire: parseInt(envs.CACHE_CONTENT_EXPIRE) || 1 * 60 * 60, // 不变内容缓存时间，单位为秒
         },
         memory: {
-            max: envs.MEMORY_MAX || Math.pow(2, 8), // The maximum number of items that remain in the cache. This must be a positive finite intger.
+            max: parseInt(envs.MEMORY_MAX) || Math.pow(2, 8), // The maximum number of items that remain in the cache. This must be a positive finite intger.
             // https://github.com/isaacs/node-lru-cache#options
         },
         redis: {


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #9351 

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

Not related to any routes.

## 新 RSS 检查列表 / New RSS Script Checklist
  
Not related.

## 说明 / Note

Just found that the `MEMORY_MAX` cannot be set. It's because LRUCache requires an integer but we read and pass the value as a string.

I noticed `CACHE_EXPIRE`, `CACHE_CONTENT_EXPIRE` and some other values all convert to integer with `parseInt`, so I copied the pattern.