### PR TITLE
feat(route): add crac

### DIFF
--- a/docs/government.md
+++ b/docs/government.md
@@ -1066,6 +1066,18 @@ pageClass: routes
 
 <Route author="Fatpandac" example="/tingshen" path="/tingshen"/>
 
+## 中国无线电协会业余无线电分会
+
+### 最新资讯
+
+<Route author="Misaka13514" example="/crac/2" path="/crac/:type?" :paramsDesc="['类型，见下表，默认为全部']" radar="1" rssbud="1">
+
+| 新闻动态 | 通知公告 | 政策法规 | 常见问题 | 资料下载 | English | 业余中继台 | 科普专栏 |
+| ---- | ---- | ---- | ---- | ---- | ------- | ----- | ---- |
+| 1    | 2    | 3    | 5    | 6    | 7       | 8     | 9    |
+
+</Route>
+
 ## 中国信息通信研究院
 
 ### 白皮书

--- a/lib/v2/crac/index.js
+++ b/lib/v2/crac/index.js
@@ -1,0 +1,46 @@
+const cheerio = require('cheerio');
+const got = require('@/utils/got');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const baseUrl = 'http://www.crac.org.cn/News/List';
+    const type = ctx.params.type;
+    const link = type ? `${baseUrl}?type=${type}` : baseUrl;
+
+    const response = await got({
+        method: 'get',
+        url: link,
+    });
+
+    const $ = cheerio.load(response.data);
+    const list = $('div.InCont_r_d_cont > li')
+        .map((_, item) => {
+            item = $(item);
+            return {
+                title: item.find('a').text(),
+                link: new URL(item.find('a').attr('href'), baseUrl).href,
+                pubDate: parseDate(item.find('span.cont_d').text(), 'YYYY-MM-DD'),
+            };
+        })
+        .get();
+
+    await Promise.all(
+        list.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const response = await got({
+                    method: 'get',
+                    url: item.link,
+                });
+                const content = cheerio.load(response.data);
+                item.description = content('div.r_d_cont').html();
+                return item;
+            })
+        )
+    );
+
+    ctx.state.data = {
+        title: $('title').text(),
+        link,
+        item: list,
+    };
+};

--- a/lib/v2/crac/index.js
+++ b/lib/v2/crac/index.js
@@ -3,9 +3,9 @@ const got = require('@/utils/got');
 const { parseDate } = require('@/utils/parse-date');
 
 module.exports = async (ctx) => {
-    const baseUrl = 'http://www.crac.org.cn/News/List';
+    const baseUrl = 'http://www.crac.org.cn';
     const type = ctx.params.type;
-    const link = type ? `${baseUrl}?type=${type}` : baseUrl;
+    const link = type ? `${baseUrl}/News/List?type=${type}` : `${baseUrl}/News/List`;
 
     const response = await got({
         method: 'get',
@@ -17,7 +17,6 @@ module.exports = async (ctx) => {
         .map((_, item) => {
             item = $(item);
             return {
-                title: item.find('a').text(),
                 link: new URL(item.find('a').attr('href'), baseUrl).href,
                 pubDate: parseDate(item.find('span.cont_d').text(), 'YYYY-MM-DD'),
             };
@@ -32,7 +31,8 @@ module.exports = async (ctx) => {
                     url: item.link,
                 });
                 const content = cheerio.load(response.data);
-                item.description = content('div.r_d_cont').html();
+                item.title = content('div.r_d_cont_title > h3').text();
+                item.description = content('div.r_d_cont').html().trim().replace(/\n/g, '');
                 return item;
             })
         )

--- a/lib/v2/crac/maintainer.js
+++ b/lib/v2/crac/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/:type?': ['Misaka13514'],
+};

--- a/lib/v2/crac/radar.js
+++ b/lib/v2/crac/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'crac.org.cn': {
+        _name: '中国无线电协会业余无线电分会',
+        www: [
+            {
+                title: '最新资讯',
+                docs: 'https://docs.rsshub.app/government.html#zhong-guo-wu-xian-dian-xie-hui-ye-yu-wu-xian-dian-fen-hui',
+                source: '/News/List',
+                target: (params, url) => `/crac/${new URL(url).searchParams.get('type') || ''}`,
+            },
+        ],
+    },
+};

--- a/lib/v2/crac/router.js
+++ b/lib/v2/crac/router.js
@@ -1,0 +1,3 @@
+module.exports = function (router) {
+    router.get('/:type?', require('./index'));
+};


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

```routes
/crac/
/crac/1
/crac/2
/crac/3
/crac/5
/crac/6
/crac/7
/crac/8
/crac/9
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

add www.crac.org.cn
