### PR TITLE
fix(route): 联合早报图片大于两张时重定向

### DIFF
--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,7 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery .figure-media-gallery .slick-list .slick-track .figure-media-gallery-slide .figure-media-gallery-img img')
+                        html: $1('.inline-figure-gallery .figure-media-gallery-img')
                             .html()
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
                             .replace(/s3\/files/, 's3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,7 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery .figure-media-gallery-img')
+                        html: $1('.inline-figure-gallery .figure-media-gallery-slide')
                             .html()
                             .replace(/s3\/files/, 's3fs-public')
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,7 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery .slick-list')
+                        html: $1('.inline-figure-gallery .figure-media-gallery')
                             .html()
                             .replace(/s3\/files/, 's3fs-public')
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,10 +135,10 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $('.inline-figure-gallery')
+                        html: $1('.inline-figure-gallery')
                             .html()
-                            .replace(/\/\/.*\.com\/s3fs-public/g/, '//static.zaobao.com/s3fs-public')
-                            .replace(/s3\/files/g/, 's3fs-public'),
+                            .replace(/\/\/.*\.com\/s3fs-public/g, '//static.zaobao.com/s3fs-public')
+                            .replace(/s3\/files/g, 's3fs-public'),
                     });
                 }
                 if ($1('#carousel-article').length) {

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,10 +135,10 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery .figure-media-gallery')
+                        html: $1('.inline-figure-gallery .figure-media-gallery-img')
                             .html()
-                            .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
-                            .replace(/s3\/files/, 's3fs-public'),
+                            .replace(/s3\/files/, 's3fs-public')
+                            .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public'),
                     });
                 }
                 if ($1('#carousel-article').length) {

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,7 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery .slick-track')
+                        html: $1('.inline-figure-gallery .slick-list')
                             .html()
                             .replace(/s3\/files/, 's3fs-public')
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,7 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery .figure-media-gallery-slide')
+                        html: $1('.inline-figure-gallery .slick-track')
                             .html()
                             .replace(/s3\/files/, 's3fs-public')
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,7 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery>.figure-media-gallery>.slick-list>.slick-track>.figure-media-gallery-slide>.figure-media-gallery-img')
+                        html: $1('.figure-media-gallery-slide .figure-media-gallery-img')
                             .html()
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
                             .replace(/s3\/files/, 's3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,7 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.figure-media-gallery-slide .figure-media-gallery-img')
+                        html: $1('.inline-figure-gallery .figure-media-gallery .slick-list .slick-track .figure-media-gallery-slide .figure-media-gallery-img img')
                             .html()
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
                             .replace(/s3\/files/, 's3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -142,7 +142,7 @@ const parseList = async (ctx, sectionUrl) => {
                             .replace(/s3\/files/, 's3fs-public')
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public'),
                     });
-                    }
+                    };
                 }
                 if ($1('#carousel-article').length) {
                     // for HK version

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -133,7 +133,7 @@ const parseList = async (ctx, sectionUrl) => {
                 }
                 if ($1('.inline-figure-gallery').length) {
                     // for SG version
-                    var totalNumber = 1
+                    var totalNumber = 1;
                     for (totalNumber = 1; totalNumber < $1('.inline-figure-gallery').length; totalNumber++) {
                     imageDataArray.push({
                         type: 'normalHTML',

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -133,16 +133,13 @@ const parseList = async (ctx, sectionUrl) => {
                 }
                 if ($1('.inline-figure-gallery').length) {
                     // for SG version
-                    var totalNumber = 1;
-                    for (totalNumber = 1; totalNumber < $1('.inline-figure-gallery').length; totalNumber++) {
                     imageDataArray.push({
                         type: 'normalHTML',
                         html: $('.inline-figure-gallery .figure-media-gallery')
                             .html()
-                            .replace(/s3\/files/, 's3fs-public')
-                            .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public'),
+                            .replace(/\/\/.*\.com\/s3fs-public/g, '//static.zaobao.com/s3fs-public')
+                            .replace(/s3\/files/g, 's3fs-public'),
                     });
-                    };
                 }
                 if ($1('#carousel-article').length) {
                     // for HK version

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -142,13 +142,13 @@ const parseList = async (ctx, sectionUrl) => {
                     });
                 }
                 if ($1('#carousel-article').length) {
-                    // for HK version
+                    // for HK version, HK version of multi images use same selector as single image, so g is needed for all pages
                     imageDataArray.push({
                         type: 'normalHTML',
                         html: $1('#carousel-article .carousel-inner')
                             .html()
-                            .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
-                            .replace(/s3\/files/, 's3fs-public'),
+                            .replace(/\/\/.*\.com\/s3fs-public/g, '//static.zaobao.com/s3fs-public')
+                            .replace(/s3\/files/g, 's3fs-public'),
                     });
                 }
 

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,10 +135,10 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $('.inline-figure-gallery .figure-media-gallery')
+                        html: $('.inline-figure-gallery')
                             .html()
-                            .replace(/\/\/.*\.com\/s3fs-public/g, '//static.zaobao.com/s3fs-public')
-                            .replace(/s3\/files/g, 's3fs-public'),
+                            .replace(/\/\/.*\.com\/s3fs-public/g/, '//static.zaobao.com/s3fs-public')
+                            .replace(/s3\/files/g/, 's3fs-public'),
                     });
                 }
                 if ($1('#carousel-article').length) {

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -133,13 +133,16 @@ const parseList = async (ctx, sectionUrl) => {
                 }
                 if ($1('.inline-figure-gallery').length) {
                     // for SG version
+                    var totalNumber = 1
+                    for (totalNumber = 1; totalNumber < $1('.inline-figure-gallery').length; totalNumber++) {
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery .figure-media-gallery')
+                        html: $('.inline-figure-gallery .figure-media-gallery')
                             .html()
                             .replace(/s3\/files/, 's3fs-public')
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public'),
                     });
+                    }
                 }
                 if ($1('#carousel-article').length) {
                     // for HK version

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -131,7 +131,7 @@ const parseList = async (ctx, sectionUrl) => {
                         title: $1('.body-content .loadme picture img').attr('title'),
                     });
                 }
