### PR TITLE
fix(route): use GraphQL query in GitHub trending

### DIFF
--- a/docs/en/programming.md
+++ b/docs/en/programming.md
@@ -137,7 +137,7 @@ GitHub provides some official RSS feeds:
 
 ### Trending
 
-<RouteEn author="DIYgod" path="/github/trending/:since/:language/:spoken_language?" example="/github/trending/daily/javascript/en" :paramsDesc="['time frame, available in [Trending page](https://github.com/trending/javascript?since=monthly) \'s URL, possible values are: `daily`, `weekly` or `monthly`', 'the feed language, available in [Trending page](https://github.com/trending/javascript?since=monthly) \'s URL, don\'t filter option is `any`', 'natural language, available in [Trending page](https://github.com/trending/javascript?since=monthly) \'s URL']" radar="1" rssbud="1"/>
+<RouteEn author="DIYgod" path="/github/trending/:since/:language/:spoken_language?" example="/github/trending/daily/javascript/en" :paramsDesc="['time frame, available in [Trending page](https://github.com/trending/javascript?since=monthly) \'s URL, possible values are: `daily`, `weekly` or `monthly`', 'the feed language, available in [Trending page](https://github.com/trending/javascript?since=monthly) \'s URL, don\'t filter option is `any`', 'natural language, available in [Trending page](https://github.com/trending/javascript?since=monthly) \'s URL']" radar="1" rssbud="1" selfhost="1"/>
 
 ### Topics
 

--- a/docs/programming.md
+++ b/docs/programming.md
@@ -237,7 +237,7 @@ GitHub 官方也提供了一些 RSS:
 
 ### Trending
 
-<Route author="DIYgod" example="/github/trending/daily/javascript/zh" path="/github/trending/:since/:language/:spoken_language?" :paramsDesc="['时间跨度，可在 [Trending 页](https://github.com/trending/javascript?since=monthly&spoken_language_code=zh) URL 中找到，可选 `daily` `weekly` `monthly`', '语言，可在 [Trending 页](https://github.com/trending/javascript?since=monthly&spoken_language_code=zh) URL 中找到，`any`表示不设语言限制', '自然语言，可在 [Trending 页](https://github.com/trending/javascript?since=monthly&spoken_language_code=zh) URL 中找到']" radar="1" rssbud="1"/>
+<Route author="DIYgod" example="/github/trending/daily/javascript/zh" path="/github/trending/:since/:language/:spoken_language?" :paramsDesc="['时间跨度，可在 [Trending 页](https://github.com/trending/javascript?since=monthly&spoken_language_code=zh) URL 中找到，可选 `daily` `weekly` `monthly`', '语言，可在 [Trending 页](https://github.com/trending/javascript?since=monthly&spoken_language_code=zh) URL 中找到，`any`表示不设语言限制', '自然语言，可在 [Trending 页](https://github.com/trending/javascript?since=monthly&spoken_language_code=zh) URL 中找到']" radar="1" rssbud="1" selfhost="1"/>
 
 ### Topics
 

--- a/lib/v2/github/trending.js
+++ b/lib/v2/github/trending.js
@@ -1,59 +1,91 @@
+const config = require('@/config').value;
 const got = require('@/utils/got');
 const { art } = require('@/utils/render');
 const cheerio = require('cheerio');
 const path = require('path');
 
 module.exports = async (ctx) => {
+    if (!config.github || !config.github.access_token) {
+        throw 'GitHub trending RSS is disabled due to the lack of <a href="https://docs.rsshub.app/install/#pei-zhi-bu-fen-rss-mo-kuai-pei-zhi">relevant config</a>';
+    }
     const since = ctx.params.since;
     const language = ctx.params.language === 'any' ? '' : ctx.params.language;
     const spoken_language = ctx.params.spoken_language ?? '';
-    const url = `https://github.com/trending/${encodeURIComponent(language)}?since=${since}&spoken_language_code=${spoken_language}`;
 
-    const response = await got({
+    const trendingUrl = `https://github.com/trending/${encodeURIComponent(language)}?since=${since}&spoken_language_code=${spoken_language}`;
+    const { data: trendingPage } = await got({
         method: 'get',
-        url,
+        url: trendingUrl,
         headers: {
-            Referer: url,
+            Referer: trendingUrl,
+        },
+    });
+    const $ = cheerio.load(trendingPage);
+
+    const articles = $('article');
+    const trendingRepos = articles
+        .map((_, item) => {
+            const [owner, name] = $(item).find('h1').text().split('/');
+            return {
+                name: name.trim(),
+                owner: owner.trim(),
+            };
+        })
+        .get();
+
+    const { data: repoData } = await got({
+        method: 'post',
+        url: 'https://api.github.com/graphql',
+        headers: {
+            Authorization: `bearer ${config.github.access_token}`,
+        },
+        json: {
+            query: `
+            query {
+            ${trendingRepos
+                .map(
+                    (repo, index) => `
+                _${index}: repository(owner: "${repo.owner}", name: "${repo.name}") {
+                    ...RepositoryFragment
+                }
+            `
+                )
+                .join('\n')}
+            }
+
+            fragment RepositoryFragment on Repository {
+                description
+                forkCount
+                nameWithOwner
+                openGraphImageUrl
+                primaryLanguage {
+                    name
+                }
+                stargazerCount
+            }
+            `,
         },
     });
 
-    const data = response.data;
-
-    const $ = cheerio.load(data);
-    const list = $('article');
-
-    const items = await Promise.all(
-        list.map((_, item) => {
-            item = $(item);
-            const endpoint = item.find('h1 a').attr('href');
-            const link = `https://github.com${endpoint}`;
-            return ctx.cache.tryGet(`github:trending:${endpoint}`, async () => {
-                const response = await got(link);
-
-                const $ = cheerio.load(response.data);
-                const cover = $('meta[property="og:image"]');
-
-                const single = {
-                    title: item.find('h1').text(),
-                    author: item.find('h1').text().split('/')[0].trim(),
-                    description: art(path.join(__dirname, 'templates/trending-description.art'), {
-                        cover: cover.attr('content'),
-                        desc: item.find('p').text(),
-                        lang: item.find('span[itemprop="programmingLanguage"]').text() || 'Unknown',
-                        stars: item.find('.Link--muted').eq(0).text().trim(),
-                        forks: item.find('.Link--muted').eq(1).text().trim(),
-                    }),
-                    link,
-                };
-
-                return single;
-            });
-        })
-    );
+    const repos = Object.values(repoData.data).map((repo) => {
+        const found = trendingRepos.find((r) => `${r.owner}/${r.name}` === repo.nameWithOwner);
+        return { ...found, ...repo };
+    });
 
     ctx.state.data = {
         title: $('title').text(),
-        link: url,
-        item: items,
+        link: trendingUrl,
+        item: repos.map((r) => ({
+            title: r.nameWithOwner,
+            author: r.owner,
+            description: art(path.join(__dirname, 'templates/trending-description.art'), {
+                cover: r.openGraphImageUrl,
+                desc: r.description,
+                forks: r.forkCount,
+                lang: r.primaryLanguage?.name || 'Unknown',
+                stars: r.stargazerCount,
+            }),
+            link: `https://github.com/${r.nameWithOwner}`,
+        })),
     };
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Not applicable.

## 完整路由地址 / Example for the proposed route(s)

```routes
/github/trending/daily/any/en
/github/trending/weekly/javascript
/github/trending/monthly/unknown
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

Follow-up from #10189. GitHub now returns `openGraphImageUrl` correctly. Uses GraphQL to get desired repository data instead of attempting to query it from the repository page.