### PR TITLE
fix(route): producthunt rss failure

### DIFF
--- a/lib/v2/producthunt/today.js
+++ b/lib/v2/producthunt/today.js
@@ -17,10 +17,10 @@ module.exports = async (ctx) => {
                 const detailresponse = await got.get(`https://www.producthunt.com/posts/${item.slug}`);
 
                 const data = JSON.parse(cheerio.load(detailresponse.data)('#__NEXT_DATA__').html());
-                const descData = Object.values(data.props.apolloState)[0];
+                const descData = data.props.apolloState[`Post${item.id}`];
 
                 return {
-                    title: `${descData.slug} - ${item.tagline}`,
+                    title: `${item.slug} - ${item.tagline}`,
                     description:
                         descData.description +
                         art(path.join(__dirname, 'templates/descImg.art'), {


### PR DESCRIPTION
apolloState prop has been changed from putting the "Post" item first into the third one.

## 该 PR 相关 Issue / Involved issue

Close #
https://github.com/DIYgod/RSSHub/issues/10688
## 完整路由地址 / Example for the proposed route(s)


```routes
/producthunt/today
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
