### PR TITLE
fix(route): 修复机核网资讯

### DIFF
--- a/lib/v2/gcores/category.js
+++ b/lib/v2/gcores/category.js
@@ -98,7 +98,6 @@ module.exports = async (ctx) => {
                 const basicItem = {
                     title: item.title,
                     description: cover + content,
-                    category: item.category,
                     link: articleUrl,
                     guid: articleUrl,
                 };

--- a/lib/v2/gcores/category.js
+++ b/lib/v2/gcores/category.js
@@ -12,16 +12,26 @@ module.exports = async (ctx) => {
     const $ = cheerio.load(data);
     const feedTitle = $('title').text();
 
-    const list = $('.original.am_card.original-normal')
-        .map(function () {
+    let list;
+    if (category === 'news') {
+        list = $('a.news').map(function () {
+            const item = {
+                url: $(this).attr('href'),
+                title: $(this).find('.news_content>h3').text(),
+            };
+            return item;
+        });
+    } else {
+        list = $('.original.am_card.original-normal').map(function () {
             const item = {
                 url: $(this).find('.am_card_inner>a').attr('href'),
                 title: $(this).find('h3.am_card_title').text(),
                 category: $(this).find('span.original_category>a').text(),
             };
             return item;
-        })
-        .get();
+        });
+    }
+    list = list.get();
 
     if (list.length > 0 && list.every((item) => item.url === undefined)) {
         throw new Error('Article URL not found! Please submit an issue on GitHub.');
@@ -85,13 +95,14 @@ module.exports = async (ctx) => {
                 $('.story_hidden').replaceWith('');
 
                 const content = $('.story.story-show').html();
-                return {
+                const basicItem = {
                     title: item.title,
                     description: cover + content,
                     category: item.category,
                     link: articleUrl,
                     guid: articleUrl,
                 };
+                return category === 'news' ? basicItem : { ...basicItem, category: item.category };
             });
         })
     );


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #11397

## 完整路由地址 / Example for the proposed route(s)

```routes
/gcores/category/news
```

## 说明 / Note
机核网不再提供资讯分类，故 /gcores/category/news 下的条目不再包含 category 信息。