### PR TITLE
fix(route): 修复infoq recommend接口获取代码片段源数据为空会导致报错的边界错误

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -659,7 +659,7 @@ Tag
 
 ### 话题
 
-<Route author="brilon" example="/infoq/topic/1" path="/infoq/topic/:id" :paramsDesc="['话题id，可在[InfoQ全部话题](https://www.infoq.cn/topics)页面找到URL里的话题id']" />
+<Route author="brilon" example="/infoq/topic/1" path="/infoq/topic/:id" :paramsDesc="['话题id，可在 [InfoQ全部话题](https://www.infoq.cn/topics) 页面找到URL里的话题id']" />
 
 ## IT 之家
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -1466,8 +1466,8 @@ router.get('/zucc/cssearch/latest/:webVpn/:key', lazyloadRouteHandler('./routes/
 router.get('/ccnu/career', lazyloadRouteHandler('./routes/universities/ccnu/career'));
 
 // Infoq
-router.get('/infoq/recommend', lazyloadRouteHandler('./routes/infoq/recommend'));
-router.get('/infoq/topic/:id', lazyloadRouteHandler('./routes/infoq/topic'));
+// router.get('/infoq/recommend', lazyloadRouteHandler('./routes/infoq/recommend'));
+// router.get('/infoq/topic/:id', lazyloadRouteHandler('./routes/infoq/topic'));
 
 // checkee
 router.get('/checkee/:dispdate', lazyloadRouteHandler('./routes/checkee/index'));

--- a/lib/routes/infoq/utils.js
+++ b/lib/routes/infoq/utils.js
@@ -67,9 +67,13 @@ const parseToSimpleTexts = (content) =>
                 return `<img src="${img}"></img>`;
             },
             codeblock: () => {
-                const lang = i.attrs.lang;
-                const code = parseToSimpleText(i.content);
-                return `<code lang="${lang}">${code}</code>`;
+                if (i.content) {
+                    const lang = i.attrs.lang;
+                    const code = parseToSimpleText(i.content);
+                    return `<code lang="${lang}">${code}</code>`;
+                } else {
+                    return '';
+                }
             },
             link: () => {
                 const href = i.attrs.href;

--- a/lib/v2/infoq/maintainer.js
+++ b/lib/v2/infoq/maintainer.js
@@ -1,0 +1,4 @@
+module.exports = {
+    '/recommend': ['brilon'],
+    '/topic/:id': ['brilon'],
+};

--- a/lib/v2/infoq/radar.js
+++ b/lib/v2/infoq/radar.js
@@ -1,0 +1,19 @@
+module.exports = {
+    'infoq.cn': {
+        _name: 'InfoQ 中文',
+        '.': [
+            {
+                title: '推荐',
+                docs: 'https://docs.rsshub.app/new-media.html#infoq-zhong-wen',
+                source: ['/'],
+                target: '/infoq/recommend',
+            },
+            {
+                title: '话题',
+                docs: 'https://docs.rsshub.app/new-media.html#infoq-zhong-wen',
+                source: ['/topic/:id'],
+                target: '/infoq/topic/:id',
+            },
+        ],
+    },
+};

--- a/lib/v2/infoq/recommend.js
+++ b/lib/v2/infoq/recommend.js
@@ -5,14 +5,12 @@ module.exports = async (ctx) => {
     const apiUrl = 'https://www.infoq.cn/public/v1/my/recommond';
     const pageUrl = 'https://www.infoq.cn';
 
-    const resp = await got({
-        method: 'post',
-        url: apiUrl,
+    const resp = await got.post(apiUrl, {
         headers: {
             Referer: pageUrl,
         },
         json: {
-            size: 5,
+            size: ctx.query.limit ? Number(ctx.query.limit) : 30,
         },
     });
 
@@ -20,9 +18,8 @@ module.exports = async (ctx) => {
     const items = await utils.ProcessFeed(data, ctx.cache);
 
     ctx.state.data = {
-        title: 'InfoQ推荐',
+        title: 'InfoQ 推荐',
         link: pageUrl,
-        description: 'InfoQ推荐',
         item: items,
     };
 };

--- a/lib/v2/infoq/router.js
+++ b/lib/v2/infoq/router.js
@@ -1,0 +1,4 @@
+module.exports = (router) => {
+    router.get('/recommend', require('./recommend'));
+    router.get('/topic/:id', require('./topic'));
+};

--- a/lib/v2/infoq/topic.js
+++ b/lib/v2/infoq/topic.js
@@ -2,32 +2,28 @@ const got = require('@/utils/got');
 const utils = require('./utils');
 
 module.exports = async (ctx) => {
-    const paramId = parseInt(ctx.params.id);
+    const paramId = ctx.params.id;
     const apiUrl = 'https://www.infoq.cn/public/v1/article/getList';
     const infoUrl = 'https://www.infoq.cn/public/v1/topic/getInfo';
     const pageUrl = `https://www.infoq.cn/topic/${paramId}`;
 
-    const info = await got({
-        method: 'post',
-        url: infoUrl,
+    const infoBody = isNaN(paramId) ? { alias: paramId } : { id: parseInt(paramId) };
+
+    const info = await got.post(infoUrl, {
         headers: {
             Referer: pageUrl,
         },
-        json: {
-            id: paramId,
-        },
+        json: infoBody,
     });
     const topicName = info.data.data.name;
     const type = info.data.data.type;
 
-    const resp = await got({
-        method: 'post',
-        url: apiUrl,
+    const resp = await got.post(apiUrl, {
         headers: {
             Referer: pageUrl,
         },
         json: {
-            size: 5,
+            size: ctx.query.limit ? Number(ctx.query.limit) : 30,
             type,
             id: paramId,
         },
@@ -37,9 +33,10 @@ module.exports = async (ctx) => {
     const items = await utils.ProcessFeed(data, ctx.cache);
 
     ctx.state.data = {
-        title: `InfoQ话题 - ${topicName}`,
+        title: `InfoQ 话题 - ${topicName}`,
+        description: info.data.data.desc,
+        image: info.data.data.cover,
         link: pageUrl,
-        description: `InfoQ话题 - ${topicName}`,
         item: items,
     };
 };

--- a/lib/v2/infoq/utils.js
+++ b/lib/v2/infoq/utils.js
@@ -1,4 +1,5 @@
 const got = require('@/utils/got');
+const { parseDate } = require('@/utils/parse-date');
 
 const ProcessFeed = async (list, cache) => {
     const detailUrl = 'https://www.infoq.cn/public/v1/article/getDetail';
@@ -8,9 +9,7 @@ const ProcessFeed = async (list, cache) => {
             const uuid = e.uuid;
             const single = await cache.tryGet(uuid, async () => {
                 const link = `https://www.infoq.cn/article/${uuid}`;
-                const resp = await got({
-                    method: 'post',
-                    url: detailUrl,
+                const resp = await got.post(detailUrl, {
                     headers: {
                         Referer: link,
                     },
@@ -21,19 +20,19 @@ const ProcessFeed = async (list, cache) => {
 
                 const data = resp.data.data;
                 const author = data.author ? data.author.map((p) => p.nickname).join(',') : data.no_author;
-                const pubDate = new Date();
-                pubDate.setTime(data.publish_time);
+                const category = e.topic.map((t) => t.name).concat(e.label.map((l) => l.name));
 
                 return {
                     title: data.article_title,
                     description: parseContent(data.content),
-                    pubDate,
+                    pubDate: parseDate(e.publish_time, 'x'),
+                    category,
                     author,
                     link,
                 };
             });
 
-            return Promise.resolve(single);
+            return single;
         })
     );
 


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/infoq/recommend
```

## 说明 / Note

修复了一处边界case，在某些情况下源站会获取到内容为空的代码片段，导致该路由出现问题
![image](https://user-images.githubusercontent.com/6964737/181918684-52727325-7f84-452f-8bfd-878be26e2c1f.png)
