### PR TITLE
docs: 格式化文档

### DIFF
--- a/docs/.vuepress/components/Route.vue
+++ b/docs/.vuepress/components/Route.vue
@@ -15,7 +15,7 @@
   <div v-if="path.match(/:.*?(\/|$)/g)">
   <p>
     参数:
-  <ul><li class="params" v-for="(item, index) in path.match(/:.*?(\/|$)/g)">{{item.replace(':','').replace('/','').replace('?','')}}, {{(item.includes('?'))?'可选':'必选'}} - <span v-html="renderMarkdown(paramsDesc[index])"></span></li></ul> </p>
+  <ul><li class="params" v-for="(item, index) in path.match(/:.*?(\/|$)/g)"><code>{{item.replace(':','').replace('/','').replace('?','')}}</code>, {{(item.includes('?'))?'可选':'必选'}} - <span v-html="renderMarkdown(paramsDesc[index])"></span></li></ul> </p>
   </div>
   <div v-else><p>参数: 无</p></div>
   <slot></slot>

--- a/docs/.vuepress/components/RouteEn.vue
+++ b/docs/.vuepress/components/RouteEn.vue
@@ -15,7 +15,7 @@
   <div v-if="path.match(/(?<=:).*?(?=\/|$)/g)">
   <p>
     Parameters:
-  <ul><li class="params" v-for="(item, index) in path.match(/(?<=:).*?(?=\/|$)/g)">{{item.replace('?','')}}, {{(item.includes('?'))?'optional':'required'}} - <span v-html="renderMarkdown(paramsDesc[index])"></span></li></ul> </p>
+  <ul><li class="params" v-for="(item, index) in path.match(/(?<=:).*?(?=\/|$)/g)"><code>{{item.replace('?','')}}</code>, {{(item.includes('?'))?'optional':'required'}} - <span v-html="renderMarkdown(paramsDesc[index])"></span></li></ul> </p>
   </div>
   <div v-else><p>Parameters: N/A</p></div>
   <slot></slot>

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,7 +18,7 @@ RSSHub 提供下列 API 接口:
 
 参数:
 
--   name, 路由一级名称，对应 <https://github.com/DIYgod/RSSHub/tree/master/lib/routes> 中的文件夹名称。可选，**缺省则返回所有可用路由**.
+-   `name`, 路由一级名称，对应 <https://github.com/DIYgod/RSSHub/tree/master/lib/routes> 中的文件夹名称。可选，**缺省则返回所有可用路由**.
 
 成功请求将会返回 HTTP 状态码 `200 OK` 与 JSON 结果，格式如下:
 

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -18,7 +18,7 @@ Route: `/api/routes/:name?`
 
 Parameters:
 
--   name, route's top level name as in [https://github.com/DIYgod/RSSHub/tree/master/lib/routes](https://github.com/DIYgod/RSSHub/tree/master/lib/routes). Optional, **returns all public routes if not specified**.
+-   `name`, route's top level name as in [https://github.com/DIYgod/RSSHub/tree/master/lib/routes](https://github.com/DIYgod/RSSHub/tree/master/lib/routes). Optional, **returns all public routes if not specified**.
 
 A successful request returns a HTTP status code `200 OK` with the result in JSON:
 

--- a/docs/en/parameter.md
+++ b/docs/en/parameter.md
@@ -2,7 +2,7 @@
 
 ::: tip
 
-All parameters can be linked with `&` to used together to generate a complex feed.
+The parameters can be linked with `&` to used together to generate a complex feed.
 
 :::
 
@@ -12,27 +12,27 @@ The following URL query parameters are supported, Regex support is built-in.
 
 Set `filter` to include the content
 
--   filter: filter title and description
+-   `filter`: filter `title` and description
 
--   filter_title: filter title only
+-   `filter_title`: filter `title` only
 
--   filter_description: filter description only
+-   `filter_description`: filter `description` only
 
--   filter_author: filter author only
+-   `filter_author`: filter `author` only
 
