### PR TITLE
fix(route): fetch rich HTML content on chinanews

### DIFF
--- a/lib/v2/chinanews/index.js
+++ b/lib/v2/chinanews/index.js
@@ -28,6 +28,7 @@ module.exports = async (ctx) => {
                     url: item.link,
                 });
                 const content = cheerio.load(detailResponse.data);
+                content('.adInContent').remove();
                 if (content('div.content_desc').length > 0) {
                     item.description = content('div.content_desc').html();
                     item.author = content('a.source').text();

--- a/lib/v2/chinanews/index.js
+++ b/lib/v2/chinanews/index.js
@@ -29,18 +29,18 @@ module.exports = async (ctx) => {
                 });
                 const content = cheerio.load(detailResponse.data);
                 if (content('div.content_desc').length > 0) {
-                    item.description = content('div.content_desc').text();
+                    item.description = content('div.content_desc').html();
                     item.author = content('a.source').text();
                     const info = content('p', '.left').text().trim().slice(5).split(' ');
                     item.author = info[2].trim();
                     item.pubDate = timezone(parseDate(info[0] + info[1], 'YYYY年MM月DD日HH:mm'), +8);
                 } else if (content('div.t3').length > 0) {
-                    item.description = content('div.t3').text();
+                    item.description = content('div.t3').html();
                     const info = content('div[style="text-align:right;font-size:12px;"]').text().slice(5).split(' ');
                     item.author = info[2];
                     item.pubDate = timezone(parseDate(info[0] + info[1], 'YYYY-MM-DDHH:mm'), +8);
                 } else {
-                    item.description = content('div.left_zw').text();
+                    item.description = content('div.left_zw').html();
                     const info = content('div.left-t')
                         .contents()
                         .filter(function () {


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

无

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/chinanews
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

现有 RSSHub 的中新网全文获取仅仅抓取了纯文本，不仅不能显示新闻文章可能出现的附图，还会因为部分 RSS 阅读器无法正确处理 `\n` 换行符而导致阅读困难：

![image](https://user-images.githubusercontent.com/36147447/169650439-704eec96-fd5f-4263-bf0f-6eec9e8f547c.png)

将代码中获取正文的函数从 `.text()` 改为 `.html()` 后，新闻文章可正确显示换行，以及文章附图：

![image](https://user-images.githubusercontent.com/36147447/169650515-05982d82-d1e6-4624-85ee-3885793ec50b.png)

![image](https://user-images.githubusercontent.com/36147447/169650533-d0385cfa-0c79-4786-a4a8-3b129edd81a7.png)
