### PR TITLE
feat(route): add douban list and collections 添加豆瓣的榜单与集合

### DIFF
--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -1259,7 +1259,7 @@ YouTube 官方亦有提供频道 RSS，形如 <https://www.youtube.com/feeds/vid
 
 ### 榜单与集合
 
-<Route author="5upernova-heng" example="/douban/list/subject_real_time_hotest" path="/douban/list/:type" :paramsDesc="['榜单类型，见下表。默认为实时热门书影音']">
+<Route author="5upernova-heng" example="/douban/list/subject_real_time_hotest" path="/douban/list/:type?" :paramsDesc="['榜单类型，见下表。默认为实时热门书影音']">
 
 | 榜单/集合          | 路由（type）               |
 | ------------------ | -------------------------- |
@@ -1282,7 +1282,7 @@ YouTube 官方亦有提供频道 RSS，形如 <https://www.youtube.com/feeds/vid
 >
 > 如何找到榜单对应的路由参数：
 > 在豆瓣手机 APP 中，对应地榜单页面右上角，点击分享链接。链接路径 `subject_collection` 后的路径就是路由参数 `type`。
-> 如：小说热门榜的分享链接为：`https://m.douban.com/subject_collection/ECDIHUN4A`，其对应本 RSS 路由的 `type` 为 `ECDIHUN4A`，对应的订阅链接路由：`/douban/list/ECDIHUN4A`
+> 如：小说热门榜的分享链接为：`https://m.douban.com/subject_collection/ECDIHUN4A`，其对应本 RSS 路由的 `type` 为 `ECDIHUN4A`，对应的订阅链接路由：[`/douban/list/ECDIHUN4A`](https://rsshub.app/douban/list/ECDIHUN4A)
 
 </Route>
 

--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -500,7 +500,7 @@ Tiny Tiny RSS 会给所有 iframe 元素添加 `sandbox="allow-scripts"` 属性�
 
 ### 用户 / 标签 - Private API
 
-<Route author="oppilate DIYgod" example="/instagram/user/stefaniejoosten" path="/instagram/:category/:key" :paramsDesc="['类别，见下表', '用户名／标签名']" radar="1" anticrawler="1" radar="1">
+<Route author="oppilate DIYgod" example="/instagram/user/stefaniejoosten" path="/instagram/:category/:key" :paramsDesc="['类别，见下表', '用户名／标签名']" radar="1" anticrawler="1" selfhost="1">
 
 | 用户时间线 | 标签   |
 | ----- | ---- |
@@ -946,7 +946,8 @@ YouTube 官方亦有提供频道 RSS，形如 <https://www.youtube.com/feeds/vid
 | 热门音乐人      | 热门歌曲     | 热门音乐视频    | 时下流行           |
 | ---------- | -------- | --------- | -------------- |
 | TopArtists | TopSongs | TopVideos | TrendingVideos |
-| :::        |          |           |                |
+
+:::
 
 ::: details 国家代码
 
@@ -985,7 +986,8 @@ YouTube 官方亦有提供频道 RSS，形如 <https://www.youtube.com/feeds/vid
 | Uruguay | Zimbabwe |
 | ------- | -------- |
 | uy      | zw       |
-| :::     |          |
+
+:::
 
 </Route>
 
@@ -1261,24 +1263,24 @@ YouTube 官方亦有提供频道 RSS，形如 <https://www.youtube.com/feeds/vid
 
 <Route author="5upernova-heng" example="/douban/list/subject_real_time_hotest" path="/douban/list/:type?" :paramsDesc="['榜单类型，见下表。默认为实时热门书影音']">
 
-| 榜单/集合          | 路由（type）               |
-| ------------------ | -------------------------- |
-| 实时热门书影音     | subject_real_time_hotest   |
-| 影院热映           | movie_showing              |
-| 实时热门电影       | movie_real_time_hotest     |
-| 实时热门电视       | tv_real_time_hotest        |
-| 一周口碑电影榜     | movie_weekly_best          |
-| 华语口碑剧集榜     | tv_chinese_best_weekly     |
-| 全球口碑剧集榜     | tv_global_best_weekly      |
-| 国内口碑综艺榜     | show_chinese_best_weekly   |
-| 国外口碑综艺榜     | show_global_best_weekly    |
-| 虚构类小说热门榜   | book_fiction_hot_weekly    |
+| 榜单 / 集合   | 路由（type）                   |
+| --------- | -------------------------- |
+| 实时热门书影音   | subject_real_time_hotest   |
+| 影院热映      | movie_showing              |
+| 实时热门电影    | movie_real_time_hotest     |
+| 实时热门电视    | tv_real_time_hotest        |
+| 一周口碑电影榜   | movie_weekly_best          |
+| 华语口碑剧集榜   | tv_chinese_best_weekly     |
+| 全球口碑剧集榜   | tv_global_best_weekly      |
+| 国内口碑综艺榜   | show_chinese_best_weekly   |
+| 国外口碑综艺榜   | show_global_best_weekly    |
+| 虚构类小说热门榜  | book_fiction_hot_weekly    |
 | 非虚构类小说热门榜 | book_nonfiction_hot_weekly |
-| 热门单曲榜         | music_single               |
-| 华语新碟榜         | music_chinese              |
-| ...                | ...                        |
+| 热门单曲榜     | music_single               |
+| 华语新碟榜     | music_chinese              |
+| ...       | ...                        |
 
-> 上面的榜单/集合并没有列举完整。
+> 上面的榜单 / 集合并没有列举完整。
 >
 > 如何找到榜单对应的路由参数：
 > 在豆瓣手机 APP 中，对应地榜单页面右上角，点击分享链接。链接路径 `subject_collection` 后的路径就是路由参数 `type`。

--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -1257,6 +1257,35 @@ YouTube 官方亦有提供频道 RSS，形如 <https://www.youtube.com/feeds/vid
 
 </Route>
 
+### 榜单与集合
+
+<Route author="5upernova-heng" example="/douban/list/subject_real_time_hotest" path="/douban/list/:type" :paramsDesc="['榜单类型，见下表。默认为实时热门书影音']">
+
+| 榜单/集合          | 路由（type）               |
+| ------------------ | -------------------------- |
+| 实时热门书影音     | subject_real_time_hotest   |
+| 影院热映           | movie_showing              |
+| 实时热门电影       | movie_real_time_hotest     |
+| 实时热门电视       | tv_real_time_hotest        |
+| 一周口碑电影榜     | movie_weekly_best          |
+| 华语口碑剧集榜     | tv_chinese_best_weekly     |
+| 全球口碑剧集榜     | tv_global_best_weekly      |
+| 国内口碑综艺榜     | show_chinese_best_weekly   |
+| 国外口碑综艺榜     | show_global_best_weekly    |
+| 虚构类小说热门榜   | book_fiction_hot_weekly    |
+| 非虚构类小说热门榜 | book_nonfiction_hot_weekly |
+| 热门单曲榜         | music_single               |
+| 华语新碟榜         | music_chinese              |
+| ...                | ...                        |
+
+> 上面的榜单/集合并没有列举完整。
+>
+> 如何找到榜单对应的路由参数：
+> 在豆瓣手机 APP 中，对应地榜单页面右上角，点击分享链接。链接路径 `subject_collection` 后的路径就是路由参数 `type`。
+> 如：小说热门榜的分享链接为：`https://m.douban.com/subject_collection/ECDIHUN4A`，其对应本 RSS 路由的 `type` 为 `ECDIHUN4A`，对应的订阅链接路由：`/douban/list/ECDIHUN4A`
+
+</Route>
+
 ## 饭否
 
 ::: warning 注意

--- a/lib/v2/douban/maintainer.js
+++ b/lib/v2/douban/maintainer.js
@@ -11,6 +11,7 @@ module.exports = {
     '/explore': ['clarkzsd'],
     '/explore_column/:id': ['LogicJake'],
     '/group/:groupid/:type?': ['DIYgod'],
+    '/list/:type?': ['5upernova-heng'],
     '/jobs/:type': ['Fatpandac'],
     '/movie/classification/:sort?/:score?/:tags?': ['zzwab'],
     '/movie/later': ['DIYgod'],

--- a/lib/v2/douban/other/list.js
+++ b/lib/v2/douban/other/list.js
@@ -1,0 +1,40 @@
+const got = require('@/utils/got');
+const path = require('path');
+const { art } = require('@/utils/render');
+
+module.exports = async (ctx) => {
+    const type = ctx.params.type || 'subject_real_time_hotest';
+    const url = `https://m.douban.com/rexxar/api/v2/subject_collection/${type}/items`;
+    const response = await got({
+        method: 'get',
+        url,
+        headers: {
+            Referer: `https://m.douban.com/subject_collection/${type}`,
+        },
+    });
+    const description = response.data.subject_collection.description;
+    const items = response.data.subject_collection_items.map((item) => {
+        const title = item.title;
+        const link = item.url;
+        const description = art(path.join(__dirname, '../templates/list_description.art'), {
+            ranking_value: item.ranking_value,
+            title,
+            original_title: item.original_title,
+            rate: item.rating ? item.rating.value : null,
+            card_subtitle: item.card_subtitle,
+            description: item.cards ? item.cards[0].content : item.abstract,
+            cover: item.cover_url || item.cover.url,
+        });
+        return {
+            title,
+            link,
+            description,
+        };
+    });
+    ctx.state.data = {
+        title: `豆瓣 - ${response.data.subject_collection.name}`,
+        link: 'https://m.douban.com/subject_collection/subject_real_time_hotest',
+        item: items,
+        description,
+    };
+};

--- a/lib/v2/douban/radar.js
+++ b/lib/v2/douban/radar.js
@@ -29,6 +29,12 @@ module.exports = {
                 source: '/group/:groupid',
                 target: '/douban/group/:groupid/elite',
             },
+            {
+                title: '榜单与集合',
+                docs: 'https://docs.rsshub.app/social-media.html#douban',
+                source: ['/subject_collection'],
+                target: '/douban/list/:type',
+            },
         ],
         jobs: [
             {

--- a/lib/v2/douban/radar.js
+++ b/lib/v2/douban/radar.js
@@ -32,7 +32,7 @@ module.exports = {
             {
                 title: '榜单与集合',
                 docs: 'https://docs.rsshub.app/social-media.html#douban',
-                source: ['/subject_collection'],
+                source: ['/subject_collection/:type'],
                 target: '/douban/list/:type',
             },
         ],

--- a/lib/v2/douban/router.js
+++ b/lib/v2/douban/router.js
@@ -12,6 +12,7 @@ module.exports = function (router) {
     router.get('/explore/column/:id', require('./other/explore_column'));
     router.get('/group/:groupid/:type?', require('./other/group'));
     router.get('/jobs/:type', require('./other/jobs.js'));
+    router.get('/list/:type?', require('./other/list'));
     router.get('/movie/classification/:sort?/:score?/:tags?', require('./other/classification.js'));
     router.get('/movie/later', require('./other/later'));
     router.get('/movie/playing', require('./other/playing'));

--- a/lib/v2/douban/templates/list_description.art
+++ b/lib/v2/douban/templates/list_description.art
@@ -1,0 +1,25 @@
+{{ if ranking_value }}
+<p>{{ ranking_value }}<p>
+{{ /if }}
+
+<p>{{ title }}</p>
+
+{{ if original_title }}
+<p>{{ original_title }}</p>
+{{ /if }}
+
+{{ if rate }}
+<p>{{ rate }}</p>
+{{ /if }}
+
+{{ if card_subtitle }}
+<p>{{ card_subtitle }}</p>
+{{ /if }}
+
+{{ if description }}
+<p>{{ description }}</p>
+{{ /if }}
+
+{{ if cover }}
+<img src="{{ cover }}" />
+{{ /if }}


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #12083 

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/douban/list/:type
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
这个新的路由可以支持豆瓣的大多数榜单/集合，我尝试过的路由都作为例子列在了 docs 的表格里面。

事实上，这个新路由的功能和 /douban 里面很多老路由发生了功能上的重复，[#108](https://github.com/DIYgod/RSSHub/pull/10887) 的和本路由调用的是同一种 API，要求同一种路由参数（只不过其部分榜单不支持，比如 `/douban/movie/weekly/music_single`）
我原本想把所有和新路由重复的文件整合到一起，但这会让原本的用户没办法用老路由。所以最终我选择新建一个路由来实现这个功能。

This new route can fit in most rank lists with url `https://m.douban.com/subject_collection/*` (I tried more than 10 rank list/collections, as I list in the docs)

Actually there already have many routes in this folder calling the same fucntion as this new route. [#108](https://github.com/DIYgod/RSSHub/pull/10887) is calling the same api and asking for the same router param (However, some extra rank list will not fit properly in by using this route, such as `/douban/movie/weekly/music_single`).
I want to combine them together, but that will make original rss link doesn't work. So eventually I choose to add a new route, implement almost the same function.