### PR TITLE
fix(route)(wechat/ce): anti-crawler and pubDate

### DIFF
--- a/lib/routes/tencent/wechat/ce.js
+++ b/lib/routes/tencent/wechat/ce.js
@@ -1,33 +1,62 @@
 const parser = require('@/utils/rss-parser');
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
+const { fixArticleContent } = require('@/utils/wechat-mp');
+const { parseDate } = require('@/utils/parse-date');
+
+// any UA containing "RSS" can pass the check
+// mark the UA as a desktop UA with "(X11; Linux x86_64)"
+const UA = 'Mozilla/5.0 (X11; Linux x86_64) RSS Reader';
 
 module.exports = async (ctx) => {
     const { id } = ctx.params;
 
-    const feed = await parser.parseURL(`https://posts.careerengine.us/author/${id}/rss`);
+    const feed = await parser.parseString(
+        await got
+            .get(`https://posts.careerengine.us/author/${id}/rss`, {
+                headers: {
+                    'User-Agent': UA,
+                },
+            })
+            .then((_) => _.data)
+    );
 
     const items = await Promise.all(
         feed.items.splice(0, 10).map(async (item) => {
-            const response = await got.get(item.link);
+            // generally speaking, changing `item.link` of an existing route could potentially break `item.guid`
+            // but since the route has been down for at least 8 months, it's probably safe
+            item.link = item.link.replace(/^http:\/\//, 'https://');
+            return await ctx.cache.tryGet(item.link, async () => {
+                const response = await got.get(item.link, {
+                    headers: {
+                        'User-Agent': UA,
+                    },
+                });
 
-            const $ = cheerio.load(response.data);
-            const post = $('.post');
+                const $ = cheerio.load(response.data);
 
-            post.find('img').each((_, img) => {
-                const dataSrc = $(img).attr('data-src');
-                if (dataSrc) {
-                    $(img).attr('src', dataSrc);
+                const description = fixArticleContent($('.post'));
+
+                let pubDate = item.pubDate;
+                if (!pubDate || pubDate === 'Invalid Date') {
+                    // sometimes the pubDate is not available in the official feed
+                    const postDate = $('.post-date')
+                        .text()
+                        .replace(/\s+|发表/g, '');
+                    // the date format is "发表 YYYY年MM月DD日 "
+                    // following the official feed behavior: imprecise date is in UTC
+                    // `<pubDate>Mon, 04 Apr 2022 00:00:00 GMT</pubDate>`
+                    pubDate = parseDate(postDate, 'YYYY年MM月DD日');
+                    pubDate = new Date(pubDate.getTime() - pubDate.getTimezoneOffset() * 60 * 1000);
                 }
-            });
 
-            const single = {
-                title: item.title,
-                description: post.html(),
-                pubDate: item.pubDate,
-                link: item.link,
-            };
-            return Promise.resolve(single);
+                return {
+                    title: item.title,
+                    description,
+                    pubDate,
+                    link: item.link,
+                };
+            });
         })
     );
 


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #7986

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/wechat/ce/5b0d5cbbd65e20012e6d8307
/wechat/ce/595a5b14d7164e53908f1606
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [x] 反爬/频率限制 anti-bot or rate limit?
  - [x] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
