### PR TITLE
fix(route): producthunt rss failure #10688

### DIFF
--- a/lib/v2/producthunt/today.js
+++ b/lib/v2/producthunt/today.js
@@ -5,7 +5,7 @@ const { art } = require('@/utils/render');
 const path = require('path');
 
 module.exports = async (ctx) => {
-    const response = await got.get('https://www.producthunt.com/');
+    const response = await got('https://www.producthunt.com/');
 
     const data = JSON.parse(cheerio.load(response.data)('#__NEXT_DATA__').html());
 
@@ -17,7 +17,7 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         list.map((item) =>
             ctx.cache.tryGet(item.slug, async () => {
-                const detailresponse = await got.get(`https://www.producthunt.com/posts/${item.slug}`);
+                const detailresponse = await got(`https://www.producthunt.com/posts/${item.slug}`);
 
                 const data = JSON.parse(cheerio.load(detailresponse.data)('#__NEXT_DATA__').html());
                 const descData = data.props.apolloState[`Post${item.id}`];

--- a/lib/v2/producthunt/today.js
+++ b/lib/v2/producthunt/today.js
@@ -17,10 +17,10 @@ module.exports = async (ctx) => {
                 const detailresponse = await got.get(`https://www.producthunt.com/posts/${item.slug}`);
 
                 const data = JSON.parse(cheerio.load(detailresponse.data)('#__NEXT_DATA__').html());
-                const descData = Object.values(data.props.apolloState)[0];
+                const descData = data.props.apolloState[`Post${item.id}`];
 
                 return {
-                    title: `${descData.slug} - ${item.tagline}`,
+                    title: `${item.slug} - ${item.tagline}`,
                     description:
                         descData.description +
                         art(path.join(__dirname, 'templates/descImg.art'), {

--- a/lib/v2/producthunt/today.js
+++ b/lib/v2/producthunt/today.js
@@ -9,7 +9,10 @@ module.exports = async (ctx) => {
 
     const data = JSON.parse(cheerio.load(response.data)('#__NEXT_DATA__').html());
 
-    const list = Object.values(data.props.apolloState).filter((o) => o.__typename === 'Post');
+    const list = Object.values(data.props.apolloState)
+        .filter((o) => o.__typename === 'Post')
+        // only includes new post, not product
+        .filter((o) => o.hasOwnProperty('redirectToProduct') && o.redirectToProduct === null);
 
     const items = await Promise.all(
         list.map((item) =>


### PR DESCRIPTION
the `apolloState` prop in `https://www.producthunt.com/posts/${item.slug}`  has been changed from putting the "Post" item first into the third one.

<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #10688

## 完整路由地址 / Example for the proposed route(s)


```routes
/producthunt/today
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
