### PR TITLE
fix(core): fix category filtering

### DIFF
--- a/lib/middleware/parameter.js
+++ b/lib/middleware/parameter.js
@@ -181,7 +181,7 @@ module.exports = async (ctx, next) => {
                     const title = item.title || '';
                     const description = item.description || title;
                     const author = item.author || '';
-                    const category = item.category || [];
+                    const category = item.category ? (Array.isArray(item.category) ? item.category : [item.category]) : [];
                     const isFilter =
                         title.match(makeRegex(ctx.query.filter)) || description.match(makeRegex(ctx.query.filter)) || author.match(makeRegex(ctx.query.filter)) || category.some((c) => c.match(makeRegex(ctx.query.filter)));
                     return isFilter;
@@ -194,7 +194,7 @@ module.exports = async (ctx, next) => {
                     const title = item.title || '';
                     const description = item.description || title;
                     const author = item.author || '';
-                    const category = item.category || [];
+                    const category = item.category ? (Array.isArray(item.category) ? item.category : [item.category]) : [];
                     let isFilter = true;
                     ctx.query.filter_title && (isFilter = title.match(makeRegex(ctx.query.filter_title)));
                     ctx.query.filter_description && (isFilter = isFilter && description.match(makeRegex(ctx.query.filter_description)));
@@ -213,7 +213,7 @@ module.exports = async (ctx, next) => {
                     const title = item.title;
                     const description = item.description || title;
                     const author = item.author || '';
-                    const category = item.category || [];
+                    const category = item.category ? (Array.isArray(item.category) ? item.category : [item.category]) : [];
                     let isFilter = true;
                     ctx.query.filterout_title && (isFilter = !title.match(makeRegex(ctx.query.filterout_title)));
                     ctx.query.filterout_description && (isFilter = isFilter && !description.match(makeRegex(ctx.query.filterout_description)));

--- a/lib/v2/test/index.js
+++ b/lib/v2/test/index.js
@@ -33,6 +33,14 @@ module.exports = async (ctx) => {
                 author: `DIYgod0`,
                 category: ['Category0', 'Category1', 'Category2'],
             },
+            {
+                title: 'Filter Title3',
+                description: 'Description3',
+                pubDate: new Date(`2019-3-1`).toUTCString(),
+                link: `https://github.com/DIYgod/RSSHub/issues/1`,
+                author: `DIYgod0`,
+                category: 'Category3',
+            },
         ];
     } else if (ctx.params.id === 'long') {
         item.push({

--- a/test/middleware/parameter.js
+++ b/test/middleware/parameter.js
@@ -105,6 +105,13 @@ describe('filter', () => {
         expect(parsed.items[1].title).toBe('Filter Title2');
     });
 
+    it(`filter_category filter_case_sensitive=false category string`, async () => {
+        const response = await request.get('/test/filter?filter_category=category3&filter_case_sensitive=false');
+        const parsed = await parser.parseString(response.text);
+        expect(parsed.items.length).toBe(1);
+        expect(parsed.items[0].title).toBe('Filter Title3');
+    });
+
     it(`filter_time`, async () => {
         const response = await request.get('/test/current_time?filter_time=25');
         const parsed = await parser.parseString(response.text);
@@ -210,28 +217,29 @@ describe('filter', () => {
     it(`filterout_category`, async () => {
         const response = await request.get('/test/filter?filterout_category=Category0|Category1');
         const parsed = await parser.parseString(response.text);
-        expect(parsed.items.length).toBe(5);
-        expect(parsed.items[0].title).toBe('Title1');
-        expect(parsed.items[1].title).toBe('Title2');
-        expect(parsed.items[2].title).toBe('Title3');
+        expect(parsed.items.length).toBe(6);
+        expect(parsed.items[0].title).toBe('Filter Title3');
+        expect(parsed.items[1].title).toBe('Title1');
+        expect(parsed.items[2].title).toBe('Title2');
     });
 
     it(`filterout_category filter_case_sensitive default`, async () => {
         const response = await request.get('/test/filter?filterout_category=category0|category1');
         const parsed = await parser.parseString(response.text);
-        expect(parsed.items.length).toBe(7);
+        expect(parsed.items.length).toBe(8);
         expect(parsed.items[0].title).toBe('Filter Title1');
         expect(parsed.items[1].title).toBe('Filter Title2');
-        expect(parsed.items[2].title).toBe('Title1');
+        expect(parsed.items[2].title).toBe('Filter Title3');
+        expect(parsed.items[3].title).toBe('Title1');
     });
 
     it(`filterout_category filter_case_sensitive=false`, async () => {
         const response = await request.get('/test/filter?filterout_category=category0|category1&filter_case_sensitive=false');
         const parsed = await parser.parseString(response.text);
-        expect(parsed.items.length).toBe(5);
-        expect(parsed.items[0].title).toBe('Title1');
-        expect(parsed.items[1].title).toBe('Title2');
-        expect(parsed.items[2].title).toBe('Title3');
+        expect(parsed.items.length).toBe(6);
+        expect(parsed.items[0].title).toBe('Filter Title3');
+        expect(parsed.items[1].title).toBe('Title1');
+        expect(parsed.items[2].title).toBe('Title2');
     });
 
     it(`filter combination`, async () => {


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #11446

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/gcores/category/radios?filter=GadioNews
```

## 说明 / Note

Ensure typeof `category` is `Array`
