### PR TITLE
feat(route): add u3c3 

### DIFF
--- a/docs/en/multimedia.md
+++ b/docs/en/multimedia.md
@@ -373,11 +373,11 @@ Refer to [Pornhub F.A.Qs](https://help.pornhub.com/hc/en-us/articles/36004432703
 
 ### search keyword
 
-\<Route author="noname1897", example="/u3c3/search/les", path="/u3c3/search/:keyword?" :paramsDesc="\[' search keyword ']" supportBT="1" />
+<RouteEn author="noname1897" example="/u3c3/search/les" path="/u3c3/search/:keyword?" :paramsDesc="['search keyword']" supportBT="1" />
 
 ### 分类
 
-\<Route author="noname1897", example="/u3c3/U3C3", path="/u3c3/:type?" :paramsDesc="\[' typename, pay attention to case, it should be same as the choices: `U3C3`/`Video`/`Photo`/`Book`/`Game`/`Software`/`Other`'], if no type is provided, show the index "supportBT="1" />
+<RouteEn author="noname1897" example="/u3c3/U3C3" path="/u3c3/:type?" :paramsDesc="['type, pay attention to case, it should be exactly same as the choices: `U3C3`/`Video`/`Photo`/`Book`/`Game`/`Software`/`Other`, if no type is provided, show the home index']" supportBT="1" />
 
 ## YouTube
 

--- a/docs/en/multimedia.md
+++ b/docs/en/multimedia.md
@@ -369,6 +369,16 @@ Refer to [Pornhub F.A.Qs](https://help.pornhub.com/hc/en-us/articles/36004432703
 
 <RouteEn author="hoilc" example="/trakt/collection/tomyangsh/movies" path="/trakt/collection/:username/:type?" :paramsDesc="['Username','Collection type, can be `movies`,`shows`,`episodes`,`all`, default to `all`']" radar="1" rssbud="1" />
 
+## u3c3
+
+### search keyword
+
+\<Route author="noname1897", example="/u3c3/search/les", path="/u3c3/search/:keyword?" :paramsDesc="\[' search keyword ']" supportBT="1" />
+
+### 分类
+
+\<Route author="noname1897", example="/u3c3/U3C3", path="/u3c3/:type?" :paramsDesc="\[' typename, pay attention to case, it should be same as the choices: `U3C3`/`Video`/`Photo`/`Book`/`Game`/`Software`/`Other`'], if no type is provided, show the index "supportBT="1" />
+
 ## YouTube
 
 Refer to [#youtube](/en/social-media.html#youtube)

--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -1099,11 +1099,11 @@ JavDB 有多个备用域名，本路由默认使用永久域名 <https://javdb.c
 
 ### 关键词搜索
 
-\<Route author="noname1897", example="/u3c3/search/ 新片速递", path="/u3c3/search/:keyword?" :paramsDesc="\[' 搜索关键字 ']" supportBT="1" />
+<Route author="noname1897" example="/u3c3/search/ 新片速递" path="/u3c3/search/:keyword?" :paramsDesc="['搜索关键字']" supportBT="1" />
 
 ### 分类
 
-\<Route author="noname1897", example="/u3c3/U3C3", path="/u3c3/:type?" :paramsDesc="\[' 类别名称，注意大小写，需要严格对应！可选的 `type` 有 `U3C3`/`Video`/`Photo`/`Book`/`Game`/`Software`/`Other`']，如果不设置 type，则展示首页 "supportBT="1" />
+<Route author="noname1897" example="/u3c3/U3C3" path="/u3c3/:type?" :paramsDesc="['类别名称，注意大小写，需要严格对应！可选的 `type` 有 `U3C3`/`Video`/`Photo`/`Book`/`Game`/`Software`/`Other`，如果不设置 type，则展示首页']" supportBT="1" />
 
 ## Yahoo! テレビ
 

--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -1095,6 +1095,16 @@ JavDB 有多个备用域名，本路由默认使用永久域名 <https://javdb.c
 
 <Route author="hoilc" example="/trakt/collection/tomyangsh/movies" path="/trakt/collection/:username/:type?" :paramsDesc="['用户名','收藏类型，可选`movies`,`shows`,`episodes`,`all`，默认为`all`']" radar="1" rssbud="1" />
 
+## u3c3
+
+### 关键词搜索
+
+\<Route author="noname1897", example="/u3c3/search/ 新片速递", path="/u3c3/search/:keyword?" :paramsDesc="\[' 搜索关键字 ']" supportBT="1" />
+
+### 分类
+
+\<Route author="noname1897", example="/u3c3/U3C3", path="/u3c3/:type?" :paramsDesc="\[' 类别名称，注意大小写，需要严格对应！可选的 `type` 有 `U3C3`/`Video`/`Photo`/`Book`/`Game`/`Software`/`Other`']，如果不设置 type，则展示首页 "supportBT="1" />
+
 ## Yahoo! テレビ
 
 ### 番組検索

--- a/lib/v2/u3c3/index.js
+++ b/lib/v2/u3c3/index.js
@@ -1,0 +1,64 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+
+const host = 'https://www.u3c3.com';
+
+module.exports = async (ctx) => {
+    const type = ctx.params.type;
+    // should be:
+    // undefined
+    // U3C3
+    // Videos
+    // Photo
+    // Book
+    // Game
+    // Software
+    // Other
+    let link = host;
+    let title = host;
+    if (typeof type === 'undefined') {
+        link = host;
+        title = host;
+    } else if (type === 'search') {
+        const keyword = typeof ctx.params.keyword === 'undefined' ? '' : ctx.params.keyword;
+        link = `${host}/?search=${keyword}`;
+        title = `search ${keyword} - ${host}`;
+    } else {
+        link = `${host}/?type=${type}&p=1`;
+        title = `${type} - ${host}`;
+    }
+
+    const response = await got({
+        method: 'get',
+        url: link,
+    });
+
+    const $ = cheerio.load(response.data);
+
+    const items = $('body > div.container > div.table-responsive > table > tbody > tr')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const title = item.find('td:nth-of-type(2) > a ').attr('title');
+            const guid = host + item.find('td:nth-of-type(2) > a').attr('href');
+            const link = guid;
+            const pubDate = item.find('td:nth-of-type(5)').text();
+            const enclosure_url = item.find('td:nth-of-type(3) > a:nth-of-type(2)').attr('href');
+            return {
+                title,
+                guid,
+                link,
+                pubDate,
+
+                enclosure_url,
+                enclosure_type: 'application/x-bittorrent',
+            };
+        });
+
+    ctx.state.data = {
+        title,
+        description: title,
+        link,
+        item: items,
+    };
+};

--- a/lib/v2/u3c3/index.js
+++ b/lib/v2/u3c3/index.js
@@ -1,8 +1,6 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 
-const host = 'https://www.u3c3.com';
-
 module.exports = async (ctx) => {
     const type = ctx.params.type;
     // should be:
@@ -14,23 +12,24 @@ module.exports = async (ctx) => {
     // Game
     // Software
     // Other
-    let link = host;
-    let title = host;
+    const rootURL = 'https://www.u3c3.com';
+    let currentURL = rootURL;
+    let title = 'u3c3';
     if (typeof type === 'undefined') {
-        link = host;
-        title = host;
+        currentURL = rootURL;
+        title = 'home - u3c3';
     } else if (type === 'search') {
         const keyword = typeof ctx.params.keyword === 'undefined' ? '' : ctx.params.keyword;
-        link = `${host}/?search=${keyword}`;
-        title = `search ${keyword} - ${host}`;
+        currentURL = `${rootURL}/?search=${keyword}`;
+        title = `search ${keyword} - u3c3`;
     } else {
-        link = `${host}/?type=${type}&p=1`;
-        title = `${type} - ${host}`;
+        currentURL = `${rootURL}/?type=${type}&p=1`;
+        title = `${type} - u3c3`;
     }
 
     const response = await got({
         method: 'get',
-        url: link,
+        url: currentURL,
     });
 
     const $ = cheerio.load(response.data);
@@ -40,7 +39,7 @@ module.exports = async (ctx) => {
         .map((item) => {
             item = $(item);
             const title = item.find('td:nth-of-type(2) > a ').attr('title');
-            const guid = host + item.find('td:nth-of-type(2) > a').attr('href');
+            const guid = rootURL + item.find('td:nth-of-type(2) > a').attr('href');
             const link = guid;
             const pubDate = item.find('td:nth-of-type(5)').text();
             const enclosure_url = item.find('td:nth-of-type(3) > a:nth-of-type(2)').attr('href');
@@ -58,7 +57,7 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title,
         description: title,
-        link,
+        link: currentURL,
         item: items,
     };
 };

--- a/lib/v2/u3c3/maintainer.js
+++ b/lib/v2/u3c3/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/:type?/:keyword?': ['noname1897'],
+};

--- a/lib/v2/u3c3/router.js
+++ b/lib/v2/u3c3/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/:type?/:keyword?', require('./index'));
+};


### PR DESCRIPTION

## 完整路由地址 / Example for the proposed route(s)

```route
/u3c3/U3C3
/u3c3/search/les
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [x] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

此[网站](http://u3c3.com)长得有点像 https://sukebei.nyaa.si/ ，但是数据应该是不一样的

- 支持 magnet
- 支持 search
- u3c3 的几个类型页面
- 中英文说明文档
