### PR TITLE
fix(route): 南京航空航天大学路由缓存

### DIFF
--- a/docs/university.md
+++ b/docs/university.md
@@ -1811,7 +1811,7 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 ### 教务处
 
-<Route author="arcosx Seiry qrzbing Xm798" example="/nuaa/jwc/tzgg" path="/nuaa/jwc/:type/:getDescription?" :paramsDesc="['分类名', '是否获取全文']" puppeteer="1">
+<Route author="arcosx Seiry qrzbing Xm798" example="/nuaa/jwc/tzgg/getDescription" path="/nuaa/jwc/:type/:getDescription?" :paramsDesc="['分类名，见下表', '是否获取全文']" puppeteer="1" radar="1">
 
 | 通知公告 | 教学服务 | 教学建设 | 学生培养 | 教学资源 |
 | ---- | ---- | ---- | ---- | ---- |
@@ -1821,7 +1821,7 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 ### 研究生院
 
-<Route author="junfengP Seiry Xm798" example="/nuaa/yjsy/tzgg" path="/nuaa/yjsy/:getDescription?" :paramsDesc="['分类名', '是否获取全文']" puppeteer="1">
+<Route author="junfengP Seiry Xm798" example="/nuaa/yjsy/tzgg/getDescription" path="/nuaa/yjsy/:type/:getDescription?" :paramsDesc="['分类名，见下表', '是否获取全文']" puppeteer="1" radar="1">
 
 | 通知公告 | 新闻动态 | 学术信息 | 师生风采 |
 | ---- | ---- | ---- | ---- |
@@ -1831,7 +1831,7 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 ### 自动化学院
 
-<Route author="Seiry qrzbing Xm798" example="/nuaa/cae/zhxw" path="/nuaa/cs/:type/:getDescription?" :paramsDesc="['分类名', '是否获取全文']" puppeteer="1">
+<Route author="Xm798" example="/nuaa/cae/zhxw" path="/nuaa/cs/:type/:getDescription?" :paramsDesc="['分类名，见下表', '是否获取全文']" puppeteer="1" radar="1">
 
 | 综合新闻 | 党委行政 | 人事 / 合作 | 研究生培养 | 本科生培养 | 学生工作 | 通知公告 | 学术信息 | 答辩公告 |
 | ---- | ---- | ------- | ----- | ----- | ---- | ---- | ---- | ---- |
@@ -1839,7 +1839,7 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 ### 计算机科学与技术学院
 
-<Route author="LogicJake Seiry qrzbing Xm798" example="/nuaa/cs/jxdt" path="/nuaa/cs/:type/:getDescription?" :paramsDesc="['分类名', '是否获取全文']" puppeteer="1">
+<Route author="LogicJake Seiry qrzbing Xm798" example="/nuaa/cs/jxdt" path="/nuaa/cs/:type/:getDescription?" :paramsDesc="['分类名，见下表', '是否获取全文']" puppeteer="1" radar="1">
 
 | 通知公告 | 热点新闻 | 学科科研 | 教学动态 | 本科生培养 | 研究生培养 | 学生工作 |
 | ---- | ---- | ---- | ---- | ----- | ----- | ---- |

