### PR TITLE
feat(route): add csdnblogs route

### DIFF
--- a/docs/blog.md
+++ b/docs/blog.md
@@ -30,6 +30,32 @@ pageClass: routes
 
 <Route author="nczitzk" example="/google/sites/recentChanges/outlierseconomics" path="/google/sites/recentChanges/:id" :paramsDesc="['Site ID, 可在 URL 中找到']"/>
 
+## 博客园
+
+### 10天推荐排行榜
+
+<Route author="hujingnb" example="/cnblogs/aggsite/topdiggs" path="/cnblogs/aggsite/topdiggs" radar="1" rssbud="1"/>
+
+### 48小时阅读排行
+
+<Route author="hujingnb" example="/cnblogs/aggsite/topviews" path="/cnblogs/aggsite/topviews" radar="1" rssbud="1"/>
+
+### 编辑推荐
+
+<Route author="hujingnb" example="/cnblogs/aggsite/headline" path="/cnblogs/aggsite/headline" radar="1" rssbud="1"/>
+
+### 分类
+
+<Route author="hujingnb" example="/cnblogs/cate/go" path="/cnblogs/cate/:type" :paramsDesc="['类型']" radar="1" rssbud="1">
+
+在博客园主页的分类出可查看所有类型. 例如, go的分类地址为: `https://www.cnblogs.com/cate/go/`, 则: [`/cnblogs/cate/go`](https://rsshub.app/cnblogs/cate/go)
+
+</Route>
+
+### 精华区
+
+<Route author="hujingnb" example="/cnblogs/pick" path="/cnblogs/pick" radar="1" rssbud="1"/>
+
 ## Gwern Branwen
 
 ### 博客

--- a/lib/v2/cnblogs/common.js
+++ b/lib/v2/cnblogs/common.js
@@ -1,0 +1,38 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+const timezone = require('@/utils/timezone');
+
+
+module.exports = async (ctx) => {
+    const link = `https://www.cnblogs.com${ctx.path}`;
+    const response = await got(link);
+    const data = response.data;
+
+    const $ = cheerio.load(data);
+    const list = $('#post_list article')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            return {
+                title: item.find('.post-item-title').text(),
+                link: item.find('.post-item-title').attr('href'),
+                pubDate: timezone(
+                    parseDate(
+                        item.find('.post-item-foot .post-meta-item span').text() ||
+                        item.find('.editorpick-item-meta').text(),
+                        ['YYYY-MM-DD HH:mm', 'YYYY-MM-DD']
+                    ),
+                    +8
+                ),
+                description: item.find('.post-item-summary').text(),
+                author: item.find('.post-item-author span').text(),
+            };
+        });
+
+    ctx.state.data = {
+        title: $('title').text(),
+        link,
+        item: list,
+    };
+};

--- a/lib/v2/cnblogs/maintainer.js
+++ b/lib/v2/cnblogs/maintainer.js
@@ -2,6 +2,6 @@ module.exports = {
     '/aggsite/topdiggs': ['hujingnb'],
     '/aggsite/topviews': ['hujingnb'],
     '/aggsite/headline': ['hujingnb'],
-    '/cate': ['hujingnb'],
+    '/cate/:type': ['hujingnb'],
     '/pick': ['hujingnb'],
 };

--- a/lib/v2/cnblogs/maintainer.js
+++ b/lib/v2/cnblogs/maintainer.js
@@ -1,0 +1,7 @@
+module.exports = {
+    '/aggsite/topdiggs': ['hujingnb'],
+    '/aggsite/topviews': ['hujingnb'],
+    '/aggsite/headline': ['hujingnb'],
+    '/cate': ['hujingnb'],
+    '/pick': ['hujingnb'],
+};

