### PR TITLE
feat(route): bluesky post search ("keyword")

### DIFF
--- a/docs/en/social-media.md
+++ b/docs/en/social-media.md
@@ -4,6 +4,12 @@ pageClass: routes
 
 # Social Media
 
+## Bluesky (bsky)
+
+### Keywords
+
+<RouteEn author="untitaker" example="/bsky/keyword/hello" path="/bsky/keyword/:keyword" radar="1" rssbud="1" />
+
 ## Crossbell
 
 ### Notes

--- a/docs/social-media.md
+++ b/docs/social-media.md
@@ -24,6 +24,12 @@ Tiny Tiny RSS 会给所有 iframe 元素添加 `sandbox="allow-scripts"` 属性�
 
 :::
 
+## Bluesky (bsky)
+
+### 关键词
+
+<Route author="untitaker" example="/bsky/keyword/hello" path="/bsky/keyword/:keyword" radar="1" rssbud="1" />
+
 ### 番剧
 
 <Route author="DIYgod" example="/bilibili/bangumi/media/9192" path="/bilibili/bangumi/media/:mediaid" :paramsDesc="['番剧媒体 id, 番剧主页 URL 中获取']"/>

--- a/lib/v2/bsky/keyword.js
+++ b/lib/v2/bsky/keyword.js
@@ -1,0 +1,22 @@
+const got = require('@/utils/got');
+
+module.exports = async (ctx) => {
+    const { keyword } = ctx.params;
+    const apiLink = `https://search.bsky.social/search/posts?q=${encodeURIComponent(keyword)}`;
+
+    const { data } = await got(apiLink);
+
+    const items = data.map((item) => ({
+        title: item.post.text,
+        link: `https://bsky.app/profile/${item.user.handle}/post/${item.tid.split('/')[1]}`,
+        description: item.post.text,
+        pubDate: new Date(item.post.createdAt / 1000000),
+        author: item.user.handle,
+    }));
+
+    ctx.state.data = {
+        title: `Bluesky Keyword - ${keyword}`,
+        link: `https://bsky.app/search?q=${encodeURIComponent(keyword)}`,
+        item: items,
+    };
+};

--- a/lib/v2/bsky/maintainer.js
+++ b/lib/v2/bsky/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/keyword/:keyword/:routeParams?': ['untitaker'],
+};

--- a/lib/v2/bsky/radar.js
+++ b/lib/v2/bsky/radar.js
@@ -1,0 +1,13 @@
+module.exports = {
+    'bsky.app': {
+        _name: 'Bluesky',
+        '.': [
+            {
+                title: '关键词',
+                docs: 'https://docs.rsshub.app/social-media.html#bsky',
+                source: '/search',
+                target: (params, url) => `/bsky/keyword/${new URL(url).searchParams.get('q')}`,
+            },
+        ],
+    },
+};

--- a/lib/v2/bsky/router.js
+++ b/lib/v2/bsky/router.js
@@ -1,0 +1,3 @@
+module.exports = (router) => {
+    router.get('/keyword/:keyword/:routeParams?', require('./keyword'));
+};


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

There is no issue to reference.

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/bsky/keyword/:keyword
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/bsky/keyword/:keyword
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [x] 中文文档 CN
  - [x] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [x] 可以解析 Parsed
  - [x] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note

I think I filled out the checklist as far as it applies.

* There is no pupeteer involved
* I don't understand what "new package added" means
* timezones are correct (I have not found dedicated utilities for parsing timestamps from POSIX timestamps, but JS-native `new Date()` works fine)
* i have no idea about rate limit (did not try it out)
* there's no attempt to fetch fulltext (it's one API call)
* documentation is there in CN+EN, mostly copypasted from twitter