### PR TITLE
feat(route): Nyaa migrated to v2 and add sukebei support

### DIFF
--- a/docs/en/multimedia.md
+++ b/docs/en/multimedia.md
@@ -261,9 +261,13 @@ See [Directory](https://www.javlibrary.com/en/star_list.php) to view all stars.
 
 ## Nyaa
 
-### Seatch Result
+### Search Result
 
-<RouteEn author="Lava-Swimmer" example="/nyaa/search/psycho-pass" path="/nyaa/search/:keyword" :paramsDesc="['Search keyword']" supportBT="1"/>
+<RouteEn author="Lava-Swimmer noname1897" example="/nyaa/search/psycho-pass" path="/nyaa/search/:query?" :paramsDesc="['Search keyword']" supportBT="1" radar="1"/>
+
+### Sukebei Search Result
+
+<RouteEn author="Lava-Swimmer noname1897" example="/nyaa/sukebei/search/hi" path="/nyaa/sukebei/search/:query?" :paramsDesc="['Search keyword']" supportBT="1" radar="1"/>
 
 ## PornHub
 

--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -902,7 +902,7 @@ JavDB 有多个备用域名，本路由默认使用永久域名 <https://javdb.c
 
 <Route author="Lava-Swimmer noname1897" example="/nyaa/search/psycho-pass" path="/nyaa/search/:query?" :paramsDesc="['搜索关键字']" supportBT="1" radar="1"/>
 
-### sukebei 搜索结果
+### Sukebei 搜索结果
 
 <Route author="Lava-Swimmer noname1897" example="/nyaa/sukebei/search/hi" path="/nyaa/sukebei/search/:query?" :paramsDesc="['搜索关键字']" supportBT="1" radar="1"/>
 

--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -900,7 +900,11 @@ JavDB 有多个备用域名，本路由默认使用永久域名 <https://javdb.c
 
 ### 搜索结果
 
-<Route author="Lava-Swimmer" example="/nyaa/search/psycho-pass" path="/nyaa/search/:keyword" :paramsDesc="['搜索关键字']" supportBT="1"/>
+<Route author="Lava-Swimmer noname1897" example="/nyaa/search/psycho-pass" path="/nyaa/search/:query?" :paramsDesc="['搜索关键字']" supportBT="1" radar="1"/>
+
+### sukebei 搜索结果
+
+<Route author="Lava-Swimmer noname1897" example="/nyaa/sukebei/search/hi" path="/nyaa/sukebei/search/:query?" :paramsDesc="['搜索关键字']" supportBT="1" radar="1"/>
 
 ## OneJAV
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -2265,8 +2265,8 @@ router.get('/transferwise/pair/:source/:target', lazyloadRouteHandler('./routes/
 // chocolatey
 router.get('/chocolatey/software/:name?', lazyloadRouteHandler('./routes/chocolatey/software'));
 
-// Nyaa
-router.get('/nyaa/search/:query?', lazyloadRouteHandler('./routes/nyaa/search'));
+// Nyaa migrated to v2
+// router.get('/nyaa/search/:query?', lazyloadRouteHandler('./routes/nyaa/search'));
 
 // 片源网 migrated to v2
 // router.get('/pianyuan/index/:media?', lazyloadRouteHandler('./routes/pianyuan/app'));

--- a/lib/v2/nyaa/maintainer.js
+++ b/lib/v2/nyaa/maintainer.js
@@ -1,0 +1,4 @@
+module.exports = {
+    '/search/:query?': ['Lava-Swimmer', 'noname1897'],
+    '/subekei/search/:query?': ['Lava-Swimmer', 'noname1897'],
+};

--- a/lib/v2/nyaa/radar.js
+++ b/lib/v2/nyaa/radar.js
@@ -1,0 +1,32 @@
+module.exports = {
+    'nyaa.si': {
+        _name: 'nyaa',
+        '.': [
+            {
+                title: '搜索结果',
+                docs: 'https://docs.rsshub.app/multimedia.html#nyaa-sou-suo-jie-guo',
+                source: '/',
+                target: (params, url) => {
+                    url = new URL(url);
+                    if (url.hostname.split('.')[0] === 'nyaa') {
+                        const searchParams = url.searchParams;
+                        const query = searchParams.has('q') ? searchParams.get('q') : '';
+                        return `/nyaa/search/${query}`;
+                    }
+                },
+            },
+        ],
+        'sukebei': [
+            {
+                title: 'sukebei 搜索结果',
+                docs: 'https://docs.rsshub.app/multimedia.html#nyaa-sukebei-sou-suo-jie-guo',
+                source: '/',
+                target: (params, url) => {
+                    const searchParams = new URL(url).searchParams;
+                    const query = searchParams.has('q') ? searchParams.get('q') : '';
+                    return `/nyaa/sukebei/search/${query}`;
+                },
+            },
+        ],
+    },
+};

--- a/lib/v2/nyaa/router.js
+++ b/lib/v2/nyaa/router.js
@@ -1,0 +1,4 @@
+module.exports = (router) => {
+    router.get('/search/:query?', require('./search'));
+    router.get('/sukebei/search/:query?', require('./search'));
+};

--- a/lib/v2/nyaa/search.js
+++ b/lib/v2/nyaa/search.js
@@ -11,8 +11,10 @@ module.exports = async (ctx) => {
         },
     });
 
+    const rootURL = ctx.routerPath.split('/')[1] === 'sukebei' ? 'https://sukebei.nyaa.si' : 'https://nyaa.si';
     const { query = '' } = ctx.params;
-    const feed = await parser.parseURL(`https://nyaa.si/?page=rss&c=0_0&f=0&q=${encodeURI(query)}`);
+
+    const feed = await parser.parseURL(`${rootURL}/?page=rss&c=0_0&f=0&q=${encodeURI(query)}`);
 
     feed.items.map((item) => {
         item.link = item.guid;
@@ -24,7 +26,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: feed.title,
-        link: `https://nyaa.si/?f=0&c=0_0&q=${query}`,
+        link: `${rootURL}/?f=0&c=0_0&q=${query}`,
         description: feed.description,
         item: feed.items,
     };


### PR DESCRIPTION
- 将 nyaa 的实现更新到 v2
- 新增 sukebei.nyaa.si 的搜索支持

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/nyaa/search/hi
/nyaa/sukebei/search/hi
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [x] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
