### PR TITLE
fix(route): 优化知乎问题获取方式，不必设置环境变量

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -815,6 +815,3 @@ RSSHub 支持使用访问密钥 / 码，白名单和黑名单三种方式进行�
 
     -   `ZHIHU_COOKIES`: 知乎登录后的 cookie 值.
         1.  可以在知乎网页版的一些请求的请求头中找到，如 `GET /moments` 请求头中的 `cookie` 值.
-
--   知乎问题
-    -   `ZHIHU_COOKIES_NO_LOGIN`: 知乎非登陆状态下的 cookie 值，其中 dc\_0 是必要的，其他可删除

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,6 @@ require('dotenv').config();
 const randUserAgent = require('@/utils/rand-user-agent');
 let envs = process.env;
 let value;
-
 const calculateValue = () => {
     const bilibili_cookies = {};
     const twitter_tokens = {};
@@ -258,7 +257,6 @@ const calculateValue = () => {
         },
         zhihu: {
             cookies: envs.ZHIHU_COOKIES,
-            cookies_no_login: envs.ZHIHU_COOKIES_NO_LOGIN,
         },
     };
 };

--- a/lib/v2/zhihu/question.js
+++ b/lib/v2/zhihu/question.js
@@ -1,22 +1,36 @@
 const got = require('@/utils/got');
 const utils = require('./utils');
