### PR TITLE
fix(utils): parse relative date with meridiem

### DIFF
--- a/lib/utils/parse-date.js
+++ b/lib/utils/parse-date.js
@@ -129,7 +129,7 @@ module.exports = {
 
         // 将 `\d+年\d+月...\d+秒前` 分割成 `['\d+年', ..., '\d+秒前']`
 
-        const matches = theDate.match(/(?:\D+)?\d+(?!:|-|\/)\D+/g);
+        const matches = theDate.match(/(?:\D+)?\d+(?!:|-|\/|(a|p)m)\D+/g);
 
         if (matches) {
             // 获得最后的时间单元，如 `\d+秒前`
@@ -187,7 +187,9 @@ module.exports = {
             for (const w of words) {
                 const wordMatches = w.regExp.exec(theDate);
                 if (wordMatches) {
-                    return dayjs(`${w.startAt.format('YYYY-MM-DD')} ${wordMatches[1]}`).toDate();
+                    // The default parser of dayjs() can parse '8:00 pm' but not '8:00pm'
+                    // so we need to insert a space in between
+                    return dayjs(`${w.startAt.format('YYYY-MM-DD')} ${wordMatches[1].endsWith('am') || wordMatches[1].endsWith('pm') ? wordMatches[1].replace(/(a|p)m/g, ' $&') : wordMatches[1]}`).toDate();
                 }
             }
         }

--- a/lib/utils/parse-date.js
+++ b/lib/utils/parse-date.js
@@ -189,7 +189,7 @@ module.exports = {
                 if (wordMatches) {
                     // The default parser of dayjs() can parse '8:00 pm' but not '8:00pm'
                     // so we need to insert a space in between
-                    return dayjs(`${w.startAt.format('YYYY-MM-DD')} ${wordMatches[1].endsWith('am') || wordMatches[1].endsWith('pm') ? wordMatches[1].replace(/(a|p)m/g, ' $&') : wordMatches[1]}`).toDate();
+                    return dayjs(`${w.startAt.format('YYYY-MM-DD')} ${/a|pm$/.test(wordMatches[1]) ? wordMatches[1].replace(/a|pm/, ' $&') : wordMatches[1]}`).toDate();
                 }
             }
         }

--- a/test/utils/parse-date.js
+++ b/test/utils/parse-date.js
@@ -112,6 +112,10 @@ describe('parseRelativeDate', () => {
         expect(+new Date(parseRelativeDate('Today 08:00'))).toBe(+date + 8 * hour);
     });
 
+    it('Today, h:m a', () => {
+        expect(+new Date(parseRelativeDate('Today, 8:00 pm'))).toBe(+date + 20 * hour);
+    });
+
     it('TDA H:m:s', () => {
         expect(+new Date(parseRelativeDate('TDA 08:00:00'))).toBe(+date + 8 * hour);
     });


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
The default parser of dayjs() can parse '8:00 pm' but not '8:00pm', so we need to insert a space in between
