### PR TITLE
refactor(route/mastodon): quick fix on empty reposted toots

### DIFF
--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -1,7 +1,13 @@
 const got = require('@/utils/got');
+const { parseDate } = require('@/utils/parse-date');
 
 const parseStatuses = (data) =>
     data.map((item) => {
+        // docs on: https://docs.joinmastodon.org/entities/status/
+
+        const accountRepostedBy = item.reblog ? item.account : null;
+        item = item.reblog ? item.reblog : item;
+
         const content = item.content ? item.content.replace(/<span.*?>|<\/span.*?>/gm, '') : '';
         const contentRemovedHtml = content.replace(/<(?:.|\n)*?>/gm, '\n');
 
@@ -26,25 +32,19 @@ const parseStatuses = (data) =>
                 })
                 .join('');
 
-        let author, link, titleAuthor, media;
-        if (item.reblog !== null) {
-            author = `${item.reblog.account.display_name} (@${item.reblog.account.acct})`;
-            link = item.reblog.url;
-            titleAuthor = `Re @${item.reblog.account.username}`;
-            media = mediaParse(item.reblog.media_attachments);
-        } else {
-            author = `${item.account.display_name} (@${item.account.acct})`;
-            link = item.url;
-            titleAuthor = `@${item.account.username}`;
-            media = mediaParse(item.media_attachments);
-        }
+        const author = `${item.account.display_name} (@${item.account.acct})`;
+        const link = item.url;
+        const media = mediaParse(item.media_attachments);
+
+        const titleAuthor = accountRepostedBy ? `Re @${accountRepostedBy.username}` : `@${item.account.username}`;
         const titleText = item.sensitive === true ? `(CW) ${item.spoiler_text}` : contentRemovedHtml;
+        const title = `${titleAuthor}: "${titleText}"`;
 
         return {
-            title: `${titleAuthor}: "${titleText}"`,
+            title,
             author,
             description: item.spoiler_text + '<hr />' + content + media,
-            pubDate: new Date(item.created_at).toUTCString(),
+            pubDate: parseDate(item.created_at),
             link,
             guid: item.uri,
         };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #9697 

## 完整路由地址 / Example for the proposed route(s)

```routes
/mastodon/account_id/mastodon.social/23634/statuses
/mastodon/timeline/mstdn.maud.io
/mastodon/remote/mstdn.maud.io
```

## 说明 / Note

This series of route is still on v1. Please consider this pr to be a quick fix on issue #9657, and I will work on a list of feature request before finally migrating these routes to v2. 

## 新 RSS 检查列表 / New RSS Script Checklist
  
n/a, not a new route. All following was not changed. 
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`
