### PR TITLE
fix: #10901

### DIFF
--- a/lib/v2/jandan/section.js
+++ b/lib/v2/jandan/section.js
@@ -44,6 +44,5 @@ module.exports = async (ctx) => {
         title: `${$('title').text()} - 煎蛋`,
         link: currentUrl,
         item: items,
-        description: response.data.match(/"description": "([\s\S]*)",/)[1],
     };
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #10901

## 完整路由地址 / Example for the proposed route(s)

```routes
NOROUTE
```

## 说明 / Note

移除了不规范的写法：没有检查是否匹配就调用数组索引，导致异常：

```js
response.data.match(/"description": "([\s\S]*)",/)[1]
```