### PR TITLE
fix(route): bilibili dynamic

### DIFF
--- a/lib/v2/bilibili/dynamic.js
+++ b/lib/v2/bilibili/dynamic.js
@@ -159,7 +159,7 @@ module.exports = async (ctx) => {
                 const emoji = item.display.emoji_info.emoji_details;
                 emoji.forEach((item) => {
                     data_content = data_content.replace(
-                        new RegExp(`\\${item.text}`, 'g'),
+                        new RegExp(`\\${item.text}`.replace(new RegExp('\\?', 'g'), '\\?'), 'g'),
                         `<img alt="${item.text}" src="${item.url}"style="margin: -1px 1px 0px; display: inline-block; width: 20px; height: 20px; vertical-align: text-bottom;" title="" referrerpolicy="no-referrer">`
                     );
                 });

--- a/lib/v2/bilibili/dynamic.js
+++ b/lib/v2/bilibili/dynamic.js
@@ -155,6 +155,8 @@ module.exports = async (ctx) => {
 
             // emoji
             let data_content = getDes(data);
+            // 换行处理
+            data_content = data_content.replace(new RegExp('\r\n', 'g'), '<br>').replace(new RegExp('\n', 'g'), '<br>');
             if (item.display.emoji_info) {
                 const emoji = item.display.emoji_info.emoji_details;
                 emoji.forEach((item) => {

--- a/lib/v2/bilibili/dynamic.js
+++ b/lib/v2/bilibili/dynamic.js
@@ -1,6 +1,7 @@
 const got = require('@/utils/got');
 const JSONbig = require('json-bigint');
 const utils = require('./utils');
+const { parseDate } = require('@/utils/parse-date');
 
 /**
     @by CaoMeiYouRen 2020-05-05 添加注释
@@ -200,7 +201,7 @@ module.exports = async (ctx) => {
                     const videoHTMLSource = videoHTML ? `<br>${videoHTML}` : '';
                     return `${description}${originName}<br>${getUrl(data)}${getUrl(origin)}${getIframe(data)}${getIframe(origin)}${imgHTMLSource}${videoHTMLSource}`;
                 })(),
-                pubDate: new Date(item.desc.timestamp * 1000),
+                pubDate: item.desc ? (item.desc.timestamp ? parseDate(item.desc.timestamp, 'X') : null) : null,
                 link,
             };
         }),


### PR DESCRIPTION
修复bilibili动态在特定表情下会产生正则表达式错误的问题，如动态中包含表情[2022拜年纪_???]，正则表达式会产生匹配错误导致页面无法正常输出。  
修复bilibili动态内容没有处理换行的问题。
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

无

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/bilibili/user/dynamic/4000867
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
