### PR TITLE
fix(route)(twitter/keyword): wrong mode in web API

### DIFF
--- a/lib/v2/twitter/maintainer.js
+++ b/lib/v2/twitter/maintainer.js
@@ -1,7 +1,7 @@
 module.exports = {
     '/collection/:uid/:collectionId/:routeParams?': ['TonyRL'],
     '/followings/:id/:routeParams?': ['DIYgod'],
-    '/keyword/:keyword/:routeParams?/:limit?': ['DIYgod', 'yindaheng98', 'Rongronggg9'],
+    '/keyword/:keyword/:routeParams?': ['DIYgod', 'yindaheng98', 'Rongronggg9'],
     '/likes/:id/:routeParams?': ['xyqfer'],
     '/list/:id/:name/:routeParams?': ['xyqfer'],
     '/media/:id/:routeParams?': ['yindaheng98', 'Rongronggg9'],

--- a/lib/v2/twitter/router.js
+++ b/lib/v2/twitter/router.js
@@ -1,7 +1,7 @@
 module.exports = (router) => {
     router.get('/collection/:uid/:collectionId/:routeParams?', require('./collection'));
     router.get('/followings/:id/:routeParams?', require('./followings'));
-    router.get('/keyword/:keyword/:routeParams?/:limit?', require('./keyword'));
+    router.get('/keyword/:keyword/:routeParams?', require('./keyword'));
     router.get('/likes/:id/:routeParams?', require('./likes'));
     router.get('/list/:id/:name/:routeParams?', require('./list'));
     router.get('/media/:id/:routeParams?', require('./media'));

--- a/lib/v2/twitter/web-api/twitter-api.js
+++ b/lib/v2/twitter/web-api/twitter-api.js
@@ -106,6 +106,7 @@ const timelineKeywords = (keywords, params = {}) =>
         ..._params,
         ...params,
         q: keywords,
+        tweet_search_mode: 'live',
         query_source: 'typed_query',
         pc: 1,
     });


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #10537

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/twitter/keyword/RSS?forceWebApi=1
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
