### PR TITLE
fix(route): 36kr dom parse errors

### DIFF
--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -50,7 +50,7 @@ module.exports = async (ctx) => {
                     });
 
                     const cipherTextList = detailResponse.data.match(/{"state":"(.*)","isEncrypt":true}/) ?? [];
-                    if (cipherTextList.length === 0) {
+                    if (cipherTextList.length !== 0) {
                         const key = CryptoJS.enc.Utf8.parse('efabccee-b754-4c');
                         const content = JSON.parse(
                             CryptoJS.AES.decrypt(cipherTextList[1], key, {

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -28,35 +28,19 @@ module.exports = async (ctx) => {
 
     const data = JSON.parse(response.data.match(/"itemList":(\[.*?\])/)[1]);
 
-    let items = data.slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 30).map((item) => {
-        let itemType = item.itemType;
-        item = item.templateMaterial ?? item;
-        if (itemType === 0) {
-            // itemType === 0 is ads, if dont want ads, just skip it.
-            // maybe we could set a switch like `ads=false` to control it?
-            // if (!showAds) { continue; }
-
-            // for now, we just continue to parse it.
-            item = JSON.parse(item.adJsonContent);
+    let items = data.slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 30)
+        .filter((item)=> item.itemType !== 0)
+        .map((item) => {
+            if (item.itemType === 0) { continue; }
+            item = item.templateMaterial ?? item;
             return {
-                title: item.title.replace(/<\/?em>/g, ''),
-                author: '36kr',
-                pubDate: parseDate(Date.now()),
-                link: decodeURIComponent(atob(querystring.parse(item.href)['param.redirectUrl'])
-                    .split('').map(c => `%${
-                        ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-                    }`).join('')),
-                description: item.description,
-            }
-        }
-        return {
-            title: item.widgetTitle.replace(/<\/?em>/g, ''),
-            author: item.author,
-            pubDate: parseDate(item.publishTime),
-            link: `${rootUrl}/${path === '/newsflashes' ? 'newsflashes' : 'p'}/${item.itemId}`,
-            description: item.widgetContent ?? item.content,
-        };
-    });
+                title: item.widgetTitle.replace(/<\/?em>/g, ''),
+                author: item.author,
+                pubDate: parseDate(item.publishTime),
+                link: `${rootUrl}/${path === '/newsflashes' ? 'newsflashes' : 'p'}/${item.itemId}`,
+                description: item.widgetContent ?? item.content,
+            };
+        });
 
     if (!/^\/(search|newsflashes)/.test(path)) {
         items = await Promise.all(

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -50,7 +50,7 @@ module.exports = async (ctx) => {
                     });
 
                     const cipherTextList = detailResponse.data.match(/{"state":"(.*)","isEncrypt":true}/);
-                    if (cipherTextList) {
+                    if (cipherTextList === undefined) {
                         const key = CryptoJS.enc.Utf8.parse('efabccee-b754-4c');
                         const content = JSON.parse(
                             CryptoJS.AES.decrypt(cipherText, key, {
@@ -65,9 +65,6 @@ module.exports = async (ctx) => {
                         const $ = cheerio.load(detailResponse.body);
                         item.description = $('div.articleDetailContent').html();
                     }
-
-                    item.description = content.widgetContent;
-
                     return item;
                 })
             )

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -2,6 +2,7 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const { parseDate } = require('@/utils/parse-date');
 const CryptoJS = require('crypto-js');
+const querystring = require("querystring");
 
 const shortcuts = {
     '/information': '/information/web_news',

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -1,6 +1,8 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const { parseDate } = require('@/utils/parse-date');
+const CryptoJS = require('crypto-js');
+
 const shortcuts = {
     '/information': '/information/web_news',
     '/information/latest': '/information/web_news',
@@ -47,31 +49,22 @@ module.exports = async (ctx) => {
                         url: item.link,
                     });
 
-                    const cipherText = detailResponse.data.match(/{"state":"(.*)","isEncrypt":true}/)[1];
+                    const cipherTextList = detailResponse.data.match(/{"state":"(.*)","isEncrypt":true}/);
                     if (cipherTextList) {
-                    const key = CryptoJS.enc.Utf8.parse('efabccee-b754-4c');
-                    const content = JSON.parse(
-                        CryptoJS.AES.decrypt(cipherText, key, {
-                        mode: CryptoJS.mode.ECB,
-                        padding: CryptoJS.pad.Pkcs7,
-                    })
-                    .toString(CryptoJS.enc.Utf8)
-                    .toString()
-                ).articleDetail.articleDetailData.data;
-                item.description = content.widgetContent;
-            } else {
-                let $ = cheerio.load(detailResponse.body);
-                item.description = $('div.articleDetailContent').html();
-            }
-
-                    const content = JSON.parse(
-                        CryptoJS.AES.decrypt(cipherText, key, {
+                        const key = CryptoJS.enc.Utf8.parse('efabccee-b754-4c');
+                        const content = JSON.parse(
+                            CryptoJS.AES.decrypt(cipherText, key, {
                             mode: CryptoJS.mode.ECB,
                             padding: CryptoJS.pad.Pkcs7,
                         })
                             .toString(CryptoJS.enc.Utf8)
                             .toString()
-                    ).articleDetail.articleDetailData.data;
+                        ).articleDetail.articleDetailData.data;
+                        item.description = content.widgetContent;
+                    } else {
+                        const $ = cheerio.load(detailResponse.body);
+                        item.description = $('div.articleDetailContent').html();
+                    }
 
                     item.description = content.widgetContent;
 

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -31,7 +31,6 @@ module.exports = async (ctx) => {
     let items = data.slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 30)
         .filter((item)=> item.itemType !== 0)
         .map((item) => {
-            if (item.itemType === 0) { continue; }
             item = item.templateMaterial ?? item;
             return {
                 title: item.widgetTitle.replace(/<\/?em>/g, ''),

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -1,8 +1,6 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const { parseDate } = require('@/utils/parse-date');
-const CryptoJS = require('crypto-js');
-
 const shortcuts = {
     '/information': '/information/web_news',
     '/information/latest': '/information/web_news',
@@ -49,8 +47,22 @@ module.exports = async (ctx) => {
                         url: item.link,
                     });
 
-                    const key = CryptoJS.enc.Utf8.parse('efabccee-b754-4c');
                     const cipherText = detailResponse.data.match(/{"state":"(.*)","isEncrypt":true}/)[1];
+                    if (cipherTextList) {
+                    const key = CryptoJS.enc.Utf8.parse('efabccee-b754-4c');
+                    const content = JSON.parse(
+                        CryptoJS.AES.decrypt(cipherText, key, {
+                        mode: CryptoJS.mode.ECB,
+                        padding: CryptoJS.pad.Pkcs7,
+                    })
+                    .toString(CryptoJS.enc.Utf8)
+                    .toString()
+                ).articleDetail.articleDetailData.data;
+                item.description = content.widgetContent;
+            } else {
+                let $ = cheerio.load(detailResponse.body);
+                item.description = $('div.articleDetailContent').html();
+            }
 
                     const content = JSON.parse(
                         CryptoJS.AES.decrypt(cipherText, key, {

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -49,8 +49,8 @@ module.exports = async (ctx) => {
                         url: item.link,
                     });
 
-                    const cipherTextList = detailResponse.data.match(/{"state":"(.*)","isEncrypt":true}/);
-                    if (cipherTextList === undefined) {
+                    const cipherTextList = detailResponse.data.match(/{"state":"(.*)","isEncrypt":true}/) ?? [];
+                    if (cipherTextList.length === 0) {
                         const key = CryptoJS.enc.Utf8.parse('efabccee-b754-4c');
                         const content = JSON.parse(
                             CryptoJS.AES.decrypt(cipherText, key, {

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -2,7 +2,6 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const { parseDate } = require('@/utils/parse-date');
 const CryptoJS = require('crypto-js');
-const querystring = require("querystring");
 
 const shortcuts = {
     '/information': '/information/web_news',
@@ -29,7 +28,7 @@ module.exports = async (ctx) => {
     const data = JSON.parse(response.data.match(/"itemList":(\[.*?\])/)[1]);
 
     let items = data.slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 30)
-        .filter((item)=> item.itemType !== 0)
+        .filter((item) => item.itemType !== 0)
         .map((item) => {
             item = item.templateMaterial ?? item;
             return {

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -28,7 +28,26 @@ module.exports = async (ctx) => {
     const data = JSON.parse(response.data.match(/"itemList":(\[.*?\])/)[1]);
 
     let items = data.slice(0, ctx.query.limit ? parseInt(ctx.query.limit) : 30).map((item) => {
+        let itemType = item.itemType;
         item = item.templateMaterial ?? item;
+        if (itemType === 0) {
+            // itemType === 0 is ads, if dont want ads, just skip it.
+            // maybe we could set a switch like `ads=false` to control it?
+            // if (!showAds) { continue; }
+
+            // for now, we just continue to parse it.
+            item = JSON.parse(item.adJsonContent);
+            return {
+                title: item.title.replace(/<\/?em>/g, ''),
+                author: '36kr',
+                pubDate: parseDate(Date.now()),
+                link: decodeURIComponent(atob(querystring.parse(item.href)['param.redirectUrl'])
+                    .split('').map(c => `%${
+                        ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+                    }`).join('')),
+                description: item.description,
+            }
+        }
         return {
             title: item.widgetTitle.replace(/<\/?em>/g, ''),
             author: item.author,

--- a/lib/v2/36kr/index.js
+++ b/lib/v2/36kr/index.js
@@ -53,7 +53,7 @@ module.exports = async (ctx) => {
                     if (cipherTextList.length === 0) {
                         const key = CryptoJS.enc.Utf8.parse('efabccee-b754-4c');
                         const content = JSON.parse(
-                            CryptoJS.AES.decrypt(cipherText, key, {
+                            CryptoJS.AES.decrypt(cipherTextList[1], key, {
                             mode: CryptoJS.mode.ECB,
                             padding: CryptoJS.pad.Pkcs7,
                         })


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #11183 

## 完整路由地址 / Example for the proposed route(s)

```routes
/36kr/information/web_news
/36kr/user/747305693
/36kr/motif/452
/36kr/topics/1818512662032001
/36kr/search/articles/ofo
/36kr/search/newsflashes/ofo
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

### fix 1

36kr 路由所获取到的的 `itemList` 中会出现 `itemType: 0` 的元素，该种元素结构与其他的元素结构不同 ，如下

```json
{
  "itemId": 16598,
  "itemType": 0,
  "templateMaterial": {
    "positionId": 933,
    "planId": 16598,
    "adSdk": "ZV5L0R2osQao_XC4QkxsjnDapfDVXT4kzJCgEiF9V9BJ_T7L8-OPX504da4Ta53Dhf8aX8euucCid_ZUYsgLug",
    "adExposureUrl": "https://adx.36kr.com/api/ad/exposure?sign=dbd383a37955308e98d8bd24b949ba0d&param.adsdk=ZV5L0R2osQao_XC4QkxsjnDapfDVXT4kzJCgEiF9V9BJ_T7L8-OPX504da4Ta53Dhf8aX8euucCid_ZUYsgLug",
    "adJsonContent": "{\"description\":\"数字增效，驱动未来。\",\"href\":\"https://adx.36kr.com/api/ad/click?sign=053708d1c026a95d6d1fd8acf232c145&param.redirectUrl=aHR0cHM6Ly8zNmtyLmNvbS9wLzE5ODEyMzI2MTQ3MzY5MDM&param.adsdk=ZV5L0R2osQao_XC4QkxsjnDapfDVXT4kzJCgEiF9V9BJ_T7L8-OPX504da4Ta53Dhf8aX8euucCid_ZUYsgLug\",\"title\":\"共商数字未来！36氪联合iDWF互博会举办「2022年数字化企服峰会」\",\"src\":\"https://img.36krcdn.com/20221101/v2_8bf63a2efd5848979445ed9503b62964_img_png\"}",
    "flag": "商业视角",
    "planType": 1
  }
}
```

在页面中点击该元素所生成的 html 节点，会指向 `templateMaterial.adJsonContent.href`，并重定向到该链接中的 `param.redirectUrl` 通过 base64 解码后的地址。

故现在 36kr 路由解析过程如下：

1. 判断 `itemType == 0`
2. 若为 0
    1. 将 `item` 替换为 `JSON.parse(item.adJsonContent)`
    2. 由于不给出作者，故默认作者为 `36kr`
    3. 由于不给出发布时间（发布时间在文章页），故设置发布时间为 `Date.now()`
    4. 通过 `querystring.parse` 解析 `item.href`，取其中的 `param.redirectUrl`
    5. base64 解码上一步得到的结果，并进行 URI 反序列化（应该不用反序列化，但是怕他之后又改什么东西）
    6. 返回结果
3. 若不为0，则按照原来的解析方式进行解析。

---

注：或许可以整一个开关来过滤显不显示这类推广内容？

### fix 2

查阅 #11183 