### PR TITLE
feat: add attachments to shmtu portal feeds with art-template

### DIFF
--- a/lib/v2/shmtu/portal.js
+++ b/lib/v2/shmtu/portal.js
@@ -22,6 +22,46 @@ const processFeed = (list, caches) =>
             caches.tryGet(item.link, async () => {
                 const detail = await loadDetail(item.link);
                 item.description = detail.body.und[0].safe_value;
+                let images = detail.field_image;
+                if (images.length !== 0 && Object.keys(images).length !== 0) {
+                    images = images.und;
+                    item.description += `
+<span style="font-size:19px">
+    图片：
+</span>
+`;
+                    for (const image of images) {
+                        item.description += `
+<p style="text-indent:32px">
+    <span style="font-size:19px">
+        <a href="https://weixin.shmtu.org/dynamic/getFile?fid=${image.fid}" target="_blank">
+            ${image.alt}：${image.filename}
+        </a>
+    </span>
+</p>
+`;
+                    }
+                }
+                let files = detail.field_file;
+                if (files.length !== 0 && Object.keys(files).length !== 0) {
+                    files = files.und;
+                    item.description += `
+<span style="font-size:19px">
+    附件：
+</span>
+`;
+                    for (const file of files) {
+                        item.description += `
+<p style="text-indent:32px">
+    <span style="font-size:19px">
+        <a href="https://weixin.shmtu.org/dynamic/getFile?fid=${file.fid}" target="_blank">
+            ${file.filename}
+        </a>
+    </span>
+</p>
+`;
+                    }
+                }
                 item.link = detail.path;
                 return item;
             })

--- a/lib/v2/shmtu/portal.js
+++ b/lib/v2/shmtu/portal.js
@@ -2,6 +2,9 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 const { parseDate } = require('@/utils/parse-date');
 const timezone = require('@/utils/timezone');
+const path = require('path');
+const { art } = require('@/utils/render');
+
 const bootstrapHost = 'https://weixin.shmtu.edu.cn/dynamic/shmtuHttps';
 const host = 'https://portal.shmtu.edu.cn/api';
 
@@ -21,47 +24,13 @@ const processFeed = (list, caches) =>
         list.map((item) =>
             caches.tryGet(item.link, async () => {
                 const detail = await loadDetail(item.link);
-                item.description = detail.body.und[0].safe_value;
-                let images = detail.field_image;
-                if (images.length !== 0 && Object.keys(images).length !== 0) {
-                    images = images.und;
-                    item.description += `
-<span style="font-size:19px">
-    图片：
-</span>
-`;
-                    for (const image of images) {
-                        item.description += `
-<p style="text-indent:32px">
-    <span style="font-size:19px">
-        <a href="https://weixin.shmtu.org/dynamic/getFile?fid=${image.fid}" target="_blank">
-            ${image.alt}：${image.filename}
-        </a>
-    </span>
-</p>
-`;
-                    }
-                }
-                let files = detail.field_file;
-                if (files.length !== 0 && Object.keys(files).length !== 0) {
-                    files = files.und;
-                    item.description += `
-<span style="font-size:19px">
-    附件：
-</span>
-`;
-                    for (const file of files) {
-                        item.description += `
-<p style="text-indent:32px">
-    <span style="font-size:19px">
-        <a href="https://weixin.shmtu.org/dynamic/getFile?fid=${file.fid}" target="_blank">
-            ${file.filename}
-        </a>
-    </span>
-</p>
-`;
-                    }
-                }
+                const files = detail.field_file;
+                const images = detail.field_image;
+                item.description = art(path.join(__dirname, 'templates/portal.art'), {
+                    body: detail.body.und[0].safe_value,
+                    images: images.length !== 0 && Object.keys(images).length !== 0 ? images.und : null,
+                    files: files.length !== 0 && Object.keys(files).length !== 0 ? files.und : null,
+                });
                 item.link = detail.path;
                 return item;
             })

--- a/lib/v2/shmtu/templates/portal.art
+++ b/lib/v2/shmtu/templates/portal.art
@@ -3,21 +3,22 @@
 <span style="font-size:19px">
   图片：
 </span>
-  {{each images image idx}}
-  <p style="text-indent:32px">
-    <span style="font-size:19px">
-      <a href="https://weixin.shmtu.org/dynamic/getFile?fid={{image.fid}}" target="_blank">
-        {{image.alt}}：{{image.filename}}
-      </a>
-    </span>
-  </p>
+  {{each images image}}
+  <figure>
+      <img src="https://weixin.shmtu.org/dynamic/getFile?fid={{image.fid}}"
+        alt="{{image.filename}}"
+        style="margin: 0 auto" />
+      <figcaption style="text-align:center;font-size:19px">
+        {{image.alt}}
+      </figcaption>
+  </figure>
   {{/each}}
 {{/if}}
 {{if files}}
 <span style="font-size:19px">
   附件：
 </span>
-  {{each files file idx}}
+  {{each files file}}
   <p style="text-indent:32px">
     <span style="font-size:19px">
       <a href="https://weixin.shmtu.org/dynamic/getFile?fid={{file.fid}}" target="_blank">

--- a/lib/v2/shmtu/templates/portal.art
+++ b/lib/v2/shmtu/templates/portal.art
@@ -1,0 +1,29 @@
+{{@ body}}
+{{if images}}
+<span style="font-size:19px">
+  图片：
+</span>
+  {{each images image idx}}
+  <p style="text-indent:32px">
+    <span style="font-size:19px">
+      <a href="https://weixin.shmtu.org/dynamic/getFile?fid={{image.fid}}" target="_blank">
+        {{image.alt}}：{{image.filename}}
+      </a>
+    </span>
+  </p>
+  {{/each}}
+{{/if}}
+{{if files}}
+<span style="font-size:19px">
+  附件：
+</span>
+  {{each files file idx}}
+  <p style="text-indent:32px">
+    <span style="font-size:19px">
+      <a href="https://weixin.shmtu.org/dynamic/getFile?fid={{file.fid}}" target="_blank">
+        {{file.filename}}
+      </a>
+    </span>
+  </p>
+  {{/each}}
+{{/if}}


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

```routes
/shmtu/portal/bmtzgg
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

为数字平台通知添加了附件链接，使用 `art-template` 渲染内容