### PR TITLE
fix: vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,6 @@
     "ext": "art,js,mjs,json"
   },
   "engines": {
-    "node": ">=14"
+    "node": "16.x"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,8 @@
 {
+    "devCommand": "yarn run docs:dev",
+    "buildCommand": "yarn run docs:build",
+    "outputDirectory": "docs/.vuepress/dist",
     "routes": [
-        { "src": "/api/.*", "dest": "/api/vercel.js" },
         { "src": "/.*", "dest": "/api/vercel.js" }
     ]
 }


### PR DESCRIPTION
This fixes two different issues when deploying to [Vercel](http://vercel.com):

1. `Error: ENOENT: no such file or directory, stat '/vercel/path0/src'` which was caused by the incorrect `outputDirectory`
2. `Error: error:0308010C:digital envelope routines::unsupported` which was caused by Node.js 18 being targeted by the incorrect `engines`

- Fixes #11647

