### PR TITLE
fix:修复/zhihu/question无法获取，需要设置非登录状态下cookie以计算x-zse-96

### DIFF
--- a/lib/routes/zhihu/execlib/g_encrypt.js
+++ b/lib/routes/zhihu/execlib/g_encrypt.js
@@ -1,0 +1,451 @@
+/**
+ * Generate x-zse-96
+ */
+const jsdom = require("jsdom");
+const {JSDOM} = jsdom;
+const dom = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);
+const window = dom.window;
+
+function t(e) {
+    return (t = "function" === typeof Symbol && "symbol" === typeof Symbol.A ? function (e) {
+                return typeof e;
+            }
+            : function (e) {
+                return e && "function" === typeof Symbol && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
+            }
+    )(e);
+}
+
+Object.defineProperty(exports, "__esModule", {
+    value: !0
+});
+const A = "2.0",
+     __g = {};
+
+function s() {
+}
+
+function i(e) {
+    this.t = (2048 & e) >> 11,
+        this.s = (1536 & e) >> 9,
+        this.i = 511 & e,
+        this.h = 511 & e;
+}
+
+function h(e) {
+    this.s = (3072 & e) >> 10,
+        this.h = 1023 & e;
+}
+
+function a(e) {
+    this.a = (3072 & e) >> 10,
+        this.c = (768 & e) >> 8,
+        this.n = (192 & e) >> 6,
+        this.t = 63 & e;
+}
+
+function c(e) {
+    this.s = e >> 10 & 3,
+        this.i = 1023 & e;
+}
+
+function n() {
+}
+
+function e(e) {
+    this.a = (3072 & e) >> 10,
+        this.c = (768 & e) >> 8,
+        this.n = (192 & e) >> 6,
+        this.t = 63 & e;
+}
+
+function o(e) {
+    this.h = (4095 & e) >> 2,
+        this.t = 3 & e;
+}
+
+function r(e) {
+    this.s = e >> 10 & 3,
+        this.i = e >> 2 & 255,
+        this.t = 3 & e;
+}
+
+s.prototype.e = function (e) {
+    e.o = !1;
+}
+    ,
+    i.prototype.e = function (e) {
+        switch (this.t) {
+            case 0:
+                e.r[this.s] = this.i;
+                break;
+            case 1:
+                e.r[this.s] = e.k[this.h];
+        }
+    }
+    ,
+    h.prototype.e = function (e) {
+        e.k[this.h] = e.r[this.s];
+    }
+    ,
+    a.prototype.e = function (e) {
+        switch (this.t) {
+            case 0:
+                e.r[this.a] = e.r[this.c] + e.r[this.n];
+                break;
+            case 1:
+                e.r[this.a] = e.r[this.c] - e.r[this.n];
+                break;
+            case 2:
+                e.r[this.a] = e.r[this.c] * e.r[this.n];
+                break;
+            case 3:
+                e.r[this.a] = e.r[this.c] / e.r[this.n];
+                break;
+            case 4:
+                e.r[this.a] = e.r[this.c] % e.r[this.n];
+                break;
+            case 5:
+                e.r[this.a] = e.r[this.c] == e.r[this.n];
+                break;
+            case 6:
+                e.r[this.a] = e.r[this.c] >= e.r[this.n];
+                break;
+            case 7:
+                e.r[this.a] = e.r[this.c] || e.r[this.n];
+                break;
+            case 8:
+                e.r[this.a] = e.r[this.c] && e.r[this.n];
+                break;
+            case 9:
+                e.r[this.a] = e.r[this.c] !== e.r[this.n];
+                break;
+            case 10:
+                e.r[this.a] = t(e.r[this.c]);
+                break;
+            case 11:
+                e.r[this.a] = e.r[this.c] in e.r[this.n];
+                break;
+            case 12:
+                e.r[this.a] = e.r[this.c] > e.r[this.n];
+                break;
+            case 13:
+                e.r[this.a] = -e.r[this.c];
+                break;
+            case 14:
+                e.r[this.a] = e.r[this.c] < e.r[this.n];
+                break;
+            case 15:
+                e.r[this.a] = e.r[this.c] & e.r[this.n];
+                break;
+            case 16:
+                e.r[this.a] = e.r[this.c] ^ e.r[this.n];
+                break;
+            case 17:
+                e.r[this.a] = e.r[this.c] << e.r[this.n];
+                break;
+            case 18:
+                e.r[this.a] = e.r[this.c] >>> e.r[this.n];
+                break;
+            case 19:
+                e.r[this.a] = e.r[this.c] | e.r[this.n];
+                break;
+            case 20:
+                e.r[this.a] = !e.r[this.c];
+        }
+    }
+    ,
+    c.prototype.e = function (e) {
+        e.Q.push(e.C),
+            e.B.push(e.k),
+            e.C = e.r[this.s],
+            e.k = [];
+        for (let t = 0; t < this.i; t++)
+            {e.k.unshift(e.f.pop());}
+        e.g.push(e.f),
+            e.f = [];
+    }
+    ,
+    n.prototype.e = function (e) {
+        e.C = e.Q.pop(),
+            e.k = e.B.pop(),
+            e.f = e.g.pop();
+    }
+    ,
+    e.prototype.e = function (e) {
+        switch (this.t) {
+            case 0:
+                e.u = e.r[this.a] >= e.r[this.c];
+                break;
+            case 1:
+                e.u = e.r[this.a] <= e.r[this.c];
+                break;
+            case 2:
+                e.u = e.r[this.a] > e.r[this.c];
+                break;
+            case 3:
+                e.u = e.r[this.a] < e.r[this.c];
+                break;
+            case 4:
+                e.u = e.r[this.a] == e.r[this.c];
+                break;
+            case 5:
+                e.u = e.r[this.a] != e.r[this.c];
+                break;
+            case 6:
+                e.u = e.r[this.a];
+                break;
+            case 7:
+                e.u = !e.r[this.a];
+        }
+    }
+    ,
+    o.prototype.e = function (e) {
+        switch (this.t) {
+            case 0:
+                e.C = this.h;
+                break;
+            case 1:
+                e.u && (e.C = this.h);
+                break;
+            case 2:
+                e.u || (e.C = this.h);
+                break;
+            case 3:
+                e.C = this.h,
+                    e.w = null;
+        }
+        e.u = !1;
+    }
+    ,
+    r.prototype.e = function (e) {
+        switch (this.t) {
+            case 0:
+                for (var t = [], n = 0; n < this.i; n++)
+                    {t.unshift(e.f.pop());}
+                e.r[3] = e.r[this.s](t[0], t[1]);
+                break;
+            case 1:
+                for (var r = e.f.pop(), i = [], o = 0; o < this.i; o++)
+                    {i.unshift(e.f.pop());}
+                e.r[3] = e.r[this.s][r](i[0], i[1]);
+                break;
+            case 2:
+                for (var a = [], c = 0; c < this.i; c++)
+                    {a.unshift(e.f.pop());}
+                e.r[3] = new e.r[this.s](a[0], a[1]);
+        }
+    }
+;
+const k = function (e) {
+    for (var t = 66, n = [], r = 0; r < e.length; r++) {
+        const i = 24 ^ e.charCodeAt(r) ^ t;
+        n.push(String.fromCharCode(i)),
+            t = i;
+    }
+    return n.join("");
+};
+
+function Q(e) {
+    this.t = (4095 & e) >> 10,
+        this.s = (1023 & e) >> 8,
+        this.i = 1023 & e,
+        this.h = 63 & e;
+}
+
+function C(e) {
+    this.t = (4095 & e) >> 10,
+        this.a = (1023 & e) >> 8,
+        this.c = (255 & e) >> 6;
+}
+
+function B(e) {
+    this.s = (3072 & e) >> 10,
+        this.h = 1023 & e;
+}
+
+function f(e) {
+    this.h = 4095 & e;
+}
+
+function g(e) {
+    this.s = (3072 & e) >> 10;
+}
+
+function u(e) {
+    this.h = 4095 & e;
+}
+
+function w(e) {
+    this.t = (3840 & e) >> 8,
+        this.s = (192 & e) >> 6,
+        this.i = 63 & e;
+}
+
+function G() {
+    this.r = [0, 0, 0, 0],
+        this.C = 0,
+        this.Q = [],
+        this.k = [],
+        this.B = [],
+        this.f = [],
+        this.g = [],
+        this.u = !1,
+        this.G = [],
+        this.b = [],
+        this.o = !1,
+        this.w = null,
+        this.U = null,
+        this.F = [],
+        this.R = 0,
+        this.J = {
+            0: s,
+            1: i,
+            2: h,
+            3: a,
+            4: c,
+            5: n,
+            6: e,
+            7: o,
+            8: r,
+            9: Q,
+            10: C,
+            11: B,
+            12: f,
+            13: g,
+            14: u,
+            15: w
+        };
+}
+
+Q.prototype.e = function (e) {
+    switch (this.t) {
+        case 0:
+            e.f.push(e.r[this.s]);
+            break;
+        case 1:
+            e.f.push(this.i);
+            break;
+        case 2:
+            e.f.push(e.k[this.h]);
+            break;
+        case 3:
+            e.f.push(k(e.b[this.h]));
+    }
+}
+    ,
+    C.prototype.e = function (A) {
+        switch (this.t) {
+            case 0:
+                var t = A.f.pop();
+                A.r[this.a] = A.r[this.c][t];
+                break;
+            case 1:
+                var s = A.f.pop(),
+                     i = A.f.pop();
+                A.r[this.c][s] = i;
+                break;
+            case 2:
+                var h = A.f.pop();
+                A.r[this.a] = eval(h);
+        }
+    }
+    ,
+    B.prototype.e = function (e) {
+        e.r[this.s] = k(e.b[this.h]);
+    }
+    ,
+    f.prototype.e = function (e) {
+        e.w = this.h;
+    }
+    ,
+    g.prototype.e = function (e) {
+        throw e.r[this.s];
+    }
+    ,
+    u.prototype.e = function (e) {
+        const t = this,
+             n = [0];
+        e.k.forEach(((e) => {
+                n.push(e);
+            }
+        ));
+        const r = function (r) {
+            const i = new G;
+            return i.k = n,
+                i.k[0] = r,
+                i.v(e.G, t.h, e.b, e.F),
+                i.r[3];
+        };
+        r.toString = function () {
+            return "() { [native code] }";
+        }
+            ,
+            e.r[3] = r;
+    }
+    ,
+    w.prototype.e = function (e) {
+        switch (this.t) {
+            case 0:
+                for (var t = {}, n = 0; n < this.i; n++) {
+                    const r = e.f.pop();
+                    t[e.f.pop()] = r;
+                }
+                e.r[this.s] = t;
+                break;
+            case 1:
+                for (var i = [], o = 0; o < this.i; o++)
+                    {i.unshift(e.f.pop());}
+                e.r[this.s] = i;
+        }
+    }
+    ,
+    G.prototype.D = function (e) {
+        for (var t = window.atob(e), n = t.charCodeAt(0) << 8 | t.charCodeAt(1), r = [], i = 2; i < n + 2; i += 2)
+            {r.push(t.charCodeAt(i) << 8 | t.charCodeAt(i + 1));}
+        this.G = r;
+        for (var o = [], a = n + 2; a < t.length;) {
+            const c = t.charCodeAt(a) << 8 | t.charCodeAt(a + 1),
+                 u = t.slice(a + 2, a + 2 + c);
+            o.push(u),
+                a += c + 2;
+        }
+        this.b = o;
+    }
+    ,
+    G.prototype.v = function (e, t, n) {
+        for (t = t || 0,
+                 n = n || [],
+                 this.C = t,
+                 "string" === typeof e ? this.D(e) : (this.G = e,
+                     this.b = n),
+                 this.o = !0,
+                 this.R = Date.now(); this.o;) {
+            const r = this.G[this.C++];
+            if ("number" !== typeof r)
+                {break;}
+            const i = Date.now();
+            if (500 < i - this.R)
+                {return;}
+            this.R = i;
+            try {
+                this.e(r);
+            } catch (e) {
+                this.U = e,
+                this.w && (this.C = this.w);
+            }
+        }
+    }
+    ,
+    G.prototype.e = function (e) {
+        const t = (61440 & e) >> 12;
+        new this.J[t](e).e(this);
+    }
+    ,
+"undefined" !== typeof window && (new G).v("AxjgB5MAnACoAJwBpAAAABAAIAKcAqgAMAq0AzRJZAZwUpwCqACQACACGAKcBKAAIAOcBagAIAQYAjAUGgKcBqFAuAc5hTSHZAZwqrAIGgA0QJEAJAAYAzAUGgOcCaFANRQ0R2QGcOKwChoANECRACQAsAuQABgDnAmgAJwMgAGcDYwFEAAzBmAGcSqwDhoANECRACQAGAKcD6AAGgKcEKFANEcYApwRoAAxB2AGcXKwEhoANECRACQAGAKcE6AAGgKcFKFANEdkBnGqsBUaADRAkQAkABgCnBagAGAGcdKwFxoANECRACQAGAKcGKAAYAZx+rAZGgA0QJEAJAAYA5waoABgBnIisBsaADRAkQAkABgCnBygABoCnB2hQDRHZAZyWrAeGgA0QJEAJAAYBJwfoAAwFGAGcoawIBoANECRACQAGAOQALAJkAAYBJwfgAlsBnK+sCEaADRAkQAkABgDkACwGpAAGAScH4AJbAZy9rAiGgA0QJEAJACwI5AAGAScH6AAkACcJKgAnCWgAJwmoACcJ4AFnA2MBRAAMw5gBnNasCgaADRAkQAkABgBEio0R5EAJAGwKSAFGACcKqAAEgM0RCQGGAYSATRFZAZzshgAtCs0QCQAGAYSAjRFZAZz1hgAtCw0QCQAEAAgB7AtIAgYAJwqoAASATRBJAkYCRIANEZkBnYqEAgaBxQBOYAoBxQEOYQ0giQKGAmQABgAnC6ABRgBGgo0UhD/MQ8zECALEAgaBxQBOYAoBxQEOYQ0gpEAJAoYARoKNFIQ/zEPkAAgChgLGgkUATmBkgAaAJwuhAUaCjdQFAg5kTSTJAsQCBoHFAE5gCgHFAQ5hDSCkQAkChgBGgo0UhD/MQ+QACAKGAsaCRQCOYGSABoAnC6EBRoKN1AUEDmRNJMkCxgFGgsUPzmPkgAaCJwvhAU0wCQFGAUaCxQGOZISPzZPkQAaCJwvhAU0wCQFGAUaCxQMOZISPzZPkQAaCJwvhAU0wCQFGAUaCxQSOZISPzZPkQAaCJwvhAU0wCQFGAkSAzRBJAlz/B4FUAAAAwUYIAAIBSITFQkTERwABi0GHxITAAAJLwMSGRsXHxMZAAk0Fw8HFh4NAwUABhU1EBceDwAENBcUEAAGNBkTGRcBAAFKAAkvHg4PKz4aEwIAAUsACDIVHB0QEQ4YAAsuAzs7AAoPKToKDgAHMx8SGQUvMQABSAALORoVGCQgERcCAxoACAU3ABEXAgMaAAsFGDcAERcCAxoUCgABSQAGOA8LGBsPAAYYLwsYGw8AAU4ABD8QHAUAAU8ABSkbCQ4BAAFMAAktCh8eDgMHCw8AAU0ADT4TGjQsGQMaFA0FHhkAFz4TGjQsGQMaFA0FHhk1NBkCHgUbGBEPAAFCABg9GgkjIAEmOgUHDQ8eFSU5DggJAwEcAwUAAUMAAUAAAUEADQEtFw0FBwtdWxQTGSAACBwrAxUPBR4ZAAkqGgUDAwMVEQ0ACC4DJD8eAx8RAAQ5GhUYAAFGAAAABjYRExELBAACWhgAAVoAQAg/PTw0NxcQPCQ5C3JZEBs9fkcnDRcUAXZia0Q4EhQgXHojMBY3MWVCNT0uDhMXcGQ7AUFPHigkQUwQFkhaAkEACjkTEQspNBMZPC0ABjkTEQsrLQ==");
+const b = function (e) {
+    return __g._encrypt(encodeURIComponent(e));
+};
+(exports.ENCRYPT_VERSION = A), (exports.default = b);
+
+module.exports = b;

