### PR TITLE
fix(route): FDA CDRH

### DIFF
--- a/lib/v2/fda/cdrh.js
+++ b/lib/v2/fda/cdrh.js
@@ -19,7 +19,6 @@ module.exports = async (ctx) => {
         .toArray()
         .map((item) => {
             item = $(item);
-
             const link = item.attr('href');
 
             return {

--- a/lib/v2/fda/cdrh.js
+++ b/lib/v2/fda/cdrh.js
@@ -46,7 +46,7 @@ module.exports = async (ctx) => {
                     item.pubDate = parseDate(content('meta[property="article:published_time"]').attr('content'));
                 }
 
-                if (cate == 'fulltext'){
+                if (cate ==  'fulltext') {
                 item.description = content('div[role="main"], .doc-content-area').html();
                 }
 

--- a/lib/v2/fda/cdrh.js
+++ b/lib/v2/fda/cdrh.js
@@ -46,7 +46,7 @@ module.exports = async (ctx) => {
                     item.pubDate = parseDate(content('meta[property="article:published_time"]').attr('content'));
                 }
 
-                if (cate ==  'fulltext') {
+                if (cate === 'fulltext') {
                 item.description = content('div[role="main"], .doc-content-area').html();
                 }
 

--- a/lib/v2/fda/cdrh.js
+++ b/lib/v2/fda/cdrh.js
@@ -5,6 +5,7 @@ const { parseDate } = require('@/utils/parse-date');
 module.exports = async (ctx) => {
     const rootUrl = 'https://www.fda.gov';
     const currentUrl = `${rootUrl}/medical-devices/news-events-medical-devices/cdrhnew-news-and-updates`;
+    const cate = ctx.params.cate ?? 'title';
 
     const response = await got({
         method: 'get',
@@ -45,7 +46,9 @@ module.exports = async (ctx) => {
                     item.pubDate = parseDate(content('meta[property="article:published_time"]').attr('content'));
                 }
 
+                if (cate == 'fulltext'){
                 item.description = content('div[role="main"], .doc-content-area').html();
+                }
 
                 return item;
             })

--- a/lib/v2/fda/radar.js
+++ b/lib/v2/fda/radar.js
@@ -6,7 +6,6 @@ module.exports = {
                 title: 'CDRHNew',
                 docs: 'https://docs.rsshub.app/government.html#mei-guo-shi-pin-yao-pin-jian-du-guan-li-ju-cdrhnew',
                 source: ['/medical-devices/news-events-medical-devices/cdrhnew-news-and-updates', '/'],
-                target: '/fda/cdrh',
             },
         ],
     },

--- a/lib/v2/fda/router.js
+++ b/lib/v2/fda/router.js
@@ -1,3 +1,3 @@
 module.exports = function (router) {
-    router.get('/cdrh/:cate*', require('./cdrh'));
+    router.get('/cdrh/:cate?', require('./cdrh'));
 };

--- a/lib/v2/fda/router.js
+++ b/lib/v2/fda/router.js
@@ -1,3 +1,3 @@
 module.exports = function (router) {
-    router.get('/cdrh', require('./cdrh'));
+    router.get('/cdrh/:cate*', require('./cdrh'));
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue
无相关issue
Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/fda/cdrh/fulltext
/fda/cdrh/title
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
2 sub routes are included: /fda/cdrh/title, and /fda/cdrh/fulltext
/fda/cdrh/fulltext would generate a lot of entries with different titles but similar contents, which would be filtered by de-duplicate algorithm. 
For some RSS reader with heavy de-duplicate algorithm, /fda/cdrh/title would preserve all entries. 