### PR TITLE
feat(route): fix 南京航空航天大学相关路由

### DIFF
--- a/docs/university.md
+++ b/docs/university.md
@@ -1811,7 +1811,7 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 ### 教务处
 
-<Route author="arcosx Seiry qrzbing" example="/nuaa/jwc/tzgg" path="/nuaa/jwc/:type/:getDescription?" :paramsDesc="['分类名', '是否获取描述']" puppeteer="1">
+<Route author="arcosx Seiry qrzbing Xm798" example="/nuaa/jwc/tzgg" path="/nuaa/jwc/:type/:getDescription?" :paramsDesc="['分类名', '是否获取全文']" puppeteer="1">
 
 | 通知公告 | 教学服务 | 教学建设 | 学生培养 | 教学资源 |
 | ---- | ---- | ---- | ---- | ---- |
@@ -1819,23 +1819,31 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 </Route>
 
+### 研究生院
+
+<Route author="junfengP Seiry Xm798" example="/nuaa/yjsy/tzgg" path="/nuaa/yjsy/:getDescription?" :paramsDesc="['分类名', '是否获取全文']" puppeteer="1">
+
+| 通知公告 | 新闻动态 | 学术信息 | 师生风采 |
+| ---- | ---- | ---- | ---- |
+| tzgg | xwdt | xsxx | ssfc |
+
+</Route>
+
+### 自动化学院
+
+<Route author="Seiry qrzbing Xm798" example="/nuaa/cae/zhxw" path="/nuaa/cs/:type/:getDescription?" :paramsDesc="['分类名', '是否获取全文']" puppeteer="1">
+
+| 综合新闻 | 党委行政 | 人事 / 合作 | 研究生培养 | 本科生培养 | 学生工作 | 通知公告 | 学术信息 | 答辩公告 |
+| ---- | ---- | ------- | ----- | ----- | ---- | ---- | ---- | ---- |
+| zhxw | dwxz | rshz    | yjs   | bks   | xsgz | tzgg | xsxx | dbgg |
+
 ### 计算机科学与技术学院
 
-<Route author="LogicJake Seiry qrzbing" example="/nuaa/cs/jxdt" path="/nuaa/cs/:type/:getDescription?" :paramsDesc="['分类名', '是否获取描述']" puppeteer="1">
+<Route author="LogicJake Seiry qrzbing Xm798" example="/nuaa/cs/jxdt" path="/nuaa/cs/:type/:getDescription?" :paramsDesc="['分类名', '是否获取全文']" puppeteer="1">
 
 | 通知公告 | 热点新闻 | 学科科研 | 教学动态 | 本科生培养 | 研究生培养 | 学生工作 |
 | ---- | ---- | ---- | ---- | ----- | ----- | ---- |
 | tzgg | rdxw | xkky | jxdt | be    | me    | xsgz |
-
-</Route>
-
-### 研究生院
-
-<Route author="junfengP Seiry" example="/nuaa/yjsy/latest" path="/nuaa/yjsy/:type?" :paramsDesc="['分类名']"/>
-
-| 最近动态   | 研院新闻 | 上级文件 | 管理文件 | 信息服务 |
-| ------ | ---- | ---- | ---- | ---- |
-| latest | yyxw | sjwj | glwj | xxfw |
 
 </Route>
 

--- a/lib/v2/nuaa/college/cae.js
+++ b/lib/v2/nuaa/college/cae.js
@@ -2,21 +2,24 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const { parseDate } = require('@/utils/parse-date');
 const getCookie = require('../utils/pypasswaf');
