### PR TITLE
docs: Fix 404 link in Getting Started guide

### DIFF
--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -14,7 +14,7 @@ RSSHub supports additional parameters such as content filtering and full-text ex
 
 ## Contribute a New Route
 
-Our thriving community is the key to RSSHub's success, we invite everyone to join us and [contribute new routes](/en/joinus) for all kinds of interesting sources.
+Our thriving community is the key to RSSHub's success, we invite everyone to join us and [contribute new routes](/en/joinus/quick-start.html) for all kinds of interesting sources.
 
 ## Use as a npm Package
 


### PR DESCRIPTION
Just fixing a broken link I stumbled upon while reading the page.