--   filter_time: filter pubDate, value for second number, return specified time range. Item without `pubDate` will not be filtered.
+-   `filter_time`: filter `pubDate`, in seconds, return specified time range. Item without `pubDate` will not be filtered.
 
 For example: [https://rsshub.app/dribbble/popular?filter=Blue|Yellow|Black](https://rsshub.app/dribbble/popular?filter=Blue|Yellow|Black)
 
 Set `filterout` to exclude unwanted content.
 
--   filterout: filter title and description
+-   `filterout`: filter `title` and description
 
--   filterout_title: filter title only
+-   `filterout_title`: filter `title` only
 
--   filterout_description: filter description only
+-   `filterout_description`: filter `description` only
 
--   filterout_author: filter author only
+-   `filterout_author`: filter `author` only
 
 For example: [https://rsshub.app/dribbble/popular?filterout=Blue|Yellow|Black](https://rsshub.app/dribbble/popular?filterout=Blue|Yellow|Black)
 
@@ -46,13 +46,13 @@ Example: [https://rsshub.app/dribbble/popular?filter=BluE|yeLLow|BlaCK&filter_ca
 
 Set `limit` to limit the number of articles in the feed.
 
-Eg: Dribbble Popular Top 10 [https://rsshub.app/dribbble/popular?limit=10](https://rsshub.app/dribbble/popular?limit=10)
+E.g. Dribbble Popular Top 10 [https://rsshub.app/dribbble/popular?limit=10](https://rsshub.app/dribbble/popular?limit=10)
 
 ## Fulltext
 
 Enable fulltext via `mode` parameter.
 
-Eg: bilibili article <https://rsshub.app/bilibili/user/article/334958638?mode=fulltext>
+E.g. Bilibili article <https://rsshub.app/bilibili/user/article/334958638?mode=fulltext>
 
 ## Access Control
 
@@ -64,27 +64,27 @@ Replace website link with Telegram's Instant View link.
 
 Enable Telegram Instant View requires a page template, it can be obtained from Telegram's [Instant View page](https://instantview.telegram.org/)
 
--   tgiv: template hash, obtained from the link of template page generated（the string after `&rhash=`）
+-   `tgiv`: template hash, obtained from the link of template page generated（the string after `&rhash=`）
 
-Eg: <https://rsshub.app/novel/biquge/94_94525?tgiv=bd3c42818a7f7e>
+E.g. <https://rsshub.app/novel/biquge/94_94525?tgiv=bd3c42818a7f7e>
 
 ## Sci-hub link
 
 Output Sci-hub link in scientific journal routes, this supports major journals or routes that output DOIs.
 
--   scihub: set to any value
+-   `scihub`: set to any value
 
-Eg: <https://rsshub.app/pnas/latest?scihub=1>
+E.g. <https://rsshub.app/pnas/latest?scihub=1>
 
 ## Conversion between Traditional and Simplified Chinese
 
--   opencc: s2t (Simplified Chinese to Traditional Chinese)、t2s (Traditional Chinese to Simplified Chinese), other optional values refer to [simplecc-wasm - Configurations](https://github.com/fengkx/simplecc-wasm#%E9%85%8D%E7%BD%AE-configurations)
+-   `opencc`: `s2t` (Simplified Chinese to Traditional Chinese)、`t2s` (Traditional Chinese to Simplified Chinese), other optional values refer to [simplecc-wasm - Configurations](https://github.com/fengkx/simplecc-wasm#%E9%85%8D%E7%BD%AE-configurations)
 
-Eg: <https://rsshub.app/dcard/posts/popular?opencc=t2s>
+E.g. <https://rsshub.app/dcard/posts/popular?opencc=t2s>
 
 ## Output Formats
 
-RSSHub conforms to RSS 2.0 and Atom Standard, simply append `.rss` `.atom` to the end of the feed address to obtain the feed in corresponding format, default to RSS 2.0.
+RSSHub conforms to RSS 2.0 and Atom Standard, simply append `.rss` `.atom` to the end of the feed address to obtain the feed in corresponding format. The default output format is RSS 2.0.
 
 For example:
 

--- a/docs/parameter.md
+++ b/docs/parameter.md
@@ -53,7 +53,7 @@
 
 可以使用 `mode` 参数来开启自动提取全文内容功能
 
-举例: Bilibili 专栏全文输出 <https://rsshub.app/bilibili/user/article/334958638?mode=fulltext>
+举例: bilibili 专栏全文输出 <https://rsshub.app/bilibili/user/article/334958638?mode=fulltext>
 
 ## 访问控制
 

--- a/docs/parameter.md
+++ b/docs/parameter.md
@@ -8,38 +8,38 @@
 
 ## 内容过滤
 
-可以使用以下 URL query 过滤内容，支持正则
+可以使用以下 URL query 过滤内容，支持通过正则表达式过滤
 
-filter 选出想要的内容
+`filter` 选出想要的内容
 
--   filter: 过滤标题和描述
+-   `filter`: 过滤标题和描述
 
--   filter_title: 过滤标题
+-   `filter_title`: 过滤标题
 
--   filter_description: 过滤描述
+-   `filter_description`: 过滤描述
 
--   filter_author: 过滤作者
+-   `filter_author`: 过滤作者
 
--   filter_time: 过滤时间，仅支持数字，单位为秒。返回指定时间范围内的内容。如果条目没有输出`pubDate`或者格式不正确将不会被过滤
+-   `filter_time`: 过滤时间，仅支持数字，单位为秒。返回指定时间范围内的内容。如果条目没有输出`pubDate`或者格式不正确将不会被过滤
 
 举例 1: `https://rsshub.app/bilibili/fav/2267573/801952073?filter=编曲|摄影`
 举例 2: <https://rsshub.app/nga/forum/489?filter_time=600>
 
-filterout 去掉不要的内容
+`filterout` 去掉不要的内容
 
--   filterout: 过滤标题和描述
+-   `filterout`: 过滤标题和描述
 
--   filterout_title: 过滤标题
+-   `filterout_title`: 过滤标题
 
--   filterout_description: 过滤描述
+-   `filterout_description`: 过滤描述
 
--   filterout_author: 过滤作者
+-   `filterout_author`: 过滤作者
 
 举例: `https://rsshub.app/bilibili/fav/2267573/801952073?filterout=编曲|摄影`
 
 `filter_case_sensitive` 过滤是否区分大小写，`filter` 和 `filterout`同时适用
 
-默认为 true，区分大小写
+默认为 `true`，区分大小写
 
 举例 1: <https://rsshub.app/bilibili/user/coin/2267573?filter=diyGOD|RSShub&filter_case_sensitive=false>
 
@@ -47,13 +47,13 @@ filterout 去掉不要的内容
 
 可以使用 `limit` 参数限制最大条数，主要用于排行榜类 RSS
 
-举例: bilibili 排行榜前 10 <https://rsshub.app/bilibili/ranking/0/3?limit=10>
+举例: Bilibili 排行榜前 10 <https://rsshub.app/bilibili/ranking/0/3?limit=10>
 
 ## 全文输出
 
 可以使用 `mode` 参数来开启自动提取全文内容功能
 
-举例: bilibili 专栏全文输出 <https://rsshub.app/bilibili/user/article/334958638?mode=fulltext>
+举例: Bilibili 专栏全文输出 <https://rsshub.app/bilibili/user/article/334958638?mode=fulltext>
 
 ## 访问控制
 
@@ -65,7 +65,7 @@ filterout 去掉不要的内容
 
 Telegram 即时预览模式需要在官网制作页面处理模板，请前往[官网](https://instantview.telegram.org/)了解更多
 
--   tgiv: 模板 hash，可从模板制作页面分享出来的链接末尾获取（`&rhash=`后面跟着的字符串）
+-   `tgiv`: 模板 hash，可从模板制作页面分享出来的链接末尾获取（`&rhash=`后面跟着的字符串）
 
 举例: <https://rsshub.app/novel/biquge/94_94525?tgiv=bd3c42818a7f7e>
 
@@ -73,13 +73,13 @@ Telegram 即时预览模式需要在官网制作页面处理模板，请前往[�
 
 可以输出 Sci-hub 链接，用于知名期刊或输出 DOI 的科学期刊类 RSS。
 
--   scihub: 任意值开启
+-   `scihub`: 任意值开启
 
 举例: <https://rsshub.app/pnas/latest?scihub=1>
 
 ## 中文简繁体转换
 
--   opencc: s2t 简体转繁体、t2s 繁体转简体，其它可选值见 [simple-wasm - Configurations](https://github.com/fengkx/simplecc-wasm#%E9%85%8D%E7%BD%AE-configurations)
+-   `opencc`: `s2t` 简体转繁体、`t2s` 繁体转简体，其它可选值见 [simple-wasm - Configurations](https://github.com/fengkx/simplecc-wasm#%E9%85%8D%E7%BD%AE-configurations)
 
 举例: <https://rsshub.app/dcard/posts/popular?opencc=t2s>
 

--- a/docs/parameter.md
+++ b/docs/parameter.md
@@ -47,7 +47,7 @@
 
 可以使用 `limit` 参数限制最大条数，主要用于排行榜类 RSS
 
-举例: Bilibili 排行榜前 10 <https://rsshub.app/bilibili/ranking/0/3?limit=10>
+举例: bilibili 排行榜前 10 <https://rsshub.app/bilibili/ranking/0/3?limit=10>
 
 ## 全文输出
 


### PR DESCRIPTION
- 更新文档「API」和「参数」页
- 把 `<Router>` 和 `<RouterEn>` 的 `parameter` 部分用 `<code>` 括起来