### PR TITLE
fix(route)(fortunechina): 修正财富中文网日期时间匹配规则、移除一些不必要评论元素

### DIFF
--- a/lib/v2/fortunechina/index.js
+++ b/lib/v2/fortunechina/index.js
@@ -41,9 +41,9 @@ module.exports = async (ctx) => {
                 const content = cheerio.load(detailResponse.data);
 
                 const spans = content('.mod-info span').text();
-                let matches = spans.match(/(\d{4}年\d{2}月\d{2}日)/);
+                let matches = spans.match(/(\d{4}-\d{2}-\d{2})/);
                 if (matches) {
-                    item.pubDate = parseDate(matches[1].replace(/年|月/g, '-').replace(/日/, ''));
+                    item.pubDate = parseDate(matches[1]);
                 } else {
                     matches = spans.match(/(\d+小时前)/);
                     if (matches) {
@@ -53,7 +53,7 @@ module.exports = async (ctx) => {
 
                 item.author = content('.name').text();
 
-                content('.mod-info, .title').remove();
+                content('.mod-info, .title, .eval-zan, .eval-pic, .sae-more').remove();
 
                 item.description = content('#articleContent, .eval-desc').html();
 


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue
无相关 issue
Close #

## 完整路由地址 / Example for the proposed route(s)
```route
/fortunechina
/fortunechina/shangye
/fortunechina/lingdaoli
/fortunechina/keji
/fortunechina/report
```


## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
- 修正财富中文网日期时间匹配规则
- 移除一些不必要评论元素（尺寸不一的头像、点赞数、打开 App 提示）