-                if ($1('figure-media-gallery-img).length) {
+                if ($1('figure-media-gallery-img').length) {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,7 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery .figure-media-gallery .slick-list .slick-track .figure-media-gallery-slide .figure-media-gallery-img')
+                        html: $1('.inline-figure-gallery>.figure-media-gallery>.slick-list>.slick-track>.figure-media-gallery-slide>.figure-media-gallery-img')
                             .html()
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
                             .replace(/s3\/files/, 's3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -131,11 +131,21 @@ const parseList = async (ctx, sectionUrl) => {
                         title: $1('.body-content .loadme picture img').attr('title'),
                     });
                 }
-                if ($1('figure-media-gallery-img').length) {
+                if ($1('.inline-figure-gallery').length) {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('figure-media-gallery-img')
+                        html: $1('.inline-figure-gallery')
+                            .html()
+                            .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
+                            .replace(/s3\/files/, 's3fs-public'),
+                    });
+                }
+                if ($1('article-rotator-img').length) {
+                    // for SG version
+                    imageDataArray.push({
+                        type: 'normalHTML',
+                        html: $1('article-rotator-img')
                             .html()
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
                             .replace(/s3\/files/, 's3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -131,11 +131,11 @@ const parseList = async (ctx, sectionUrl) => {
                         title: $1('.body-content .loadme picture img').attr('title'),
                     });
                 }
-                if ($1('.inline-figure-gallery').length) {
-                    // Unused?
+                if ($1('figure-media-gallery-img).length) {
+                    // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery')
+                        html: $1('figure-media-gallery-img')
                             .html()
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
                             .replace(/s3\/files/, 's3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,7 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery .figure-media-gallery-img')
+                        html: $1('.inline-figure-gallery .figure-media-gallery')
                             .html()
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
                             .replace(/s3\/files/, 's3fs-public'),

--- a/lib/v2/zaobao/util.js
+++ b/lib/v2/zaobao/util.js
@@ -135,17 +135,7 @@ const parseList = async (ctx, sectionUrl) => {
                     // for SG version
                     imageDataArray.push({
                         type: 'normalHTML',
-                        html: $1('.inline-figure-gallery')
-                            .html()
-                            .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
-                            .replace(/s3\/files/, 's3fs-public'),
-                    });
-                }
-                if ($1('article-rotator-img').length) {
-                    // for SG version
-                    imageDataArray.push({
-                        type: 'normalHTML',
-                        html: $1('article-rotator-img')
+                        html: $1('.inline-figure-gallery .figure-media-gallery .slick-list .slick-track .figure-media-gallery-slide .figure-media-gallery-img')
                             .html()
                             .replace(/\/\/.*\.com\/s3fs-public/, '//static.zaobao.com/s3fs-public')
                             .replace(/s3\/files/, 's3fs-public'),


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #10552 

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/zaobao/realtime/world
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
不太熟悉js，一点点测试的（所以commit才无比混乱但实际有用的就最后两次commit），最后才发现是因为正则没有加g只匹配一次造成的。SG版早报单图和多图使用不同选择器，所以只对多图的选择器做全局替换，能节约点资源；HK版我观察了一下，目前发现单图和多图都是同一个选择器，所以只能对全体开全局正则匹配了，测试因为我手头没香港服务器，只测试了SG版是没有问题的。