### PR TITLE
fix(utils): request without hostname

### DIFF
--- a/lib/utils/request-wrapper.js
+++ b/lib/utils/request-wrapper.js
@@ -125,7 +125,7 @@ const httpWrap = (func) => {
                 requestWrapper(url.toString(), request);
             } else {
                 const req = url;
-                requestWrapper(req.url || req.href || `${req.protocol}//${req.hostname}${req.path}`, req);
+                requestWrapper(req.url || req.href || `${req.protocol}//${req.hostname || req.host}${req.path}`, req);
             }
         } else {
             requestWrapper(url, request);


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 route 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

Fixed a case where `url` does not have `hostname` property when using [twitter-api-v2](https://www.npmjs.com/package/twitter-api-v2).
```yaml
{
  method: 'POST',
  headers: {
    'x-user-agent': 'Node.twitter-api-v2',
    Authorization: 'Basic **REDACHED**',
    'content-type': 'application/x-www-form-urlencoded;charset=UTF-8',
    'content-length': 29,
    'accept-encoding': 'br;q=1.0, gzip;q=0.8, deflate;q=0.5, *;q=0.1'
  },
  timeout: undefined,
  agent: undefined,
  host: 'api.twitter.com',
  port: undefined,
  path: '/oauth2/token',
  protocol: 'https:',
  auth: undefined
}
```

This fixed `ERR_TLS_CERT_ALTNAME_INVALID` when using [twitter-api-v2](https://www.npmjs.com/package/twitter-api-v2) as 
https://github.com/DIYgod/RSSHub/blob/969df26d3d825424d6b64d3618bf1d9721479e99/lib/utils/request-wrapper.js#L111-L114
will cause host becomes `undefined` and cannot pass cert name check