### PR TITLE
chore: remove string-similarity

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "simplecc-wasm": "0.1.5",
     "socks-proxy-agent": "8.0.1",
     "source-map": "0.7.4",
-    "string-similarity": "4.0.4",
     "tiny-async-pool": "2.1.0",
     "tough-cookie": "4.1.2",
     "twitter-api-v2": "1.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,9 +166,6 @@ dependencies:
   source-map:
     specifier: 0.7.4
     version: 0.7.4
-  string-similarity:
-    specifier: 4.0.4
-    version: 4.0.4
   tiny-async-pool:
     specifier: 2.1.0
     version: 2.1.0
@@ -6955,11 +6952,6 @@ packages:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
     dev: true
-
-  /string-similarity@4.0.4:
-    resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    dev: false
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Close #

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 说明 / Note
[string-similarity](https://www.npmjs.com/package/string-similarity) has been [deprecated](https://github.com/aceakash/string-similarity/commit/41b2e0682f32cbd3c64eda62070fd2fdbddab381).
It was introduced in #6285 and most of the code has been removed in f60744241cf7b991da92a423b712a16b74c86564
