### PR TITLE
fix(route): picuki

### DIFF
--- a/lib/v2/picuki/utils.js
+++ b/lib/v2/picuki/utils.js
@@ -3,7 +3,7 @@ const puppeteerGet = async (url, browser) => {
     // await page.setExtraHTTPHeaders({ referer: host });
     await page.setRequestInterception(true);
     page.on('request', (request) => {
-        request.resourceType() === 'document' ? request.continue() : request.abort();
+        request.resourceType() === 'document' || request.resourceType() === 'script' ? request.continue() : request.abort();
     });
     await page.goto(url, {
         waitUntil: 'domcontentloaded',


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved Issue

Close #12657

## 路由地址示例 / Example for the Proposed Route(s)

```routes
/picuki/profile/stefaniejoosten
/picuki/profile/stefaniejoosten/0
/picuki/profile/stefaniejoosten/1
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [] `Puppeteer`

## 说明 / Note
`/picuki/profile/stefaniejoosten/10` or Instagram Stories on Picuki are still broken. Not in scope of this PR.