### PR TITLE
chore(*): fix improper @pull[bot] config

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,7 @@
+version: '1'
+rules:
+  - base: master
+    upstream: diygod:master
+    # default value if this file does not exist is `hardreset`, effectively overwriting any downstream changes!
+    # previously it was the misconfigured PR route test workflow that rescued downstream changes from being overwritten
+    mergeMethod: merge

--- a/scripts/workflow/test-route/identify.js
+++ b/scripts/workflow/test-route/identify.js
@@ -1,5 +1,5 @@
 const noFound = 'Auto: Route No Found';
-const whiteListedUser = ['dependabot[bot]'];
+const whiteListedUser = ['dependabot[bot]', 'pull[bot]']; // dependabot and downstream PR requested by pull[bot]
 
 module.exports = async ({ github, context, core }, body, number, sender) => {
     core.debug(`sender: ${sender}`);


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
The [officially recommended way](https://docs.rsshub.app/en/install/#deploy-to-heroku-automatic-deploy-upon-update) to keep forks up-to-date is to set up @pull[bot]. But the misconfigured PR route test workflow effectively closes every PR opened by @pull[bot], making the recommended way nothing.

This PR is to fix the misconfigured PR route test workflow to make @pull[bot] works out-of-box (no need to manually disable the PR route test workflow). Meanwhile, a configuration of @pull[bot] has been added to prevent the bot from aggressively overwriting any downstream modifications by default. There do be some downstream repositories benefiting from the misconfigured PR route test workflow (e.g. @lfkdsk's https://github.com/MoYuTime-Podcast/RSSHub) so I consider there is such a need to disable the aggressive behavior of @pull[bot] explicitly.