### PR TITLE
fix(route): ComicsKingdom changed their UI elements

### DIFF
--- a/docs/en/anime.md
+++ b/docs/en/anime.md
@@ -18,6 +18,12 @@ For more tags, please go to [Search torrent](https://bangumi.moe/search/index)
 
 </RouteEn>
 
+## Comics Kingdom
+
+### Archive
+
+<RouteEn author="stjohnjohnson" example="/comicskingdom/pardon-my-planet" path="/comicskingdom/:name" :paramsDesc="['URL path of the strip on comicskingdom.com']" />
+
 ## Hanime.tv
 
 ### Recently updated

--- a/docs/en/picture.md
+++ b/docs/en/picture.md
@@ -104,10 +104,6 @@ pageClass: routes
 
 <RouteEn author="FHYunCai" example="/bing" path="/bing" radar="1" rssbud="1"/>
 
-## ComicsKingdom Comic Strips
-
-<RouteEn author="stjohnjohnson" example="/comicskingdom/baby-blues" path="/comicskingdom/:strip" :paramsDesc="['URL path of the strip on comicskingdom.com']" />
-
 ## DailyArt
 
 <RouteEn author="zphw" example="/dailyart/en" path="/dailyart/:language?" :paramsDesc="['Support en, es, fr, de, it, zh, jp, etc. English by default.']" />

--- a/lib/router.js
+++ b/lib/router.js
@@ -3681,7 +3681,7 @@ router.get('/mcdonalds/:category', lazyloadRouteHandler('./routes/mcdonalds/news
 router.get('/gocomics/:name', lazyloadRouteHandler('./routes/gocomics/index'));
 
 // Comics Kingdom
-router.get('/comicskingdom/:name', lazyloadRouteHandler('./routes/comicskingdom/index'));
+// router.get('/comicskingdom/:name', lazyloadRouteHandler('./routes/comicskingdom/index'));
 
 // Media Digest
 router.get('/mediadigest/:range/:category?', lazyloadRouteHandler('./routes/mediadigest/category'));

--- a/lib/routes/comicskingdom/index.js
+++ b/lib/routes/comicskingdom/index.js
@@ -18,10 +18,9 @@ module.exports = async (ctx) => {
     const author = $('div.author p').text();
 
     // Find the links for all non-archived items
-    const links = $('div.archive-tile[data-is-blocked=false]')
-        .map((i, el) => $(el).find('a[data-prem="Comic Tile"]').first().attr('href'))
-        .get()
-        .map((url) => `${baseURL}${url}`);
+    const links = $('div.tile')
+        .map((i, el) => $(el).find('a').first().attr('href'))
+        .get();
 
     if (links.length === 0) {
         throw `Comic Not Found - ${name}`;

--- a/lib/v2/comicskingdom/index.js
+++ b/lib/v2/comicskingdom/index.js
@@ -1,26 +1,25 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+const { art } = require('@/utils/render');
+const path = require('path');
 
 module.exports = async (ctx) => {
-    const baseURL = 'https://www.comicskingdom.com';
+    const baseURL = 'https://comicskingdom.com';
     const name = ctx.params.name;
     const url = `${baseURL}/${name}/archive`;
-    const response = await got({
-        method: 'get',
-        url,
-    });
+    const { data } = await got(url);
 
-    const data = response.data;
     const $ = cheerio.load(data);
 
     // Determine Comic and Author from main page
     const comic = $('title').text().replace('Comics Kingdom - ', '').trim();
-    const author = $('div.author p').text();
+    const author = $('.feature-title h2').text();
 
     // Find the links for all non-archived items
     const links = $('div.tile')
-        .map((i, el) => $(el).find('a').first().attr('href'))
-        .get();
+        .toArray()
+        .map((el) => $(el).find('a').first().attr('href'));
 
     if (links.length === 0) {
         throw `Comic Not Found - ${name}`;
@@ -28,17 +27,16 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         links.map((link) =>
             ctx.cache.tryGet(link, async () => {
-                const detailResponse = await got({
-                    method: 'get',
-                    url: link,
-                });
+                const detailResponse = await got(link);
                 const content = cheerio.load(detailResponse.data);
 
-                const title = content('title').text();
+                const title = content('meta[property="og:description"]').attr('content');
                 const image = content('meta[property="og:image"]').attr('content');
-                const description = `<img src="${image}" />`;
+                const description = art(path.join(__dirname, 'templates/desc.art'), {
+                    image,
+                });
                 // Pull the date out of the URL
-                const pubDate = new Date(link.split('/').slice(-3).join('/')).toUTCString();
+                const pubDate = parseDate(link.substring(link.lastIndexOf('/') + 1), 'YYYY-MM-DD');
 
                 return {
                     title,
@@ -53,8 +51,10 @@ module.exports = async (ctx) => {
     );
 
     ctx.state.data = {
-        title: `${comic} - Comics Kingdom`,
+        title: comic,
         link: url,
+        image: $('.feature-logo').attr('src'),
         item: items,
+        language: 'en-US',
     };
 };

--- a/lib/v2/comicskingdom/maintainer.js
+++ b/lib/v2/comicskingdom/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/:name': ['stjohnjohnson'],
+};

--- a/lib/v2/comicskingdom/radar.js
+++ b/lib/v2/comicskingdom/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'comicskingdom.com': {
+        _name: 'Comics Kingdom',
+        '.': [
+            {
+                title: 'Archive',
+                docs: 'https://docs.rsshub.app/anime.html#comics-kingdom',
+                source: ['/:name/*', '/:name'],
+                target: '/comicskingdom/:name',
+            },
+        ],
+    },
+};

--- a/lib/v2/comicskingdom/router.js
+++ b/lib/v2/comicskingdom/router.js
@@ -1,0 +1,3 @@
+module.exports = (router) => {
+    router.get('/:name', require('./index'));
+};

--- a/lib/v2/comicskingdom/templates/desc.art
+++ b/lib/v2/comicskingdom/templates/desc.art
@@ -1,0 +1,1 @@
+<img src="{{ image }}">


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #11167

## 完整路由地址 / Example for the proposed route(s)

```routes
/comicskingdom/pardon-my-planet
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

Looks like they simplified their HTML on their archive page.  This finds the same matches as before.