### PR TITLE
fix: yxdown missing cookies

### DIFF
--- a/docs/en/program-update.md
+++ b/docs/en/program-update.md
@@ -116,7 +116,7 @@ Language
 
 ### BlueStacks 5 Release Notes
 
-<RouteEn author="TonyRL" example="/bluestacks/release/5" path="/bluestacks/release/5" radar="1"/>
+<RouteEn author="TonyRL" example="/bluestacks/release/5" path="/bluestacks/release/5" radar="1" puppeteer="1"/>
 
 ## Brave
 

--- a/docs/program-update.md
+++ b/docs/program-update.md
@@ -114,7 +114,7 @@ pageClass: routes
 
 ### BlueStacks 5 版本日誌
 
-<Route author="TonyRL" example="/bluestacks/release/5" path="/bluestacks/release/5" radar="1"/>
+<Route author="TonyRL" example="/bluestacks/release/5" path="/bluestacks/release/5" radar="1" puppeteer="1"/>
 
 ## Brave
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -3755,8 +3755,8 @@ router.get('/kingarthur/:type', lazyloadRouteHandler('./routes/kingarthur/index'
 // router.get('/news/whxw', lazyloadRouteHandler('./routes/news/whxw'));
 
 // 游讯网
-router.get('/yxdown/recommend', lazyloadRouteHandler('./routes/yxdown/recommend'));
-router.get('/yxdown/news/:category?', lazyloadRouteHandler('./routes/yxdown/news'));
+// router.get('/yxdown/recommend', lazyloadRouteHandler('./routes/yxdown/recommend'));
+// router.get('/yxdown/news/:category?', lazyloadRouteHandler('./routes/yxdown/news'));
 
 // BabeHub
 router.get('/babehub/search/:keyword?', lazyloadRouteHandler('./routes/babehub/search'));

--- a/lib/routes/yxdown/news.js
+++ b/lib/routes/yxdown/news.js
@@ -9,11 +9,21 @@ module.exports = async (ctx) => {
     const rootUrl = 'http://www.yxdown.com';
     const currentUrl = `${rootUrl}/news/${category}`;
 
-    const response = await got({
+    const cookieResponse = await got({
         method: 'get',
         url: currentUrl,
     });
 
+    const cookieRegx = /(?<=.cookie=").*(?=; path)/g;
+    const cookieStr = cookieResponse.data.match(cookieRegx)[0];
+
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+        headers: {
+            Cookie: cookieStr,
+        },
+    });
     const $ = cheerio.load(response.data);
 
     const list = $('.div_zixun h2 a')

--- a/lib/v2/yxdown/maintainer.js
+++ b/lib/v2/yxdown/maintainer.js
@@ -1,0 +1,4 @@
+module.exports = {
+    '/news/:category?': ['nczitzk'],
+    '/recommend': ['nczitzk'],
+};

--- a/lib/v2/yxdown/news.js
+++ b/lib/v2/yxdown/news.js
@@ -9,9 +9,11 @@ module.exports = async (ctx) => {
 
     const currentUrl = `${rootUrl}/news/${category}`;
 
+    const cookie = await getCookie();
+
     const response = await got(currentUrl, {
         headers: {
-            Cookie: await getCookie(ctx.cache.tryGet),
+            cookie,
         },
     });
     const $ = cheerio.load(response.data);
@@ -32,7 +34,7 @@ module.exports = async (ctx) => {
             ctx.cache.tryGet(item.link, async () => {
                 const detailResponse = await got(item.link, {
                     headers: {
-                        Cookie: await getCookie(ctx.cache.tryGet),
+                        cookie,
                     },
                 });
                 const content = cheerio.load(detailResponse.data);

--- a/lib/v2/yxdown/news.js
+++ b/lib/v2/yxdown/news.js
@@ -2,24 +2,27 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const timezone = require('@/utils/timezone');
 const { parseDate } = require('@/utils/parse-date');
+const { rootUrl, getCookie } = require('./utils');
 
 module.exports = async (ctx) => {
-    const rootUrl = 'http://www.yxdown.com';
-    const currentUrl = `${rootUrl}/news`;
-    const response = await got({
-        method: 'get',
-        url: currentUrl,
-    });
+    const category = ctx.params.category ? `${ctx.params.category}/` : '';
 
+    const currentUrl = `${rootUrl}/news/${category}`;
+
+    const response = await got(currentUrl, {
+        headers: {
+            Cookie: await getCookie(ctx.cache.tryGet),
+        },
+    });
     const $ = cheerio.load(response.data);
 
-    const list = $('ul li a b')
+    const list = $('.div_zixun h2 a')
         .map((_, item) => {
             item = $(item);
 
             return {
                 title: item.text(),
-                link: item.parent().attr('href'),
+                link: `${rootUrl}${item.attr('href')}`,
             };
         })
         .get();
@@ -27,9 +30,10 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         list.map((item) =>
             ctx.cache.tryGet(item.link, async () => {
-                const detailResponse = await got({
-                    method: 'get',
-                    url: item.link,
+                const detailResponse = await got(item.link, {
+                    headers: {
+                        Cookie: await getCookie(ctx.cache.tryGet),
+                    },
                 });
                 const content = cheerio.load(detailResponse.data);
 
@@ -44,7 +48,7 @@ module.exports = async (ctx) => {
     );
 
     ctx.state.data = {
-        title: '精彩推荐 - 游讯网',
+        title: `${$('.now').text()} - 游讯网`,
         link: currentUrl,
         item: items,
     };

--- a/lib/v2/yxdown/radar.js
+++ b/lib/v2/yxdown/radar.js
@@ -1,0 +1,19 @@
+module.exports = {
+    'yxdown.com': {
+        _name: '游讯网',
+        '.': [
+            {
+                title: '资讯',
+                docs: 'https://docs.rsshub.app/game.html#you-xun-wang',
+                source: ['/news/:category', '/news'],
+                target: (params) => `/yxdown/news${params.category ? `/${params.category}` : ''}`,
+            },
+            {
+                title: '精彩推荐',
+                docs: 'https://docs.rsshub.app/game.html#you-xun-wang',
+                source: ['/'],
+                target: '/yxdown/recommend',
+            },
+        ],
+    },
+};

--- a/lib/v2/yxdown/recommend.js
+++ b/lib/v2/yxdown/recommend.js
@@ -6,9 +6,10 @@ const { rootUrl, getCookie } = require('./utils');
 
 module.exports = async (ctx) => {
     const currentUrl = `${rootUrl}/news/`;
+    const cookie = await getCookie();
     const response = await got(currentUrl, {
         headers: {
-            Cookie: await getCookie(ctx.cache.tryGet),
+            cookie,
         },
     });
 
@@ -30,7 +31,7 @@ module.exports = async (ctx) => {
             ctx.cache.tryGet(item.link, async () => {
                 const detailResponse = await got(item.link, {
                     headers: {
-                        Cookie: await getCookie(ctx.cache.tryGet),
+                        cookie,
                     },
                 });
                 const content = cheerio.load(detailResponse.data);

--- a/lib/v2/yxdown/recommend.js
+++ b/lib/v2/yxdown/recommend.js
@@ -2,37 +2,25 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const timezone = require('@/utils/timezone');
 const { parseDate } = require('@/utils/parse-date');
+const { rootUrl, getCookie } = require('./utils');
 
 module.exports = async (ctx) => {
-    const category = ctx.params.category ? `${ctx.params.category}/` : '';
-
-    const rootUrl = 'http://www.yxdown.com';
-    const currentUrl = `${rootUrl}/news/${category}`;
-
-    const cookieResponse = await got({
-        method: 'get',
-        url: currentUrl,
-    });
-
-    const cookieRegx = /(?<=.cookie=").*(?=; path)/g;
-    const cookieStr = cookieResponse.data.match(cookieRegx)[0];
-
-    const response = await got({
-        method: 'get',
-        url: currentUrl,
+    const currentUrl = `${rootUrl}/news/`;
+    const response = await got(currentUrl, {
         headers: {
-            Cookie: cookieStr,
+            Cookie: await getCookie(ctx.cache.tryGet),
         },
     });
+
     const $ = cheerio.load(response.data);
 
-    const list = $('.div_zixun h2 a')
+    const list = $('ul li a b')
         .map((_, item) => {
             item = $(item);
 
             return {
                 title: item.text(),
-                link: `${rootUrl}${item.attr('href')}`,
+                link: item.parent().attr('href'),
             };
         })
         .get();
@@ -40,9 +28,10 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         list.map((item) =>
             ctx.cache.tryGet(item.link, async () => {
-                const detailResponse = await got({
-                    method: 'get',
-                    url: item.link,
+                const detailResponse = await got(item.link, {
+                    headers: {
+                        Cookie: await getCookie(ctx.cache.tryGet),
+                    },
                 });
                 const content = cheerio.load(detailResponse.data);
 
@@ -57,7 +46,7 @@ module.exports = async (ctx) => {
     );
 
     ctx.state.data = {
-        title: `${$('.now').text()} - 游讯网`,
+        title: '精彩推荐 - 游讯网',
         link: currentUrl,
         item: items,
     };

--- a/lib/v2/yxdown/router.js
+++ b/lib/v2/yxdown/router.js
@@ -1,0 +1,4 @@
+module.exports = (router) => {
+    router.get('/news/:category?', require('./news'));
+    router.get('/recommend', require('./recommend'));
+};

--- a/lib/v2/yxdown/utils.js
+++ b/lib/v2/yxdown/utils.js
@@ -1,22 +1,15 @@
-const config = require('@/config').value;
 const got = require('@/utils/got');
 
 const rootUrl = 'http://www.yxdown.com';
 
-const getCookie = (tryGet) =>
-    tryGet(
-        'yxdown:cookie',
-        async () => {
-            const cookieResponse = await got(rootUrl);
+const getCookie = async () => {
+    const cookieResponse = await got(rootUrl);
 
-            const cookieRegx = /(?<=.cookie=").*(?=; path)/g;
-            const cookieStr = cookieResponse.data.match(cookieRegx)[0];
+    const cookieRegx = /(?<=.cookie=").*(?=; path)/g;
+    const cookieStr = cookieResponse.data.match(cookieRegx)[0];
 
-            return cookieStr;
-        },
-        config.cache.routeExpire,
-        false
-    );
+    return cookieStr;
+};
 
 module.exports = {
     rootUrl,

--- a/lib/v2/yxdown/utils.js
+++ b/lib/v2/yxdown/utils.js
@@ -1,0 +1,24 @@
+const config = require('@/config').value;
+const got = require('@/utils/got');
+
+const rootUrl = 'http://www.yxdown.com';
+
+const getCookie = (tryGet) =>
+    tryGet(
+        'yxdown:cookie',
+        async () => {
+            const cookieResponse = await got(rootUrl);
+
+            const cookieRegx = /(?<=.cookie=").*(?=; path)/g;
+            const cookieStr = cookieResponse.data.match(cookieRegx)[0];
+
+            return cookieStr;
+        },
+        config.cache.routeExpire,
+        false
+    );
+
+module.exports = {
+    rootUrl,
+    getCookie,
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #10564

## 完整路由地址 / Example for the proposed route(s)

```route
/yxdown/news/:category?
```

```routes
/yxdown/news
/yxdown/news/dongtai
/yxdown/news/yugao
/yxdown/news/xinzuo
/yxdown/news/zixun
/yxdown/news/pingce
/yxdown/news/wangluo
/yxdown/news/shouyou
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

Fixed an issue where the Yxdown News route became invalid due to a change in the forward rule