### PR TITLE
fix: outputType 为 json 时，即使 template 为空也应该填充 ctx.body

### DIFF
--- a/lib/middleware/template.js
+++ b/lib/middleware/template.js
@@ -101,11 +101,10 @@ module.exports = async (ctx, next) => {
             ctx.body = data;
             return;
         }
-        if (!template) {
-            return;
-        }
         if (outputType !== 'json') {
-            ctx.body = art(template, data);
+            if (template) {
+                ctx.body = art(template, data);
+            }
             return;
         }
         ctx.body = json(data);


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Close #

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

![image](https://user-images.githubusercontent.com/30435672/229568171-aed989bc-8764-4001-b79e-d2b559cd4235.png)

在 template 中间件中，目前分支逻辑如上图所示，也就是如果 outputType 为 json，但 template 变量为空，也是直接 return，但是 outputType 为 json 时并不依赖 template，所以合理的逻辑是当 outputType 为 json 时，不管  template 变量是否为空，都应该填充 ctx.body？

目前的代码实现的影响？没有影响，因为 template 变量总是有值，`if (!template)` 永远不会成立

修改后的代码的影响？没有影响，只是让代码分支逻辑看起来更直观一点？