### PR TITLE
feat(utils): 增加微信公众号文章音频部分处理逻辑，修正公众号文章中引入的视频内容

### DIFF
--- a/lib/utils/wechat-mp.js
+++ b/lib/utils/wechat-mp.js
@@ -35,7 +35,7 @@ const replaceTag = ($, oldTag, newTagName) => {
     oldTag.replaceWith(NewTag);
 };
 
-/**
+/*
  * Detect original article url from cheerio $.
  *
  * @param {object} $ - A cheerio Object.
@@ -116,7 +116,6 @@ const renderAudio = (options = {}) => {
  */
 const getAccountHeadImage = (html = '') => {
     const matchs = html.match(/hd_head_img = "([^"]+)"/);
-
     if (matchs) {
         return matchs[1];
     }
@@ -124,6 +123,20 @@ const getAccountHeadImage = (html = '') => {
     const matchs2 = html.match(/getXmlValue\('hd_head_img.DATA'\) \|\| '' : '([^']+)'/);
     if (matchs2) {
         return matchs2[1];
+    }
+    return null;
+};
+
+/**
+ * Get head image of the MP account.
+ *
+ * @param {string} html - The html text of the article.
+ * @return {(string|null)} - A head image url.
+ */
+const getMpVideoUrl = async (mpvid = '') => {
+    const response = await got(`https://mp.weixin.qq.com/mp/videoplayer?action=get_mp_video_play_url&preview=0&vid=${mpvid}`);
+    if (response.data && response.data.url_info && response.data.url_info[0].url) {
+        return response.data.url_info[0].url;
     }
     return null;
 };
