### PR TITLE
fix(core/parameter): absurd wrong path cache time

### DIFF
--- a/lib/middleware/parameter.js
+++ b/lib/middleware/parameter.js
@@ -10,9 +10,17 @@ module.exports = async (ctx, next) => {
     await next();
 
     if (!ctx.state.data && !ctx._matchedRoute) {
-        ctx.set({
-            'Cache-Control': `public, max-age=${config.cache.routeExpire * 100}`,
-        });
+        // Given that the official demo has a cache TTL of 2h, a "wrong path" page will be cached by CloudFlare for
+        // 200h (8.33d).
+        // What makes it worse is that the documentation contains status badges to detect the availability of routes,
+        // but the documentation is updated more timely than the official demo, so the every example path of every
+        // new route will probably have a "wrong path" page cached for at least 200h soon after accepted. That is to
+        // say, the example paths of a new route will probably be unavailable on the public demo in the first 200h
+        // after accepted.
+        // As a conclusion, the next 3 lines has been commented out. (exactly the same behavior as any internal error)
+        // ctx.set({
+        //     'Cache-Control': `public, max-age=${config.cache.routeExpire * 100}`,
+        // });
         throw Error('wrong path');
     }
 

--- a/test/middleware/parameter.js
+++ b/test/middleware/parameter.js
@@ -246,7 +246,7 @@ describe('wrong_path', () => {
     it(`wrong_path`, async () => {
         const response = await request.get('/wrong');
         expect(response.status).toBe(404);
-        expect(response.headers['cache-control']).toBe(`public, max-age=${config.cache.routeExpire * 100}`);
+        expect(response.headers['cache-control']).toBe(`public, max-age=${config.cache.routeExpire}`);
         expect(response.text).toMatch(/Error: wrong path/);
     });
 });


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
```js
    if (!ctx.state.data && !ctx._matchedRoute) {
        // Given that the official demo has a cache TTL of 2h, a "wrong path" page will be cached by CloudFlare for
        // 200h (8.33d).
        // What makes it worse is that the documentation contains status badges to detect the availability of routes,
        // but the documentation is updated more timely than the official demo, so the every example path of every
        // new route will probably have a "wrong path" page cached for at least 200h soon after accepted. That is to
        // say, the example paths of a new route will probably be unavailable on the public demo in the first 200h
        // after accepted.
        // As a conclusion, the next 3 lines has been commented out. (exactly the same behavior as any internal error)
        // ctx.set({
        //     'Cache-Control': `public, max-age=${config.cache.routeExpire * 100}`,
        // });
        throw Error('wrong path');
    }
```