-const host = 'http://aao.nuaa.edu.cn/';
+const host = 'https://cae.nuaa.edu.cn/';
 
 const map = new Map([
-    ['tzgg', { title: '通知公告 | 南京航空航天大学教务处', suffix: '8222/list.htm' }],
-    ['jxfw', { title: '教学服务 | 南京航空航天大学教务处', suffix: '8230/list.htm' }],
-    ['xspy', { title: '学生培养 | 南京航空航天大学教务处', suffix: '8231/list.htm' }],
-    ['jxjs', { title: '教学建设 | 南京航空航天大学教务处', suffix: '8232/list.htm' }],
-    ['jxzy', { title: '教学资源 | 南京航空航天大学教务处', suffix: '8233/list.htm' }],
+    ['zhxw', { title: '综合新闻 | 南京航空航天大学自动化学院', suffix: '5399/list.htm' }],
+    ['dwxz', { title: '党委行政 | 南京航空航天大学自动化学院', suffix: '13266/list.htm' }],
+    ['rshz', { title: '人事/合作 | 南京航空航天大学自动化学院', suffix: '13267/list.htm' }],
+    ['yjs', { title: '研究生培养 | 南京航空航天大学自动化学院', suffix: '13271/list.htm' }],
+    ['bks', { title: '本科生培养 | 南京航空航天大学自动化学院', suffix: '13270/list.htm' }],
+    ['xsgz', { title: '学生工作 | 南京航空航天大学自动化学院', suffix: '13268/list.htm' }],
+    ['tzgg', { title: '通知公告 | 南京航空航天大学自动化学院', suffix: '13264/list.htm' }],
+    ['xsxx', { title: '学术信息 | 南京航空航天大学自动化学院', suffix: '13265/list.htm' }],
+    ['dbgg', { title: '答辩公告 | 南京航空航天大学自动化学院', suffix: 'dbgg/list.htm' }],
 ]);
 
 module.exports = async (ctx) => {
     const type = ctx.params.type;
     const suffix = map.get(type).suffix;
     const getDescription = Boolean(ctx.params.getDescription) || false;
-
     const link = new URL(suffix, host).href;
     const cookie = await getCookie(host);
     const gotConfig = {
@@ -27,7 +30,7 @@ module.exports = async (ctx) => {
     const response = await got(link, gotConfig);
     const $ = cheerio.load(response.data);
 
-    const list = $('#wp_news_w8 ul li')
+    const list = $('#wp_news_w6 ul li')
         .slice(0, 10)
         .map(function () {
             const info = {
@@ -41,7 +44,7 @@ module.exports = async (ctx) => {
 
     const out = await Promise.all(
         list.map((info) => {
-            const title = info.title || 'tzgg';
+            const title = info.title || 'zhxw';
             const date = info.date;
             const itemUrl = new URL(info.link, host).href;
 
@@ -76,7 +79,7 @@ module.exports = async (ctx) => {
     ctx.state.data = {
         title: map.get(type).title,
         link,
-        description: '南京航空航天大学教务处RSS',
+        description: '南京航空航天大学自动化学院RSS',
         item: out,
     };
 };

--- a/lib/v2/nuaa/college/cs.js
+++ b/lib/v2/nuaa/college/cs.js
@@ -2,16 +2,16 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const { parseDate } = require('@/utils/parse-date');
 const getCookie = require('../utils/pypasswaf');
-const host = 'http://cs.nuaa.edu.cn/';
+const host = 'https://cs.nuaa.edu.cn/';
 
 const map = new Map([
-    ['tzgg', { title: '南京航空航天大学计算机科学与技术学院 -- 通知公告', suffix: 'tzgg/list.htm' }],
-    ['rdxw', { title: '南京航空航天大学计算机科学与技术学院 -- 热点新闻', suffix: '10846/list.htm' }],
-    ['xkky', { title: '南京航空航天大学计算机科学与技术学院 -- 学科科研', suffix: '10849/list.htm' }],
-    ['be', { title: '南京航空航天大学计算机科学与技术学院 -- 本科生培养', suffix: '10850/list.htm' }],
-    ['me', { title: '南京航空航天大学计算机科学与技术学院 -- 研究生培养', suffix: '10851/list.htm' }],
-    ['jxdt', { title: '南京航空航天大学计算机科学与技术学院 -- 教学动态', suffix: '1977/list.htm' }],
-    ['xsgz', { title: '南京航空航天大学计算机科学与技术学院 -- 学生工作', suffix: '1959/list.htm' }],
+    ['tzgg', { title: '通知公告 | 南京航空航天大学计算机科学与技术学院', suffix: 'tzgg/list.htm' }],
+    ['rdxw', { title: '热点新闻 | 南京航空航天大学计算机科学与技术学院', suffix: '10846/list.htm' }],
+    ['xkky', { title: '学科科研 | 南京航空航天大学计算机科学与技术学院', suffix: '10849/list.htm' }],
+    ['be', { title: '本科生培养 | 南京航空航天大学计算机科学与技术学院', suffix: '10850/list.htm' }],
+    ['me', { title: '研究生培养 | 南京航空航天大学计算机科学与技术学院', suffix: '10851/list.htm' }],
+    ['jxdt', { title: '教学动态 | 南京航空航天大学计算机科学与技术学院', suffix: '1977/list.htm' }],
+    ['xsgz', { title: '学生工作 | 南京航空航天大学计算机科学与技术学院', suffix: '1959/list.htm' }],
 ]);
 
 module.exports = async (ctx) => {
@@ -20,7 +20,7 @@ module.exports = async (ctx) => {
     const suffix = map.get(type).suffix;
 
     const link = new URL(suffix, host).href;
-    const cookie = await getCookie();
+    const cookie = await getCookie(host);
     const gotConfig = {
         headers: {
             cookie,

--- a/lib/v2/nuaa/maintainer.js
+++ b/lib/v2/nuaa/maintainer.js
@@ -1,5 +1,6 @@
 module.exports = {
     '/cs/:type/:getDescription?': ['LogicJake', 'Seiry', 'qrzbing'],
-    '/jwc/:type/:getDescription?': ['arcosx', 'Seiry', 'qrzbing'],
-    '/yjsy/:type?': ['junfengP', 'Seiry'],
+    '/cae/:type/:getDescription?': ['Seiry', 'qrzbing', 'Xm798'],
+    '/jwc/:type/:getDescription?': ['arcosx', 'Seiry', 'qrzbing', 'Xm798'],
+    '/yjsy/:type/:getDescription?': ['junfengP', 'Seiry', 'Xm798'],
 };

--- a/lib/v2/nuaa/radar.js
+++ b/lib/v2/nuaa/radar.js
@@ -13,6 +13,12 @@ module.exports = {
                 docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
             },
         ],
+        cae: [
+            {
+                title: '自动化学院',
+                docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
+            },
+        ],
         'www.graduate': [
             {
                 title: '研究生院',

--- a/lib/v2/nuaa/router.js
+++ b/lib/v2/nuaa/router.js
@@ -1,5 +1,6 @@
 module.exports = (router) => {
-    router.get('/cs/:type/:getDescription?', require('./cs/index'));
+    router.get('/cae/:type/:getDescription?', require('./college/cae'));
+    router.get('/cs/:type/:getDescription?', require('./college/cs'));
     router.get('/jwc/:type/:getDescription?', require('./jwc/jwc'));
-    router.get('/yjsy/:type?', require('./yjsy/yjsy'));
+    router.get('/yjsy/:type/:getDescription?', require('./yjsy/yjsy'));
 };

--- a/lib/v2/nuaa/utils/pypasswaf.js
+++ b/lib/v2/nuaa/utils/pypasswaf.js
@@ -1,10 +1,8 @@
-const host = 'http://aao.nuaa.edu.cn/';
-
 /**
  * async function 获取cookie
  * @desc 返回一个可用的cookie，使用 `got` 发起请求的时候，传入到`options.headers.cookie`即可
  */
-module.exports = async function getCookie() {
+module.exports = async function getCookie(host) {
     const browser = await require('@/utils/puppeteer')({ stealth: true });
     const page = await browser.newPage();
     await page.setRequestInterception(true);

--- a/lib/v2/nuaa/yjsy/yjsy.js
+++ b/lib/v2/nuaa/yjsy/yjsy.js
@@ -1,55 +1,80 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
-const host = 'http://www.graduate.nuaa.edu.cn/';
 const { parseDate } = require('@/utils/parse-date');
+const getCookie = require('../utils/pypasswaf');
+const host = 'http://www.graduate.nuaa.edu.cn/';
 
-const map = {
-    latest: '2146/list.htm',
-    yyxw: 'yyxw/list.htm',
-    sjwj: 'sjwj/list.htm',
-    glwj: '2017/list.htm',
-    xxfw: '2147/list.htm',
-};
-
-const load = (link, ctx) =>
-    ctx.cache.tryGet(link, async () => {
-        const response = await got(host + link);
-        const $ = cheerio.load(response.data);
-        const images = $('img');
-        for (let k = 0; k < images.length; k++) {
-            $(images[k]).replaceWith(`<img src="${new URL($(images[k]).attr('src'), host).href}" />`);
-        }
-        const description = $('.wp_articlecontent').html();
-        return { description };
-    });
+const map = new Map([
+    ['tzgg', { title: '通知公告 | 南京航空航天大学研究生院', suffix: '2145/list.htm' }],
+    ['xwdt', { title: '新闻动态 | 南京航空航天大学研究生院', suffix: '13276/list.htm' }],
+    ['xsxx', { title: '学术信息 | 南京航空航天大学研究生院', suffix: '13277/list.htm' }],
+    ['ssfc', { title: '师生风采 | 南京航空航天大学研究生院', suffix: '13278/list.htm' }],
+]);
 
 module.exports = async (ctx) => {
-    const type = ctx.params.type ?? 'latest';
-    const response = await got({
-        method: 'get',
-        url: host + map[type],
-    });
+    const type = ctx.params.type;
+    const suffix = map.get(type).suffix;
+    const getDescription = Boolean(ctx.params.getDescription) || false;
+    const link = new URL(suffix, host).href;
+    const cookie = await getCookie(host);
+    const gotConfig = {
+        headers: {
+            cookie,
+        },
+    };
+    const response = await got(link, gotConfig);
     const $ = cheerio.load(response.data);
-    const list = $('#news_list ul.news_ul > li').slice(0, 10).get();
-    const process = await Promise.all(
-        list.map(async (item) => {
-            const a = $(item).find('a');
-            const t = $(item).find('span');
-            const itemUrl = a.attr('href');
-            const single = {
-                title: a.text(),
-                link: new URL(itemUrl, host).href,
-                pubDate: parseDate(t.text(), 'YYYY-MM-DD'),
+
+    const list = $('#wp_news_w6 ul li')
+        .slice(0, 10)
+        .map(function () {
+            const info = {
+                title: $(this).find('a').text(),
+                link: $(this).find('a').attr('href'),
+                date: $(this).find('span').text(),
             };
-            const other = await load(itemUrl, ctx);
-            return { ...single, ...other };
+            return info;
+        })
+        .get();
+
+    const out = await Promise.all(
+        list.map((info) => {
+            const title = info.title || 'tzgg';
+            const date = info.date;
+            const itemUrl = new URL(info.link, host).href;
+
+            return ctx.cache.tryGet(itemUrl, async () => {
+                const arr = itemUrl.split('.');
+                const pageType = arr[arr.length - 1];
+
+                // 南航新 WAF 过于敏感
+                // 目前 description 需要遍历页面，会被 WAF 拦截导致无法输出
+                // 考虑换一种获取 description 的方式或者将标题当作 title。
+                let description = title + '<br><a href="' + itemUrl + '" target="_blank">查看原文</a>';
+                if (getDescription) {
+                    description = itemUrl;
+                    if (pageType === 'htm' || pageType === 'html') {
+                        const response = await got(itemUrl, gotConfig);
+                        const $ = cheerio.load(response.data);
+                        description = $('.wp_articlecontent').html() + '<br><hr /><a href="' + itemUrl + '" target="_blank">查看原文</a>';
+                    }
+                }
+
+                const single = {
+                    title,
+                    link: itemUrl,
+                    description,
+                    pubDate: parseDate(date),
+                };
+                return single;
+            });
         })
     );
 
     ctx.state.data = {
-        title: '南航研究生院',
-        link: host,
-        description: '南航研究生院RSS',
-        item: process,
+        title: map.get(type).title,
+        link,
+        description: '南京航空航天大学研究生院RSS',
+        item: out,
     };
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

NULL

## 完整路由地址 / Example for the proposed route(s)

```routes
/nuaa/jwc/tzgg
/nuaa/jwc/jxfw
/nuaa/jwc/jxjs
/nuaa/jwc/xspy
/nuaa/jwc/jxzy
/nuaa/yjsy/tzgg
/nuaa/yjsy/xwdt
/nuaa/yjsy/xsxx
/nuaa/yjsy/ssfc
/nuaa/cae/zhxw
/nuaa/cae/dwxz
/nuaa/cae/rshz
/nuaa/cae/yjs
/nuaa/cae/bks
/nuaa/cae/xsgz
/nuaa/cae/tzgg
/nuaa/cae/xsxx
/nuaa/cae/dbgg
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [x] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [x] `Puppeteer`

## 说明 / Note

- 绕过 WAF，修复了不能使用的研究生院路由
- 添加自动化学院路由
- 优化描述抓取，添加“查看原文”链接
- 在 @qrzbing #9361 的基础上统一了模板，并将学院路由路径移动到 `college` 目录下
