### PR TITLE
feat: add shmtu portal notification

### DIFF
--- a/docs/university.md
+++ b/docs/university.md
@@ -2366,6 +2366,14 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 | ---- | ---- |
 | jwgg | jwxw |
 
+### 数字平台
+
+<Route author="imbytecat" example="/shmtu/portal/bmtzgg" path="/shmtu/portal/:type" :paramsDesc="['类型名称']"/>
+
+| 部门通知公告 |
+| ---- |
+| bmtzgg |
+
 ## 上海海洋大学
 
 ### 官网信息

--- a/lib/v2/shmtu/maintainer.js
+++ b/lib/v2/shmtu/maintainer.js
@@ -1,4 +1,5 @@
 module.exports = {
     '/jwc/:type': ['simonsmh'],
     '/www/:type': ['simonsmh'],
+    '/portal/:type': ['imbytecat'],
 };

--- a/lib/v2/shmtu/portal.js
+++ b/lib/v2/shmtu/portal.js
@@ -1,0 +1,58 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+const timezone = require('@/utils/timezone');
+const bootstrapHost = 'https://weixin.shmtu.edu.cn/dynamic/shmtuHttps';
+const host = 'https://portal.shmtu.edu.cn/api';
+
+const loadDetail = async (link) => {
+    const response = await got.post(bootstrapHost, {
+        form: {
+            interfaceUrl: link,
+        },
+        https: { rejectUnauthorized: false },
+    });
+
+    return JSON.parse(response.data);
+};
+
+const processFeed = (list, caches) =>
+    Promise.all(
+        list.map((item) =>
+            caches.tryGet(item.link, async () => {
+                const detail = await loadDetail(item.link);
+                item.description = detail.body.und[0].safe_value;
+                item.link = detail.path;
+                return item;
+            })
+        )
+    );
+
+module.exports = async (ctx) => {
+    const type = ctx.params.type;
+    const info = type === 'bmtzgg' ? '部门通知公告' : '未知';
+
+    const response = await got.post(bootstrapHost, {
+        form: {
+            interfaceUrl: `${host}/${type}.json?page=0`,
+        },
+        https: { rejectUnauthorized: false },
+    });
+
+    const list = JSON.parse(response.data).map((item) => ({
+        title: cheerio.load(item.title).text(),
+        link: `${host}/node/${item.nid}.json`,
+        pubDate: timezone(parseDate(item.created), 8),
+        category: item.field_department[0],
+        author: item.field_department[0],
+    }));
+
+    const result = await processFeed(list, ctx.cache);
+
+    ctx.state.data = {
+        title: `上海海事大学 ${info}`,
+        link: 'https://portal.shmtu.edu.cn/bumentongzhigonggao',
+        description: '上海海事大学 数字平台',
+        item: result,
+    };
+};

--- a/lib/v2/shmtu/radar.js
+++ b/lib/v2/shmtu/radar.js
@@ -17,5 +17,13 @@ module.exports = {
                 target: '/shmtu/www/:type',
             },
         ],
+        portal: [
+            {
+                title: '数字平台',
+                docs: 'https://docs.rsshub.app/university.html#shang-hai-dian-li-da-xue',
+                source: ['/:type'],
+                target: '/shmtu/portal/:type',
+            },
+        ],
     },
 };

--- a/lib/v2/shmtu/router.js
+++ b/lib/v2/shmtu/router.js
@@ -1,4 +1,5 @@
 module.exports = (router) => {
     router.get('/jwc/:type', require('./jwc'));
     router.get('/www/:type', require('./www'));
+    router.get('/portal/:type', require('./portal'));
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/shmtu/portal/bmtzgg
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

- 添加了上海海事大学数字平台部门通知公告订阅
