### PR TITLE
fix(utils): 支持微信公众号单图片文章抓取; 增加输出阅读原文链接

### DIFF
--- a/lib/utils/wechat-mp.js
+++ b/lib/utils/wechat-mp.js
@@ -50,6 +50,17 @@ const detectOriginalArticleUrl = ($) => {
     return null;
 };
 
+const detectSourceUrl = ($) => {
+    const matchs = $.root()
+        .html()
+        .match(/msg_source_url = '(.+)';/);
+
+    if (matchs) {
+        return matchs[1];
+    }
+    return null;
+};
+
 /**
  * Articles from WeChat MP have weird formats, this function is used to fix them.
  *
@@ -183,6 +194,11 @@ const fetchArticle = async (ctx, url, bypassHostCheck = false) => {
             const originalResponse = await got(normalizeUrl(originalUrl, bypassHostCheck));
             const original$ = cheerio.load(originalResponse.data);
             description += fixArticleContent(original$('#js_content'));
+        }
+
+        const sourceUrl = detectSourceUrl($);
+        if (sourceUrl) {
+            description += `<a href="${sourceUrl}">阅读原文</a>`;
         }
 
         let pubDate;

--- a/lib/utils/wechat-mp.js
+++ b/lib/utils/wechat-mp.js
@@ -38,10 +38,12 @@ const replaceTag = ($, oldTag, newTagName) => {
 
 const detectOriginalArticleUrl = ($) => {
     // No article content get, try the original url
+    // example: https://mp.weixin.qq.com/s/f6sKObaZZhADTYU2Jl5Bnw
     if (!$('#js_content').text()) {
         return $('#js_share_source').attr('data-url');
     }
     // Article content is too short, try the first link
+    // example: https://mp.weixin.qq.com/s/9saVB4KaolRyJfpajzeFRg
     if ($('#js_content').text().length < 80) {
         return $('#js_content a').attr('href');
     }
@@ -90,6 +92,18 @@ const fixArticleContent = (html, skipImg = false) => {
             replaceTag($, section, 'div');
         }
     });
+
+    // fix single picture article
+    // example: https://mp.weixin.qq.com/s/4p5YmYuASiQSYFiy7KqydQ
+    $('script').each((_, script) => {
+        script = $(script);
+        const matchs = script.html().match(/document\.getElementById\('js_image_desc'\)\.innerHTML = "(.*)"\.replace/);
+
+        if (matchs) {
+            script.replaceWith(matchs[1].replace(/\r/g, '').replace(/\n/g, '<br>').replace(/\\x0d/g, '').replace(/\\x0a/g, '<br>'));
+        }
+    });
+
     // clean scripts
     $('script').remove();
     return $.html();
@@ -156,11 +170,11 @@ const fetchArticle = async (ctx, url, bypassHostCheck = false) => {
         const response = await got(url);
         const $ = cheerio.load(response.data);
 
-        const title = $('meta[property="og:title"]').attr('content');
+        const title = $('meta[property="og:title"]').attr('content').replace(/\\r/g, '').replace(/\\n/g, ' ');
         const author = $('meta[name=author]').attr('content');
         let summary = $('meta[name=description]').attr('content');
         summary = summary !== title ? summary : '';
-        let description = fixArticleContent($('div#js_content.rich_media_content'));
+        let description = fixArticleContent($('#js_content'));
 
         // No article get or article is too short, try the original url
         const originalUrl = detectOriginalArticleUrl($);


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue
无相关 issue
Close #

## 完整路由地址 / Example for the proposed route(s)
```route
/wechat/feeddd/611f6b8c65d23936d94a4479
```


## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
- 支持微信公众号单图片文章抓取 （如： <https://mp.weixin.qq.com/s/4p5YmYuASiQSYFiy7KqydQ> ）
- 增加输出阅读原文链接 