### PR TITLE
perf(route/reuters): use downsized pictures from Reuters

### DIFF
--- a/lib/v2/reuters/templates/description.art
+++ b/lib/v2/reuters/templates/description.art
@@ -9,7 +9,7 @@ Summary:
 {{ each result.related_content.galleries g }}
     {{ each g.content_elements e }}
         {{ if e.type === 'image' }}
-            <figure><img src="{{ e.renditions.original['1080w'] }}" alt="{{ e.alt_text }}">
+            <figure><img src="{{ e.renditions.original['1920w'] }}" alt="{{ e.alt_text }}">
             <figcaption>{{ e.caption }}</figcaption>
             </figure>
         {{ /if }}
@@ -17,7 +17,7 @@ Summary:
 {{ /each }}
 {{ each result.related_content.images i }}
     {{ if i.type === 'image' }}
-        <figure><img src="{{ i.renditions.original['1080w'] }}" alt="{{ i.alt_text }}">
+        <figure><img src="{{ i.renditions.original['1920w'] }}" alt="{{ i.alt_text }}">
         <figcaption>{{ i.caption }}</figcaption>
         </figure>
     {{ /if }}

--- a/lib/v2/reuters/templates/description.art
+++ b/lib/v2/reuters/templates/description.art
@@ -9,7 +9,7 @@ Summary:
 {{ each result.related_content.galleries g }}
     {{ each g.content_elements e }}
         {{ if e.type === 'image' }}
-            <figure><img src="{{ e.url }}" alt="{{ e.alt_text }}">
+            <figure><img src="{{ e.renditions.original['1080w'] }}" alt="{{ e.alt_text }}">
             <figcaption>{{ e.caption }}</figcaption>
             </figure>
         {{ /if }}
@@ -17,7 +17,7 @@ Summary:
 {{ /each }}
 {{ each result.related_content.images i }}
     {{ if i.type === 'image' }}
-        <figure><img src="{{ i.url }}" alt="{{ i.alt_text }}">
+        <figure><img src="{{ i.renditions.original['1080w'] }}" alt="{{ i.alt_text }}">
         <figcaption>{{ i.caption }}</figcaption>
         </figure>
     {{ /if }}


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Close #

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/reuters/world
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

The origal routes for /reuters request raw news pictures, which have sizes up to 5mb each. This means a single refresh of one reuters channel in an RSS reader can easily consume 100+mb data, and extreme lags can be noticed in some readers who do not optimize thumbnails when scrolling. So this pull request fixes the issue by requesting downsized images from Reuters itself. The default long side of each image is limited to 1080px (`1080w` in `/templates/description.art`), which can be adjusted to 60, 120, 240, 480, 960, 1200 and 1920 if you prefer different resolutions.
