### PR TITLE
feat(route): add support for linovelib 哩哔轻小说

### DIFF
--- a/docs/anime.md
+++ b/docs/anime.md
@@ -594,6 +594,12 @@ Sources
 
 <Route author="btdwv marvolo666 yan12125" path="/copymanga/comic/:id/:chapterCnt?" example="/copymanga/comic/zaiyishijiemigongkaihougong/5" :paramsDesc="['漫画ID','返回章节的数量，默认为0，返回所有章节']" radar="1" rssbud="1"/>
 
+## 哩哔轻小说
+
+### 小说更新
+
+<Route author="misakicoca" path="/linovelib/novel/:id" example="/linovelib/novel/2547" :paramsDesc="['小说 id，对应书架开始阅读 URL 中找到']"/>
+
 ## 漫画 DB
 
 ### 漫画 DB

--- a/lib/v2/linovelib/maintainer.js
+++ b/lib/v2/linovelib/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/novel/:id': ['misakicoca'],
+};

--- a/lib/v2/linovelib/novel.js
+++ b/lib/v2/linovelib/novel.js
@@ -1,0 +1,33 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+
+module.exports = async (ctx) => {
+    const response = await got(`https://www.linovelib.com/novel/${ctx.params.id}/catalog`);
+    const $ = cheerio.load(response.data);
+
+    const meta = $('.book-meta');
+    const title = meta.children().first().text();
+    const author = meta.find('p > span > a').text();
+
+    const list = $('.chapter-list');
+    const items = list
+        .find('li')
+        .find('a')
+        .filter((idx, item) => $(item).attr('href').startsWith('/novel/'))
+        .map((idx, item) => ({
+            title: $(item).text(),
+            author,
+            description: $(item).text(),
+            link: `https://www.linovelib.com${$(item).attr('href')}`,
+        }))
+        .get();
+    items.reverse();
+
+    ctx.state.data = {
+        title: `哩哔轻小说 - ${title}`,
+        link: `https://www.linovelib.com/novel/${ctx.params.id}/catalog`,
+        description: title,
+        language: 'zh',
+        item: items,
+    };
+};

--- a/lib/v2/linovelib/radar.js
+++ b/lib/v2/linovelib/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'linovelib.com': {
+        _name: '哩哔轻小说',
+        '.': [
+            {
+                title: '小说详情',
+                docs: 'https://docs.rsshub.app/anime.html#linovelib',
+                source: ['/novel/:id'],
+                target: '/linovellib/novel/:id',
+            },
+        ],
+    },
+};

--- a/lib/v2/linovelib/router.js
+++ b/lib/v2/linovelib/router.js
@@ -1,0 +1,3 @@
+module.exports = (router) => {
+    router.get('/novel/:id', require('./novel'));
+};


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

```route
/linovelib/novel/:id
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`
