### PR TITLE
fix(route/bilibili):fix liveSearch

### DIFF
--- a/lib/v2/bilibili/liveSearch.js
+++ b/lib/v2/bilibili/liveSearch.js
@@ -1,4 +1,6 @@
 const got = require('@/utils/got');
+const utils = require('./utils');
+const cache = require('./cache');
 
 module.exports = async (ctx) => {
     const key = ctx.params.key;
@@ -15,21 +17,26 @@ module.exports = async (ctx) => {
             orderTitle = '人气直播';
             break;
     }
+    const verifyString = await cache.getVerifyString(ctx);
+    let params = `__refresh__=true&_extra=&context=&page=1&page_size=42&order=online&duration=&from_source=&from_spmid=333.337&platform=pc&highlight=1&single_column=0&keyword=${urlEncodedKey}&qv_id=68nr2HBn3S27waWVjvFT0CLT7U3TF0U3&ad_resource=&source_tag=3&gaia_vtoken=&category_id=&search_type=live&dynamic_offset=0&web_location=1430654`;
+    params = utils.addVerifyInfo(params, verifyString);
 
     const response = await got({
         method: 'get',
-        url: `https://api.bilibili.com/x/web-interface/search/type?search_type=live_room&keyword=${urlEncodedKey}&order=${order}&coverType=user_cover&page=1`,
+        url: `https://api.bilibili.com/x/web-interface/wbi/search/type?${params}`,
         headers: {
-            Referer: `https://search.bilibili.com/live?keyword=${urlEncodedKey}&order=${order}&coverType=user_cover&page=1&search_type=live`,
+            Referer: `https://search.bilibili.com/live?keyword=${urlEncodedKey}&from_source=webtop_search&spm_id_from=444.7&search_source=3&search_type=live_room`,
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',
+            'Cookie': await cache.getCookie(ctx),
         },
     });
-    const data = response.data.data.result;
+    const data = response.data.data.result.live_room;
 
     ctx.state.data = {
         title: `哔哩哔哩直播-${key}-${orderTitle}`,
         link: `https://search.bilibili.com/live?keyword=${urlEncodedKey}&order=${order}&coverType=user_cover&page=1&search_type=live`,
         description: `哔哩哔哩直播-${key}-${orderTitle}`,
-        item: data.map((item) => ({
+        item: data && data.map((item) => ({
             title: `${item.uname} ${item.title} (${item.cate_name}-${item.live_time})`,
             description: `${item.uname} ${item.title} (${item.cate_name}-${item.live_time})`,
             pubDate: new Date(item.live_time.replace(' ', 'T') + '+08:00').toUTCString(),

--- a/lib/v2/bilibili/liveSearch.js
+++ b/lib/v2/bilibili/liveSearch.js
@@ -27,7 +27,7 @@ module.exports = async (ctx) => {
         headers: {
             Referer: `https://search.bilibili.com/live?keyword=${urlEncodedKey}&from_source=webtop_search&spm_id_from=444.7&search_source=3&search_type=live_room`,
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',
-            'Cookie': await cache.getCookie(ctx),
+            Cookie: await cache.getCookie(ctx),
         },
     });
     const data = response.data.data.result.live_room;
@@ -36,12 +36,14 @@ module.exports = async (ctx) => {
         title: `哔哩哔哩直播-${key}-${orderTitle}`,
         link: `https://search.bilibili.com/live?keyword=${urlEncodedKey}&order=${order}&coverType=user_cover&page=1&search_type=live`,
         description: `哔哩哔哩直播-${key}-${orderTitle}`,
-        item: data && data.map((item) => ({
-            title: `${item.uname} ${item.title} (${item.cate_name}-${item.live_time})`,
-            description: `${item.uname} ${item.title} (${item.cate_name}-${item.live_time})`,
-            pubDate: new Date(item.live_time.replace(' ', 'T') + '+08:00').toUTCString(),
-            guid: `https://live.bilibili.com/${item.roomid} ${item.live_time}`,
-            link: `https://live.bilibili.com/${item.roomid}`,
-        })),
+        item:
+            data &&
+            data.map((item) => ({
+                title: `${item.uname} ${item.title} (${item.cate_name}-${item.live_time})`,
+                description: `${item.uname} ${item.title} (${item.cate_name}-${item.live_time})`,
+                pubDate: new Date(item.live_time.replace(' ', 'T') + '+08:00').toUTCString(),
+                guid: `https://live.bilibili.com/${item.roomid} ${item.live_time}`,
+                link: `https://live.bilibili.com/${item.roomid}`,
+            })),
     };
 };


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved Issue

无

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/bilibili/live/search/:key/:order

参数:

key, 必选 - 搜索关键字
order, 必选 - 排序方式, live_time 开播时间, online 人气

```

## 说明 / Note

修正目前无效的搜索路由,更改为使用现役的搜索接口
