### PR TITLE
fix(route): fix luogu route date parse regex

### DIFF
--- a/lib/v2/luogu/daily.js
+++ b/lib/v2/luogu/daily.js
@@ -21,7 +21,7 @@ module.exports = async (ctx) => {
             link,
             author: firstPost.find('p').eq(1).text(),
             guid: `${link}#${issueHeading}`,
-            pubDate: parseDate(issueHeading.match(/(\d{4} 年 \d{2} 月 \d{2} 日)/)[1], 'YYYY 年 MM 月 DD 日'),
+            pubDate: parseDate(issueHeading.match(/(\d{4} 年 \d{2} 月 \d{1,2} 日)/)[1], 'YYYY 年 MM 月 DD 日'),
         },
     ];
 

--- a/lib/v2/luogu/daily.js
+++ b/lib/v2/luogu/daily.js
@@ -21,7 +21,7 @@ module.exports = async (ctx) => {
             link,
             author: firstPost.find('p').eq(1).text(),
             guid: `${link}#${issueHeading}`,
-            pubDate: parseDate(issueHeading.match(/(\d{4} 年 \d{2} 月 \d{1,2} 日)/)[1], 'YYYY 年 MM 月 DD 日'),
+            pubDate: parseDate(issueHeading.match(/(\d{4} 年 \d{2} 月 \d{1,2} 日)/)[1], 'YYYY 年 M 月 D 日'),
         },
     ];
 

--- a/lib/v2/luogu/daily.js
+++ b/lib/v2/luogu/daily.js
@@ -21,7 +21,7 @@ module.exports = async (ctx) => {
             link,
             author: firstPost.find('p').eq(1).text(),
             guid: `${link}#${issueHeading}`,
-            pubDate: parseDate(issueHeading.match(/(\d{4} 年 \d{2} 月 \d{1,2} 日)/)[1], 'YYYY 年 M 月 D 日'),
+            pubDate: parseDate(issueHeading.match(/(\d{4} 年 \d{1,2} 月 \d{1,2} 日)/)[1], 'YYYY 年 M 月 D 日'),
         },
     ];
 


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/luogu/daily
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

```
text:       "洛谷日报 第 417 期 2022 年 11 月 1 日"
regex:                        \d{4} 年 \d{2} 月 \d{2} 日
                                                  ^
                                             error here
```

