### PR TITLE
fix:修复环球网内容selector

### DIFF
--- a/lib/v2/huanqiu/index.js
+++ b/lib/v2/huanqiu/index.js
@@ -47,7 +47,7 @@ module.exports = async (ctx) => {
                     url: item.link,
                 });
                 const content = cheerio.load(detailResponse.data);
-                item.description = content('article').html();
+                item.description = content('textarea.article-content').text();
                 item.author = content('span', '.source').text();
                 item.pubDate = timezone(parseDate(content('p.time').text()), +8);
                 return item;


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```route
/huanqiu/news/china
/huanqiu/news/world
/huanqiu/news/mil
/huanqiu/news/taiwai
/huanqiu/news/opinion
```


## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
环球网使用textarea包裹实际内容，因此使用`.text()`获取内容，防止转义