### PR TITLE
fix(route): 为 yahoo news 添加 author 字段

### DIFF
--- a/lib/v2/yahoo/news/index.js
+++ b/lib/v2/yahoo/news/index.js
@@ -18,25 +18,29 @@ module.exports = async (ctx) => {
         filteredItems.map(
             async (item) =>
                 await ctx.cache.tryGet(item.link, async () => {
-                    const response = await got({
-                        method: 'get',
-                        url: item.link,
-                    });
+                    try {
+                        const response = await got({
+                            method: 'get',
+                            url: item.link,
+                        });
 
-                    const $ = cheerio.load(response.data);
-                    const author = `${$('span.caas-author-byline-collapse').text()} @${$('span.caas-attr-provider').text()}`;
+                        const $ = cheerio.load(response.data);
+                        const author = `${$('span.caas-author-byline-collapse').text()} @${$('span.caas-attr-provider').text()}`;
 
-                    $('.caas-content-byline-wrapper, .caas-xray-wrapper, .caas-header, .caas-readmore').remove();
-                    const description = $('.caas-content-wrapper').html();
+                        $('.caas-content-byline-wrapper, .caas-xray-wrapper, .caas-header, .caas-readmore').remove();
+                        const description = $('.caas-content-wrapper').html();
 
-                    const single = {
-                        title: item.title,
-                        description,
-                        author,
-                        pubDate: item.pubDate,
-                        link: item.link,
-                    };
-                    return single;
+                        const single = {
+                            title: item.title,
+                            description,
+                            author,
+                            pubDate: item.pubDate,
+                            link: item.link,
+                        };
+                        return single;
+                    } catch (e) {
+                        return Promise.resolve('');
+                    }
                 })
         )
     );

--- a/lib/v2/yahoo/news/index.js
+++ b/lib/v2/yahoo/news/index.js
@@ -16,9 +16,9 @@ module.exports = async (ctx) => {
     );
     const items = await Promise.all(
         filteredItems.map(
-            async (item) =>
-                await ctx.cache.tryGet(item.link, async () => {
-                    try {
+            async (item) => {
+                try {
+                    return await ctx.cache.tryGet(item.link, async () => {
                         const response = await got({
                             method: 'get',
                             url: item.link,
@@ -38,11 +38,11 @@ module.exports = async (ctx) => {
                             link: item.link,
                         };
                         return single;
-                    } catch (e) {
-                        return Promise.resolve('');
-                    }
-                })
-        )
+                    })
+                } catch (e) {
+                    return Promise.resolve('');
+                }
+            })
     );
 
     ctx.state.data = {

--- a/lib/v2/yahoo/news/index.js
+++ b/lib/v2/yahoo/news/index.js
@@ -9,38 +9,42 @@ module.exports = async (ctx) => {
         throw Error('Invalid region');
     }
     const category = ctx.params.category ? ctx.params.category.toLowerCase() : '';
-    const rssUrl = `https://${region ? region + '.' : ''}news.yahoo.com/rss/${category}`;
+    const rssUrl = `https://${region ? `${region}.` : ''}news.yahoo.com/rss/${category}`;
     const feed = await parser.parseURL(rssUrl);
-    const title = feed.title;
-    const link = feed.link;
-    const description = feed.description;
-    const filteredItems = feed.items.filter((item) => !item.link.includes('promotions') && new URL(item.link).hostname.match(/.*\.yahoo\.com$/));
+    const filteredItems = feed.items.filter(
+        (item) => !item.link.includes('promotions') && new URL(item.link).hostname.match(/.*\.yahoo\.com$/)
+    );
     const items = await Promise.all(
-        filteredItems.map(async (item) => {
-            const description = await ctx.cache.tryGet(item.link, async () => {
-                const response = await got({
-                    method: 'get',
-                    url: item.link,
-                });
+        filteredItems.map(
+            async (item) =>
+                await ctx.cache.tryGet(item.link, async () => {
+                    const response = await got({
+                        method: 'get',
+                        url: item.link,
+                    });
 
-                const $ = cheerio.load(response.data);
-                $('.caas-content-byline-wrapper, .caas-xray-wrapper, .caas-header, .caas-readmore').remove();
-                return $('.caas-content-wrapper').html();
-            });
-            const single = {
-                title: item.title,
-                description,
-                pubDate: item.pubDate,
-                link: item.link,
-            };
-            return single;
-        })
+                    const $ = cheerio.load(response.data);
+                    const author = `${$('span.caas-author-byline-collapse').text()} @${$('span.caas-attr-provider').text()}`;
+
+                    $('.caas-content-byline-wrapper, .caas-xray-wrapper, .caas-header, .caas-readmore').remove();
+                    const description = $('.caas-content-wrapper').html();
+
+                    const single = {
+                        title: item.title,
+                        description,
+                        author,
+                        pubDate: item.pubDate,
+                        link: item.link,
+                    };
+                    return single;
+                })
+        )
     );
 
     ctx.state.data = {
-        title,
-        link,
-        description,
+        title: feed.title,
+        link: feed.link,
+        description: feed.description,
         item: items,
     };
 };

--- a/lib/v2/yahoo/news/index.js
+++ b/lib/v2/yahoo/news/index.js
@@ -38,7 +38,7 @@ module.exports = async (ctx) => {
                             link: item.link,
                         };
                         return single;
-                    })
+                    });
                 } catch (e) {
                     return Promise.resolve('');
                 }