-const config = require('@/config').value;
 const md5 = require('@/utils/md5');
 const g_encrypt = require('./execlib/g_encrypt');
 const { parseDate } = require('@/utils/parse-date');
 
 module.exports = async (ctx) => {
-    const cookie = config.zhihu.cookies_no_login;
-    if (!cookie) {
-        throw Error('缺少未登录状态下的知乎 Cookie 值(dc_0) (请在环境变量中设置ZHIHU_COOKIES_NO_LOGIN)'); // the key is "d_c0"
-    }
+    const { questionId } = ctx.params;
+    // Because the API of zhihu.com changed,we must use the dc_0(get from cookie without logging) to calculate the x-zse-96. So we first to get the dc_0,then we get the real-data of ZhiHu question. In this way, we don't need set the cookie in .env anymore
+    // fisrt: get cookie(dc_0) from zhihu.com
+    const response1 = await got({
+        method: 'get',
+        url: `https://www.zhihu.com/question/${questionId}`,
+        headers: {
+            ...utils.header,
+            Referer: `https://www.zhihu.com/question/${questionId}`,
+        },
+    });
+
+    /*
+     *Fixme:
+     *I'm not familiar with RSSHub, but I think the cookie should store in someplace(like rsshub cache?) to avoid get cookie from zhihu.com everytime.
+     *maybe someone can improve this.
+     */
+    const cookie_org = response1.headers['set-cookie'];
+    const cookie = cookie_org.toString();
     const match = cookie.match(/d_c0=(\S+?)(?:;|$)/);
     const cookie_mes = match && match[1];
     if (!cookie_mes) {
-        throw Error('请确认环境变量ZHIHU_COOKIES_NO_LOGIN包含"dc_0"字段)'); // the key is "d_c0"
+        throw Error('未能获取cookie"dc_0"字段');
     }
 
-    const { questionId } = ctx.params;
+    // second: get real data from zhihu
     const sort = 'updated'; // or default,created
     const limit = 20;
     const include =
@@ -28,9 +42,9 @@ module.exports = async (ctx) => {
     // calculate x-zse-96, refer to https://github.com/srx-2000/spider_collection/issues/18
     const f = `101_3_2.0+${apiPath}+${cookie_mes}`;
     const xzse96 = '2.0_' + g_encrypt(md5(f));
-
     const _header = { cookie, 'x-zse-96': xzse96, 'x-app-za': 'OS=Web', 'x-zse-93': '101_3_2.0' };
-    const response = await got({
+
+    const response2 = await got({
         method: 'get',
         url,
         headers: {
@@ -40,7 +54,8 @@ module.exports = async (ctx) => {
             // Authorization: 'oauth c3cef7c66a1843f8b3a9e6a1e3160e20', // previously hard-coded in js, outdated
         },
     });
-    const listRes = response.data.data;
+
+    const listRes = response2.data.data;
 
     ctx.state.data = {
         title: `知乎-${listRes[0].question.title}`,

--- a/lib/v2/zhihu/question.js
+++ b/lib/v2/zhihu/question.js
@@ -11,27 +11,25 @@ module.exports = async (ctx) => {
     // require users to set the cookie in environmental variables anymore.
 
     // fisrt: get cookie(dc_0) from zhihu.com
-    const response1 = await got({
-        method: 'get',
-        url: `https://www.zhihu.com/question/${questionId}`,
-        headers: {
-            ...utils.header,
-            Referer: `https://www.zhihu.com/question/${questionId}`,
-        },
-    });
+    const cookie_mes = await ctx.cache.tryGet('zhihu:cookies:d_c0', async () => {
+        const response = await got({
+            method: 'get',
+            url: `https://www.zhihu.com/question/${questionId}`,
+            headers: {
+                ...utils.header,
+            },
+        });
 
-    /*
-     *Fixme:
-     *I'm not familiar with RSSHub, but I think the cookie should store in someplace(like rsshub cache?) to avoid get cookie from zhihu.com everytime.
-     *maybe someone can improve this.
-     */
-    const cookie_org = response1.headers['set-cookie'];
-    const cookie = cookie_org.toString();
-    const match = cookie.match(/d_c0=(\S+?)(?:;|$)/);
-    const cookie_mes = match && match[1];
-    if (!cookie_mes) {
-        throw Error('未能获取cookie"dc_0"字段');
-    }
+        const cookie_org = response.headers['set-cookie'];
+        const cookie = cookie_org.toString();
+        const match = cookie.match(/d_c0=(\S+?)(?:;|$)/);
+        const cookie_mes = match && match[1];
+        if (!cookie_mes) {
+            throw Error('Failed to extract `d_c0` from cookies');
+        }
+        return cookie_mes;
+    });
+    const cookie = `d_c0=${cookie_mes}`;
 
     // second: get real data from zhihu
     const sort = 'updated'; // or default,created

--- a/lib/v2/zhihu/question.js
+++ b/lib/v2/zhihu/question.js
@@ -6,7 +6,10 @@ const { parseDate } = require('@/utils/parse-date');
 
 module.exports = async (ctx) => {
     const { questionId } = ctx.params;
-    // Because the API of zhihu.com changed,we must use the dc_0(get from cookie without logging) to calculate the x-zse-96. So we first to get the dc_0,then we get the real-data of ZhiHu question. In this way, we don't need set the cookie in .env anymore
+    // Because the API of zhihu.com has changed, we must use the value of `d_c0` (extracted from cookies) to calculate
+    // `x-zse-96`. So first get `d_c0`, then get the actual data of a ZhiHu question. In this way, we don't need to
+    // require users to set the cookie in environmental variables anymore.
+
     // fisrt: get cookie(dc_0) from zhihu.com
     const response1 = await got({
         method: 'get',

--- a/lib/v2/zhihu/question.js
+++ b/lib/v2/zhihu/question.js
@@ -47,7 +47,7 @@ module.exports = async (ctx) => {
     const xzse96 = '2.0_' + g_encrypt(md5(f));
     const _header = { cookie, 'x-zse-96': xzse96, 'x-app-za': 'OS=Web', 'x-zse-93': '101_3_2.0' };
 
-    const response2 = await got({
+    const response = await got({
         method: 'get',
         url,
         headers: {

--- a/lib/v2/zhihu/question.js
+++ b/lib/v2/zhihu/question.js
@@ -58,7 +58,7 @@ module.exports = async (ctx) => {
         },
     });
 
-    const listRes = response2.data.data;
+    const listRes = response.data.data;
 
     ctx.state.data = {
         title: `知乎-${listRes[0].question.title}`,


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue
知乎api发生变化，需要每次计算x-zse-96参数，之前的处理方式需要在环境变量中提供cookie dc_0的值https://github.com/DIYgod/RSSHub/pull/9729 ，现修改为自动获取，避免自建项目


## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route

```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/zhihu/question/531833408
```

## 说明 / Note
可以改进的地方：找个地方缓存cookie，避免每次访问服务器获取，但我对缓存不熟悉。