### PR TITLE
build(docker): fix chromium favour

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN \
         yarn add puppeteer@$(cat /app/.puppeteer_version) && \
         yarn cache clean ; \
     else \
-        mkdir -p /app/node_modules/puppeteer ; \
+        mkdir -p /app/node_modules/puppeteer-core ; \
     fi;
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -143,14 +143,14 @@ RUN \
     fi; \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=chromium-downloader /app/node_modules/puppeteer /app/node_modules/puppeteer
+COPY --from=chromium-downloader /app/node_modules/puppeteer-core /app/node_modules/puppeteer-core
 
 # if grep matches nothing then it will exit with 1, thus, we cannot `set -e` here
 RUN \
     set -x && \
     if [ "$PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" = 0 ] && [ "$TARGETPLATFORM" = 'linux/amd64' ]; then \
         echo 'Verifying Chromium installation...' && \
-        ldd $(find /app/node_modules/puppeteer/ -name chrome) | grep "not found" ; \
+        ldd $(find /app/node_modules/puppeteer-core/ -name chrome) | grep "not found" ; \
         if [ "$?" = 0 ]; then \
             echo "!!! Chromium has unmet shared libs !!!" && \
             exit 1 ; \


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #11019

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/tiktok/user/@linustech
```

## 说明 / Note

- Chromium binary moved from `node_modules/puppeteer/.local-chromium` to `node_modules/puppeteer-core/.local-chromium` because of https://github.com/puppeteer/puppeteer/pull/9023