### PR TITLE
fix(route): fix the error of route hk01/channel when channel does not have publishName

### DIFF
--- a/docs/new-media.md
+++ b/docs/new-media.md
@@ -4181,6 +4181,32 @@ wechat-feeds 来源[已停止更新](https://github.com/hellodword/wechat-feeds/
 
 </Route>
 
+## 香港 01
+
+### 热门
+
+<Route author="hoilc Fatpandac nczitzk" example="/hk01/hot" path="/hk01/hot" radar="1" rssbud="1"/>
+
+### 栏目
+
+<Route author="hoilc Fatpandac nczitzk" example="/hk01/zone/11" path="/hk01/zone/:id" :paramsDesc="['栏目 id, 可在 URL 中找到']" radar="1" rssbud="1"/>
+
+### 子栏目
+
+<Route author="hoilc Fatpandac nczitzk" example="/hk01/channel/391" path="/hk01/channel/:id" :paramsDesc="['子栏目 id, 可在 URL 中找到']" radar="1" rssbud="1"/>
+
+### 专题
+
+<Route author="hoilc Fatpandac nczitzk" example="/hk01/issue/649" path="/hk01/issue/:id" :paramsDesc="['专题 id, 可在 URL 中找到']" radar="1" rssbud="1"/>
+
+### 标签
+
+<Route author="hoilc Fatpandac nczitzk" example="/hk01/tag/2787" path="/hk01/tag/:id" :paramsDesc="['标签 id, 可在 URL 中找到']" radar="1" rssbud="1"/>
+
+### 即時
+
+<Route author="5upernove-heng" example="/hk01/latest" path="/hk01/latest" radar="1" rssbud="1"/>
+
 ## 香港高登
 
 ### 頻道

--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -2186,6 +2186,10 @@ category 对应的关键词有
 
 <Route author="hoilc Fatpandac nczitzk" example="/hk01/tag/2787" path="/hk01/tag/:id" :paramsDesc="['标签 id, 可在 URL 中找到']" radar="1" rssbud="1"/>
 
+### 即時
+
+<Route author="5upernove-heng" example="/hk01/latest" path="/hk01/latest" radar="1" rssbud="1"/>
+
 ## 香港電台
 
 ### 新聞

--- a/docs/traditional-media.md
+++ b/docs/traditional-media.md
@@ -2164,32 +2164,6 @@ category 对应的关键词有
 
 </Route>
 
-## 香港 01
-
-### 热门
-
-<Route author="hoilc Fatpandac nczitzk" example="/hk01/hot" path="/hk01/hot" radar="1" rssbud="1"/>
-
-### 栏目
-
-<Route author="hoilc Fatpandac nczitzk" example="/hk01/zone/11" path="/hk01/zone/:id" :paramsDesc="['栏目 id, 可在 URL 中找到']" radar="1" rssbud="1"/>
-
-### 子栏目
-
-<Route author="hoilc Fatpandac nczitzk" example="/hk01/channel/391" path="/hk01/channel/:id" :paramsDesc="['子栏目 id, 可在 URL 中找到']" radar="1" rssbud="1"/>
-
-### 专题
-
-<Route author="hoilc Fatpandac nczitzk" example="/hk01/issue/649" path="/hk01/issue/:id" :paramsDesc="['专题 id, 可在 URL 中找到']" radar="1" rssbud="1"/>
-
-### 标签
-
-<Route author="hoilc Fatpandac nczitzk" example="/hk01/tag/2787" path="/hk01/tag/:id" :paramsDesc="['标签 id, 可在 URL 中找到']" radar="1" rssbud="1"/>
-
-### 即時
-
-<Route author="5upernove-heng" example="/hk01/latest" path="/hk01/latest" radar="1" rssbud="1"/>
-
 ## 香港電台
 
 ### 新聞

--- a/lib/v2/hk01/channel.js
+++ b/lib/v2/hk01/channel.js
@@ -18,6 +18,6 @@ module.exports = async (ctx) => {
         title: response.data.category ? `${response.data.category.publishName} | 香港01` : `Channel: ${id} | 香港01`,
         link: currentUrl,
         item: items,
-        image: response.data.category.icon,
+        image: response.data.category ? response.data.category.icon : null,
     };
 };

