### PR TITLE
docs: Add PikaPods.com as deployment option

### DIFF
--- a/docs/en/install/README.md
+++ b/docs/en/install/README.md
@@ -307,6 +307,12 @@ Heroku [no longer](https://blog.heroku.com/next-chapter) offers free product pla
 
 [![Deploy to Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/DIYgod/RSSHub)
 
+## Deploy to PikaPods
+
+Run RSSHub from just $1/month. Includes automatic updates and $5 free starting credit.
+
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=rsshub)
+
 ## Deploy to Google App Engine(GAE)
 
 ### Before You Begin

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -314,7 +314,7 @@ Heroku [不再](https://blog.heroku.com/next-chapter) 提供免费服务。
 
 ## 部署到 PikaPods
 
-每月只需 1 美元即可运行 RSSHub。 包括自动更新和 5 美元的免费起始信用。
+每月只需 1 美元即可运行 RSSHub。包括自动更新和 5 美元的免费起始额度。
 
 [![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=rsshub)
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -312,6 +312,12 @@ Heroku [不再](https://blog.heroku.com/next-chapter) 提供免费服务。
 
 [![Deploy to Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/DIYgod/RSSHub)
 
+## 部署到 PikaPods
+
+每月只需 1 美元即可运行 RSSHub。 包括自动更新和 5 美元的免费起始信用。
+
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=rsshub)
+
 ## 部署到 Google App Engine
 
 ### 准备


### PR DESCRIPTION
## 说明 / Note

This adds [PikaPods.com](https://www.pikapods.com) as deployment option.

About PikaPods: Aims to make great open source apps, like RSSHub more accessible. We already offer RSSHub in our “app store” and fine-tuned our deployment based on the feedback we got.

So I'm suggesting to add PikaPods as additional install option to run RSSHub. This would help an even wider audience to benefit from the project.

Also feel free to correct my Chinese. 😇

Preview: https://github.com/m3nu/RSSHub/tree/minor/add-pikapods/docs/en/install#deploy-to-pikapods

```routes
NOROUTE
```