### PR TITLE
fix(route): fix pubdate for scmp

### DIFF
--- a/docs/en/traditional-media.md
+++ b/docs/en/traditional-media.md
@@ -479,7 +479,7 @@ You still can customize `language`, however, it is important to note that not al
 
 </RouteEn>
 
-## SCMP
+## South China Morning Post
 
 ### News
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -2919,7 +2919,7 @@ router.get('/changku', lazyloadRouteHandler('./routes/changku/index'));
 router.get('/changku/cate/:postid', lazyloadRouteHandler('./routes/changku/index'));
 
 // SCMP
-router.get('/scmp/:category_id', lazyloadRouteHandler('./routes/scmp/index'));
+// router.get('/scmp/:category_id', lazyloadRouteHandler('./routes/scmp/index'));
 
 // 上海市生态环境局
 router.get('/gov/shanghai/sthj', lazyloadRouteHandler('./routes/gov/shanghai/sthj'));

--- a/lib/routes/scmp/index.js
+++ b/lib/routes/scmp/index.js
@@ -37,7 +37,7 @@ module.exports = async (ctx) => {
 
                 // Metadata (categories & updatedAt)
                 const updatedAt = $('meta[itemprop="dateModified"]').attr('content');
-                const publishedAt = $('meta[itemprop="datePublished"]').attr('content');
+                const publishedAt = item.pubDate || $('meta[itemprop="datePublished"]').attr('content');
 
                 const categories = $('meta[name="keywords"]')
                     .attr('content')

--- a/lib/v2/scmp/index.js
+++ b/lib/v2/scmp/index.js
@@ -1,26 +1,25 @@
 const parser = require('@/utils/rss-parser');
 const cheerio = require('cheerio');
 const got = require('@/utils/got');
+const { parseDate } = require('@/utils/parse-date');
+const chromeMobileUserAgent = require('@/utils/rand-user-agent')({ browser: 'chrome', os: 'android', device: 'mobile' });
 
 module.exports = async (ctx) => {
     const categoryId = ctx.params.category_id;
     const rssUrl = `https://www.scmp.com/rss/${categoryId}/feed`;
     const feed = await parser.parseURL(rssUrl);
-    const chromeMobileUserAgent = 'Mozilla/5.0 (Linux; Android 7.0; SM-G892A Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36';
 
     const items = await Promise.all(
         feed.items.map((item) =>
             ctx.cache.tryGet(item.link, async () => {
                 // Fetch the AMP version
                 const url = item.link.replace(/^https:\/\/www\.scmp\.com/, 'https://amp.scmp.com');
-                const response = await got({
-                    url,
-                    method: 'get',
+                const response = await got(url, {
                     headers: {
                         'User-Agent': chromeMobileUserAgent,
                     },
                 });
-                const html = response.body;
+                const html = response.data;
                 const $ = cheerio.load(html);
                 const content = $('div.article-body.clearfix');
 
@@ -89,8 +88,8 @@ module.exports = async (ctx) => {
                 return {
                     title: item.title,
                     id: item.guid,
-                    pubDate: new Date(publishedAt).toUTCString(),
-                    updated: new Date(updatedAt).toUTCString(),
+                    pubDate: parseDate(publishedAt),
+                    updated: parseDate(updatedAt),
                     author: item.creator,
                     link: item.link,
                     summary: summary.html(),

--- a/lib/v2/scmp/maintainer.js
+++ b/lib/v2/scmp/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/:category_id': ['proletarius101'],
+};

--- a/lib/v2/scmp/radar.js
+++ b/lib/v2/scmp/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'scmp.com': {
+        _name: 'South China Morning Post',
+        '.': [
+            {
+                title: 'News',
+                docs: 'https://docs.rsshub.app/en/traditional-media.html#south-china-morning-post',
+                source: ['/rss/:category_id/feed'],
+                target: '/scmp/:category_id',
+            },
+        ],
+    },
+};

--- a/lib/v2/scmp/router.js
+++ b/lib/v2/scmp/router.js
@@ -1,0 +1,3 @@
+module.exports = (router) => {
+    router.get('/:category_id', require('./index'));
+};


### PR DESCRIPTION
Currently SCMP tries to find pubDate from the actual article link. But sometimes there is no date in the link. So use pubDate in offical feed instead.

<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/scmp/4
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/scmp/4
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
