### PR TITLE
fix(route): improve economist espresso parser

### DIFF
--- a/lib/v2/economist/espresso.js
+++ b/lib/v2/economist/espresso.js
@@ -45,6 +45,7 @@ module.exports = async (ctx) => {
         return {
             guid: `${gobbetPart.id}/${index}`,
             link,
+            title: gobbetPart.headline,
             pubDate: gobbetPart.datePublished,
             description: html,
         };

--- a/lib/v2/economist/espresso.js
+++ b/lib/v2/economist/espresso.js
@@ -15,36 +15,65 @@ module.exports = async (ctx) => {
         false
     );
 
-    const gobbets = $('._gobbets ._gobbet p')
-        .toArray()
-        .map((item) => {
-            item = $(item);
-            return {
-                title: item.text(),
-                description: item.html(),
-                link,
-                guid: item.text(),
-            };
-        });
+    const nextData = JSON.parse($('script#__NEXT_DATA__').text());
+    const parts = nextData.props.pageProps.content.hasPart.parts[0].hasPart.parts.filter((part) => part.type.includes('Article'));
 
-    const articles = $('._articles ._article')
-        .toArray()
-        .map((item) => {
-            item = $(item);
-            const title = item.find('h3').text();
-            item.find('h3').remove();
-            return {
-                title,
-                description: item.html(),
-                link,
-                guid: item.text(),
-            };
-        });
+    const renderHTML = (node) => {
+        let el;
+        switch (node.type) {
+            case 'tag':
+                el = $(`<${node.name}>`);
+                for (const name in node.attribs) {
+                    el.attr(name, node.attribs[name]);
+                }
+                if (node.children) {
+                    el.append(node.children.map(renderHTML));
+                }
+                return el;
+            case 'text':
+                return node.data;
+            default:
+                el = $('<div>');
+                el.append(node.map(renderHTML));
+                return el;
+        }
+    };
+
+    const gobbetPart = parts.shift();
+    const gobbets = gobbetPart.text.map((node, index) => {
+        const html = renderHTML(node).html();
+        return {
+            guid: `${gobbetPart.id}/${index}`,
+            link,
+            pubDate: gobbetPart.datePublished,
+            description: html,
+        };
+    });
+
+    const articles = parts.map((part) => {
+        const image = part.image.main;
+        const imgNode = {
+            type: 'tag',
+            name: 'img',
+            attribs: { width: image.width, height: image.height, src: image.url.canonical },
+        };
+
+        const html = renderHTML([imgNode, ...part.text]).html();
+
+        return {
+            link,
+            guid: part.id,
+            title: part.headline,
+            pubDate: part.datePublished,
+            description: html,
+        };
+    });
 
     ctx.state.data = {
         title: $('head title').text(),
         link,
         description: $('meta[property="og:description"]').attr('content'),
+        language: 'en-gb',
         item: [...gobbets, ...articles],
     };
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/economist/espresso
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

Some improvements to the Economist Espresso section parser. The current parser produces fine content html, but its metadata has some issues. Its guids is based on the article text which often gets modified multiple times a day. It also lacks a pubDate.

It turns out, the page is based on Next.js and includes an easily to extract React API blob. This changes the parser to pull content from the Next.js blob rather than pull html from the rendered page.