### PR TITLE
fix: Luogu blog uid

### DIFF
--- a/docs/programming.md
+++ b/docs/programming.md
@@ -1015,7 +1015,7 @@ GitHub 官方也提供了一些 RSS:
 
 ### 用户博客
 
-<Route author="ftiasch" example="/luogu/user/blog/ftiasch" path="/luogu/user/blog/:username" :paramsDesc="['用户名']" radar="1" rssbud="1"/>
+<Route author="ftiasch" example="/luogu/user/blog/ftiasch" path="/luogu/user/blog/:name" :paramsDesc="['博客名称']" radar="1" rssbud="1"/>
 
 ## 码农俱乐部
 

--- a/lib/v2/luogu/radar.js
+++ b/lib/v2/luogu/radar.js
@@ -23,8 +23,8 @@ module.exports = {
             {
                 title: '用户博客',
                 docs: 'https://docs.rsshub.app/programming.html#luo-gu',
-                source: ['/blog/:username'],
-                target: '/luogu/user/blog/:username',
+                source: ['/blog/:name'],
+                target: '/luogu/user/blog/:name',
             },
         ],
     },

--- a/lib/v2/luogu/router.js
+++ b/lib/v2/luogu/router.js
@@ -2,5 +2,5 @@ module.exports = (router) => {
     router.get('/contest', require('./contest'));
     router.get('/daily/:id?', require('./daily'));
     router.get('/user/feed/:uid', require('./userFeed'));
-    router.get('/user/blog/:username', require('./userBlog'));
+    router.get('/user/blog/:name', require('./userBlog'));
 };

--- a/lib/v2/luogu/userBlog.js
+++ b/lib/v2/luogu/userBlog.js
@@ -2,29 +2,23 @@ const got = require('@/utils/got');
 const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
-    const username = ctx.params.username;
+    const name = ctx.params.name;
 
-    // Convert from `username` to `uid`
-    const userApiUrl = `https://www.luogu.com.cn/api/user/search?keyword=${username}`;
-    const uid = await ctx.cache.tryGet(userApiUrl, async () => {
-        const rsp = await got(userApiUrl).json();
-        return rsp.users[0].uid;
-    });
+    const blogBaseUrl = `https://www.luogu.com.cn/blog/${name}/`;
 
-    // Get the title and link from the sitemap
-    const sitemapUrl = `https://www.luogu.com.cn/blog/${username}/_sitemap`;
-    const { title: blogTitle, link: blogBaseUrl } = await ctx.cache.tryGet(sitemapUrl, async () => {
-        const rsp = await got(sitemapUrl);
+    // Fetch the uid & title
+    const { uid: blogUid, title: blogTitle } = await ctx.cache.tryGet(blogBaseUrl, async () => {
+        const rsp = await got(blogBaseUrl);
         const $ = cheerio.load(rsp.data);
-        const title = $('title').text();
-        const link = $('.am-alert > a').attr('href');
+        const uid = $("meta[name='blog-uid']").attr('content');
+        const name = $("meta[name='blog-name']").attr('content');
         return {
-            title,
-            link,
+            uid,
+            title: `${name} - 洛谷博客`,
         };
     });
 
-    const posts = (await got(`https://www.luogu.com.cn/api/blog/lists?uid=${uid}`).json()).data.result.map((r) => ({
+    const posts = (await got(`https://www.luogu.com.cn/api/blog/lists?uid=${blogUid}`).json()).data.result.map((r) => ({
         title: r.title,
         link: `${blogBaseUrl}${r.identifier}`,
         pubDate: new Date(r.postTime * 1000),
@@ -34,7 +28,7 @@ module.exports = async (ctx) => {
     const item = await Promise.all(
         posts.map((post) =>
             ctx.cache.tryGet(post.link, async () => {
-                const rsp = await got.get(post.link);
+                const rsp = await got(post.link);
                 const $ = cheerio.load(rsp.data);
                 return {
                     title: post.title,


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/luogu/user/blog/your-alpha1022
/luogu/user/blog/caijacky-note
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

In the previous commit for Luogu user blog, we assume that the suffix xxx in the blog url `https://www.luogu.com.cn/blog/xxx` is the user's handle, and we rely on the user api to get the uid.

A notable example occurs as `https://www.luogu.com.cn/blog/your-alpha1022/`, where his actual handle is `Alpha1022`. The previous route fails because `https://www.luogu.com.cn/api/user/search?keyword=your-alpha1022` returns nothing.

Thus, we switched to an approach that fetch the blog uid and title from the meta section of the blog directly, not requiring the user API and the sitemap API anymore. 

Beside, I also found that Luogu's user blog can be hosted on `https://${name}.blog.luogu.org`. A randomly found case can be `https://caijacky-note.blog.luogu.org`. Surprisingly enough, the logic handling the above case also works.