### PR TITLE
feat(route): enhance feed of freecomputerbooks.com with full-text sup…

### DIFF
--- a/lib/v2/freecomputerbooks/index.js
+++ b/lib/v2/freecomputerbooks/index.js
@@ -1,16 +1,20 @@
 const cheerio = require('cheerio');
+const path = require('path');
 
 const got = require('@/utils/got');
+const { art } = require('@/utils/render');
 const { parseDate } = require('@/utils/parse-date');
 
 const baseURL = 'https://freecomputerbooks.com/';
 
+async function cheerioLoad(url) {
+    return cheerio.load((await got(url)).data);
+}
+
 module.exports = async (ctx) => {
     const categoryId = ctx.params.category?.trim();
     const requestURL = categoryId ? new URL(`${categoryId}.html`, baseURL).href : baseURL;
-
-    const response = await got({ method: 'get', url: requestURL });
-    const $ = cheerio.load(response.data);
+    const $ = await cheerioLoad(requestURL);
 
     // As observation has shown that each page only has one element of the
     // class, thus to simplify the processing the text is directly extracted.
@@ -24,23 +28,22 @@ module.exports = async (ctx) => {
 
         // For a "Selected New Books" page, the <ul> element's id. is
         // `newBooksG`; for an ordinary category page, it's `newBooksL`.
-        item: $('ul[id^=newBooks] > li')
-            .toArray()
-            .map((elem) => buildPostItem($(elem), categoryTitle, $)),
+        item: await Promise.all(
+            $('ul[id^=newBooks] > li')
+                .toArray()
+                .map((elem) => buildPostItem($(elem), categoryTitle, ctx.cache))
+        ),
     };
 };
 
-function buildPostItem(listItem, categoryTitle, $) {
-    // Cover in original size, e.g., `covers/xyz_43x55.jpg` -> `covers/xyz.jpg`
-    const image = listItem.find('img');
-    image.attr('src', image.attr('src').replace(/_\d+x\d+/, ''));
+function buildPostItem(listItem, categoryTitle, cache) {
+    const $ = cheerio.load(''); // the only use below doesn't care about the content
 
     const postLink = listItem.find('a:first');
     const postInfo = listItem.find('p:contains("Post under")');
     const postItem = {
         title: postLink.text(),
-        link: postLink.attr('href'),
-        description: listItem.html(),
+        link: new URL(postLink.attr('href'), baseURL).href,
 
         // Only a "Selected New Books" page has exclicit categorization info.
         // for posts; an ordinary category page hasn't, then in which case the
@@ -62,5 +65,30 @@ function buildPostItem(listItem, categoryTitle, $) {
         postItem.pubDate = parseDate(pubDateText);
     }
 
-    return postItem;
+    return cache.tryGet(postItem.link, () => insertDescriptionInto(postItem));
+}
+
+async function insertDescriptionInto(item) {
+    const $ = await cheerioLoad(item.link);
+
+    // Eliminate all comment nodes to avoid their being selected and rendered in
+    // the final output (I know this is actually unnecessary, but please forgive
+    // my mysophobia).
+    $.root()
+        .find('*')
+        .contents()
+        .filter((_, node) => node.type === 'comment')
+        .remove();
+
+    const imageURL = $('#bookdesc img[title]').attr('src');
+    const metadata = $('#booktitle ul').removeAttr('style');
+    const content = $('#bookdesccontent').removeAttr('id');
+
+    metadata.find('li:contains(Share This)').remove();
+    content.find('img[src$="/hot.gif"]').remove();
+    content.find(':contains(Similar Books)').nextAll().addBack().remove();
+
+    item.description = art(path.join(__dirname, 'templates/desc.art'), { imageURL, metadata, content });
+
+    return item;
 }

--- a/lib/v2/freecomputerbooks/templates/desc.art
+++ b/lib/v2/freecomputerbooks/templates/desc.art
@@ -1,0 +1,3 @@
+<figure><img src="{{ imageURL }}"></figure>
+{{@ metadata }}
+{{@ content }}


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Close #

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/freecomputerbooks
/freecomputerbooks/index
/freecomputerbooks/compscAlgorithmBooks
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [x] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
A continued improvement following #12234 