### PR TITLE
feat: add more portal types for shmtu

### DIFF
--- a/docs/university.md
+++ b/docs/university.md
@@ -2352,7 +2352,7 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 ### 官网信息
 
-<Route author="simonsmh" example="/shmtu/www/events" path="/shmtu/www/:type" :paramsDesc="['类型名称']"/>
+<Route author="imbytecat simonsmh" example="/shmtu/www/events" path="/shmtu/www/:type" :paramsDesc="['类型名称']"/>
 
 | 学术讲座   | 通知公告  |
 | ------ | ----- |
@@ -2360,7 +2360,7 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 ### 教务信息
 
-<Route author="simonsmh" example="/shmtu/jwc/jwgg" path="/shmtu/jwc/:type" :paramsDesc="['类型名称']"/>
+<Route author="imbytecat simonsmh" example="/shmtu/jwc/jwgg" path="/shmtu/jwc/:type" :paramsDesc="['类型名称']"/>
 
 | 教务公告 | 教务新闻 |
 | ---- | ---- |
@@ -2370,9 +2370,9 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE_TLS
 
 <Route author="imbytecat" example="/shmtu/portal/bmtzgg" path="/shmtu/portal/:type" :paramsDesc="['类型名称']"/>
 
-| 部门通知公告 |
-| ------ |
-| bmtzgg |
+| 部门通知公告 | 学术与大型活动公告 | 部门动态 |
+| ------ | --------- | ---- |
+| bmtzgg | xsydxhdgg | bmdt |
 
 ## 上海海洋大学
 

--- a/lib/v2/shmtu/maintainer.js
+++ b/lib/v2/shmtu/maintainer.js
@@ -1,5 +1,5 @@
 module.exports = {
-    '/jwc/:type': ['simonsmh'],
+    '/jwc/:type': ['imbytecat', 'simonsmh'],
     '/portal/:type': ['imbytecat'],
-    '/www/:type': ['simonsmh'],
+    '/www/:type': ['imbytecat', 'simonsmh'],
 };

--- a/lib/v2/shmtu/portal.js
+++ b/lib/v2/shmtu/portal.js
@@ -30,7 +30,21 @@ const processFeed = (list, caches) =>
 
 module.exports = async (ctx) => {
     const type = ctx.params.type;
-    const info = type === 'bmtzgg' ? '部门通知公告' : '未知';
+    let info;
+    switch (type) {
+        case 'bmtzgg':
+            info = '部门通知公告';
+            break;
+        case 'xsydxhdgg':
+            info = '学术与大型活动公告';
+            break;
+        case 'bmdt':
+            info = '部门动态';
+            break;
+        default:
+            info = '未知';
+            break;
+    }
 
     const response = await got.post(bootstrapHost, {
         form: {


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/shmtu/portal/xsydxhdgg
/shmtu/portal/bmdt
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

为数字平台添加更多类型的通知
