### PR TITLE
feat(radar): NGA track the poster

### DIFF
--- a/lib/v2/nga/radar.js
+++ b/lib/v2/nga/radar.js
@@ -20,7 +20,7 @@ module.exports = {
                 source: '/read.php',
                 target: (params, url, document) => {
                     const tid = new URL(url).searchParams.get('tid');
-                    const authorId = document.documentElement.innerHTML.match(/commonui\.userInfo\.setAll\(   {"(\d+)"/)[1];
+                    const authorId = document.documentElement.innerHTML.match(/commonui\.userInfo\.setAll\(\s{3}{"(\d+)"/)[1];
                     return `/nga/post/${tid}/${authorId}`;
                 }
             },
@@ -47,7 +47,7 @@ module.exports = {
                 source: '/read.php',
                 target: (params, url, document) => {
                     const tid = new URL(url).searchParams.get('tid');
-                    const authorId = document.documentElement.innerHTML.match(/commonui\.userInfo\.setAll\(   {"(\d+)"/)[1];
+                    const authorId = document.documentElement.innerHTML.match(/commonui\.userInfo\.setAll\(\s{3}{"(\d+)"/)[1];
                     return `/nga/post/${tid}/${authorId}`;
                 }
             },

--- a/lib/v2/nga/radar.js
+++ b/lib/v2/nga/radar.js
@@ -14,6 +14,16 @@ module.exports = {
                 source: '/read.php',
                 target: (params, url) => new URL(url).searchParams.get('tid') && `/nga/post/${new URL(url).searchParams.get('tid')}`,
             },
+            {
+                title: '帖子 - 只看作者',
+                docs: 'https://docs.rsshub.app/bbs.html#nga-tie-zi',
+                source: '/read.php',
+                target: (params, url, document) => {
+                    const tid = new URL(url).searchParams.get('tid');
+                    const authorId = document.documentElement.innerHTML.match(/commonui\.userInfo\.setAll\(   {"(\d+)"/)[1];
+                    return `/nga/post/${tid}/${authorId}`;
+                }
+            },
         ],
     },
     '178.com': {
@@ -30,6 +40,16 @@ module.exports = {
                 docs: 'https://docs.rsshub.app/bbs.html#nga-tie-zi',
                 source: '/read.php',
                 target: (params, url) => new URL(url).searchParams.get('tid') && `/nga/post/${new URL(url).searchParams.get('tid')}`,
+            },
+            {
+                title: '帖子 - 只看作者',
+                docs: 'https://docs.rsshub.app/bbs.html#nga-tie-zi',
+                source: '/read.php',
+                target: (params, url, document) => {
+                    const tid = new URL(url).searchParams.get('tid');
+                    const authorId = document.documentElement.innerHTML.match(/commonui\.userInfo\.setAll\(   {"(\d+)"/)[1];
+                    return `/nga/post/${tid}/${authorId}`;
+                }
             },
         ],
     },

--- a/lib/v2/nga/radar.js
+++ b/lib/v2/nga/radar.js
@@ -4,13 +4,13 @@ module.exports = {
         bbs: [
             {
                 title: '分区帖子',
-                docs: 'https://docs.rsshub.app/bbs.html#nga',
+                docs: 'https://docs.rsshub.app/bbs.html#nga-fen-qu-tie-zi',
                 source: '/thread.php',
                 target: (params, url) => new URL(url).searchParams.get('fid') && `/nga/forum/${new URL(url).searchParams.get('fid')}`,
             },
             {
                 title: '帖子',
-                docs: 'https://docs.rsshub.app/bbs.html#nga',
+                docs: 'https://docs.rsshub.app/bbs.html#nga-tie-zi',
                 source: '/read.php',
                 target: (params, url) => new URL(url).searchParams.get('tid') && `/nga/post/${new URL(url).searchParams.get('tid')}`,
             },
@@ -22,20 +22,14 @@ module.exports = {
             {
                 title: '分区帖子',
                 docs: 'https://docs.rsshub.app/bbs.html#nga-fen-qu-tie-zi',
-                source: ['/thread.php'],
-                target: (params, url) => {
-                    const fid = new URL(url).searchParams.get('fid');
-                    return `/nga/forum/${fid}`;
-                },
+                source: '/thread.php',
+                target: (params, url) => new URL(url).searchParams.get('fid') && `/nga/forum/${new URL(url).searchParams.get('fid')}`,
             },
             {
                 title: '帖子',
                 docs: 'https://docs.rsshub.app/bbs.html#nga-tie-zi',
-                source: ['/read.php'],
-                target: (params, url) => {
-                    const tid = new URL(url).searchParams.get('tid');
-                    return `/nga/post/${tid}`;
-                },
+                source: '/read.php',
+                target: (params, url) => new URL(url).searchParams.get('tid') && `/nga/post/${new URL(url).searchParams.get('tid')}`,
             },
         ],
     },


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
NOROUTE
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

添加一个 radar 规则，现在可以直接生成只看贴主的 RSS 链接了。

NGA forum has the ability to track anyone in a post, but mostly people only track the poster.

Add a radar rule. Now can directly generate the RSS link which track the poster, so no need to manualy find and copy the poster's `authorId`.

This radar rule uses `document`, but the others don't. I'm not sure if I need to remove the rssbud flag, yet I didn't.