### PR TITLE
fix(route): NMPA get accurate pubdate

### DIFF
--- a/lib/v2/gov/nmpa/generic.js
+++ b/lib/v2/gov/nmpa/generic.js
@@ -1,4 +1,5 @@
 const cheerio = require('cheerio');
+const timezone = require('@/utils/timezone');
 const { parseDate } = require('@/utils/parse-date');
 const { finishArticleItem } = require('@/utils/wechat-mp');
 const config = require('@/config').value;
@@ -62,6 +63,7 @@ module.exports = async (ctx) => {
                     await page.close();
                     const $ = cheerio.load(html);
                     item.description = $('.text').html();
+                    item.pubDate = timezone(parseDate($('meta[name="PubDate"]').attr('content')), +8);
                     return item;
                 });
             } else if (/^https:\/\/mp\.weixin\.qq\.com\//.test(item.link)) {


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

None.

## 完整路由地址 / Example for the proposed route(s)

```route
/gov/nmpa/:path+
/gov/nmpa/ylqx/ylqxzhcjd
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [x] 反爬/频率限制 anti-bot or rate limit?
  - [x] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [x] `Puppeteer`

## 说明 / Note
Get accurate pubdate for NMPA entries.