### PR TITLE
fix(route): zhihu daily

### DIFF
--- a/lib/v2/zhihu/daily.js
+++ b/lib/v2/zhihu/daily.js
@@ -5,15 +5,38 @@ const { parseDate } = require('@/utils/parse-date');
 // 参考：https://github.com/izzyleung/ZhihuDailyPurify/wiki/%E7%9F%A5%E4%B9%8E%E6%97%A5%E6%8A%A5-API-%E5%88%86%E6%9E%90
 // 文章给出了v4版 api的信息，包含全文api
 
+async function dohResolve(name) {
+    const response = await got('https://223.5.5.5/resolve', {
+        searchParams: {
+            name,
+            type: 'A',
+            edns_client_subnet: '223.5.5.5', // 使用国内的ip地址
+        },
+        headers: {
+            accept: 'application/dns-json',
+        },
+    });
+    return response.data.Answer.map((item) => item.data);
+}
+
 module.exports = async (ctx) => {
     const api = 'https://news-at.zhihu.com/api/4/news';
+    const HOST = 'news-at.zhihu.com';
+    let address = HOST;
+    try {
+        await got(`${api}/latest`);
+    } catch (e) {
+        address = (await dohResolve(HOST)).pop(); // 国外ip证书配置有误，解析到国内地址
+    }
     const listRes = await got({
         method: 'get',
         url: `${api}/latest`,
         headers: {
             ...utils.header,
             Referer: `${api}/latest`,
+            Host: HOST,
         },
+        host: address,
     });
     // 根据api的说明，过滤掉极个别站外链接
     const storyList = listRes.data.stories.filter((el) => el.type === 0);
@@ -36,7 +59,9 @@ module.exports = async (ctx) => {
                     url,
                     headers: {
                         Referer: url,
+                        Host: HOST,
                     },
+                    host: address,
                 });
                 return utils.ProcessImage(storyDetail.data.body.replace(/<div class="meta">([\s\S]*?)<\/div>/g, '<strong>$1</strong>').replace(/<\/?h2.*?>/g, ''));
             });


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #11003

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/zhihu/daily
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

知乎日报在国外解析到的ip地址存在证书错误，这里使用edns来获取国内的ip地址。doh解析参考了https://github.com/DIYgod/RSSHub/pull/5962