### PR TITLE
fix(route): add Open Graph image to GitHub trending

### DIFF
--- a/lib/v2/github/trending.js
+++ b/lib/v2/github/trending.js
@@ -20,24 +20,39 @@ module.exports = async (ctx) => {
     const $ = cheerio.load(data);
     const list = $('article');
 
+    const items = await Promise.all(
+        list.map((_, item) => {
+            item = $(item);
+            const endpoint = item.find('h1 a').attr('href');
+            const link = `https://github.com${endpoint}`;
+            return ctx.cache.tryGet(`github:trending:${endpoint}`, async () => {
+                const response = await got({
+                    method: 'get',
+                    url: link,
+                });
+
+                const $ = cheerio.load(response.data);
+                const cover = $('meta[property="og:image"]');
+
+                const single = {
+                    title: item.find('h1').text(),
+                    author: item.find('h1').text().split('/')[0].trim(),
+                    description: `<img src="${cover.attr('content')}">
+                        <br>${item.find('p').text()}<br>
+                        <br>Language: ${item.find('span[itemprop="programmingLanguage"]').text() || 'Unknown'}
+                        <br>Star: ${item.find('.Link--muted').eq(0).text().trim()}
+                        <br>Fork: ${item.find('.Link--muted').eq(1).text().trim()}`,
+                    link,
+                };
+
+                return single;
+            });
+        })
+    );
+
     ctx.state.data = {
         title: $('title').text(),
         link: url,
-        item:
-            list &&
-            list
-                .map((_, item) => {
-                    item = $(item);
-                    return {
-                        title: item.find('h1').text(),
-                        author: item.find('h1').text().split('/')[0].trim(),
-                        description: `${item.find('.pr-4').text()}<br>
-                            <br>Language: ${item.find('span[itemprop="programmingLanguage"]').text() ?? 'unknown'}
-                            <br>Star: ${item.find('.Link--muted').eq(0).text().trim()}
-                            <br>Fork: ${item.find('.Link--muted').eq(1).text().trim()}`,
-                        link: `https://github.com${item.find('h1 a').attr('href')}`,
-                    };
-                })
-                .get(),
+        item: items,
     };
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Not applicable.

## 完整路由地址 / Example for the proposed route(s)

```routes
/github/trending/daily/any/en
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

Adds Open Graph image for each repository to the GitHub trending feed. Also, corrects unknown languages. I'd love to use GraphQL in place of got / cheerio, but I [ran into an issue where `openGraphImageUrl` is not returning what we want here](https://support.github.com/ticket/personal/0/1700375). Hopefully that gets fixed, and we can improve this in a future pull request 🙂 

This is my first pull request here. I couldn't understand most of the checklist options, but if I'm missing anything please let me know and I'll try to get it corrected 😊👍 