--- a/lib/v2/cnblogs/radar.js
+++ b/lib/v2/cnblogs/radar.js
@@ -1,0 +1,37 @@
+module.exports = {
+    'cnblogs.com': {
+        _name: '博客园',
+        www: [
+            {
+                title: '10天推荐排行榜',
+                docs: 'https://docs.rsshub.app/blog.html#博客园',
+                source: ['/aggsite/topdiggs'],
+                target: '/cnblogs/aggsite/topdiggs',
+            },
+            {
+                title: '48小时阅读排行',
+                docs: 'https://docs.rsshub.app/blog.html#博客园',
+                source: ['/aggsite/topviews'],
+                target: '/cnblogs/aggsite/topviews',
+            },
+            {
+                title: '编辑推荐',
+                docs: 'https://docs.rsshub.app/blog.html#博客园',
+                source: ['/aggsite/headline'],
+                target: '/cnblogs/aggsite/headline',
+            },
+            {
+                title: '分类',
+                docs: 'https://docs.rsshub.app/blog.html#博客园',
+                source: ['/cate/:type'],
+                target: '/cnblogs/cate/:type',
+            },
+            {
+                title: '精华区',
+                docs: 'https://docs.rsshub.app/blog.html#博客园',
+                source: ['/pick'],
+                target: '/cnblogs/pick',
+            },
+        ],
+    },
+};

--- a/lib/v2/cnblogs/router.js
+++ b/lib/v2/cnblogs/router.js
@@ -1,0 +1,7 @@
+module.exports = (router) => {
+    router.get('/aggsite/topdiggs', require('./common'));
+    router.get('/aggsite/topviews', require('./common'));
+    router.get('/aggsite/headline', require('./common'));
+    router.get('/cate/:type', require('./common'));
+    router.get('/pick', require('./common'));
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/cnblogs/aggsite/topdiggs
/cnblogs/aggsite/topviews
/cnblogs/aggsite/headline
/cnblogs/pick
/cnblogs/cate/2
/cnblogs/cate/108698
/cnblogs/cate/java
/cnblogs/cate/python
/cnblogs/cate/go
/cnblogs/cate/php
/cnblogs/cate/cpp
/cnblogs/cate/ruby
/cnblogs/cate/swift
/cnblogs/cate/c
/cnblogs/cate/erlang
/cnblogs/cate/delphi
/cnblogs/cate/scala
/cnblogs/cate/r
/cnblogs/cate/verilog
/cnblogs/cate/dart
/cnblogs/cate/rust
/cnblogs/cate/otherlang
/cnblogs/cate/108701
/cnblogs/cate/design
/cnblogs/cate/oo
/cnblogs/cate/dp
/cnblogs/cate/ddd
/cnblogs/cate/108703
/cnblogs/cate/web
/cnblogs/cate/javascript
/cnblogs/cate/jquery
/cnblogs/cate/html5
/cnblogs/cate/angular
/cnblogs/cate/react
/cnblogs/cate/vue
/cnblogs/cate/108704
/cnblogs/cate/bpm
/cnblogs/cate/sharepoint
/cnblogs/cate/gis
/cnblogs/cate/sap
/cnblogs/cate/OracleERP
/cnblogs/cate/dynamics
/cnblogs/cate/infosec
/cnblogs/cate/3
/cnblogs/cate/108705
/cnblogs/cate/android
/cnblogs/cate/ios
/cnblogs/cate/flutter
/cnblogs/cate/harmonyos
/cnblogs/cate/mobile
/cnblogs/cate/108709
/cnblogs/cate/agile
/cnblogs/cate/pm
/cnblogs/cate/Engineering
/cnblogs/cate/108712
/cnblogs/cate/sqlserver
/cnblogs/cate/oracle
/cnblogs/cate/mysql
/cnblogs/cate/postgresql
/cnblogs/cate/nosql
/cnblogs/cate/bigdata
/cnblogs/cate/database
/cnblogs/cate/108724
/cnblogs/cate/win7
/cnblogs/cate/winserver
/cnblogs/cate/linux
/cnblogs/cate/osx
/cnblogs/cate/eos
/cnblogs/cate/4
/cnblogs/cate/life
/cnblogs/cate/k8s
/cnblogs/cate/testing
/cnblogs/cate/software
/cnblogs/cate/cg
/cnblogs/cate/gamedev
/cnblogs/cate/codelife
/cnblogs/cate/job
/cnblogs/cate/book
/cnblogs/cate/quoted
/cnblogs/cate/translate
/cnblogs/cate/opensource
/cnblogs/cate/cloud
/cnblogs/cate/algorithm
/cnblogs/cate/ai
/cnblogs/cate/blockchain
/cnblogs/cate/networksecurity
/cnblogs/cate/misc
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

获取博客园相关的多个推荐页面

因本人是后端开发, 其中难免会存在一些不规范或有问题的地方. 您提出来后我来改