### PR TITLE
fix(route): tju oaa news and notification url

### DIFF
--- a/docs/en/university.md
+++ b/docs/en/university.md
@@ -46,6 +46,18 @@ Note: [Source website](https://gs.bjtu.edu.cn/) only provides articles in Chines
 
 <RouteEn author="exuanbo" example="/polimi/news" path="/polimi/news/:language?" :paramsDesc="['English language code en']" />
 
+## Tianjin University
+
+### The Office of Academic Affairs
+
+<Route author="AmosChenYQ" example="/tjpyu/oaa/news" path="/tjpyu/oaa/:type" :paramsDesc="['default `news`']">
+
+| News | Notification |
+| ---- | ------------ |
+| news | notification |
+
+</Route>
+
 ## UMASS Amherst
 
 ### College of Electrical and Computer Engineering

--- a/docs/university.md
+++ b/docs/university.md
@@ -2387,7 +2387,7 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 ### 天津大学教务处
 
-<Route author="AmosChenYQ" example="/tjpyu/ooa/news" path="/tjpyu/ooa/:type" :paramsDesc="['默认为`news`']">
+<Route author="AmosChenYQ" example="/tjpyu/oaa/news" path="/tjpyu/oaa/:type" :paramsDesc="['默认为`news`']">
 
 | 新闻动态 | 通知公告         |
 | ---- | ------------ |

--- a/lib/router.js
+++ b/lib/router.js
@@ -732,7 +732,7 @@ router.get('/wzbc/:type?', lazyloadRouteHandler('./routes/universities/wzbc/news
 router.get('/henu/:type?', lazyloadRouteHandler('./routes/universities/henu/news'));
 
 // 天津大学
-router.get('/tjpyu/ooa/:type?', lazyloadRouteHandler('./routes/universities/tjpyu/ooa'));
+router.get('/tjpyu/oaa/:type?', lazyloadRouteHandler('./routes/universities/tjpyu/oaa'));
 
 // 南开大学
 router.get('/nku/jwc/:type?', lazyloadRouteHandler('./routes/universities/nku/jwc/index'));

--- a/lib/routes/universities/tjpyu/oaa.js
+++ b/lib/routes/universities/tjpyu/oaa.js
@@ -1,5 +1,6 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
+const timezone = require('@/utils/timezone');
 
 const oaa_base_url = 'http://oaa.tju.edu.cn/';
 const repo_url = 'https://github.com/DIYgod/RSSHub/issues';
@@ -61,7 +62,7 @@ module.exports = async (ctx) => {
                 list
                     .map((index, item) => ({
                         title: $('h2', item).text(),
-                        pubDate: new Date($('.fl_01_r_time', item).text().slice(2) + '-' + $('.fl_01_r_time', item).text().slice(0, 2)).toUTCString(),
+                        pubDate: timezone(new Date($('.fl_01_r_time', item).text().slice(2) + '-' + $('.fl_01_r_time', item).text().slice(0, 2)).toUTCString(), +8),
                         link: $('a', item).attr('href'),
                         description: $('p', item).text(),
                     }))

--- a/lib/routes/universities/tjpyu/oaa.js
+++ b/lib/routes/universities/tjpyu/oaa.js
@@ -1,7 +1,7 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 
-const ooa_base_url = 'http://oaa.tju.edu.cn/';
+const oaa_base_url = 'http://oaa.tju.edu.cn/';
 const repo_url = 'https://github.com/DIYgod/RSSHub/issues';
 
 module.exports = async (ctx) => {
@@ -25,9 +25,9 @@ module.exports = async (ctx) => {
     try {
         response = await got({
             method: 'get',
-            url: ooa_base_url + path,
+            url: oaa_base_url + path,
             headers: {
-                Referer: ooa_base_url,
+                Referer: oaa_base_url,
             },
         });
     } catch (e) {
@@ -38,8 +38,8 @@ module.exports = async (ctx) => {
     if (response === null) {
         ctx.state.data = {
             title: '天津大学教务处 - ' + subtitle,
-            link: ooa_base_url + path,
-            description: '链接失效' + ooa_base_url + path,
+            link: oaa_base_url + path,
+            description: '链接失效' + oaa_base_url + path,
             item: [
                 {
                     title: '提示信息',
@@ -54,7 +54,7 @@ module.exports = async (ctx) => {
 
         ctx.state.data = {
             title: '天津大学教务处 - ' + subtitle,
-            link: ooa_base_url + path,
+            link: oaa_base_url + path,
             description: null,
             item:
                 list &&

--- a/lib/routes/universities/tjpyu/ooa.js
+++ b/lib/routes/universities/tjpyu/ooa.js
@@ -11,15 +11,15 @@ module.exports = async (ctx) => {
     switch (type) {
         case 'news':
             subtitle = '新闻动态';
-            path = 'zytz';
+            path = 'xwdt.htm';
             break;
         case 'notification':
             subtitle = '通知公告';
-            path = 'zygg';
+            path = 'tzgg.htm';
             break;
         default:
             subtitle = '新闻动态';
-            path = 'zytz';
+            path = 'xwdt.htm';
     }
     let response = null;
     try {
@@ -50,7 +50,7 @@ module.exports = async (ctx) => {
         };
     } else {
         const $ = cheerio.load(response.data);
-        const list = $('.iplan > ul > li').slice(0, 10);
+        const list = $('.notice_l > ul > li > dl > dt').slice(0, 15);
 
         ctx.state.data = {
             title: '天津大学教务处 - ' + subtitle,
@@ -60,10 +60,8 @@ module.exports = async (ctx) => {
                 list &&
                 list
                     .map((index, item) => ({
-                        title: $('h2', item)
-                            .text()
-                            .replace(/(\d+)-(\d+)-(\d+)$/, ''), // remove duplicate date at the end of h2 element
-                        pubDate: new Date($('span', item).text()).toUTCString(),
+                        title: $('h2', item).text(),
+                        pubDate: new Date($('.fl_01_r_time', item).text().slice(2) + '-' + $('.fl_01_r_time', item).text().slice(0, 2)).toUTCString(),
                         link: $('a', item).attr('href'),
                         description: $('p', item).text(),
                     }))


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

```route
/tjpyu/oaa/news
/tjpyu/oaa/notification
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [x] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

修改了已有的天津大学教务处 RSS，原 URL 已失效。
Modified the existing RSS of the Academic Affairs Office of Tianjin University, the original URL has become invalid.