### PR TITLE
fix(route): novel/biqugeinfo 在使用 redis 作为缓存时无法正常工作

### DIFF
--- a/lib/routes/novel/biqugeinfo.js
+++ b/lib/routes/novel/biqugeinfo.js
@@ -35,7 +35,7 @@ module.exports = async (ctx) => {
 
     const items = [];
     for await (const item of asyncPool(3, chapter_item, (item) =>
-        ctx.cache.tryGet(item, async () => {
+        ctx.cache.tryGet(item.link.href, async () => {
             const response = await got({
                 method: 'get',
                 url: item.link,
@@ -61,7 +61,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `笔趣阁 ${title}`,
-        link: pageUrl,
+        link: pageUrl.href,
         image: cover_url,
         description,
         item: items,


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/novel/biqugeinfo/18_18905
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`


## 说明 / Note
针对该路由(/noval/biqugeinfo)
- 当使用 redis 作为 cache 并通过 [ctx.cache.tryGet](https://github.com/DIYgod/RSSHub/blob/master/lib/middleware/cache/index.js#L58) 获取/设置缓存时，会调用 [getCacheTtlKey](https://github.com/DIYgod/RSSHub/blob/196a951fe2ecf4eb586f6e9cdebf58db75735ae5/lib/middleware/cache/redis.js#L26) 方法。而 getCacheTtlKey 中会使用 startsWith 来判断缓存的 key 是否符合要求。这需要 key 的类型必须为 string。因此将缓存的 key 改为 URL string 来修复使用 redis 缓存时该路由出错的问题。
- 按照规范 `ctx.state.data.link` 也应该是一个 string，但之前则是一个 URL 对象。这会导致首次访问路由时 [parameter middleware](https://github.com/DIYgod/RSSHub/blob/196a951fe2ecf4eb586f6e9cdebf58db75735ae5/lib/middleware/parameter.js#L53) 无法处理而抛出错误，顺便修复了这个问题。