### PR TITLE
fix(route): The New York Times 新闻简报

### DIFF
--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -1358,9 +1358,9 @@ category 对应的关键词有
 
 ### 新闻简报
 
-<Route author="yueyericardo" example="/nytimes/daily_briefing_chinese" path="/nytimes/daily_briefing_chinese">
+<Route author="yueyericardo nczitzk" example="/nytimes/daily_briefing_chinese" path="/nytimes/daily_briefing_chinese">
 
-网站地址：<https://www.nytimes.com/zh-hans/series/daily-briefing-chinese/>
+网站地址：<https://www.nytimes.com/zh-hans/series/daily-briefing-chinese>
 
 </Route>
 

--- a/lib/v2/nytimes/daily_briefing_chinese.js
+++ b/lib/v2/nytimes/daily_briefing_chinese.js
@@ -1,61 +1,86 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const { parseDate } = require('@/utils/parse-date');
+const { art } = require('@/utils/render');
+const path = require('path');
 
 module.exports = async (ctx) => {
-    const url = 'https://www.nytimes.com/zh-hans/series/daily-briefing-chinese';
+    const rootUrl = 'https://www.nytimes.com';
+    const currentUrl = `${rootUrl}/zh-hans/series/daily-briefing-chinese`;
+
     const response = await got({
         method: 'get',
-        url,
+        url: currentUrl,
     });
-    const data = response.data;
-    const $ = cheerio.load(data);
-    const post = $('.css-13mho3u .css-ye6x8s')
-        .map((index, elem) => {
-            const $item = $(elem);
-            const $link = $item.find('a');
-            const $title = $item.find('h2');
 
-            return {
-                title: $title.text(),
-                link: 'https://www.nytimes.com' + $link.attr('href'),
-            };
-        })
-        .get();
+    const listData = JSON.parse(response.data.match(/<script>window\.__preloadedData = {"initialState":(.*),"config"/)[1]);
 
-    const items = await Promise.all(
-        post.map((item) =>
+    let items = [];
+    Object.keys(listData).forEach((key) => {
+        if (/^Article:/.test(key) && listData[key].url) {
+            const item = listData[key];
+            items.push({
+                link: item.url,
+                pubDate: parseDate(item.firstPublished),
+            });
+        }
+    });
+
+    items = await Promise.all(
+        items.map((item) =>
             ctx.cache.tryGet(item.link, async () => {
-                const response = await got.get(item.link);
-                const data = response.data;
-                const arr = data.match(/"url":"https:\\u002F\\u002Fstatic(\S*)"articleLarge"/g);
-                const imageLink = arr.map((e) => JSON.parse(`{${e}}`).url);
-
-                const $ = cheerio.load(data);
-                $('.css-pncxxs.etfikam0').remove();
-                // remove 'Credit...'
-                $('.css-1ly73wi.e1tej78p0').remove();
-                $('.css-1xdhyk6.erfvjey0').each((i, e) => $(e).replaceWith(`<img src="${imageLink[i]}">`));
-
-                $('.css-1l44abu.ewdxa0s0').each((i, e) => {
-                    const figureNote = $(e)
-                        .children()
-                        .map((i, e) => $(e).text())
-                        .get();
-                    $(e).replaceWith(`<p><small>${figureNote.join(' ')}</small><p>`);
+                const detailResponse = await got({
+                    method: 'get',
+                    url: item.link,
                 });
-                const date = $('time').attr('datetime');
 
-                item.description = $('.meteredContent.css-1r7ky0e').html();
-                item.pubDate = parseDate(date);
+                const content = cheerio.load(detailResponse.data);
+                const itemData = JSON.parse(detailResponse.data.match(/<script>window\.__preloadedData = {"initialState":(.*),"config"/)[1]);
+
+                // to remove ads
+                content('.StoryBodyCompanionColumn').last().find('p').last().remove();
+
+                const images = [];
+                Object.keys(itemData).forEach((key) => {
+                    if (/^Image:/.test(key) && itemData[key].__typename === 'Image') {
+                        let cropKey = '';
+                        const image = itemData[key];
+
+                        Object.keys(image).forEach((c) => {
+                            if (/^crops/.test(c)) {
+                                cropKey = c;
+                                return;
+                            }
+                        });
+                        images.push({
+                            caption: image.legacyHtmlCaption,
+                            url: itemData[itemData[image[cropKey][0].id].renditions[0].id].url,
+                        });
+                    }
+                });
+
+                let i = 0;
+                content('figure').each(function () {
+                    content(this).html(
+                        art(path.join(__dirname, 'templates/image.art'), {
+                            url: images[i].url,
+                            caption: images[i++].caption,
+                        })
+                    );
+                });
+
+                item.title = content('meta[property="og:title"]').attr('content');
+                item.author = content('meta[name="byl"]').attr('content').replace(/By /, '');
+                item.description = content('section[name="articleBody"]').html();
+
                 return item;
             })
         )
     );
 
     ctx.state.data = {
-        title: '纽约时报中文网|新闻简报',
-        link: url,
+        title: '新闻简报 - The New York Times',
+        link: currentUrl,
         item: items,
     };
 };

--- a/lib/v2/nytimes/maintainer.js
+++ b/lib/v2/nytimes/maintainer.js
@@ -1,6 +1,6 @@
 module.exports = {
     '/author/:byline': ['kevinschaul'],
     '/book/:category?': ['melvinto'],
-    '/daily_briefing_chinese': ['yueyericardo'],
+    '/daily_briefing_chinese': ['yueyericardo', 'nczitzk'],
     '/:lang?': ['HenryQW'],
 };

--- a/lib/v2/nytimes/templates/image.art
+++ b/lib/v2/nytimes/templates/image.art
@@ -1,0 +1,4 @@
+<figure>
+<img src="{{ url }}">
+<figcaption>{{ caption }}</figcaption>
+</figure>


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #9973

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/nytimes/daily_briefing_chinese
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
