### PR TITLE
fix(route): 修复机核网路由, 并增加错误抛出

### DIFF
--- a/lib/v2/gcores/category.js
+++ b/lib/v2/gcores/category.js
@@ -23,6 +23,10 @@ module.exports = async (ctx) => {
         })
         .get();
 
+    if (list.length > 0 && list.every((item) => item.url === undefined)) {
+        throw new Error('Article URL not found! Please submit an issue on GitHub.');
+    }
+
     const out = await Promise.all(
         list.map((item) => {
             const articleUrl = `https://www.gcores.com${item.url}`;

--- a/lib/v2/gcores/category.js
+++ b/lib/v2/gcores/category.js
@@ -15,7 +15,7 @@ module.exports = async (ctx) => {
     const list = $('.original.am_card.original-normal')
         .map(function () {
             const item = {
-                url: $(this).find('a.am_card_content.original_content').attr('href'),
+                url: $(this).find('.am_card_inner>a').attr('href'),
                 title: $(this).find('h3.am_card_title').text(),
                 category: $(this).find('span.original_category>a').text(),
             };

--- a/lib/v2/gcores/tag.js
+++ b/lib/v2/gcores/tag.js
@@ -23,6 +23,10 @@ module.exports = async (ctx) => {
             return item;
         })
         .get();
+        
+    if (list.length > 0 && list.every((item) => item.url === undefined)) {
+        throw new Error('Article URL not found! Please submit an issue on GitHub.');
+    }
 
     const out = await Promise.all(
         list.map((item) => {

--- a/lib/v2/gcores/tag.js
+++ b/lib/v2/gcores/tag.js
@@ -16,7 +16,7 @@ module.exports = async (ctx) => {
     const list = $('.original.am_card.original-normal')
         .map(function () {
             const item = {
-                url: $(this).find('a.am_card_content.original_content').attr('href'),
+                url: $(this).find('.am_card_inner>a').attr('href'),
                 title: $(this).find('h3.am_card_title').text(),
                 category: $(this).find('span.original_category>a').text(),
             };

--- a/lib/v2/gcores/tag.js
+++ b/lib/v2/gcores/tag.js
@@ -23,7 +23,7 @@ module.exports = async (ctx) => {
             return item;
         })
         .get();
-        
+
     if (list.length > 0 && list.every((item) => item.url === undefined)) {
         throw new Error('Article URL not found! Please submit an issue on GitHub.');
     }


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #9877 

## 完整路由地址 / Example for the proposed route(s)

```routes
/gcores/category/news
/gcores/tag/42
```

## 说明 / Note
修复了文章地址抓取，并为可能出现的地址抓取失败抛出该错误，而不再提示连接失败。