### PR TITLE
fix(route): infoq 部分文章内容解析错误导致无法生成订阅文件

### DIFF
--- a/lib/v2/infoq/utils.js
+++ b/lib/v2/infoq/utils.js
@@ -58,8 +58,12 @@ const parseToSimpleTexts = (content) =>
                 }
             },
             blockquote: () => {
-                const text = parseToSimpleText(i.content);
-                return `<blockquote>${text}</blockquote>`;
+                if (i.content) {
+                    const text = parseToSimpleText(i.content);
+                    return `<blockquote>${text}</blockquote>`;
+                } else {
+                    return '';
+                }
             },
             image: () => {
                 const img = i.attrs.src;
@@ -76,7 +80,7 @@ const parseToSimpleTexts = (content) =>
             },
             link: () => {
                 const href = i.attrs.href;
-                const text = parseToSimpleText(i.content);
+                const text = i.content ? parseToSimpleText(i.content) : '';
                 return `<a href="${href}">${text}</a>"`;
             },
         };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

无相关 issue

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/infoq/topic/4
```

## 说明 / Note

修复在解析 infoq 文章内容时 content 为空导致的解析失败，进而导致无法生成对应订阅文件的问题。

**修复前**：

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/18042424/182364848-2c35bc90-0773-405f-b790-e5a69436833c.png">

**修复后**：

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/18042424/182364886-75939eb0-fb22-4d62-8c97-21c0e96d3a49.png">