--- a/lib/v2/hk01/channel.js
+++ b/lib/v2/hk01/channel.js
@@ -15,7 +15,7 @@ module.exports = async (ctx) => {
     const items = await ProcessItems(response.data.items, ctx.query.limit, ctx.cache.tryGet);
 
     ctx.state.data = {
-        title: `${response.data.category.publishName} | 香港01`,
+        title: response.data.category ? `${response.data.category.publishName} | 香港01` : `Channel: ${id} | 香港01`,
         link: currentUrl,
         item: items,
         image: response.data.category.icon,

--- a/lib/v2/hk01/latest.js
+++ b/lib/v2/hk01/latest.js
@@ -1,0 +1,20 @@
+const got = require('@/utils/got');
+const { rootUrl, apiRootUrl, ProcessItems } = require('./utils');
+
+module.exports = async (ctx) => {
+    const currentUrl = `${rootUrl}/latest`;
+    const apiUrl = `${apiRootUrl}/v2/page/latest`;
+
+    const response = await got({
+        method: 'get',
+        url: apiUrl,
+    });
+
+    const items = await ProcessItems(response.data.items, ctx.query.limit, ctx.cache.tryGet);
+
+    ctx.state.data = {
+        title: '即時 | 香港01',
+        link: currentUrl,
+        item: items,
+    };
+};

--- a/lib/v2/hk01/maintainer.js
+++ b/lib/v2/hk01/maintainer.js
@@ -1,6 +1,7 @@
 module.exports = {
     '/channel/:id': ['hoilc', 'Fatpandac', 'nczitzk'],
     '/hot': ['hoilc', 'Fatpandac', 'nczitzk'],
+    '/latest': ['5upernova-heng'],
     '/issue/:id': ['hoilc', 'Fatpandac', 'nczitzk'],
     '/tag/:id': ['hoilc', 'Fatpandac', 'nczitzk'],
     '/zone/:id': ['hoilc', 'Fatpandac', 'nczitzk'],

--- a/lib/v2/hk01/radar.js
+++ b/lib/v2/hk01/radar.js
@@ -32,6 +32,12 @@ module.exports = {
                 source: ['/tag/:id', '/'],
                 target: '/hk01/tag/:id?',
             },
+            {
+                title: '即時',
+                docs: '',
+                source: ['/latest', '/'],
+                target: '/hk01/latest',
+            },
         ],
     },
 };

--- a/lib/v2/hk01/radar.js
+++ b/lib/v2/hk01/radar.js
@@ -34,7 +34,7 @@ module.exports = {
             },
             {
                 title: '即時',
-                docs: '',
+                docs: 'https://docs.rsshub.app/traditional-media.html#xiang-gang-01-ji-shi',
                 source: ['/latest', '/'],
                 target: '/hk01/latest',
             },

--- a/lib/v2/hk01/radar.js
+++ b/lib/v2/hk01/radar.js
@@ -4,37 +4,37 @@ module.exports = {
         '.': [
             {
                 title: '热门',
-                docs: 'https://docs.rsshub.app/traditional-media.html#xiang-gang-01-re-men',
+                docs: 'https://docs.rsshub.app/new-media.html#xiang-gang-01-re-men',
                 source: ['/hot', '/'],
                 target: '/hk01/hot',
             },
             {
                 title: '栏目',
-                docs: 'https://docs.rsshub.app/traditional-media.html#xiang-gang-01-lan-mu',
+                docs: 'https://docs.rsshub.app/new-media.html#xiang-gang-01-lan-mu',
                 source: ['/zone/:id', '/'],
                 target: '/hk01/zone/:id?',
             },
             {
                 title: '子栏目',
-                docs: 'https://docs.rsshub.app/traditional-media.html#xiang-gang-01-zi-lan-mu',
+                docs: 'https://docs.rsshub.app/new-media.html#xiang-gang-01-zi-lan-mu',
                 source: ['/channel/:id', '/'],
                 target: '/hk01/channel/:id?',
             },
             {
                 title: '专题',
-                docs: 'https://docs.rsshub.app/traditional-media.html#xiang-gang-01-zhuan-ti',
+                docs: 'https://docs.rsshub.app/new-media.html#xiang-gang-01-zhuan-ti',
                 source: ['/issue/:id', '/'],
                 target: '/hk01/issue/:id?',
             },
             {
                 title: '标签',
-                docs: 'https://docs.rsshub.app/traditional-media.html#xiang-gang-01-biao-qian',
+                docs: 'https://docs.rsshub.app/new-media.html#xiang-gang-01-biao-qian',
                 source: ['/tag/:id', '/'],
                 target: '/hk01/tag/:id?',
             },
             {
                 title: '即時',
-                docs: 'https://docs.rsshub.app/traditional-media.html#xiang-gang-01-ji-shi',
+                docs: 'https://docs.rsshub.app/new-media.html#xiang-gang-01-ji-shi',
                 source: ['/latest', '/'],
                 target: '/hk01/latest',
             },

--- a/lib/v2/hk01/router.js
+++ b/lib/v2/hk01/router.js
@@ -2,6 +2,7 @@ module.exports = function (router) {
     router.get('/channel/:id?', require('./channel'));
     router.get('/hot', require('./hot'));
     router.get('/issue/:id?', require('./issue'));
+    router.get('/latest', require('./latest'));
     router.get('/tag/:id?', require('./tag'));
     router.get('/zone/:id?', require('./zone'));
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://github.com/DIYgod/RSSHub/discussions/8002
Reference: https://github.com/DIYgod/RSSHub/discussions/8002
-->

## 该 PR 相关 Issue / Involved issue

Close #12141 

## 完整路由地址 / Example for the proposed route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/hk01/channel/1
/hk01/latest
```

## 新 RSS 检查列表 / New RSS Script Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
In #12141 "即时" can be fetched by api `https://web-data.api.hk01.com/v2/feed/category/:id`, which is already implemented by route `/hk01/channel/:id`.

However, categories(or channels) like "即时" does not have `category` object in its json data. This will cause an error when using it's property to be the title of the rss feed. For example `/hk01/channel/0`. This commit is to fix this problem.

What's more, the only way I've found to get rss subscription like "即时", is to look up what the api the page called, which might be hard for those users who are not familiar with web to find the `id` of the page they want. It will be better if there's a proper solution to this problem.