### PR TITLE
feat(route): 支持网易云音乐用户动态

### DIFF
--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -1596,6 +1596,10 @@ JavDB 有多个备用域名，本路由默认使用永久域名 <https://javdb.c
 
 <Route author="alfredcai" example="/ncm/user/playrecords/45441555/1" path="/ncm/user/playrecords/:uid/:type?" :paramsDesc="['用户 uid, 可在用户主页 URL 中找到','排行榜类型，0所有时间(默认)，1最近一周']" />
 
+### 用户动态
+
+<Route author="Master-Hash" example="/ncm/user/events/585804522" path="/ncm/user/events/:uid" :paramsDesc="['用户 uid, 可在用户主页 URL 中找到']" rader="1" />
+
 ### 歌手专辑
 
 <Route author="metowolf" example="/ncm/artist/2116" path="/ncm/artist/:id" :paramsDesc="[' 歌手 id, 可在歌手详情页 URL 中找到']" radar="1" />

--- a/lib/v2/ncm/maintainer.js
+++ b/lib/v2/ncm/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/user/events/:id': ['Master-Hash'],
+};

--- a/lib/v2/ncm/radar.js
+++ b/lib/v2/ncm/radar.js
@@ -1,0 +1,20 @@
+module.exports = {
+    '163.com': {
+        music: [
+            {
+                title: '用户动态',
+                docs: 'https://docs.rsshub.app/multimedia.html#wang-yi-yun-yin-yue-yong-hu-dong-tai',
+                source: ['/'],
+                // source: ['/#/user/evnet?id=:id'],
+                // target: '/ncm/user/events/:id',
+            },
+        ],
+        'y.music': [
+            {
+                title: '用户动态',
+                docs: 'https://docs.rsshub.app/multimedia.html#wang-yi-yun-yin-yue-yong-hu-dong-tai',
+                source: ['/m/user'],
+            },
+        ],
+    },
+};

--- a/lib/v2/ncm/router.js
+++ b/lib/v2/ncm/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/user/events/:id', require('./userevents'));
+};

--- a/lib/v2/ncm/templates/description.art
+++ b/lib/v2/ncm/templates/description.art
@@ -1,0 +1,1 @@
+<p>{{ each description.split('\n') }}{{$value}}{{if $index !== description.split('\n').length - 1}}<br>{{/if}}{{/each}}</p>

--- a/lib/v2/ncm/templates/description.art
+++ b/lib/v2/ncm/templates/description.art
@@ -1,1 +1,1 @@
-<p>{{ each description.split('\n') }}{{$value}}{{if $index !== description.split('\n').length - 1}}<br>{{/if}}{{/each}}</p>
+<p>{{ each description.split('\n') }}{{$value}}{{if $index !== description.split('\n').length - 1}}<br>{{/if}}{{/each}}{{ each pics }}<img src="{{$value}}">{{/each}}</p>

--- a/lib/v2/ncm/userevents.js
+++ b/lib/v2/ncm/userevents.js
@@ -1,7 +1,7 @@
 const path = require('node:path');
 const got = require('@/utils/got');
 const { art } = require('@/utils/render');
-const renderDescription = (description) => art(path.join(__dirname, 'templates/description.art'), description);
+const renderDescription = (info) => art(path.join(__dirname, 'templates/description.art'), info);
 
 module.exports = async (ctx) => {
     const { id } = ctx.params;
@@ -25,10 +25,21 @@ module.exports = async (ctx) => {
             const title = item.info.commentThread.resourceTitle,
                 userId = item.user.userId,
                 description = JSON.parse(item.json).msg,
+                pics = item.pics.map(({ originUrl }) => originUrl),
                 eventId = item.id;
+
+            /**
+             * @todo 根据 `item.info.commentThread.resourceInfo.eventType` 生成 Media
+             * 17 分享节目
+             * 18 分享单曲
+             * 19 分享专辑
+             * 35 空
+             * 因为我不需要，我就不写了。
+             * 因为 api 并没有 mp3 URL，生成 `media` 字段会有困难。
+             */
             return {
                 title,
-                description: renderDescription({ description }),
+                description: renderDescription({ description, pics }),
                 link: `https://music.163.com/#/event?id=${eventId}&uid=${userId}`,
                 pubDate: new Date(item.eventTime),
                 published: new Date(item.eventTime),

--- a/lib/v2/ncm/userevents.js
+++ b/lib/v2/ncm/userevents.js
@@ -1,0 +1,41 @@
+const path = require('node:path');
+const got = require('@/utils/got');
+const { art } = require('@/utils/render');
+const renderDescription = (description) => art(path.join(__dirname, 'templates/description.art'), description);
+
+module.exports = async (ctx) => {
+    const { id } = ctx.params;
+
+    const response = await got({
+        method: 'get',
+        url: `https://music.163.com/api/event/get/${id}`,
+        headers: {
+            Referer: 'https://music.163.com/',
+        },
+    });
+
+    const { data } = response;
+    const { nickname } = data.events[0].user;
+
+    ctx.state.data = {
+        title: `${nickname}的云村动态`,
+        link: `https://music.163.com/#/user/event?id=${id}`,
+        description: `网易云音乐用户动态 - ${nickname}`,
+        item: data.events.map((item) => {
+            const title = item.info.commentThread.resourceTitle,
+                userId = item.user.userId,
+                description = JSON.parse(item.json).msg,
+                eventId = item.id;
+            return {
+                title,
+                description: renderDescription({ description }),
+                link: `https://music.163.com/#/event?id=${eventId}&uid=${userId}`,
+                pubDate: new Date(item.eventTime),
+                published: new Date(item.eventTime),
+                author: nickname,
+                upvotes: item.info.likedCount,
+                comments: item.info.commentCount,
+            };
+        }),
+    };
+};


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #3956 task 1

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/ncm/user/events/585804522
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/ncm/user/events/585804522
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

[开发文档](https://docs.rsshub.app/joinus/quick-start.html#ti-jiao-xin-de-rsshub-radar-gui-ze-bian-xie-gui-ze)说，

> hash 应该定位到一级标题

但仓库里的示例并非如此。我仿照示例定位到了 `###` 标题，但愿能过。

---

此外，hash route 有办法进一步改善 RSS Radar 吗？

---

api 给的是时间戳，“时区处理”应该不成问题——不过我也没用相关库，不知道该不该勾选。