### PR TITLE
fix: ignore shmtu ssl verification

### DIFF
--- a/lib/routes/universities/shmtu/jwc.js
+++ b/lib/routes/universities/shmtu/jwc.js
@@ -4,7 +4,7 @@ const url = require('url');
 const host = 'https://jwc.shmtu.edu.cn';
 
 async function load(link) {
-    const response = await got.get(link);
+    const response = await got.get(link, { https: { rejectUnauthorized: false } });
     const $ = cheerio.load(response.data);
 
     $('.field-item img').each((index, elem) => {
@@ -57,6 +57,7 @@ module.exports = async (ctx) => {
         headers: {
             Referer: host,
         },
+        https: { rejectUnauthorized: false },
     });
 
     const $ = cheerio.load(response.data);

--- a/lib/routes/universities/shmtu/www.js
+++ b/lib/routes/universities/shmtu/www.js
@@ -1,10 +1,10 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const url = require('url');
-const host = 'http://www.shmtu.edu.cn';
+const host = 'https://www.shmtu.edu.cn';
 
 async function load(link) {
-    const response = await got.get(link);
+    const response = await got.get(link, { https: { rejectUnauthorized: false } });
     const $ = cheerio.load(response.data);
 
     const description = $('meta[name="description"]').attr('content');
@@ -45,6 +45,7 @@ module.exports = async (ctx) => {
         headers: {
             Referer: host,
         },
+        https: { rejectUnauthorized: false },
     });
 
     const $ = cheerio.load(response.data);


### PR DESCRIPTION
因为上海海事大学（SHMTU）网站证书链不完整导致的 `unable to verify the first certificate` 的问题，通过 got 请求时忽略证书校验解决。