### PR TITLE
fix(route): nytimes author

### DIFF
--- a/lib/v2/nytimes/author.js
+++ b/lib/v2/nytimes/author.js
@@ -19,7 +19,7 @@ module.exports = async (ctx) => {
         .map((index, elem) => {
             const $item = $(elem);
             const $info = $item.find('div > div');
-            const title = $info.find('h2').text();
+            const title = $info.find('h3').text();
             const href = $info.find('a').attr('href');
             const link = new URL(href, authorUrl);
             const description = $info.find('a > p').text();

--- a/lib/v2/nytimes/author.js
+++ b/lib/v2/nytimes/author.js
@@ -19,7 +19,7 @@ module.exports = async (ctx) => {
         .map((index, elem) => {
             const $item = $(elem);
             const $info = $item.find('div > div');
-            const title = $info.find('h3').text();
+            const title = $info.find('h2').text();
             const href = $info.find('a').attr('href');
             const link = new URL(href, authorUrl);
             const description = $info.find('a > p').text();

--- a/package.json
+++ b/package.json
@@ -76,8 +76,10 @@
   },
   "dependencies": {
     "@koa/router": "12.0.0",
+    "@napi-rs/pinyin": "^1.7.1",
     "@postlight/parser": "2.2.3",
     "@sentry/node": "7.51.0",
+    "@vuepress/shared-utils": "^1.9.9",
     "aes-js": "3.1.2",
     "art-template": "4.13.2",
     "bbcodejs": "0.0.4",
@@ -112,6 +114,7 @@
     "lz-string": "1.5.0",
     "mailparser": "3.6.4",
     "markdown-it": "13.0.1",
+    "markdown-it-emoji": "^2.0.2",
     "module-alias": "2.2.2",
     "pidusage": "3.0.2",
     "plist": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -76,10 +76,8 @@
   },
   "dependencies": {
     "@koa/router": "12.0.0",
-    "@napi-rs/pinyin": "^1.7.1",
     "@postlight/parser": "2.2.3",
     "@sentry/node": "7.51.0",
-    "@vuepress/shared-utils": "^1.9.9",
     "aes-js": "3.1.2",
     "art-template": "4.13.2",
     "bbcodejs": "0.0.4",
@@ -114,7 +112,6 @@
     "lz-string": "1.5.0",
     "mailparser": "3.6.4",
     "markdown-it": "13.0.1",
-    "markdown-it-emoji": "^2.0.2",
     "module-alias": "2.2.2",
     "pidusage": "3.0.2",
     "plist": "3.0.6",


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Fixes missing titles (they are now `h3` instead of `h2`)

## 路由地址示例 / Example for the Proposed Route(s)



```routes
/nytimes/author/farhad-manjoo
```