--- a/lib/v2/yahoo/news/index.js
+++ b/lib/v2/yahoo/news/index.js
@@ -15,34 +15,27 @@ module.exports = async (ctx) => {
         (item) => !item.link.includes('promotions') && new URL(item.link).hostname.match(/.*\.yahoo\.com$/)
     );
     const items = await Promise.all(
-        filteredItems.map(
-            async (item) => {
-                try {
-                    return await ctx.cache.tryGet(item.link, async () => {
-                        const response = await got({
-                            method: 'get',
-                            url: item.link,
-                        });
+        filteredItems.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const response = await got({
+                    method: 'get',
+                    url: item.link,
+                });
+                const $ = cheerio.load(response.data);
+                const author = `${$('span.caas-author-byline-collapse').text()} @${$('span.caas-attr-provider').text()}`;
+                $('.caas-content-byline-wrapper, .caas-xray-wrapper, .caas-header, .caas-readmore').remove();
+                const description = $('.caas-content-wrapper').html();
 
-                        const $ = cheerio.load(response.data);
-                        const author = `${$('span.caas-author-byline-collapse').text()} @${$('span.caas-attr-provider').text()}`;
-
-                        $('.caas-content-byline-wrapper, .caas-xray-wrapper, .caas-header, .caas-readmore').remove();
-                        const description = $('.caas-content-wrapper').html();
-
-                        const single = {
-                            title: item.title,
-                            description,
-                            author,
-                            pubDate: item.pubDate,
-                            link: item.link,
-                        };
-                        return single;
-                    });
-                } catch (e) {
-                    return Promise.resolve('');
-                }
+                const single = {
+                    title: item.title,
+                    description,
+                    author,
+                    pubDate: item.pubDate,
+                    link: item.link,
+                };
+                return single;
             })
+        )
     );
 
     ctx.state.data = {


### PR DESCRIPTION
规范化代码，添加作者字段，方便根据作者过滤

出发点是因为 [瘾科技中文版](https://chinese.engadget.com/) 关站，整合到yahoo新闻中，那么想要订阅瘾科技，就需要根据作者进行过滤
这个pr给yahoo新闻的rss添加了author字段，以页面上的 `作者 @团体`的形式，因此可以使用rsshub的filter_author功能，以路由 `/yahoo/news/tw/technology?filter_author=Engadget` 即可订阅所有瘾科技的文章

此pr不仅对瘾科技有意义，对于只想订阅yahoo新闻特定作者、特定团体文章的需求都有价值

<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Close #

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/yahoo/news/tw
/yahoo/news/tw/technology
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [ ] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
