### PR TITLE
fix(core/utils): invalid request header `Server`

### DIFF
--- a/lib/utils/request-wrapper.js
+++ b/lib/utils/request-wrapper.js
@@ -102,9 +102,6 @@ const requestWrapper = (url, options) => {
         options.headers['user-agent'] = config.ua;
     }
 
-    // server
-    options.headers.server = 'RSSHub';
-
     try {
         const urlHandler = new URL(url);
         // referer

--- a/test/utils/request-wrapper.js
+++ b/test/utils/request-wrapper.js
@@ -43,7 +43,6 @@ describe('got', () => {
             .get(/.*/)
             .times(3)
             .reply(function () {
-                expect(this.req.headers.server).toBe('RSSHub');
                 expect(this.req.headers.referer).toBe('http://api.rsshub.test');
                 expect(this.req.headers.host).toBe('api.rsshub.test');
                 return [200, simpleResponse];


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
`Server` is only a valid **response** header, not a **request** header. Adding this header typically does nothing unless the maintainers of websites manually audit incoming requests. However, if the website is behind a firewall, there is a concern that weird request headers could potentially make requests harder to pass the firewall in some cases.
If there is indeed such a need to let websites know the request is from RSSHub, that's the business of `User-Agent`. Or alternatively, any non-standard header should start with `X-` (indeed, this prefix was deprecated in RFC 6648, but it is still a powerful de facto standard). But still, adding `X-Server` has the same concern.

In any case, if do need to expose the identity of RSSHub, users should still take the control of it.

Ref: [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html), [RFC 7231](https://httpwg.org/specs/rfc7231.html#rfc.section.7.4.2)