### PR TITLE
feat(route): Spotify show route

### DIFF
--- a/docs/en/multimedia.md
+++ b/docs/en/multimedia.md
@@ -525,27 +525,27 @@ Refer to [Pornhub F.A.Qs](https://help.pornhub.com/hc/en-us/articles/36004432703
 
 ### Artist Albums
 
-<RouteEn author="outloudvi" example="/spotify/artist/6k9TBCxyr4bXwZ8Y21Kwn1" path="/spotify/artist/:id" :paramsDesc="['Artist ID']" />
+<RouteEn author="outloudvi" example="/spotify/artist/6k9TBCxyr4bXwZ8Y21Kwn1" path="/spotify/artist/:id" :paramsDesc="['Artist ID']" selfhost="1"/>
 
 ### Playlist
 
-<RouteEn author="outloudvi" example="/spotify/playlist/4UBVy1LttvodwivPUuwJk2" path="/spotify/playlist/:id" :paramsDesc="['Playlist ID']" />
+<RouteEn author="outloudvi" example="/spotify/playlist/4UBVy1LttvodwivPUuwJk2" path="/spotify/playlist/:id" :paramsDesc="['Playlist ID']" selfhost="1"/>
 
 ### Personal Saved Tracks
 
-<RouteEn author="outloudvi" example="/spotify/saved/50" path="/spotify/saved/:limit?" :paramsDesc="['Track count, 50 by default']" />
+<RouteEn author="outloudvi" example="/spotify/saved/50" path="/spotify/saved/:limit?" :paramsDesc="['Track count, 50 by default']" selfhost="1"/>
 
 ### Personal Top Tracks
 
-<RouteEn author="outloudvi" example="/spotify/top/tracks" path="/spotify/top/tracks" />
+<RouteEn author="outloudvi" example="/spotify/top/tracks" path="/spotify/top/tracks" selfhost="1" selfhost="1"/>
 
 ### Personal Top Artists
 
-<RouteEn author="outloudvi" example="/spotify/top/artists" path="/spotify/top/artists" />
+<RouteEn author="outloudvi" example="/spotify/top/artists" path="/spotify/top/artists" selfhost="1"/>
 
 ### Show
 
-<RouteEn author="caiohsramos" example="/spotify/show/38bS44xjbVVZ3No3ByF1dJ" path="/spotify/show/:id" :paramsDesc="['Show ID']" />
+<RouteEn author="caiohsramos" example="/spotify/show/38bS44xjbVVZ3No3ByF1dJ" path="/spotify/show/:id" :paramsDesc="['Show ID']" selfhost="1"/>
 
 ## The Movie Database
 

--- a/docs/en/multimedia.md
+++ b/docs/en/multimedia.md
@@ -537,7 +537,7 @@ Refer to [Pornhub F.A.Qs](https://help.pornhub.com/hc/en-us/articles/36004432703
 
 ### Personal Top Tracks
 
-<RouteEn author="outloudvi" example="/spotify/top/tracks" path="/spotify/top/tracks" selfhost="1" selfhost="1"/>
+<RouteEn author="outloudvi" example="/spotify/top/tracks" path="/spotify/top/tracks" selfhost="1"/>
 
 ### Personal Top Artists
 

--- a/docs/en/multimedia.md
+++ b/docs/en/multimedia.md
@@ -543,6 +543,10 @@ Refer to [Pornhub F.A.Qs](https://help.pornhub.com/hc/en-us/articles/36004432703
 
 <RouteEn author="outloudvi" example="/spotify/top/artists" path="/spotify/top/artists" />
 
+### Show
+
+<RouteEn author="caiohsramos" example="/spotify/show/38bS44xjbVVZ3No3ByF1dJ" path="/spotify/show/:id" :paramsDesc="['Show ID']" />
+
 ## The Movie Database
 
 ::: tip Tips

--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -1201,27 +1201,27 @@ JavDB 有多个备用域名，本路由默认使用永久域名 <https://javdb.c
 
 ### 艺术家专辑
 
-<Route author="outloudvi" example="/spotify/artist/6k9TBCxyr4bXwZ8Y21Kwn1" path="/spotify/artist/:id" :paramsDesc="['艺术家 ID']" />
+<Route author="outloudvi" example="/spotify/artist/6k9TBCxyr4bXwZ8Y21Kwn1" path="/spotify/artist/:id" :paramsDesc="['艺术家 ID']" selfhost="1"/>
 
 ### 播放列表
 
-<Route author="outloudvi" example="/spotify/playlist/4UBVy1LttvodwivPUuwJk2" path="/spotify/playlist/:id" :paramsDesc="['播放列表 ID']" />
+<Route author="outloudvi" example="/spotify/playlist/4UBVy1LttvodwivPUuwJk2" path="/spotify/playlist/:id" :paramsDesc="['播放列表 ID']" selfhost="1"/>
 
 ### 个人 Saved Tracks
 
-<Route author="outloudvi" example="/spotify/saved/50" path="/spotify/saved/:limit?" :paramsDesc="['歌曲数量，默认为 50']" />
+<Route author="outloudvi" example="/spotify/saved/50" path="/spotify/saved/:limit?" :paramsDesc="['歌曲数量，默认为 50']" selfhost="1"/>
 
 ### 个人 Top Tracks
 
-<Route author="outloudvi" example="/spotify/top/tracks" path="/spotify/top/tracks" />
+<Route author="outloudvi" example="/spotify/top/tracks" path="/spotify/top/tracks" selfhost="1"/>
 
 ### 个人 Top Artists
 
-<Route author="outloudvi" example="/spotify/top/artists" path="/spotify/top/artists" />
+<Route author="outloudvi" example="/spotify/top/artists" path="/spotify/top/artists" selfhost="1"/>
 
 ### 节目
 
-<Route author="caiohsramos" example="/spotify/show/38bS44xjbVVZ3No3ByF1dJ" path="/spotify/show/:id" :paramsDesc="['节目 ID']" />
+<Route author="caiohsramos" example="/spotify/show/38bS44xjbVVZ3No3ByF1dJ" path="/spotify/show/:id" :paramsDesc="['节目 ID']" selfhost="1"/>
 
 ## Sub HD
 

--- a/docs/multimedia.md
+++ b/docs/multimedia.md
@@ -1219,6 +1219,10 @@ JavDB 有多个备用域名，本路由默认使用永久域名 <https://javdb.c
 
 <Route author="outloudvi" example="/spotify/top/artists" path="/spotify/top/artists" />
 
+### 节目
+
+<Route author="caiohsramos" example="/spotify/show/38bS44xjbVVZ3No3ByF1dJ" path="/spotify/show/:id" :paramsDesc="['节目 ID']" />
+
 ## Sub HD
 
 ### 字幕

--- a/lib/v2/spotify/maintainer.js
+++ b/lib/v2/spotify/maintainer.js
@@ -2,7 +2,7 @@ module.exports = {
     '/artist/:id': ['outloudvi'],
     '/playlist/:id': ['outloudvi'],
     '/saved/:limit?': ['outloudvi'],
+    '/show/:id': ['caiohsramos'],
     '/top/tracks': ['outloudvi'],
     '/top/artists': ['outloudvi'],
-    '/show/:id': ['caiohsramos'],
 };

--- a/lib/v2/spotify/maintainer.js
+++ b/lib/v2/spotify/maintainer.js
@@ -4,4 +4,5 @@ module.exports = {
     '/saved/:limit?': ['outloudvi'],
     '/top/tracks': ['outloudvi'],
     '/top/artists': ['outloudvi'],
+    '/show/:id': ['caiohsramos'],
 };

--- a/lib/v2/spotify/radar.js
+++ b/lib/v2/spotify/radar.js
@@ -3,16 +3,16 @@ module.exports = {
         _name: 'Spotify',
         open: [
             {
-                title: '播放列表',
-                docs: 'https://docs.rsshub.app/multimedia.html#spotify',
-                source: ['/playlist/:id'],
-                target: '/spotify/playlist/:id',
-            },
-            {
                 title: '歌手专辑',
                 docs: 'https://docs.rsshub.app/multimedia.html#spotify',
                 source: ['/artist/:id'],
                 target: '/spotify/artist/:id',
+            },
+            {
+                title: '播放列表',
+                docs: 'https://docs.rsshub.app/multimedia.html#spotify',
+                source: ['/playlist/:id'],
+                target: '/spotify/playlist/:id',
             },
             {
                 title: '用户 Saved Tracks',
@@ -21,10 +21,10 @@ module.exports = {
                 target: '/spotify/saved',
             },
             {
-                title: '用户 Top Tracks',
+                title: '节目',
                 docs: 'https://docs.rsshub.app/multimedia.html#spotify',
-                source: ['/'],
-                target: '/spotify/top/tracks',
+                source: ['/show/:id'],
+                target: '/spotify/show/:id',
             },
             {
                 title: '用户 Top Artists',
@@ -33,10 +33,10 @@ module.exports = {
                 target: '/spotify/top/artists',
             },
             {
-                title: '节目',
+                title: '用户 Top Tracks',
                 docs: 'https://docs.rsshub.app/multimedia.html#spotify',
-                source: ['/show/:id'],
-                target: '/spotify/show/:id',
+                source: ['/'],
+                target: '/spotify/top/tracks',
             },
         ],
     },

--- a/lib/v2/spotify/radar.js
+++ b/lib/v2/spotify/radar.js
@@ -32,6 +32,12 @@ module.exports = {
                 source: ['/'],
                 target: '/spotify/top/artists',
             },
+            {
+                title: '节目',
+                docs: 'https://docs.rsshub.app/multimedia.html#spotify',
+                source: ['/show/:id'],
+                target: '/spotify/show/:id',
+            },
         ],
     },
 };

--- a/lib/v2/spotify/router.js
+++ b/lib/v2/spotify/router.js
@@ -2,7 +2,7 @@ module.exports = function (router) {
     router.get('/artist/:id', require('./artist'));
     router.get('/playlist/:id', require('./playlist'));
     router.get('/saved/:limit?', require('./saved'));
-    router.get('/top/tracks', require('./top')('tracks'));
-    router.get('/top/artists', require('./top')('artists'));
     router.get('/show/:id', require('./show'));
+    router.get('/top/artists', require('./top')('artists'));
+    router.get('/top/tracks', require('./top')('tracks'));
 };

--- a/lib/v2/spotify/router.js
+++ b/lib/v2/spotify/router.js
@@ -4,4 +4,5 @@ module.exports = function (router) {
     router.get('/saved/:limit?', require('./saved'));
     router.get('/top/tracks', require('./top')('tracks'));
     router.get('/top/artists', require('./top')('artists'));
+    router.get('/show/:id', require('./show'));
 };

--- a/lib/v2/spotify/show.js
+++ b/lib/v2/spotify/show.js
@@ -1,0 +1,35 @@
+const utils = require('./utils');
+const got = require('@/utils/got');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const token = await utils.getPublicToken();
+    const { id } = ctx.params;
+
+    const meta = await got
+        .get(`https://api.spotify.com/v1/shows/${id}?market=US`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+        .json();
+
+    const episodes = meta.episodes.items;
+
+    ctx.state.data = {
+        title: meta.name,
+        description: meta.description,
+        link: meta.external_urls.spotify,
+        allowEmpty: true,
+        item: episodes.map((x) => ({
+            title: x.name,
+            description: x.description,
+            pubDate: parseDate(x.release_date),
+            link: x.external_urls.spotify,
+        })),
+    };
+
+    if (meta.images.length) {
+        ctx.state.data.image = meta.images[0].url;
+    }
+};

--- a/lib/v2/spotify/show.js
+++ b/lib/v2/spotify/show.js
@@ -20,12 +20,20 @@ module.exports = async (ctx) => {
         title: meta.name,
         description: meta.description,
         link: meta.external_urls.spotify,
+        language: meta.languages[0],
+        itunes_author: meta.publisher,
+        itunes_category: meta.type,
+        itunes_explicit: meta.explicit,
         allowEmpty: true,
         item: episodes.map((x) => ({
             title: x.name,
-            description: x.description,
+            description: x.html_description,
             pubDate: parseDate(x.release_date),
             link: x.external_urls.spotify,
+            itunes_item_image: x.images[0].url,
+            itunes_duration: x.duration_ms * 1000,
+            enclosure_url: x.audio_preview_url,
+            enclosure_type: 'audio/mpeg',
         })),
     };
 


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Close #12944

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
/spotify/show/6WRTzGhq3uFxMrxHrHh1lo
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [X] 新的路由 New Route
  - [X] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [X] 文档说明 Documentation
  - [X] 中文文档 CN
  - [X] 英文文档 EN
- [ ] 全文获取 fulltext
  - [ ] 使用缓存 Use Cache
- [ ] 反爬/频率限制 anti-bot or rate limit?
  - [ ] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [X] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [X] 可以解析 Parsed
  - [X] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [ ] `Puppeteer`

## 说明 / Note
- The param `market` was added because the API won't work without it. According to the docs:
> If a valid user access token is specified in the request header, the country associated with the user account will take priority over this parameter.
- I'm not sure if the chinese translation is correct