@@ -140,7 +153,7 @@ const getAccountHeadImage = (html = '') => {
  * @param {object} voiceInfo - Voice info.
  * @return {string} - The fixed html, a string.
  */
-const fixArticleContent = (html, skipImg = false, voiceInfo = null) => {
+const fixArticleContent = async (html, skipImg = false, voiceInfo = null) => {
     html = html && html.html ? html.html() : html; // do not disturb the original tree
     if (!html) {
         return '';
@@ -171,6 +184,32 @@ const fixArticleContent = (html, skipImg = false, voiceInfo = null) => {
             replaceTag($, section, 'div');
         }
     });
+
+    // fix iframe
+    // example: https://mp.weixin.qq.com/s/FnjcMXZ1xdS-d6n-pUUyyw , https://mp.weixin.qq.com/s/n4LhnX5av5V8J2-daUNMHA
+    const $iframes = $('iframe');
+    for (const item of $iframes) {
+        const iframe = $(item);
+        let src = iframe.attr('data-src');
+        const mpvid = iframe.attr('data-mpvid');
+        if (!src && !mpvid) {
+            return;
+        }
+        const urlObject = new URL(src);
+        if (urlObject.host === 'v.qq.com' && urlObject.searchParams.has('vid')) {
+            src = `https://v.qq.com/txp/iframe/player.html?origin=https%3A%2F%2Fmp.weixin.qq.com&containerId=js_tx_video_container_0.3863487104715233&vid=${urlObject.searchParams.get(
+                'vid'
+            )}&width=677&height=380.8125&autoplay=false&allowFullScreen=true&chid=17&full=true&show1080p=false&isDebugIframe=false`;
+        } else if (mpvid) {
+            // eslint-disable-next-line no-await-in-loop
+            src = await getMpVideoUrl(mpvid);
+        }
+        iframe.attr('src', src);
+        const width = Math.min(iframe.attr('data-w'), 677);
+        iframe.attr('width', width);
+        iframe.attr('height', width / iframe.attr('data-ratio'));
+        iframe.removeAttr('data-src');
+    }
 
     // fix voice
     $('mpvoice').each((_, mpvoice) => {
@@ -282,7 +321,7 @@ const fetchArticle = async (ctx, url, bypassHostCheck = false) => {
         summary = summary !== title ? summary : '';
         const headImage = getAccountHeadImage(rootHtml);
         const voiceInfo = detectVoiceInfo(rootHtml);
-        let description = fixArticleContent($('#js_content'), false, voiceInfo);
+        let description = await fixArticleContent($('#js_content'), false, voiceInfo);
 
         // No article get or article is too short, try the original url
         const originalUrl = detectOriginalArticleUrl($);
@@ -291,7 +330,7 @@ const fetchArticle = async (ctx, url, bypassHostCheck = false) => {
             const originalResponse = await got(normalizeUrl(originalUrl, bypassHostCheck));
             const original$ = cheerio.load(originalResponse.data);
             const originalVoiceInfo = detectVoiceInfo(originalResponse.data);
-            description += fixArticleContent(original$('#js_content'), false, originalVoiceInfo);
+            description += await fixArticleContent(original$('#js_content'), false, originalVoiceInfo);
         }
 
         const sourceUrl = detectSourceUrl(rootHtml);

--- a/lib/utils/wechat-mp.js
+++ b/lib/utils/wechat-mp.js
@@ -35,6 +35,12 @@ const replaceTag = ($, oldTag, newTagName) => {
     oldTag.replaceWith(NewTag);
 };
 
+/**
+ * Detect original article url from cheerio $.
+ *
+ * @param {object} $ - A cheerio Object.
+ * @return {(string|null)} - A original url.
+ */
 const detectOriginalArticleUrl = ($) => {
     // No article content get, try the original url
     // example: https://mp.weixin.qq.com/s/f6sKObaZZhADTYU2Jl5Bnw
@@ -49,13 +55,75 @@ const detectOriginalArticleUrl = ($) => {
     return null;
 };
 
-const detectSourceUrl = ($) => {
-    const matchs = $.root()
-        .html()
-        .match(/msg_source_url = '(.+)';/);
+/**
+ * Detect source url from the html text of the article.
+ *
+ * @param {string} html - The html text of the article.
+ * @return {(string|null)} - A source url.
+ */
+const detectSourceUrl = (html = '') => {
+    const matchs = html.match(/msg_source_url = '(.+)';/);
 
     if (matchs) {
         return matchs[1];
+    }
+    return null;
+};
+
+/**
+ * Detect Voice info from the html text of the article.
+ *
+ * @param {string} html - The html text of the article.
+ * @return {(object|null)} - An object containing the voice id, duration and name.
+ */
+const detectVoiceInfo = (html = '') => {
+    // example: https://mp.weixin.qq.com/s/FY6yQC_e4NMAxK0FBr6jwQ
+    const voiceIdMatchs = html.match(/"voice_id":"([^"]+)",/);
+    const durationMatchs = html.match(/\bduration : "([^"]+)"\*1,/);
+    const nameMatchs = html.match(/\bwindow\.title = "(.+)";/);
+
+    if (voiceIdMatchs) {
+        return {
+            voiceId: voiceIdMatchs[1],
+            duration: durationMatchs ? durationMatchs[1] : '',
+            name: nameMatchs ? nameMatchs[1] : '',
+        };
+    }
+    return null;
+};
+
+/**
+ * Render <audio> html.
+ *
+ * @param {object} options - The info of voice.
+ * @param {string} options.voiceId - The voice id of voice.
+ * @param {string} [options.name] - The name of voice.
+ * @param {string} [options.duration] - The duration of voice .
+ * @return {string} - The <audio> html, a string.
+ */
+const renderAudio = (options = {}) => {
+    if (options.voiceId) {
+        return `<audio controls="controls" preload="auto" duration="${options.duration || ''}"  style="width:100%" src="https://res.wx.qq.com/voice/getvoice?mediaid=${options.voiceId}" title="${options.name || ''}"></audio>`;
+    }
+    return '';
+};
+
+/**
+ * Get head image of the MP account.
+ *
+ * @param {string} html - The html text of the article.
+ * @return {(string|null)} - A head image url.
+ */
+const getAccountHeadImage = (html = '') => {
+    const matchs = html.match(/hd_head_img = "([^"]+)"/);
+
+    if (matchs) {
+        return matchs[1];
+    }
+
+    const matchs2 = html.match(/getXmlValue\('hd_head_img.DATA'\) \|\| '' : '([^']+)'/);
+    if (matchs2) {
+        return matchs2[1];
     }
     return null;
 };
@@ -69,9 +137,10 @@ const detectSourceUrl = ($) => {
  * Example usage: item.description = fixArticleContent($('div#js_content.rich_media_content'));
  * @param {*} html - The html to be fixed, a string or a cheerio object.
  * @param {boolean} skipImg - Whether to skip fixing images.
+ * @param {object} voiceInfo - Voice info.
  * @return {string} - The fixed html, a string.
  */
-const fixArticleContent = (html, skipImg = false) => {
+const fixArticleContent = (html, skipImg = false, voiceInfo = null) => {
     html = html && html.html ? html.html() : html; // do not disturb the original tree
     if (!html) {
         return '';
@@ -103,14 +172,40 @@ const fixArticleContent = (html, skipImg = false) => {
         }
     });
 
-    // fix single picture article
+    // fix voice
+    $('mpvoice').each((_, mpvoice) => {
+        mpvoice = $(mpvoice);
+        const voiceId = mpvoice.attr('voice_encode_fileid');
+        const name = mpvoice.attr('name') || '';
+        const duration = mpvoice.attr('play_length') || '';
+        if (voiceId) {
+            mpvoice.html(
+                renderAudio({
+                    voiceId,
+                    name,
+                    duration,
+                })
+            );
+        }
+    });
+
+    // fix single voice article
+    // example: https://mp.weixin.qq.com/s/FY6yQC_e4NMAxK0FBr6jwQ
+    $('#voice_parent').each((_, voice) => {
+        voice = $(voice);
+        if (voiceInfo) {
+            voice.html(renderAudio(voiceInfo));
+        }
+    });
+
+    // fix single picture/vocice article
     // example: https://mp.weixin.qq.com/s/4p5YmYuASiQSYFiy7KqydQ
     $('script').each((_, script) => {
         script = $(script);
-        const matchs = script.html().match(/document\.getElementById\('js_image_desc'\)\.innerHTML = "(.*)"\.replace/);
+        const matchs = script.html().match(/document\.getElementById\('(?:js_image_desc|js_audio_desc)'\)\.innerHTML = (?:'|")(.*)(?:'|")\.replace/);
 
         if (matchs) {
-            script.replaceWith(matchs[1].replace(/\r/g, '').replace(/\n/g, '<br>').replace(/\\x0d/g, '').replace(/\\x0a/g, '<br>'));
+            script.replaceWith(matchs[1].replace(/\r|\\x0d/g, '').replace(/\n|\\x0a/g, '<br>'));
         }
     });
 
@@ -178,13 +273,16 @@ const fetchArticle = async (ctx, url, bypassHostCheck = false) => {
     url = normalizeUrl(url, bypassHostCheck);
     return await ctx.cache.tryGet(url, async () => {
         const response = await got(url);
-        const $ = cheerio.load(response.data);
+        const rootHtml = response.data;
+        const $ = cheerio.load(rootHtml);
 
         const title = ($('meta[property="og:title"]').attr('content') || '').replace(/\\r/g, '').replace(/\\n/g, ' ');
         const author = $('meta[name=author]').attr('content');
         let summary = $('meta[name=description]').attr('content');
         summary = summary !== title ? summary : '';
-        let description = fixArticleContent($('#js_content'));
+        const headImage = getAccountHeadImage(rootHtml);
+        const voiceInfo = detectVoiceInfo(rootHtml);
+        let description = fixArticleContent($('#js_content'), false, voiceInfo);
 
         // No article get or article is too short, try the original url
         const originalUrl = detectOriginalArticleUrl($);
@@ -192,10 +290,11 @@ const fetchArticle = async (ctx, url, bypassHostCheck = false) => {
             // try to fetch the description from the original article
             const originalResponse = await got(normalizeUrl(originalUrl, bypassHostCheck));
             const original$ = cheerio.load(originalResponse.data);
-            description += fixArticleContent(original$('#js_content'));
+            const originalVoiceInfo = detectVoiceInfo(originalResponse.data);
+            description += fixArticleContent(original$('#js_content'), false, originalVoiceInfo);
         }
 
-        const sourceUrl = detectSourceUrl($);
+        const sourceUrl = detectSourceUrl(rootHtml);
         if (sourceUrl) {
             description += `<a href="${sourceUrl}">阅读原文</a>`;
         }
@@ -211,7 +310,7 @@ const fetchArticle = async (ctx, url, bypassHostCheck = false) => {
         let mpName = $('.profile_nickname').first().text();
         mpName = mpName && mpName.trim();
 
-        return { title, author, description, summary, pubDate, mpName, link: url };
+        return { title, author, description, summary, pubDate, mpName, link: url, voiceInfo, headImage };
     });
 };
 
@@ -232,11 +331,12 @@ const fetchArticle = async (ctx, url, bypassHostCheck = false) => {
  * @return {Promise<object>} - The incoming `item` object, with the article and its metadata filled in.
  */
 const finishArticleItem = async (ctx, item, setMpNameAsAuthor = false, skipLink = false) => {
-    const { title, author, description, summary, pubDate, mpName, link } = await fetchArticle(ctx, item.link);
+    const { title, author, description, summary, pubDate, mpName, link, voiceInfo, headImage } = await fetchArticle(ctx, item.link);
     item.title = title || item.title;
     item.description = description || item.description;
     item.summary = summary || item.summary;
     item.pubDate = pubDate || item.pubDate;
+    item.headImage = headImage || '';
     if (setMpNameAsAuthor) {
         // the Official Account itself. if your route return articles from different accounts, you may want to use this
         item.author = mpName || item.author;
@@ -246,6 +346,10 @@ const finishArticleItem = async (ctx, item, setMpNameAsAuthor = false, skipLink 
     }
     if (!skipLink) {
         item.link = link || item.link;
+    }
+    if (voiceInfo && voiceInfo.voiceId) {
+        item.enclosure_url = `https://res.wx.qq.com/voice/getvoice?mediaid=${voiceInfo.voiceId}`;
+        item.enclosure_type = 'audio/mp3';
     }
     return item;
 };

--- a/lib/v2/gzh360/utils.js
+++ b/lib/v2/gzh360/utils.js
@@ -49,7 +49,7 @@ const finishArticleItem = async (ctx, item, skipAuthor = false) => {
         }
         item.title = item.title || $('div.desc > h1').text();
         item.pubDate = item.pubDate || parseDate($('div.desc span[data-timestamp]').attr('data-timestamp'));
-        item.description = fixArticleContent($('div.rich_media_content'), true); // sometimes it is an empty string due to the website's fault
+        item.description = await fixArticleContent($('div.rich_media_content'), true); // sometimes it is an empty string due to the website's fault
     }
 
     return item;

--- a/lib/v2/wechat/ce.js
+++ b/lib/v2/wechat/ce.js
@@ -35,7 +35,7 @@ module.exports = async (ctx) => {
 
                 const $ = cheerio.load(response.data);
 
-                const description = fixArticleContent($('.post'));
+                const description = await fixArticleContent($('.post'));
 
                 let pubDate = item.pubDate;
                 if (!pubDate || pubDate === 'Invalid Date') {

--- a/lib/v2/wechat/feeddd.js
+++ b/lib/v2/wechat/feeddd.js
@@ -20,10 +20,13 @@ module.exports = async (ctx) => {
 
     items = await Promise.all(items.map(async (item) => await finishArticleItem(ctx, item)));
 
+    const image = (items && items[0] && items[0].headImage) || '';
+
     ctx.state.data = {
         title: response.data.title,
         link: response.data.feed_url,
         description: response.data.title,
+        image,
         item: items,
         allowEmpty: true,
     };
@@ -32,6 +35,7 @@ module.exports = async (ctx) => {
         title: response.data.title,
         link: response.data.feed_url,
         description: response.data.title,
+        image,
         item: items,
     };
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue
无相关 issue
Close #

## 完整路由地址 / Example for the proposed route(s)
```route
/wechat/feeddd/6131e1401269c358aa0e1867
/wechat/feeddd/615b3b7a1269c358aa15a17b
/wechat/feeddd/625d00c2a4ca6e10e36bb689
```


## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
- 增加微信公众号文章中音频部分处理逻辑
- 修正公众号文章中引入的视频 <iframe> 内容