--- a/lib/v2/nuaa/college/cae.js
+++ b/lib/v2/nuaa/college/cae.js
@@ -43,36 +43,30 @@ module.exports = async (ctx) => {
         .get();
 
     const out = await Promise.all(
-        list.map((info) => {
-            const title = info.title || 'zhxw';
+        list.map(async (info) => {
+            const title = info.title || 'tzgg';
             const date = info.date;
             const itemUrl = new URL(info.link, host).href;
+            let description = title + '<br><a href="' + itemUrl + '" target="_blank">查看原文</a>';
 
-            return ctx.cache.tryGet(itemUrl, async () => {
-                const arr = itemUrl.split('.');
-                const pageType = arr[arr.length - 1];
-
-                // 南航新 WAF 过于敏感
-                // 目前 description 需要遍历页面，会被 WAF 拦截导致无法输出
-                // 考虑换一种获取 description 的方式或者将标题当作 title。
-                let description = title + '<br><a href="' + itemUrl + '" target="_blank">查看原文</a>';
-                if (getDescription) {
-                    description = itemUrl;
+            if (getDescription) {
+                description = await ctx.cache.tryGet(itemUrl, async () => {
+                    const arr = itemUrl.split('.');
+                    const pageType = arr[arr.length - 1];
                     if (pageType === 'htm' || pageType === 'html') {
                         const response = await got(itemUrl, gotConfig);
                         const $ = cheerio.load(response.data);
-                        description = $('.wp_articlecontent').html() + '<br><hr /><a href="' + itemUrl + '" target="_blank">查看原文</a>';
+                        return $('.wp_articlecontent').html() + '<br><hr /><a href="' + itemUrl + '" target="_blank">查看原文</a>';
                     }
-                }
+                });
+            }
 
-                const single = {
-                    title,
-                    link: itemUrl,
-                    description,
-                    pubDate: parseDate(date),
-                };
-                return single;
-            });
+            return {
+                title,
+                link: itemUrl,
+                description,
+                pubDate: parseDate(date),
+            };
         })
     );
 

--- a/lib/v2/nuaa/college/cs.js
+++ b/lib/v2/nuaa/college/cs.js
@@ -42,39 +42,30 @@ module.exports = async (ctx) => {
         .get();
 
     const out = await Promise.all(
-        list.map((info) => {
+        list.map(async (info) => {
             const title = info.title || 'tzgg';
             const date = info.date;
             const itemUrl = new URL(info.link, host).href;
+            let description = title + '<br><a href="' + itemUrl + '" target="_blank">查看原文</a>';
 
-            return ctx.cache.tryGet(itemUrl, async () => {
-                const arr = itemUrl.split('.');
-                const pageType = arr[arr.length - 1];
-
-                // 南航新 WAF 过于敏感
-                // 目前 description 需要遍历页面，会被 WAF 拦截导致无法输出
-                // 考虑换一种获取 description 的方式或者将标题当作 title。
-                let description = title;
-                if (getDescription) {
-                    description = itemUrl;
+            if (getDescription) {
+                description = await ctx.cache.tryGet(itemUrl, async () => {
+                    const arr = itemUrl.split('.');
+                    const pageType = arr[arr.length - 1];
                     if (pageType === 'htm' || pageType === 'html') {
-                        const response = await got.get(itemUrl, gotConfig);
+                        const response = await got(itemUrl, gotConfig);
                         const $ = cheerio.load(response.data);
-                        description = $('.wp_articlecontent')
-                            .html()
-                            .replace(/src="\//g, `src="${new URL('.', host).href}`)
-                            .trim();
+                        return $('.wp_articlecontent').html() + '<br><hr /><a href="' + itemUrl + '" target="_blank">查看原文</a>';
                     }
-                }
+                });
+            }
 
-                const single = {
-                    title,
-                    link: itemUrl,
-                    description,
-                    pubDate: parseDate(date),
-                };
-                return single;
-            });
+            return {
+                title,
+                link: itemUrl,
+                description,
+                pubDate: parseDate(date),
+            };
         })
     );
 

--- a/lib/v2/nuaa/jwc/jwc.js
+++ b/lib/v2/nuaa/jwc/jwc.js
@@ -40,36 +40,30 @@ module.exports = async (ctx) => {
         .get();
 
     const out = await Promise.all(
-        list.map((info) => {
+        list.map(async (info) => {
             const title = info.title || 'tzgg';
             const date = info.date;
             const itemUrl = new URL(info.link, host).href;
+            let description = title + '<br><a href="' + itemUrl + '" target="_blank">查看原文</a>';
 
-            return ctx.cache.tryGet(itemUrl, async () => {
-                const arr = itemUrl.split('.');
-                const pageType = arr[arr.length - 1];
-
-                // 南航新 WAF 过于敏感
-                // 目前 description 需要遍历页面，会被 WAF 拦截导致无法输出
-                // 考虑换一种获取 description 的方式或者将标题当作 title。
-                let description = title + '<br><a href="' + itemUrl + '" target="_blank">查看原文</a>';
-                if (getDescription) {
-                    description = itemUrl;
+            if (getDescription) {
+                description = await ctx.cache.tryGet(itemUrl, async () => {
+                    const arr = itemUrl.split('.');
+                    const pageType = arr[arr.length - 1];
                     if (pageType === 'htm' || pageType === 'html') {
                         const response = await got(itemUrl, gotConfig);
                         const $ = cheerio.load(response.data);
-                        description = $('.wp_articlecontent').html() + '<br><hr /><a href="' + itemUrl + '" target="_blank">查看原文</a>';
+                        return $('.wp_articlecontent').html() + '<br><hr /><a href="' + itemUrl + '" target="_blank">查看原文</a>';
                     }
-                }
+                });
+            }
 
-                const single = {
-                    title,
-                    link: itemUrl,
-                    description,
-                    pubDate: parseDate(date),
-                };
-                return single;
-            });
+            return {
+                title,
+                link: itemUrl,
+                description,
+                pubDate: parseDate(date),
+            };
         })
     );
 

--- a/lib/v2/nuaa/maintainer.js
+++ b/lib/v2/nuaa/maintainer.js
@@ -1,6 +1,6 @@
 module.exports = {
-    '/cs/:type/:getDescription?': ['LogicJake', 'Seiry', 'qrzbing', 'Xm798'],
     '/cae/:type/:getDescription?': ['Xm798'],
+    '/cs/:type/:getDescription?': ['LogicJake', 'Seiry', 'qrzbing', 'Xm798'],
     '/jwc/:type/:getDescription?': ['arcosx', 'Seiry', 'qrzbing', 'Xm798'],
     '/yjsy/:type/:getDescription?': ['junfengP', 'Seiry', 'Xm798'],
 };

--- a/lib/v2/nuaa/maintainer.js
+++ b/lib/v2/nuaa/maintainer.js
@@ -1,6 +1,6 @@
 module.exports = {
-    '/cae/:type/:getDescription?': ['Seiry', 'qrzbing', 'Xm798'],
-    '/cs/:type/:getDescription?': ['LogicJake', 'Seiry', 'qrzbing'],
+    '/cs/:type/:getDescription?': ['LogicJake', 'Seiry', 'qrzbing', 'Xm798'],
+    '/cae/:type/:getDescription?': ['Xm798'],
     '/jwc/:type/:getDescription?': ['arcosx', 'Seiry', 'qrzbing', 'Xm798'],
     '/yjsy/:type/:getDescription?': ['junfengP', 'Seiry', 'Xm798'],
 };

--- a/lib/v2/nuaa/radar.js
+++ b/lib/v2/nuaa/radar.js
@@ -7,15 +7,15 @@ module.exports = {
                 docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
             },
         ],
-        cs: [
-            {
-                title: '计算机科学与技术学院',
-                docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
-            },
-        ],
         cae: [
             {
                 title: '自动化学院',
+                docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
+            },
+        ],
+        cs: [
+            {
+                title: '计算机科学与技术学院',
                 docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
             },
         ],

--- a/lib/v2/nuaa/radar.js
+++ b/lib/v2/nuaa/radar.js
@@ -7,15 +7,15 @@ module.exports = {
                 docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
             },
         ],
-        cae: [
-            {
-                title: '自动化学院',
-                docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
-            },
-        ],
         cs: [
             {
                 title: '计算机科学与技术学院',
+                docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
+            },
+        ],
+        cae: [
+            {
+                title: '自动化学院',
                 docs: 'https://docs.rsshub.app/university.html#nan-jing-hang-kong-hang-tian-da-xue',
             },
         ],

--- a/lib/v2/nuaa/yjsy/yjsy.js
+++ b/lib/v2/nuaa/yjsy/yjsy.js
@@ -38,36 +38,30 @@ module.exports = async (ctx) => {
         .get();
 
     const out = await Promise.all(
-        list.map((info) => {
+        list.map(async (info) => {
             const title = info.title || 'tzgg';
             const date = info.date;
             const itemUrl = new URL(info.link, host).href;
+            let description = title + '<br><a href="' + itemUrl + '" target="_blank">查看原文</a>';
 
-            return ctx.cache.tryGet(itemUrl, async () => {
-                const arr = itemUrl.split('.');
-                const pageType = arr[arr.length - 1];
-
-                // 南航新 WAF 过于敏感
-                // 目前 description 需要遍历页面，会被 WAF 拦截导致无法输出
-                // 考虑换一种获取 description 的方式或者将标题当作 title。
-                let description = title + '<br><a href="' + itemUrl + '" target="_blank">查看原文</a>';
-                if (getDescription) {
-                    description = itemUrl;
+            if (getDescription) {
+                description = await ctx.cache.tryGet(itemUrl, async () => {
+                    const arr = itemUrl.split('.');
+                    const pageType = arr[arr.length - 1];
                     if (pageType === 'htm' || pageType === 'html') {
                         const response = await got(itemUrl, gotConfig);
                         const $ = cheerio.load(response.data);
-                        description = $('.wp_articlecontent').html() + '<br><hr /><a href="' + itemUrl + '" target="_blank">查看原文</a>';
+                        return $('.wp_articlecontent').html() + '<br><hr /><a href="' + itemUrl + '" target="_blank">查看原文</a>';
                     }
-                }
+                });
+            }
 
-                const single = {
-                    title,
-                    link: itemUrl,
-                    description,
-                    pubDate: parseDate(date),
-                };
-                return single;
-            });
+            return {
+                title,
+                link: itemUrl,
+                description,
+                pubDate: parseDate(date),
+            };
         })
     );
 


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

NULL

## 完整路由地址 / Example for the proposed route(s)

```routes
/nuaa/jwc/tzgg
/nuaa/jwc/tzgg/getDescription
/nuaa/jwc/jxfw
/nuaa/jwc/jxfw/getDescription
/nuaa/jwc/jxjs
/nuaa/jwc/jxjs/getDescription
/nuaa/jwc/xspy
/nuaa/jwc/xspy/getDescription
/nuaa/jwc/jxzy
/nuaa/jwc/jxzy/getDescription
/nuaa/yjsy/tzgg
/nuaa/yjsy/tzgg/getDescription
/nuaa/yjsy/xwdt
/nuaa/yjsy/xwdt/getDescription
/nuaa/yjsy/xsxx
/nuaa/yjsy/xsxx/getDescription
/nuaa/yjsy/ssfc
/nuaa/yjsy/ssfc/getDescription
/nuaa/cae/zhxw
/nuaa/cae/zhxw/getDescription
/nuaa/cae/dwxz
/nuaa/cae/dwxz/getDescription
/nuaa/cae/rshz
/nuaa/cae/rshz/getDescription
/nuaa/cae/yjs
/nuaa/cae/yjs/getDescription
/nuaa/cae/bks
/nuaa/cae/bks/getDescription
/nuaa/cae/xsgz
/nuaa/cae/xsgz/getDescription
/nuaa/cae/tzgg
/nuaa/cae/tzgg/getDescription
/nuaa/cae/xsxx
/nuaa/cae/xsxx/getDescription
/nuaa/cae/dbgg
/nuaa/cae/dbgg/getDescription
/nuaa/cs/tzgg
/nuaa/cs/tzgg/getDescription
/nuaa/cs/rdxw
/nuaa/cs/rdxw/getDescription
/nuaa/cs/xkky
/nuaa/cs/xkky/getDescription
/nuaa/cs/be
/nuaa/cs/be/getDescription
/nuaa/cs/me
/nuaa/cs/me/getDescription
/nuaa/cs/jxdt
/nuaa/cs/jxdt/getDescription
/nuaa/cs/xsgz
/nuaa/cs/xsgz/getDescription
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [x] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [x] `Puppeteer`

## 说明 / Note

修改缓存策略，以修复缓存导致的调整路由中 `getDescription` 参数不生效的问题。
