### PR TITLE
fix: agirls routes

### DIFF
--- a/lib/v2/agirls/index.js
+++ b/lib/v2/agirls/index.js
@@ -13,7 +13,7 @@ module.exports = async (ctx) => {
     const category = ctx.params.category ?? '';
 
     const response = await got({
-        url: baseUrl + '/posts' + (category ? `/${category}` : ''),
+        url: `${baseUrl}/posts${category ? `/${category}` : ''}`,
         headers: {
             Referer: baseUrl,
         },
@@ -22,12 +22,12 @@ module.exports = async (ctx) => {
 
     const $ = cheerio.load(response.data);
 
-    let items = $('div a.flex.flex-col')
+    let items = $('.ag-post-item__link')
         .map((_, item) => {
             item = $(item);
             return {
-                title: item.find('h2').text().trim(),
-                link: baseUrl + item.attr('href'),
+                title: item.text().trim(),
+                link: `${baseUrl}${item.attr('href')}`,
             };
         })
         .get();
@@ -38,20 +38,22 @@ module.exports = async (ctx) => {
                 const detailResponse = await got({
                     url: item.link,
                     headers: {
-                        Referer: baseUrl + '/posts/' + (category ? `/${category}` : ''),
+                        Referer: `${baseUrl}/posts/${category ? `/${category}` : ''}`,
                     },
                     cookieJar,
                 });
                 const content = cheerio.load(detailResponse.data);
 
-                item.category = content('a.mr-2.bg-neutral-lightest.px-2.py-1.text-sm.text-neutral-light')
+                // Tags are displayed in both the header and footer.
+                item.category = Array.from(new Set(content('.ag-article__tag')
                     .toArray()
-                    .map((e) => content(e).text().trim().replace('#', ''));
+                    .map((e) => content(e).text().trim().replace('#', ''))));
+
                 item.description = art(path.join(__dirname, 'templates/description.art'), {
-                    desc: content('div.post-content').html(),
+                    desc: content('.ag-article').html(),
                 });
-                item.pubDate = timezone(parseDate(content('time').text().trim()), +8);
-                item.author = content('a.mr-1.text-primary').text().trim();
+                item.pubDate = timezone(parseDate(content('time').text().trim(), 'YYYY/MM/DD'), +8);
+                item.author = content('.ag-article__authorlink').text().trim();
 
                 return item;
             })
@@ -60,7 +62,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: $('head title').text().trim(),
-        link: baseUrl + '/' + category,
+        link: `${baseUrl}/posts/${category}`,
         description: $('head meta[name=description]').attr('content'),
         item: items,
         language: $('html').attr('lang'),
@@ -68,7 +70,7 @@ module.exports = async (ctx) => {
 
     ctx.state.json = {
         title: $('head title').text().trim(),
-        link: baseUrl + '/' + category,
+        link: `${baseUrl}/posts/${category}`,
         description: $('head meta[name=description]').attr('content'),
         item: items,
         language: $('html').attr('lang'),

--- a/lib/v2/agirls/topic.js
+++ b/lib/v2/agirls/topic.js
@@ -10,7 +10,7 @@ module.exports = async (ctx) => {
     const topic = ctx.params.topic;
 
     const response = await got({
-        url: baseUrl + '/topic/' + topic,
+        url: `${baseUrl}/topic/${topic}`,
         headers: {
             Referer: baseUrl,
         },
@@ -18,12 +18,12 @@ module.exports = async (ctx) => {
 
     const $ = cheerio.load(response.data);
 
-    let items = $('div.col-12 div.row a')
+    let items = $('.ag-post-item__link')
         .map((_, item) => {
             item = $(item);
             return {
-                title: item.find('h3').text().trim(),
-                link: baseUrl + item.attr('href'),
+                title: item.text().trim(),
+                link: `${baseUrl}${item.attr('href')}`,
             };
         })
         .get();
@@ -34,19 +34,21 @@ module.exports = async (ctx) => {
                 const detailResponse = await got({
                     url: item.link,
                     headers: {
-                        Referer: baseUrl + '/topic/' + topic,
+                        Referer: `${baseUrl}/topic/${topic}`,
                     },
                 });
                 const content = cheerio.load(detailResponse.data);
 
-                item.category = content('a.mr-2.bg-neutral-lightest.px-2.py-1.text-sm.text-neutral-light')
+                // Tags are displayed in both the header and footer.
+                item.category = Array.from(new Set(content('.ag-article__tag')
                     .toArray()
-                    .map((e) => content(e).text().trim().replace('#', ''));
+                    .map((e) => content(e).text().trim().replace('#', ''))));
+
                 item.description = art(path.join(__dirname, 'templates/description.art'), {
-                    desc: content('div.post-content').html(),
+                    desc: content('.ag-article').html(),
                 });
-                item.pubDate = timezone(parseDate(content('time').text().trim()), +8);
-                item.author = content('a.mr-1.text-primary').text().trim();
+                item.pubDate = timezone(parseDate(content('time').text().trim(), 'YYYY/MM/DD'), +8);
+                item.author = content('.ag-article__authorlink').text().trim();
 
                 return item;
             })
@@ -55,7 +57,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: $('head title').text().trim(),
-        link: baseUrl + '/' + topic,
+        link: `${baseUrl}/topic/${topic}`,
         description: $('head meta[name=description]').attr('content'),
         item: items,
         language: $('html').attr('lang'),
@@ -63,7 +65,7 @@ module.exports = async (ctx) => {
 
     ctx.state.json = {
         title: $('head title').text().trim(),
-        link: baseUrl + '/' + topic,
+        link: `${baseUrl}/topic/${topic}`,
         description: $('head meta[name=description]').attr('content'),
         item: items,
         language: $('html').attr('lang'),

--- a/lib/v2/agirls/topic_list.js
+++ b/lib/v2/agirls/topic_list.js
@@ -6,7 +6,7 @@ module.exports = async (ctx) => {
     const category = 'topic';
 
     const response = await got({
-        url: baseUrl + '/' + category,
+        url: `${baseUrl}/${category}`,
         headers: {
             Referer: baseUrl,
         },
@@ -14,13 +14,13 @@ module.exports = async (ctx) => {
 
     const $ = cheerio.load(response.data);
 
-    const items = $('div div.border-b.border-neutral-lighter')
+    const items = $('.ag-topic')
         .map((_, item) => {
             item = $(item);
-            const link = baseUrl + item.find('a').attr('href');
+            const link = `${baseUrl}${item.find('.ag-topic__link').attr('href')}`;
             return ctx.cache.tryGet(link, () => ({
-                title: item.find('h2').text().trim(),
-                description: item.find('a').attr('href').replace('/topic/', ''),
+                title: item.find('.ag-topic__link').text().trim(),
+                description: item.find('.ag-topic__summery').text().trim(),
                 link,
             }));
         })
@@ -28,7 +28,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: $('head title').text().trim(),
-        link: baseUrl + '/' + category,
+        link: `${baseUrl}/${category}`,
         description: $('head meta[name=description]').attr('content'),
         item: items,
         language: $('html').attr('lang'),
@@ -36,7 +36,7 @@ module.exports = async (ctx) => {
 
     ctx.state.json = {
         title: $('head title').text().trim(),
-        link: baseUrl + '/' + category,
+        link: `${baseUrl}/${category}`,
         description: $('head meta[name=description]').attr('content'),
         item: items,
         language: $('html').attr('lang'),


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Close #

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/agirls
/agirls/computer
/agirls/topic/chatgpt-2023
/agirls/topic_list
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [ ] 新的路由 New Route
  - [ ] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [ ] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [ ] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [ ] 可以解析 Parsed
  - [ ] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

This pull request fixes `/agirls/:category?`, `/agirls/topic/:topic` and `/agirls/topic_list`.