### PR TITLE
feat(route): add IEEE xplore early access journal

### DIFF
--- a/docs/en/journal.md
+++ b/docs/en/journal.md
@@ -200,6 +200,10 @@ Return results from 2020
 
 <RouteEn author="Derekmini auto-bot-ty" example="/ieee/journal/78/recent" path="/ieee/journal/:journal/recent/:sortType?" :paramsDesc="['Journal code, the number of the `punumber` in the URL','Sort Type, default: `vol-only-seq`, the part of the URL after `sortType`']" radar="1" rssbud="1"/>
 
+### Early Access Journal
+
+<RouteEn author="5upernova-heng" example="/ieee/journal/5306045/earlyaccess" path="/ieee/journal/:journal/earlyaccess/:sortType?" :paramsDesc="['Issue code, the number of the `isnumber` in the URL','Sort Type, default: `vol-only-seq`, the part of the URL after `sortType`']" radar="1" rssbud="1"/>
+
 ## INFORMS
 
 ### Category

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -194,6 +194,11 @@ pageClass: routes
 
 <Route author="Derekmini auto-bot-ty" example="/ieee/journal/78/recent" path="/ieee/journal/:journal/recent/:sortType?" :paramsDesc="['期刊代码，URL 中 `punumber` 部分','排序方式，默认`vol-only-seq`，URL 中 `sortType` 部分']" radar="1" rssbud="1"/>
 
+### 预印版
+
+<Route author="5upernova-heng" example="/ieee/journal/5306045/earlyaccess" path="/ieee/journal/:journal/earlyaccess/:sortType?" :paramsDesc="['发布代码，URL 中 `isnumber` 部分','排序方式，默认`vol-only-seq`，URL 中 `sortType` 部分']" radar="1" rssbud="1"/>
+
+
 ## INFORMS
 
 ### 类型

--- a/lib/v2/ieee/earlyaccess.js
+++ b/lib/v2/ieee/earlyaccess.js
@@ -39,8 +39,7 @@ module.exports = async (ctx) => {
         if (item.hasOwnProperty('authors')) {
             authors = item.authors.map((itemAuth) => itemAuth.preferredName).join('; ');
         }
-        let abstract = '';
-        item.hasOwnProperty('abstract') ? (abstract = item.abstract) : (abstract = '');
+        const abstract = item.hasOwnProperty('abstract') ? item.abstract : '';
         return {
             title,
             link,

--- a/lib/v2/ieee/earlyaccess.js
+++ b/lib/v2/ieee/earlyaccess.js
@@ -1,0 +1,78 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const path = require('path');
+const { art } = require('@/utils/render');
+
+const { CookieJar } = require('tough-cookie');
+const cookieJar = new CookieJar();
+
+module.exports = async (ctx) => {
+    const isnumber = ctx.params.journal;
+    const sortType = ctx.params.sortType ?? 'vol-only-seq';
+    const host = 'https://ieeexplore.ieee.org';
+    const jrnlUrl = `${host}/xpl/tocresult.jsp?isnumber=${isnumber}`;
+
+    const response = await got(`${host}/rest/publication/home/metadata?issueid=${isnumber}`, {
+        cookieJar,
+    }).json();
+    const punumber = response.publicationNumber;
+    const volume = response.currentIssue.volume;
+    const jrnlName = response.displayTitle;
+
+    const response2 = await got
+        .post(`${host}/rest/search/pub/${punumber}/issue/${isnumber}/toc`, {
+            cookieJar,
+            json: {
+                punumber,
+                isnumber,
+                sortType,
+                rowsPerPage: '100',
+            },
+        })
+        .json();
+    let list = response2.records.map((item) => {
+        const $2 = cheerio.load(item.articleTitle);
+        const title = $2.text();
+        const link = item.htmlLink;
+        const doi = item.doi;
+        let authors = 'Do not have author';
+        if (item.hasOwnProperty('authors')) {
+            authors = item.authors.map((itemAuth) => itemAuth.preferredName).join('; ');
+        }
+        let abstract = '';
+        item.hasOwnProperty('abstract') ? (abstract = item.abstract) : (abstract = '');
+        return {
+            title,
+            link,
+            authors,
+            doi,
+            volume,
+            abstract,
+        };
+    });
+
+    const renderDesc = (item) =>
+        art(path.join(__dirname, 'templates/description.art'), {
+            item,
+        });
+    list = await Promise.all(
+        list.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                if (item.abstract !== '') {
+                    const response3 = await got(`${host}${item.link}`);
+                    const { abstract } = JSON.parse(response3.body.match(/metadata=(.*);/)[1]);
+                    const $3 = cheerio.load(abstract);
+                    item.abstract = $3.text();
+                    item.description = renderDesc(item);
+                }
+                return item;
+            })
+        )
+    );
+
+    ctx.state.data = {
+        title: jrnlName,
+        link: jrnlUrl,
+        item: list,
+    };
+};

--- a/lib/v2/ieee/maintainer.js
+++ b/lib/v2/ieee/maintainer.js
@@ -1,4 +1,5 @@
 module.exports = {
     '/journal/:journal/:sortType?': ['Derekmini', 'auto-bot-ty'],
     '/journal/:journal/recent/:sortType?': ['Derekmini', 'auto-bot-ty'],
+    '/journal/:journal/earlyaccess/:sortType?': ['5upernova-heng'],
 };

--- a/lib/v2/ieee/radar.js
+++ b/lib/v2/ieee/radar.js
@@ -14,6 +14,12 @@ module.exports = {
                 source: '/*',
                 target: (params, url) => `/ieee/journal/${new URL(url).searchParams.get('punumber')}/recent`,
             },
+            {
+                title: 'Early Access Journal',
+                docs: 'https://docs.rsshub.app/journal.html#ieee-xplore',
+                source: '/*',
+                target: (params, url) => `/ieee/journal/${new URL(url).searchParams.get('isnumber')}/earlyaccess`,
+            },
         ],
     },
 };

--- a/lib/v2/ieee/router.js
+++ b/lib/v2/ieee/router.js
@@ -1,6 +1,7 @@
 module.exports = function (router) {
     router.get('/:journal/latest/vol/:sortType?', require('./journal')); // deprecated
     router.get('/:journal/latest/date/:sortType?', require('./recent')); // deprecated
-    router.get('/journal/:journal/:sortType?', require('./journal'));
+    router.get('/journal/:journal/earlyaccess/:sortType?', require('./earlyaccess'));
     router.get('/journal/:journal/recent/:sortType?', require('./recent'));
+    router.get('/journal/:journal/:sortType?', require('./journal'));
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Close #12189 

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/ieee/journal/5306045/earlyaccess
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [x] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
