### PR TITLE
fix(route): 联合早报强制使用sg版爬取

### DIFF
--- a/lib/v2/zaobao/index.js
+++ b/lib/v2/zaobao/index.js
@@ -1,5 +1,5 @@
 const { parseList } = require('./util');
-const baseUrl = 'https://www.zaobao.com';
+const baseUrl = 'https://www.zaobao.com.sg';
 
 module.exports = async (ctx) => {
     const type = ctx.params.type ?? 'realtime';

--- a/lib/v2/zaobao/interactive.js
+++ b/lib/v2/zaobao/interactive.js
@@ -1,5 +1,5 @@
 const { parseList } = require('./util');
-const baseUrl = 'https://www.zaobao.com';
+const baseUrl = 'https://www.zaobao.com.sg';
 
 module.exports = async (ctx) => {
     const sectionLink = `/interactive-graphics`;

--- a/lib/v2/zaobao/realtime.js
+++ b/lib/v2/zaobao/realtime.js
@@ -1,5 +1,5 @@
 const { parseList } = require('./util');
-const baseUrl = 'https://www.zaobao.com';
+const baseUrl = 'https://www.zaobao.com.sg';
 
 module.exports = async (ctx) => {
     const section = ctx.params.section ?? 'china';

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -5,7 +5,7 @@ const timezone = require('@/utils/timezone');
 const { art } = require('@/utils/render');
 const path = require('path');
 
-const baseUrl = 'https://www.zaobao.com';
+const baseUrl = 'https://www.zaobao.com.sg';
 const got_ins = got.extend({
     headers: {
         Referer: baseUrl,
@@ -52,7 +52,7 @@ const parseList = async (ctx, sectionUrl) => {
             let resultItem = {};
 
             if (link[0] !== '/') {
-                // https://www.zaobao.com/interactive-graphics
+                // https://www.zaobao.com.sg/interactive-graphics
                 const title = $item.find('a').text();
                 let dateNodes = $item.find('.meta-published-date');
                 if (dateNodes.length === 0) {

--- a/lib/v2/zaobao/znews.js
+++ b/lib/v2/zaobao/znews.js
@@ -1,5 +1,5 @@
 const { parseList } = require('./util');
-const baseUrl = 'https://www.zaobao.com';
+const baseUrl = 'https://www.zaobao.com.sg';
 
 module.exports = async (ctx) => {
     const section = ctx.params.section;


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #10309

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/zaobao/realtime/world
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
尝试强制使用sg版联合早报爬取内容。但由于实机直接访问联合早报网页发现这玩意至少会对来自大陆的ip强制重定向到hk版，故先弄成draft，等其他人的测试结果。未测试来自hk的ip访问是个什么情况