### PR TITLE
fix(core): offending RFC4287

### DIFF
--- a/lib/middleware/template.js
+++ b/lib/middleware/template.js
@@ -2,7 +2,7 @@ const art = require('art-template');
 const path = require('path');
 const config = require('@/config').value;
 const typeRegex = /\.(atom|rss|debug\.json)$/;
-const { collapseWhitespace } = require('@/utils/common-utils');
+const { collapseWhitespace, convertDateToISO8601 } = require('@/utils/common-utils');
 
 module.exports = async (ctx, next) => {
     if (ctx.headers['user-agent'] && ctx.headers['user-agent'].includes('Reeder')) {
@@ -28,7 +28,8 @@ module.exports = async (ctx, next) => {
     if (!ctx.body) {
         let template;
 
-        switch (ctx.state.type[1]) {
+        const outputType = ctx.state.type[1];
+        switch (outputType) {
             case 'atom':
                 template = path.resolve(__dirname, '../views/atom.art');
                 break;
@@ -65,6 +66,11 @@ module.exports = async (ctx, next) => {
                         item.itunes_duration = +item.itunes_duration;
                         item.itunes_duration =
                             Math.floor(item.itunes_duration / 3600) + ':' + (Math.floor((item.itunes_duration % 3600) / 60) / 100).toFixed(2).slice(-2) + ':' + (((item.itunes_duration % 3600) % 60) / 100).toFixed(2).slice(-2);
+                    }
+
+                    if (outputType === 'atom') {
+                        item.pubDate = convertDateToISO8601(item.pubDate);
+                        item.updated = convertDateToISO8601(item.updated);
                     }
                 });
         }

--- a/lib/utils/common-utils.js
+++ b/lib/utils/common-utils.js
@@ -1,3 +1,5 @@
+const { parseDate } = require('@/utils/parse-date');
+
 // convert a string into title case
 const toTitleCase = (str) =>
     str
@@ -17,7 +19,19 @@ const collapseWhitespace = (str) => {
     return str;
 };
 
+const convertDateToISO8601 = (date) => {
+    if (!date) {
+        return date;
+    }
+    if (typeof date !== 'object') {
+        // some routes may call `.toUTCString()` before passing the date to ctx...
+        date = parseDate(date);
+    }
+    return date.toISOString();
+};
+
 module.exports = {
     toTitleCase,
     collapseWhitespace,
+    convertDateToISO8601,
 };

--- a/lib/views/atom.art
+++ b/lib/views/atom.art
@@ -37,8 +37,10 @@
         <id>{{ $e.guid || $e.id || $e.link }}</id>
         <title><![CDATA[{{@ $e.title }}]]></title>
 
-        <published>{{ $e.pubDate || $e.updated }}</published>
-        <updated>{{ $e.updated }}</updated>
+        {{ if ($e.pubDate && $e.updated) }}
+        <published>{{ $e.pubDate }}</published>
+        {{ /if }}
+        <updated>{{ $e.updated || $e.pubDate }}</updated>
 
         {{ if $e.author }}
         <author>

--- a/test/middleware/template.js
+++ b/test/middleware/template.js
@@ -10,6 +10,8 @@ afterAll(() => {
 });
 
 describe('template', () => {
+    const expectPubDate = new Date(1546272000000 - 10 * 1000);
+
     it(`.rss`, async () => {
         const response1 = await request.get('/test/1.rss');
         const parsed1 = await parser.parseString(response1.text);
@@ -25,7 +27,7 @@ describe('template', () => {
         expect(parsed1.items[0]).toEqual(expect.any(Object));
         expect(parsed1.items[0].title).toEqual(expect.any(String));
         expect(parsed1.items[0].link).toEqual(expect.any(String));
-        expect(parsed1.items[0].pubDate).toEqual(expect.any(String));
+        expect(parsed1.items[0].pubDate).toBe(expectPubDate.toUTCString());
         expect(parsed1.items[0].author).toEqual(expect.any(String));
         expect(parsed1.items[0].content).toEqual(expect.any(String));
         expect(parsed1.items[0].guid).toEqual(expect.any(String));
@@ -54,7 +56,7 @@ describe('template', () => {
         expect(parsed.items[0]).toEqual(expect.any(Object));
         expect(parsed.items[0].title).toEqual(expect.any(String));
         expect(parsed.items[0].link).toEqual(expect.any(String));
-        expect(parsed.items[0].pubDate).toEqual(expect.any(String));
+        expect(parsed.items[0].pubDate).toBe(expectPubDate.toISOString());
         expect(parsed.items[0].author).toEqual(expect.any(String));
         expect(parsed.items[0].content).toEqual(expect.any(String));
         expect(parsed.items[0].id).toEqual(expect.any(String));

--- a/test/utils/common-utils.js
+++ b/test/utils/common-utils.js
@@ -4,4 +4,33 @@ describe('common-utils', () => {
     it('toTitleCase', () => {
         expect(utils.toTitleCase('RSSHub IS AS aweSOme aS henry')).toBe('Rsshub Is As Awesome As Henry');
     });
+
+    it('convertDateToISO8601', () => {
+        expect(utils.convertDateToISO8601('')).toBe('');
+        expect(utils.convertDateToISO8601(null)).toBe(null);
+        expect(utils.convertDateToISO8601(undefined)).toBe(undefined);
+
+        const date = new Date('2019-01-01');
+        const expected = date.toISOString();
+        expect(utils.convertDateToISO8601(date)).toBe(expected);
+        expect(utils.convertDateToISO8601(date.toISOString())).toBe(expected);
+        expect(utils.convertDateToISO8601(date.toUTCString())).toBe(expected);
+        expect(utils.convertDateToISO8601(date.toLocaleString())).toBe(expected);
+        expect(utils.convertDateToISO8601('Tue, 01 Jan 2019 08:00:00 UTC+8')).toBe(expected);
+
+        expect(utils.convertDateToISO8601('Tue, 01 Jan 2019 00:00:00')).toBe(new Date(date.getTime() + new Date().getTimezoneOffset() * 60 * 1000).toISOString());
+        // need to pass a function in order to use `toThrow`
+        expect(() => {
+            utils.convertDateToISO8601('something invalid');
+        }).toThrow(RangeError);
+    });
+
+    it('collapseWhitespace', () => {
+        expect(utils.collapseWhitespace('')).toBe('');
+        expect(utils.collapseWhitespace(null)).toBe(null);
+        expect(utils.collapseWhitespace(undefined)).toBe(undefined);
+        expect(utils.collapseWhitespace('   \n\n\n    ')).toBe('');
+        expect(utils.collapseWhitespace('a string already collapsed')).toBe('a string already collapsed');
+        expect(utils.collapseWhitespace(' \n  a lot of     whitespaces   and \n\n\n\n linebreaks   \n\n ')).toBe('a lot of whitespaces and linebreaks');
+    });
 });


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
Offending RFC4287 could potentially break some readers when rendering the date.
```
fix(core): offending RFC4287

`<published>` is optional while `<updated>` is not
should not leave `<updated>` blank when `<published>` is not blank
these two fields MUST conform to the "date-time" production in RFC3339

Signed-off-by: Rongrong <15956627+Rongronggg9@users.noreply.github.com>
```