### PR TITLE
refactor: try to mimic the js cookie behavior and bypass the anti spider in ccdi.gov

### DIFF
--- a/docs/government.md
+++ b/docs/government.md
@@ -1339,7 +1339,7 @@ pageClass: routes
 
 ### 要闻
 
-<Route author="bigfei" example="/gov/ccdi/yaowenn" path="/gov/ccdi/:path+" :paramsDesc="['路径，默认为 要闻']" anticrawler="1">
+<Route author="bigfei" example="/gov/ccdi/yaowenn" path="/gov/ccdi/:path+" :paramsDesc="['路径，默认为 要闻']">
 
 ::: tip 提示
 

--- a/lib/v2/gov/ccdi/index.js
+++ b/lib/v2/gov/ccdi/index.js
@@ -1,11 +1,4 @@
-/* eslint-disable no-await-in-loop */
 const { rootUrl, parseNewsList, parseArticle } = require('./utils');
-
-const getRandomInt = (min, max) => {
-    min = Math.ceil(min);
-    max = Math.floor(max);
-    return Math.floor(Math.random() * (max - min) + min); // The maximum is exclusive and the minimum is inclusive
-};
 
 module.exports = async (ctx) => {
     const defaultPath = '/yaowenn/';
@@ -15,13 +8,7 @@ module.exports = async (ctx) => {
     const currentUrl = `${rootUrl}${pathname}`;
 
     const { list, title } = await parseNewsList(currentUrl, '.list_news_dl li', ctx);
-    const items = [];
-
-    for (const item of list) {
-        items.push(await parseArticle(item, ctx));
-        // sleep randomly for anti rate limit on ccdi site
-        await new Promise((r) => setTimeout(r, getRandomInt(1000, 2500)));
-    }
+    const items = await Promise.all(list.map((item) => parseArticle(item, ctx)));
 
     ctx.state.data = {
         title,

--- a/lib/v2/gov/ccdi/utils.js
+++ b/lib/v2/gov/ccdi/utils.js
@@ -47,19 +47,19 @@ const parseArticle = async (item, ctx) =>
         parseCookie(data);
 
         const $ = cheerio.load(data);
-        const title = $('.daty').text().trim();
+        const title = $('.daty, .source-box').text().trim();
         item.author = title.match(/来源：(.*)发布时间/s)?.[1].trim() ?? owner;
         item.pubDate = timezone(parseDate(title.match(/发布时间：(.*)分享/s)?.[1].trim() ?? item.pubDate), +8);
 
         // Change the img src from relative to absolute for a better compatibility
-        $('.content')
+        $('.content, .bom-box')
             .find('img')
             .each((_, el) => {
                 $(el).attr('src', new URL($(el).attr('src'), item.link).href);
                 // oldsrc is causing freshrss imageproxy not to work correctly
                 $(el).removeAttr('oldsrc').removeAttr('alt');
             });
-        item.description = $('.content').html();
+        item.description = $('.content, .bom-box').html();
         return item;
     });
 

--- a/lib/v2/gov/ccdi/utils.js
+++ b/lib/v2/gov/ccdi/utils.js
@@ -8,7 +8,7 @@ const cookieJar = new CookieJar();
 
 const owner = '中央纪委国家监委网站';
 const rootUrl = 'https://www.ccdi.gov.cn';
-const regex = /([A-Z_]+)=((.*?)(?=; max-age)|([a-fA-F0-9]+))/gm;
+const regex = /([A-Z_]+=(?:.*?(?=; max-age)|[a-fA-F0-9]+))/gm;
 
 const parseCookie = async (body) => {
     const cookies = body.match(regex);

--- a/lib/v2/gov/ccdi/utils.js
+++ b/lib/v2/gov/ccdi/utils.js
@@ -8,12 +8,23 @@ const cookieJar = new CookieJar();
 
 const owner = '中央纪委国家监委网站';
 const rootUrl = 'https://www.ccdi.gov.cn';
+const regex = /([A-Z_]+)=((.*?)(?=; max-age)|([a-fA-F0-9]+))/gm;
+
+const parseCookie = async (body) => {
+    const cookies = body.match(regex);
+    if (cookies) {
+        await Promise.all(cookies.map((c) => cookieJar.setCookie(c, rootUrl)));
+    }
+};
 
 const parseNewsList = async (url, selector, ctx) => {
     const response = await got(url, { cookieJar });
-    const $ = cheerio.load(response.data);
+    const data = response.data;
+    parseCookie(data);
+
+    const $ = cheerio.load(data);
     const list = $(selector)
-        .slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 8)
+        .slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 20)
         .toArray()
         .map((item) => {
             item = $(item);
@@ -32,8 +43,10 @@ const parseNewsList = async (url, selector, ctx) => {
 const parseArticle = async (item, ctx) =>
     await ctx.cache.tryGet(item.link, async () => {
         const response = await got(item.link, { cookieJar });
-        const $ = cheerio.load(response.data);
+        const data = response.data;
+        parseCookie(data);
 
+        const $ = cheerio.load(data);
         const title = $('.daty').text().trim();
         item.author = title.match(/来源：(.*)发布时间/s)?.[1].trim() ?? owner;
         item.pubDate = timezone(parseDate(title.match(/发布时间：(.*)分享/s)?.[1].trim() ?? item.pubDate), +8);


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #10879 

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/gov/ccdi
/gov/ccdi/lswhn/wenhua
/gov/ccdi/scdcn/zggb/zjsc
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [x] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
  bypass the anti crawler by trying to mimic the cookie setting behavior
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
