### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   check-env:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     outputs:
       check-docker: ${{ steps.check-docker.outputs.defined }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -11,6 +11,9 @@ on:
       - 'yarn.lock'
   # Please, always create a pull request instead of push to master.
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Docker build & tests

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   format:
+    permissions:
+      contents: write  # for Git to git push
     name: Auto format
     runs-on: ubuntu-latest
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'lib/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: npm publish

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   rebase:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') && github.event.comment.author_association == 'COLLABORATOR'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   jest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