--- a/lib/routes/zhihu/question.js
+++ b/lib/routes/zhihu/question.js
@@ -1,19 +1,39 @@
 const got = require('@/utils/got');
 const utils = require('./utils');
+const crypto = require('crypto');
+const g_encrypt = require('./execlib/g_encrypt');
+const config = require('@/config').value;
+
+const md5 = (i) => crypto.createHash('md5').update(i).digest().toString('hex');
 
 module.exports = async (ctx) => {
+    const cookie = config.zhihu.cookies;
+    if (cookie === undefined) {
+        throw Error('缺少知乎Cookie 值(不需要登录即可抓取Cookie)'); // the key is "d_c0"
+    }
+
     const { questionId } = ctx.params;
-    const sort = 'created';
+    const sort = 'updated'; // or default,created
     const limit = 20;
-    const include = `data[*].content.excerpt&limit=${limit}&offset=0`;
-    const url = `https://www.zhihu.com/api/v4/questions/${questionId}/answers?include=${include}&sort_by=${sort}`;
+    const include = "data%5B*%5D.is_normal%2Cadmin_closed_comment%2Creward_info%2Cis_collapsed%2Cannotation_action%2Cannotation_detail%2Ccollapse_reason%2Cis_sticky%2Ccollapsed_by%2Csuggest_edit%2Ccomment_count%2Ccan_comment%2Ccontent%2Ceditable_content%2Cattachment%2Cvoteup_count%2Creshipment_settings%2Ccomment_permission%2Ccreated_time%2Cupdated_time%2Creview_info%2Crelevant_info%2Cquestion%2Cexcerpt%2Cis_labeled%2Cpaid_info%2Cpaid_info_content%2Crelationship.is_authorized%2Cis_author%2Cvoting%2Cis_thanked%2Cis_nothelp%2Cis_recognized%3Bdata%5B*%5D.mark_infos%5B*%5D.url%3Bdata%5B*%5D.author.follower_count%2Cbadge%5B*%5D.topics%3Bdata%5B*%5D.settings.table_of_content.enabled&offset=0";
+    const url = `https://www.zhihu.com/api/v4/questions/${questionId}/answers?include=${include}&limit=${limit}&sort_by=${sort}&platform=desktop`;
+
+    // calcuate x-zse-96, see https://github.com/srx-2000/spider_collection/issues/18
+    const pattern = /d_c0=(\S*);/;
+    const cookie_mes = cookie.match(pattern)[1];
+    const parse_url = url.replace("https://www.zhihu.com", "");
+    const f = "101_3_2.0" + "+" + parse_url + "+" + cookie_mes;
+    const xzse96 = '2.0_' + g_encrypt(md5(f));
+
+    const _header = {cookie, 'x-zse-96':xzse96, 'x-app-za': 'OS=Web', 'x-zse-93': '101_3_2.0'};
     const response = await got({
         method: 'get',
         url,
         headers: {
-            ...utils.header,
+	    ...utils.header,
+	    ..._header,
             Referer: `https://www.zhihu.com/question/${questionId}`,
-            Authorization: 'oauth c3cef7c66a1843f8b3a9e6a1e3160e20', // hard-coded in js
+            // Authorization: 'oauth c3cef7c66a1843f8b3a9e6a1e3160e20', // hard-coded in js, no need any more
         },
     });
     const listRes = response.data.data;


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue
知乎使用了x-zse-96加密算法，原api接口无法获取指定question相关内容
Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/zhihu/question/531833408
```

## 说明 / Note
本修复方案需要提供知乎非登录状态下的cookie，类似dc_0=AJLFKJS...，为避免法律风险，未将cookie字段写入代码，需手动在.env 下设置 ZHIHU_COOKIE环境变量。
解决方案参考了https://github.com/srx-2000/spider_collection/issues/18