### PR TITLE
fix: Improve route "codeforces" time expression readability

### DIFF
--- a/lib/v2/codeforces/contests.js
+++ b/lib/v2/codeforces/contests.js
@@ -2,15 +2,14 @@ const got = require('@/utils/got');
 const path = require('path');
 const { art } = require('@/utils/render');
 
-function sec2str (secStr) {
-	const sec = Math.abs(parseInt(secStr));
-	const d = (Math.floor(sec / 86400) + ":" + (new Date(sec * 1000)).toISOString().substr(11, 8)).split(":");
-	let str = `${d[1]} 小时, ${d[2]} 分钟, ${d[3]} 秒 `;
-	if (d[0] !== 0) {
-		str = `${d[0]} 天, ` + str;
-	}
-	return str;
-}
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/localizedFormat'));
+dayjs.extend(require('dayjs/plugin/duration'));
+dayjs.extend(require('dayjs/plugin/relativeTime'));
+require('dayjs/locale/zh-cn');
+dayjs.locale('zh-cn');
+
+const sec2str = (sec) => dayjs.duration(parseInt(sec), 'seconds').humanize();
 
 const contestAPI = 'https://codeforces.com/api/contest.list';
 
@@ -22,11 +21,10 @@ module.exports = async (ctx) => {
         .filter((contests) => contests.phase === 'BEFORE')
         .map((contest) => {
             const title = String(contest.name);
-            const date = new Date(parseInt(contest.startTimeSeconds) * 1000);
-            const options = { weekday: 'long', year: 'numeric', month: 'numeric', day: 'numeric' };
+            const date = dayjs.unix(parseInt(contest.startTimeSeconds));
             const description = art(path.join(__dirname, 'templates/contest.art'), {
                 title,
-                startTime: date.toLocaleTimeString('zh-CN', options),
+                startTime: date.format('LL LT'),
                 durationTime: sec2str(contest.durationSeconds),
                 // relativeTime: sec2str(contest.relativeTimeSeconds),
                 type: contest.type,

--- a/lib/v2/codeforces/contests.js
+++ b/lib/v2/codeforces/contests.js
@@ -1,15 +1,12 @@
 const got = require('@/utils/got');
 const path = require('path');
 const { art } = require('@/utils/render');
-const timezone = require('@/utils/timezone');
-const { parseDate } = require('@/utils/parse-date');
 
-function sec2str (secStr){
+function sec2str (secStr) {
 	const sec = Math.abs(parseInt(secStr));
-	const d = (Math.floor(sec / 86400) + ":"
-	  + (new Date(sec * 1000)).toISOString().substr(11, 8)).split(":");
-	const str = `${d[1]} 小时, ${d[2]} 分钟, ${d[3]} 秒 `;
-	if (d[0] != 0) {
+	const d = (Math.floor(sec / 86400) + ":" + (new Date(sec * 1000)).toISOString().substr(11, 8)).split(":");
+	let str = `${d[1]} 小时, ${d[2]} 分钟, ${d[3]} 秒 `;
+	if (d[0] !== 0) {
 		str = `${d[0]} 天, ` + str;
 	}
 	return str;
@@ -31,7 +28,7 @@ module.exports = async (ctx) => {
                 title,
                 startTime: date.toLocaleTimeString('zh-CN', options),
                 durationTime: sec2str(contest.durationSeconds),
-                //relativeTime: sec2str(contest.relativeTimeSeconds),
+                // relativeTime: sec2str(contest.relativeTimeSeconds),
                 type: contest.type,
             });
 

--- a/lib/v2/codeforces/contests.js
+++ b/lib/v2/codeforces/contests.js
@@ -4,6 +4,17 @@ const { art } = require('@/utils/render');
 const timezone = require('@/utils/timezone');
 const { parseDate } = require('@/utils/parse-date');
 
+function sec2str (secStr){
+	const sec = Math.abs(parseInt(secStr));
+	const d = (Math.floor(sec / 86400) + ":"
+	  + (new Date(sec * 1000)).toISOString().substr(11, 8)).split(":");
+	const str = `${d[1]} 小时, ${d[2]} 分钟, ${d[3]} 秒 `;
+	if (d[0] != 0) {
+		str = `${d[0]} 天, ` + str;
+	}
+	return str;
+}
+
 const contestAPI = 'https://codeforces.com/api/contest.list';
 
 module.exports = async (ctx) => {
@@ -14,11 +25,13 @@ module.exports = async (ctx) => {
         .filter((contests) => contests.phase === 'BEFORE')
         .map((contest) => {
             const title = String(contest.name);
+            const date = new Date(parseInt(contest.startTimeSeconds) * 1000);
+            const options = { weekday: 'long', year: 'numeric', month: 'numeric', day: 'numeric' };
             const description = art(path.join(__dirname, 'templates/contest.art'), {
                 title,
-                startTime: timezone(parseDate(contest.startTimeSeconds * 1000), +0),
-                durationTime: contest.durationSeconds / 60,
-                relativeTime: Math.floor(contest.relativeTimeSeconds / 60),
+                startTime: date.toLocaleTimeString('zh-CN', options),
+                durationTime: sec2str(contest.durationSeconds),
+                //relativeTime: sec2str(contest.relativeTimeSeconds),
                 type: contest.type,
             });
 

--- a/lib/v2/codeforces/templates/contest.art
+++ b/lib/v2/codeforces/templates/contest.art
@@ -1,6 +1,5 @@
 <p>比赛：{{ title }}</p>
 <p>开始时间：{{ startTime }}</p>
-<p>持续时间：{{ durationTime }} 分钟</p>
-<p>相对时间：{{ relativeTime }} 分钟</p>
+<p>持续时间：{{ durationTime }}</p>
+<!-- <p>相对时间：{{ relativeTime }}</p> -->
 <p>比赛类型：{{ type }}</p>
-


### PR DESCRIPTION
## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/codeforces/contests
```

## 说明 / Note
The time was previously presented bare and coarse. This PR makes it more human-readable.
Plus, `relativeTime` was removed, as it only depends on when the endpoint is requested.