### PR TITLE
refactor: replace re2 with re2-wasm

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/devcontainers/images/blob/v0.2.24/src/javascript-node/.devcontainer/devcontainer.json
 {
     "name": "Node.js",
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:18-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:18-bookworm",
 
     // Configure tool-specific properties.
     "customizations": {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,6 @@ jobs:
         node-version: [ 18, 20 ]
     name: Jest on Node ${{ matrix.node-version }}
     steps:
-      - name: Collect Workflow Telemetry
-        uses: runforesight/foresight-workflow-kit-action@v1
-        if: success() || failure()
-        with:
-          api_key: ${{ secrets.FORESIGHT_KEY }}
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
         if: ${{ matrix.chromium.dependency != '' }}
         # 'chromium-browser' from Ubuntu APT repo is a dummy package. Its version (85.0.4183.83) means
         # nothing since it calls Snap (disgusting!) to install Chromium, which should be up-to-date.
-        # That's not really a problem since the Chromium-bundled Docker image is based on Debian bullseye,
+        # That's not really a problem since the Chromium-bundled Docker image is based on Debian bookworm,
         # which provides up-to-date native packages.
         run: |
           set -ex

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye as dep-builder
+FROM node:18-bookworm AS dep-builder
 # Here we use the non-slim image to provide build-time deps (compilers and python), thus no need to install later.
 # This effectively speeds up qemu-based cross-build.
 
@@ -28,11 +28,11 @@ RUN \
 
 # ---------------------------------------------------------------------------------------------------------------------
 
-FROM debian:bullseye-slim as dep-version-parser
+FROM debian:bookworm-slim AS dep-version-parser
 # This stage is necessary to limit the cache miss scope.
 # With this stage, any modification to package.json won't break the build cache of the next two stages as long as the
 # version unchanged.
-# node:18-bullseye-slim is based on debian:bullseye-slim so this stage would not cause any additional download.
+# node:18-bookworm-slim is based on debian:bookworm-slim so this stage would not cause any additional download.
 
 WORKDIR /ver
 COPY ./package.json /app/
@@ -44,7 +44,7 @@ RUN \
 
 # ---------------------------------------------------------------------------------------------------------------------
 
-FROM node:18-bullseye-slim as docker-minifier
+FROM node:18-bookworm-slim AS docker-minifier
 # The stage is used to further reduce the image size by removing unused files.
 
 WORKDIR /minifier
@@ -66,9 +66,13 @@ COPY --from=dep-builder /app /app
 
 RUN \
     set -ex && \
+    # Minify Docker image
     cp /app/scripts/docker/minify-docker.js /minifier/ && \
     export PROJECT_ROOT=/app && \
     node /minifier/minify-docker.js && \
+    # Add back anything that are required but removed by by @vercel/nft
+    cp /app/node_modules/re2-wasm/build/wasm/re2.wasm /app/app-minimal/node_modules/re2-wasm/build/wasm/re2.wasm && \
+    # Use the minified node_modules
     rm -rf /app/node_modules /app/scripts && \
     mv /app/app-minimal/node_modules /app/ && \
     rm -rf /app/app-minimal && \
@@ -77,7 +81,7 @@ RUN \
 
 # ---------------------------------------------------------------------------------------------------------------------
 
-FROM node:18-bullseye-slim as chromium-downloader
+FROM node:18-bookworm-slim AS chromium-downloader
 # This stage is necessary to improve build concurrency and minimize the image size.
 # Yeah, downloading Chromium never needs those dependencies below.
 
@@ -109,7 +113,7 @@ RUN \
 
 # ---------------------------------------------------------------------------------------------------------------------
 
-FROM node:18-bullseye-slim as app
+FROM node:18-bookworm-slim AS app
 
 LABEL org.opencontainers.image.authors="https://github.com/DIYgod/RSSHub"
 
@@ -123,7 +127,7 @@ ARG TARGETPLATFORM
 ARG PUPPETEER_SKIP_DOWNLOAD=1
 # https://pptr.dev/troubleshooting#chrome-headless-doesnt-launch-on-unix
 # https://github.com/puppeteer/puppeteer/issues/7822
-# https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html#noteworthy-obsolete-packages
+# https://www.debian.org/releases/bookworm/amd64/release-notes/ch-information.en.html#noteworthy-obsolete-packages
 # The official recommended way to use Puppeteer on arm/arm64 is to install Chromium from the distribution repositories:
 # https://github.com/puppeteer/puppeteer/blob/07391bbf5feaf85c191e1aa8aa78138dce84008d/packages/puppeteer-core/src/node/BrowserFetcher.ts#L128-L131
 RUN \

--- a/lib/middleware/parameter.js
+++ b/lib/middleware/parameter.js
@@ -3,7 +3,7 @@ const cheerio = require('cheerio');
 const { simplecc } = require('simplecc-wasm');
 const got = require('@/utils/got');
 const config = require('@/config').value;
-const RE2 = require('re2');
+const { RE2 } = require('re2-wasm');
 
 let mercury_parser;
 
@@ -167,7 +167,7 @@ module.exports = async (ctx, next) => {
                         case 'regexp':
                             return new RegExp(string, 'i');
                         case 're2':
-                            return new RE2(string, 'i');
+                            return new RE2(string, 'iu');
                         default:
                             throw Error(`Invalid Engine Value: ${engine}, please check your config.`);
                     }
@@ -176,7 +176,7 @@ module.exports = async (ctx, next) => {
                         case 'regexp':
                             return new RegExp(string);
                         case 're2':
-                            return new RE2(string);
+                            return new RE2(string, 'u');
                         default:
                             throw Error(`Invalid Engine Value: ${engine}, please check your config.`);
                     }

--- a/lib/router.js
+++ b/lib/router.js
@@ -16,70 +16,11 @@ const lazyloadRouteHandler = (routeHandlerPath) => (ctx) => {
 
 // Deprecated: DO NOT ADD ANY NEW ROUTES HERE
 
-// RSSHub migrated to v2
-// router.get('/rsshub/rss', lazyloadRouteHandler('./routes/rsshub/routes')); // 弃用
-// router.get('/rsshub/routes', lazyloadRouteHandler('./routes/rsshub/routes'));
-// router.get('/rsshub/sponsors', lazyloadRouteHandler('./routes/rsshub/sponsors'));
-
 // 1draw
 router.get('/1draw', lazyloadRouteHandler('./routes/1draw/index'));
 
-// quicker
-// router.get('/quicker/qa', lazyloadRouteHandler('./routes/quicker/qa.js'));
-// router.get('/quicker/update', lazyloadRouteHandler('./routes/quicker/update.js'));
-// router.get('/quicker/user/action/:uid/:person', lazyloadRouteHandler('./routes/quicker/person.js'));
-// router.get('/quicker/user/:uid/:person', lazyloadRouteHandler('./routes/quicker/person.js'));
-
 // Benedict Evans
 router.get('/benedictevans', lazyloadRouteHandler('./routes/benedictevans/recent.js'));
-
-// bangumi
-// router.get('/bangumi/calendar/today', lazyloadRouteHandler('./routes/bangumi/calendar/today'));
-// router.get('/bangumi/subject/:id/:type', lazyloadRouteHandler('./routes/bangumi/subject'));
-// router.get('/bangumi/person/:id', lazyloadRouteHandler('./routes/bangumi/person'));
-// router.get('/bangumi/topic/:id', lazyloadRouteHandler('./routes/bangumi/group/reply'));
-// router.get('/bangumi/group/:id', lazyloadRouteHandler('./routes/bangumi/group/topic'));
-// router.get('/bangumi/subject/:id', lazyloadRouteHandler('./routes/bangumi/subject'));
-// router.get('/bangumi/user/blog/:id', lazyloadRouteHandler('./routes/bangumi/user/blog'));
-
-// 報導者 migrated to v2
-// router.get('/twreporter/newest', lazyloadRouteHandler('./routes/twreporter/newest'));
-// router.get('/twreporter/photography', lazyloadRouteHandler('./routes/twreporter/photography'));
-// router.get('/twreporter/category/:cid', lazyloadRouteHandler('./routes/twreporter/category'));
-
-// 微博 migrated to v2
-// router.get('/weibo/user/:uid/:routeParams?', lazyloadRouteHandler('./routes/weibo/user'));
-// router.get('/weibo/keyword/:keyword/:routeParams?', lazyloadRouteHandler('./routes/weibo/keyword'));
-// router.get('/weibo/search/hot', lazyloadRouteHandler('./routes/weibo/search/hot'));
-// router.get('/weibo/super_index/:id/:type?/:routeParams?', lazyloadRouteHandler('./routes/weibo/super_index'));
-// router.get('/weibo/oasis/user/:userid', lazyloadRouteHandler('./routes/weibo/oasis/user'));
-
-// 贴吧 migrated to v2
-// router.get('/tieba/forum/:kw', lazyloadRouteHandler('./routes/tieba/forum'));
-// router.get('/tieba/forum/good/:kw/:cid?', lazyloadRouteHandler('./routes/tieba/forum'));
-// router.get('/tieba/post/:id', lazyloadRouteHandler('./routes/tieba/post'));
-// router.get('/tieba/post/lz/:id', lazyloadRouteHandler('./routes/tieba/post'));
-// router.get('/tieba/user/:uid', lazyloadRouteHandler('./routes/tieba/user'));
-
-// 网易云音乐
-// router.get('/ncm/playlist/:id', lazyloadRouteHandler('./routes/ncm/playlist'));
-// router.get('/ncm/user/playlist/:uid', lazyloadRouteHandler('./routes/ncm/userplaylist'));
-// router.get('/ncm/artist/:id', lazyloadRouteHandler('./routes/ncm/artist'));
-// router.get('/ncm/djradio/:id', lazyloadRouteHandler('./routes/ncm/djradio'));
-// router.get('/ncm/user/playrecords/:uid/:type?', lazyloadRouteHandler('./routes/ncm/userplayrecords'));
-
-// 掘金 migrated to v2
-// router.get('/juejin/category/:category', lazyloadRouteHandler('./routes/juejin/category'));
-// router.get('/juejin/tag/:tag', lazyloadRouteHandler('./routes/juejin/tag'));
-// router.get('/juejin/trending/:category/:type', lazyloadRouteHandler('./routes/juejin/trending'));
-// router.get('/juejin/books', lazyloadRouteHandler('./routes/juejin/books'));
-// router.get('/juejin/pins/:type?', lazyloadRouteHandler('./routes/juejin/pins'));
-// router.get('/juejin/posts/:id', lazyloadRouteHandler('./routes/juejin/posts'));
-// router.get('/juejin/news/:id', lazyloadRouteHandler('./routes/juejin/news'));
-// router.get('/juejin/collections/:userId', lazyloadRouteHandler('./routes/juejin/favorites'));
-// router.get('/juejin/collection/:collectionId', lazyloadRouteHandler('./routes/juejin/collection'));
-// router.get('/juejin/shares/:userId', lazyloadRouteHandler('./routes/juejin/shares'));
-// router.get('/juejin/column/:id', lazyloadRouteHandler('./routes/juejin/column'));
 
 // 自如
 router.get('/ziroom/room/:city/:iswhole/:room/:keyword', lazyloadRouteHandler('./routes/ziroom/room'));
@@ -90,25 +31,6 @@ router.get('/jianshu/trending/:timeframe', lazyloadRouteHandler('./routes/jiansh
 router.get('/jianshu/collection/:id', lazyloadRouteHandler('./routes/jianshu/collection'));
 router.get('/jianshu/user/:id', lazyloadRouteHandler('./routes/jianshu/user'));
 
-// 知乎 migrated to v2
-// router.get('/zhihu/collection/:id/:getAll?', lazyloadRouteHandler('./routes/zhihu/collection'));
-// router.get('/zhihu/people/activities/:id', lazyloadRouteHandler('./routes/zhihu/activities'));
-// router.get('/zhihu/people/answers/:id', lazyloadRouteHandler('./routes/zhihu/answers'));
-// router.get('/zhihu/posts/:usertype/:id', lazyloadRouteHandler('./routes/zhihu/posts'));
-// router.get('/zhihu/zhuanlan/:id', lazyloadRouteHandler('./routes/zhihu/zhuanlan'));
-// router.get('/zhihu/daily', lazyloadRouteHandler('./routes/zhihu/daily'));
-// router.get('/zhihu/daily/section/:sectionId', lazyloadRouteHandler('./routes/zhihu/daily_section'));
-// router.get('/zhihu/hotlist', lazyloadRouteHandler('./routes/zhihu/hotlist'));
-// router.get('/zhihu/pin/hotlist', lazyloadRouteHandler('./routes/zhihu/pin/hotlist'));
-// router.get('/zhihu/question/:questionId', lazyloadRouteHandler('./routes/zhihu/question'));
-// router.get('/zhihu/topic/:topicId', lazyloadRouteHandler('./routes/zhihu/topic'));
-// router.get('/zhihu/people/pins/:id', lazyloadRouteHandler('./routes/zhihu/pin/people'));
-// router.get('/zhihu/bookstore/newest', lazyloadRouteHandler('./routes/zhihu/bookstore/newest'));
-// router.get('/zhihu/pin/daily', lazyloadRouteHandler('./routes/zhihu/pin/daily'));
-// router.get('/zhihu/weekly', lazyloadRouteHandler('./routes/zhihu/weekly'));
-// router.get('/zhihu/timeline', lazyloadRouteHandler('./routes/zhihu/timeline'));
-// router.get('/zhihu/hot/:category?', lazyloadRouteHandler('./routes/zhihu/hot'));
-
 // 妹子图
 router.get('/mzitu/home/:type?', lazyloadRouteHandler('./routes/mzitu/home'));
 router.get('/mzitu/tags', lazyloadRouteHandler('./routes/mzitu/tags'));
@@ -116,26 +38,11 @@ router.get('/mzitu/category/:category', lazyloadRouteHandler('./routes/mzitu/cat
 router.get('/mzitu/post/:id', lazyloadRouteHandler('./routes/mzitu/post'));
 router.get('/mzitu/tag/:tag', lazyloadRouteHandler('./routes/mzitu/tag'));
 
-// pixiv migrated to v2
-// router.get('/pixiv/user/bookmarks/:id', lazyloadRouteHandler('./routes/pixiv/bookmarks'));
-// router.get('/pixiv/user/illustfollows', lazyloadRouteHandler('./routes/pixiv/illustfollow'));
-// router.get('/pixiv/user/:id', lazyloadRouteHandler('./routes/pixiv/user'));
-// router.get('/pixiv/ranking/:mode/:date?', lazyloadRouteHandler('./routes/pixiv/ranking'));
-// router.get('/pixiv/search/:keyword/:order?/:mode?', lazyloadRouteHandler('./routes/pixiv/search'));
-
 // pixiv-fanbox
 router.get('/fanbox/:user?', lazyloadRouteHandler('./routes/fanbox/main'));
 
 // 法律白話文運動
 router.get('/plainlaw/archives', lazyloadRouteHandler('./routes/plainlaw/archives.js'));
-
-// 煎蛋
-// router.get('/jandan/article', lazyloadRouteHandler('./routes/jandan/article'));
-// router.get('/jandan/:sub_model', lazyloadRouteHandler('./routes/jandan/pic'));
-
-// 喷嚏
-// router.get('/dapenti/tugua', lazyloadRouteHandler('./routes/dapenti/tugua'));
-// router.get('/dapenti/subject/:id', lazyloadRouteHandler('./routes/dapenti/subject'));
 
 // Dockone
 router.get('/dockone/weekly', lazyloadRouteHandler('./routes/dockone/weekly'));
@@ -151,33 +58,9 @@ router.get('/jinritoutiao/keyword/:keyword', lazyloadRouteHandler('./routes/jinr
 // Disqus
 router.get('/disqus/posts/:forum', lazyloadRouteHandler('./routes/disqus/posts'));
 
-// Twitter
-// router.get('/twitter/user/:id/:routeParams?', lazyloadRouteHandler('./routes/twitter/user'));
-// router.get('/twitter/list/:id/:name/:routeParams?', lazyloadRouteHandler('./routes/twitter/list'));
-// router.get('/twitter/likes/:id/:routeParams?', lazyloadRouteHandler('./routes/twitter/likes'));
-// router.get('/twitter/followings/:id/:routeParams?', lazyloadRouteHandler('./routes/twitter/followings'));
-// router.get('/twitter/keyword/:keyword/:routeParams?/:limit?', lazyloadRouteHandler('./routes/twitter/keyword'));
-// router.get('/twitter/trends/:woeid?', lazyloadRouteHandler('./routes/twitter/trends'));
-// router.get('/twitter/media/:id/:routeParams?', lazyloadRouteHandler('./routes/twitter/media'));
-
-// YouTube migrated to v2
-// router.get('/youtube/user/:username/:embed?', lazyloadRouteHandler('./routes/youtube/user'));
-// router.get('/youtube/channel/:id/:embed?', lazyloadRouteHandler('./routes/youtube/channel'));
-// router.get('/youtube/playlist/:id/:embed?', lazyloadRouteHandler('./routes/youtube/playlist'));
-
 // 极客时间
 router.get('/geektime/column/:cid', lazyloadRouteHandler('./routes/geektime/column'));
 router.get('/geektime/news', lazyloadRouteHandler('./routes/geektime/news'));
-
-// 界面新闻
-// router.get('/jiemian/list/:cid', lazyloadRouteHandler('./routes/jiemian/list.js'));
-
-// 好奇心日报
-// router.get('/qdaily/:type/:id', lazyloadRouteHandler('./routes/qdaily/index'));
-
-// 爱奇艺
-// router.get('/iqiyi/dongman/:id', lazyloadRouteHandler('./routes/iqiyi/dongman'));
-// router.get('/iqiyi/user/video/:uid', lazyloadRouteHandler('./routes/iqiyi/video'));
 
 // 南方周末
 router.get('/infzm/:id', lazyloadRouteHandler('./routes/infzm/news'));
@@ -187,15 +70,8 @@ router.get('/dribbble/popular/:timeframe?', lazyloadRouteHandler('./routes/dribb
 router.get('/dribbble/user/:name', lazyloadRouteHandler('./routes/dribbble/user'));
 router.get('/dribbble/keyword/:keyword', lazyloadRouteHandler('./routes/dribbble/keyword'));
 
-// 斗鱼
-// router.get('/douyu/room/:id', lazyloadRouteHandler('./routes/douyu/room'));
-
 // 虎牙
 router.get('/huya/live/:id', lazyloadRouteHandler('./routes/huya/live'));
-
-// 浪Play(原kingkong)直播
-// router.get('/kingkong/room/:id', lazyloadRouteHandler('./routes/langlive/room'));
-// router.get('/langlive/room/:id', lazyloadRouteHandler('./routes/langlive/room'));
 
 // SHOWROOM直播
 router.get('/showroom/room/:id', lazyloadRouteHandler('./routes/showroom/room'));
@@ -204,10 +80,6 @@ router.get('/showroom/room/:id', lazyloadRouteHandler('./routes/showroom/room'))
 router.get('/v2ex/topics/:type', lazyloadRouteHandler('./routes/v2ex/topics'));
 router.get('/v2ex/post/:postid', lazyloadRouteHandler('./routes/v2ex/post'));
 router.get('/v2ex/tab/:tabid', lazyloadRouteHandler('./routes/v2ex/tab'));
-
-// Readhub migrated to v2
-// router.get('/readhub/category/:category?', lazyloadRouteHandler('./routes/readhub/index'));
-// router.get('/readhub/:category?', lazyloadRouteHandler('./routes/readhub/index'));
 
 // f-droid
 router.get('/fdroid/apprelease/:app', lazyloadRouteHandler('./routes/fdroid/apprelease'));
@@ -228,71 +100,20 @@ router.get('/pornhub/:language?/users/:username', lazyloadRouteHandler('./routes
 router.get('/pornhub/:language?/model/:username/:sort?', lazyloadRouteHandler('./routes/pornhub/model'));
 router.get('/pornhub/:language?/pornstar/:username/:sort?', lazyloadRouteHandler('./routes/pornhub/pornstar'));
 
-// Prestige migrated to v2
-// router.get('/prestige-av/series/:mid/:sort?', lazyloadRouteHandler('./routes/prestige-av/series'));
-
 // yande.re
 router.get('/yande.re/post/popular_recent', lazyloadRouteHandler('./routes/yande.re/post_popular_recent'));
 router.get('/yande.re/post/popular_recent/:period', lazyloadRouteHandler('./routes/yande.re/post_popular_recent'));
 
-// 纽约时报 migrated to v2
-// router.get('/nytimes/daily_briefing_chinese', lazyloadRouteHandler('./routes/nytimes/daily_briefing_chinese'));
-// router.get('/nytimes/book/:category?', lazyloadRouteHandler('./routes/nytimes/book.js'));
-// router.get('/nytimes/author/:byline', lazyloadRouteHandler('./routes/nytimes/author.js'));
-// router.get('/nytimes/:lang?', lazyloadRouteHandler('./routes/nytimes/index'));
-
-// 3dm
-// router.get('/3dm/:name/:type', lazyloadRouteHandler('./routes/3dm/game'));
-// router.get('/3dm/news', lazyloadRouteHandler('./routes/3dm/news_center'));
-
-// 喜马拉雅
-// router.get('/ximalaya/:type/:id/:all?', lazyloadRouteHandler('./routes/ximalaya/album'));
-// router.get('/ximalaya/:type/:id/:all/:shownote?', lazyloadRouteHandler('./routes/ximalaya/album'));
-
 // EZTV
 router.get('/eztv/torrents/:imdb_id', lazyloadRouteHandler('./routes/eztv/imdb'));
-
-// 什么值得买
-// router.get('/smzdm/keyword/:keyword', lazyloadRouteHandler('./routes/smzdm/keyword'));
-// router.get('/smzdm/ranking/:rank_type/:rank_id/:hour', lazyloadRouteHandler('./routes/smzdm/ranking'));
-// router.get('/smzdm/haowen/:day?', lazyloadRouteHandler('./routes/smzdm/haowen'));
-// router.get('/smzdm/haowen/fenlei/:name/:sort?', lazyloadRouteHandler('./routes/smzdm/haowen_fenlei'));
-// router.get('/smzdm/article/:uid', lazyloadRouteHandler('./routes/smzdm/article'));
-// router.get('/smzdm/baoliao/:uid', lazyloadRouteHandler('./routes/smzdm/baoliao'));
 
 // 新京报
 router.get('/bjnews/:cat', lazyloadRouteHandler('./routes/bjnews/news'));
 router.get('/bjnews/epaper/:cat', lazyloadRouteHandler('./routes/bjnews/epaper'));
 
-// 停水通知 migrated to v2
-// router.get('/tingshuitz/hangzhou', lazyloadRouteHandler('./routes/tingshuitz/hangzhou'));
-// router.get('/tingshuitz/xiaoshan', lazyloadRouteHandler('./routes/tingshuitz/xiaoshan'));
-// router.get('/tingshuitz/dalian', lazyloadRouteHandler('./routes/tingshuitz/dalian'));
-// router.get('/tingshuitz/guangzhou', lazyloadRouteHandler('./routes/tingshuitz/guangzhou'));
-// router.get('/tingshuitz/dongguan', lazyloadRouteHandler('./routes/tingshuitz/dongguan'));
-// router.get('/tingshuitz/xian', lazyloadRouteHandler('./routes/tingshuitz/xian'));
-// router.get('/tingshuitz/yangjiang', lazyloadRouteHandler('./routes/tingshuitz/yangjiang'));
-// router.get('/tingshuitz/nanjing', lazyloadRouteHandler('./routes/tingshuitz/nanjing'));
-// router.get('/tingshuitz/wuhan', lazyloadRouteHandler('./routes/tingshuitz/wuhan'));
-
 // 米哈游
 router.get('/mihoyo/bh3/:type', lazyloadRouteHandler('./routes/mihoyo/bh3'));
 router.get('/mihoyo/bh2/:type', lazyloadRouteHandler('./routes/mihoyo/bh2'));
-
-// 新闻联播 migrated to v2
-// router.get('/cctv/xwlb', lazyloadRouteHandler('./routes/cctv/xwlb'));
-// 央视新闻
-// router.get('/cctv/lm/:id?', lazyloadRouteHandler('./routes/cctv/lm'));
-// router.get('/cctv/:category', lazyloadRouteHandler('./routes/cctv/category'));
-// router.get('/cctv/photo/jx', lazyloadRouteHandler('./routes/cctv/jx'));
-// router.get('/cctv-special/:id?', lazyloadRouteHandler('./routes/cctv/special'));
-
-// 财新博客
-// router.get('/caixin/blog/:column', lazyloadRouteHandler('./routes/caixin/blog'));
-// router.get('/caixin/article', lazyloadRouteHandler('./routes/caixin/article'));
-// router.get('/caixin/database', lazyloadRouteHandler('./routes/caixin/database'));
-// router.get('/caixin/yxnews', lazyloadRouteHandler('./routes/caixin/yxnews'));
-// router.get('/caixin/:column/:category', lazyloadRouteHandler('./routes/caixin/category'));
 
 // 草榴社区
 router.get('/t66y/post/:tid', lazyloadRouteHandler('./routes/t66y/post'));
@@ -300,11 +121,6 @@ router.get('/t66y/:id/:type?', lazyloadRouteHandler('./routes/t66y/index'));
 
 // 色中色
 router.get('/sexinsex/:id/:type?', lazyloadRouteHandler('./routes/sexinsex/index'));
-
-// 国家地理 migrated to v2
-// router.get('/natgeo/dailyselection', lazyloadRouteHandler('./routes/natgeo/dailyselection'));
-// router.get('/natgeo/dailyphoto', lazyloadRouteHandler('./routes/natgeo/dailyphoto'));
-// router.get('/natgeo/:cat/:type?', lazyloadRouteHandler('./routes/natgeo/natgeo'));
 
 // 一个
 router.get('/one', lazyloadRouteHandler('./routes/one/index'));
@@ -335,15 +151,6 @@ router.get('/mi/crowdfunding', lazyloadRouteHandler('./routes/mi/crowdfunding'))
 router.get('/miui/:device/:type?/:region?', lazyloadRouteHandler('./routes/mi/miui/index'));
 router.get('/mi/bbs/board/:boardId', lazyloadRouteHandler('./routes/mi/board'));
 
-// Keep
-// router.get('/keep/user/:id', lazyloadRouteHandler('./routes/keep/user'));
-
-// 起点 migrated to v2
-// router.get('/qidian/chapter/:id', lazyloadRouteHandler('./routes/qidian/chapter'));
-// router.get('/qidian/forum/:id', lazyloadRouteHandler('./routes/qidian/forum'));
-// router.get('/qidian/free/:type?', lazyloadRouteHandler('./routes/qidian/free'));
-// router.get('/qidian/free-next/:type?', lazyloadRouteHandler('./routes/qidian/free-next'));
-
 // 纵横
 router.get('/zongheng/chapter/:id', lazyloadRouteHandler('./routes/zongheng/chapter'));
 
@@ -357,14 +164,6 @@ router.get('/namoc/media', lazyloadRouteHandler('./routes/namoc/media'));
 router.get('/namoc/exhibition', lazyloadRouteHandler('./routes/namoc/exhibition'));
 router.get('/namoc/specials', lazyloadRouteHandler('./routes/namoc/specials'));
 
-// 懂球帝 migrated to v2
-// router.get('/dongqiudi/daily', lazyloadRouteHandler('./routes/dongqiudi/daily'));
-// router.get('/dongqiudi/result/:team', lazyloadRouteHandler('./routes/dongqiudi/result'));
-// router.get('/dongqiudi/team_news/:team', lazyloadRouteHandler('./routes/dongqiudi/team_news'));
-// router.get('/dongqiudi/player_news/:id', lazyloadRouteHandler('./routes/dongqiudi/player_news'));
-// router.get('/dongqiudi/special/:id', lazyloadRouteHandler('./routes/dongqiudi/special'));
-// router.get('/dongqiudi/top_news/:id?', lazyloadRouteHandler('./routes/dongqiudi/top_news'));
-
 // 维基百科 Wikipedia
 router.get('/wikipedia/mainland', lazyloadRouteHandler('./routes/wikipedia/mainland'));
 
@@ -377,38 +176,15 @@ router.get('/egsea/flash', lazyloadRouteHandler('./routes/egsea/flash'));
 // 选股宝
 router.get('/xuangubao/subject/:subject_id', lazyloadRouteHandler('./routes/xuangubao/subject'));
 
-// 雪球 migrated to v2
-// router.get('/xueqiu/user/:id/:type?', lazyloadRouteHandler('./routes/xueqiu/user'));
-// router.get('/xueqiu/favorite/:id', lazyloadRouteHandler('./routes/xueqiu/favorite'));
-// router.get('/xueqiu/user_stock/:id', lazyloadRouteHandler('./routes/xueqiu/user_stock'));
-// router.get('/xueqiu/fund/:id', lazyloadRouteHandler('./routes/xueqiu/fund'));
-// router.get('/xueqiu/stock_info/:id/:type?', lazyloadRouteHandler('./routes/xueqiu/stock_info'));
-// router.get('/xueqiu/snb/:id', lazyloadRouteHandler('./routes/xueqiu/snb'));
-// router.get('/xueqiu/hots', lazyloadRouteHandler('./routes/xueqiu/hots'));
-// router.get('/xueqiu/stock_comments/:id/:titleLength?', lazyloadRouteHandler('./routes/xueqiu/stock_comments'));
-
-// Greasy Fork migrated to v2
-// router.get('/greasyfork/:language/:domain?', lazyloadRouteHandler('./routes/greasyfork/scripts'));
-
 // Gwern Bran­wen
 router.get('/gwern/:category', lazyloadRouteHandler('./routes/gwern/category'));
 
 // LinkedKeeper
 router.get('/linkedkeeper/:type/:id?', lazyloadRouteHandler('./routes/linkedkeeper/index'));
 
-// 开源中国 migrated to v2
-// router.get('/oschina/news/:category?', lazyloadRouteHandler('./routes/oschina/news'));
-// router.get('/oschina/user/:id', lazyloadRouteHandler('./routes/oschina/user'));
-// router.get('/oschina/u/:id', lazyloadRouteHandler('./routes/oschina/u'));
-// router.get('/oschina/topic/:topic', lazyloadRouteHandler('./routes/oschina/topic'));
-
 // MIT Technology Review
 router.get('/technologyreview', lazyloadRouteHandler('./routes/technologyreview/index'));
 router.get('/technologyreview/:category_name', lazyloadRouteHandler('./routes/technologyreview/topic'));
-
-// 安全客
-// router.get('/aqk/vul', lazyloadRouteHandler('./routes/aqk/vul'));
-// router.get('/aqk/:category', lazyloadRouteHandler('./routes/aqk/category'));
 
 // 腾讯游戏开发者社区
 router.get('/gameinstitute/community/:tag?', lazyloadRouteHandler('./routes/tencent/gameinstitute/community'));
@@ -454,11 +230,6 @@ router.get('/hopper/:lowestOnly/:from/:to?', lazyloadRouteHandler('./routes/hopp
 router.get('/mafengwo/note/:type', lazyloadRouteHandler('./routes/mafengwo/note'));
 router.get('/mafengwo/ziyouxing/:code', lazyloadRouteHandler('./routes/mafengwo/ziyouxing'));
 
-// 中国地震局震情速递（与地震台网同步更新）migrated to v2
-// router.get('/earthquake/:region?', lazyloadRouteHandler('./routes/earthquake'));
-// 中国地震台网
-// router.get('/earthquake/ceic/:type', lazyloadRouteHandler('./routes/earthquake/ceic'));
-
 // 小说
 // router.get('/novel/biquge/:id', lazyloadRouteHandler('./routes/novel/biquge'));
 // router.get('/novel/biqugeinfo/:id/:limit?', lazyloadRouteHandler('./routes/novel/biqugeinfo'));
@@ -487,17 +258,6 @@ router.get('/sayhuahuo', lazyloadRouteHandler('./routes/galgame/sayhuahuo'));
 // 终点分享
 router.get('/zdfx', lazyloadRouteHandler('./routes/galgame/zdfx'));
 
-// 北京林业大学 migrated to v2
-// router.get('/bjfu/grs', lazyloadRouteHandler('./routes/universities/bjfu/grs'));
-// router.get('/bjfu/kjc', lazyloadRouteHandler('./routes/universities/bjfu/kjc'));
-// router.get('/bjfu/jwc/:type', lazyloadRouteHandler('./routes/universities/bjfu/jwc/index'));
-// router.get('/bjfu/news/:type', lazyloadRouteHandler('./routes/universities/bjfu/news/index'));
-// router.get('/bjfu/it/:type', lazyloadRouteHandler('./routes/universities/bjfu/it/index'));
-
-// 北京理工大学
-// router.get('/bit/jwc', lazyloadRouteHandler('./routes/universities/bit/jwc/jwc'));
-// router.get('/bit/cs', lazyloadRouteHandler('./routes/universities/bit/cs/cs'));
-
 // 北京交通大学
 router.get('/bjtu/gs/:type', lazyloadRouteHandler('./routes/universities/bjtu/gs'));
 
@@ -505,50 +265,17 @@ router.get('/bjtu/gs/:type', lazyloadRouteHandler('./routes/universities/bjtu/gs
 router.get('/dpu/jiaowu/news/:type?', lazyloadRouteHandler('./routes/universities/dpu/jiaowu/news'));
 router.get('/dpu/wlfw/news/:type?', lazyloadRouteHandler('./routes/universities/dpu/wlfw/news'));
 
-// 大连理工大学
-// router.get('/dut/:subsite/:type', lazyloadRouteHandler('./routes/universities/dut/index'));
-
-// 东南大学
-// router.get('/seu/radio/academic', lazyloadRouteHandler('./routes/universities/seu/radio/academic'));
-// router.get('/seu/yzb/:type', lazyloadRouteHandler('./routes/universities/seu/yzb'));
-// router.get('/seu/cse/:type?', lazyloadRouteHandler('./routes/universities/seu/cse'));
-
 // 南京工业大学
 router.get('/njtech/jwc', lazyloadRouteHandler('./routes/universities/njtech/jwc'));
-
-// 南京航空航天大学 migrated to v2
-// router.get('/nuaa/jwc/:type/:getDescription?', lazyloadRouteHandler('./routes/universities/nuaa/jwc/jwc'));
-// router.get('/nuaa/cs/:type/:getDescription?', lazyloadRouteHandler('./routes/universities/nuaa/cs/index'));
-// router.get('/nuaa/yjsy/:type?', lazyloadRouteHandler('./routes/universities/nuaa/yjsy/yjsy'));
 
 // 河海大学
 router.get('/hhu/libNews', lazyloadRouteHandler('./routes/universities/hhu/libNews'));
 // 河海大学常州校区
 router.get('/hhu/libNewsc', lazyloadRouteHandler('./routes/universities/hhu/libNewsc'));
 
-// 哈尔滨工业大学 migrated to v2
-// router.get('/hit/jwc', lazyloadRouteHandler('./routes/universities/hit/jwc'));
-// router.get('/hit/today/:category', lazyloadRouteHandler('./routes/universities/hit/today'));
-
-// 哈尔滨工业大学（深圳）
-// router.get('/hitsz/article/:category?', lazyloadRouteHandler('./routes/universities/hitsz/article'));
-
-// 哈尔滨工业大学（威海）
-// router.get('/hitwh/today', lazyloadRouteHandler('./routes/universities/hitwh/today'));
-
 // 上海科技大学
 router.get('/shanghaitech/activity', lazyloadRouteHandler('./routes/universities/shanghaitech/activity'));
 router.get('/shanghaitech/sist/activity', lazyloadRouteHandler('./routes/universities/shanghaitech/sist/activity'));
-
-// 上海交通大学
-// router.get('/sjtu/seiee/academic', lazyloadRouteHandler('./routes/universities/sjtu/seiee/academic'));
-// router.get('/sjtu/seiee/bjwb/:type', lazyloadRouteHandler('./routes/universities/sjtu/seiee/bjwb'));
-// router.get('/sjtu/seiee/xsb/:type?', lazyloadRouteHandler('./routes/universities/sjtu/seiee/xsb'));
-
-// router.get('/sjtu/gs/tzgg/:type?', lazyloadRouteHandler('./routes/universities/sjtu/gs/tzgg'));
-// router.get('/sjtu/jwc/:type?', lazyloadRouteHandler('./routes/universities/sjtu/jwc'));
-// router.get('/sjtu/tongqu/:type?', lazyloadRouteHandler('./routes/universities/sjtu/tongqu/activity'));
-// router.get('/sjtu/yzb/zkxx/:type', lazyloadRouteHandler('./routes/universities/sjtu/yzb/zkxx'));
 
 // 江南大学
 router.get('/ju/jwc/:type?', lazyloadRouteHandler('./routes/universities/ju/jwc'));
@@ -562,17 +289,6 @@ router.get('/lit/tw/:name?', lazyloadRouteHandler('./routes/universities/lit/tw'
 router.get('/thu/career', lazyloadRouteHandler('./routes/universities/thu/career'));
 router.get('/thu/:type', lazyloadRouteHandler('./routes/universities/thu/index'));
 
-// 北京大学 migrated to v2
-// router.get('/pku/eecs/:type?', lazyloadRouteHandler('./routes/universities/pku/eecs'));
-// router.get('/pku/rccp/mzyt', lazyloadRouteHandler('./routes/universities/pku/rccp/mzyt'));
-// router.get('/pku/cls/lecture', lazyloadRouteHandler('./routes/universities/pku/cls/lecture'));
-// router.get('/pku/bbs/hot', lazyloadRouteHandler('./routes/universities/pku/bbs/hot'));
-// router.get('/pku/scc/recruit/:type?', lazyloadRouteHandler('./routes/universities/pku/scc/recruit'));
-
-// 上海海事大学 migrated to v2
-// router.get('/shmtu/www/:type', lazyloadRouteHandler('./routes/universities/shmtu/www'));
-// router.get('/shmtu/jwc/:type', lazyloadRouteHandler('./routes/universities/shmtu/jwc'));
-
 // 上海海洋大学
 router.get('/shou/www/:type', lazyloadRouteHandler('./routes/universities/shou/www'));
 
@@ -580,23 +296,6 @@ router.get('/shou/www/:type', lazyloadRouteHandler('./routes/universities/shou/w
 router.get('/swust/jwc/news', lazyloadRouteHandler('./routes/universities/swust/jwc_news'));
 router.get('/swust/jwc/notice/:type?', lazyloadRouteHandler('./routes/universities/swust/jwc_notice'));
 router.get('/swust/cs/:type?', lazyloadRouteHandler('./routes/universities/swust/cs'));
-
-// 华南师范大学
-// router.get('/scnu/jw', lazyloadRouteHandler('./routes/universities/scnu/jw'));
-// router.get('/scnu/library', lazyloadRouteHandler('./routes/universities/scnu/library'));
-// router.get('/scnu/cs/match', lazyloadRouteHandler('./routes/universities/scnu/cs/match'));
-
-// 广东工业大学
-// router.get('/gdut/news', lazyloadRouteHandler('./routes/universities/gdut/news'));
-
-// 中国科学院
-// router.get('/cas/sim/academic', lazyloadRouteHandler('./routes/universities/cas/sim/academic'));
-// router.get('/cas/mesalab/kb', lazyloadRouteHandler('./routes/universities/cas/mesalab/kb'));
-// router.get('/cas/iee/kydt', lazyloadRouteHandler('./routes/universities/cas/iee/kydt'));
-// router.get('/cas/cg/:caty?', lazyloadRouteHandler('./routes/universities/cas/cg/index'));
-
-// 中国传媒大学
-// router.get('/cuc/yz', lazyloadRouteHandler('./v2/cuc/yz'));
 
 // UTdallas ISSO
 router.get('/utdallas/isso', lazyloadRouteHandler('./routes/universities/utdallas/isso'));
@@ -611,16 +310,6 @@ router.get('/cqu/news/tz', lazyloadRouteHandler('./routes/universities/cqu/news/
 router.get('/cqu/youth/:category', lazyloadRouteHandler('./routes/universities/cqu/youth/info'));
 router.get('/cqu/sci/:category', lazyloadRouteHandler('./routes/universities/cqu/sci/info'));
 router.get('/cqu/net/:category', lazyloadRouteHandler('./routes/universities/cqu/net/info'));
-
-// 南京信息工程大学
-// router.get('/nuist/bulletin/:category?', lazyloadRouteHandler('./routes/universities/nuist/bulletin'));
-// router.get('/nuist/jwc/:category?', lazyloadRouteHandler('./routes/universities/nuist/jwc'));
-// router.get('/nuist/yjs/:category?', lazyloadRouteHandler('./routes/universities/nuist/yjs'));
-// router.get('/nuist/xgc', lazyloadRouteHandler('./routes/universities/nuist/xgc'));
-// router.get('/nuist/scs/:category?', lazyloadRouteHandler('./routes/universities/nuist/scs'));
-// router.get('/nuist/lib', lazyloadRouteHandler('./routes/universities/nuist/library/lib'));
-// router.get('/nuist/sese/:category?', lazyloadRouteHandler('./routes/universities/nuist/sese'));
-// router.get('/nuist/cas/:category?', lazyloadRouteHandler('./routes/universities/nuist/cas'));
 
 // 成都信息工程大学
 router.get('/cuit/cxxww/:type?', lazyloadRouteHandler('./routes/universities/cuit/cxxww'));
@@ -646,16 +335,6 @@ router.get('/sctu/xgxy', lazyloadRouteHandler('./routes/universities/sctu/inform
 router.get('/sctu/xgxy/:id', lazyloadRouteHandler('./routes/universities/sctu/information-engineer-faculty/context'));
 router.get('/sctu/jwc/:type?', lazyloadRouteHandler('./routes/universities/sctu/jwc/index'));
 router.get('/sctu/jwc/:type/:id', lazyloadRouteHandler('./routes/universities/sctu/jwc/context'));
-
-// 电子科技大学
-// router.get('/uestc/jwc/:type?', lazyloadRouteHandler('./routes/universities/uestc/jwc'));
-// router.get('/uestc/is/:type?', lazyloadRouteHandler('./routes/universities/uestc/is'));
-// router.get('/uestc/news/:type?', lazyloadRouteHandler('./routes/universities/uestc/news'));
-// router.get('/uestc/auto/:type?', lazyloadRouteHandler('./routes/universities/uestc/auto'));
-// router.get('/uestc/cs/:type?', lazyloadRouteHandler('./routes/universities/uestc/cs'));
-// router.get('/uestc/cqe/:type?', lazyloadRouteHandler('./routes/universities/uestc/cqe'));
-// router.get('/uestc/gr', lazyloadRouteHandler('./routes/universities/uestc/gr'));
-// router.get('/uestc/sice', lazyloadRouteHandler('./routes/universities/uestc/sice'));
 
 // 西北农林科技大学
 router.get('/nwafu/news', lazyloadRouteHandler('./routes/universities/nwafu/news'));
@@ -686,28 +365,8 @@ router.get('/kmust/job/jobfairs', lazyloadRouteHandler('./routes/universities/km
 router.get('/whu/cs/:type', lazyloadRouteHandler('./routes/universities/whu/cs'));
 router.get('/whu/news/:type?', lazyloadRouteHandler('./routes/universities/whu/news'));
 
-// 潍坊学院 migrated to v2
-// router.get('/wfu/news/:type?', require('./routes/universities/wfu/news'));
-// router.get('/wfu/jwc', require('./routes/universities/wfu/jwc'));
-
-// 华中科技大学
-// router.get('/hust/auto/notice/:type?', lazyloadRouteHandler('./routes/universities/hust/aia/notice'));
-// router.get('/hust/auto/news', lazyloadRouteHandler('./routes/universities/hust/aia/news'));
-// router.get('/hust/aia/news', lazyloadRouteHandler('./routes/universities/hust/aia/news'));
-// router.get('/hust/aia/notice/:type?', lazyloadRouteHandler('./routes/universities/hust/aia/notice'));
-
 // 井冈山大学
 router.get('/jgsu/jwc', lazyloadRouteHandler('./routes/universities/jgsu/jwc'));
-
-// 山东大学 migrated to v2
-// router.get('/sdu/sc/:type?', lazyloadRouteHandler('./routes/universities/sdu/sc'));
-// router.get('/sdu/cs/:type?', lazyloadRouteHandler('./routes/universities/sdu/cs'));
-// router.get('/sdu/cmse/:type?', lazyloadRouteHandler('./routes/universities/sdu/cmse'));
-// router.get('/sdu/mech/:type?', lazyloadRouteHandler('./routes/universities/sdu/mech'));
-// router.get('/sdu/epe/:type?', lazyloadRouteHandler('./routes/universities/sdu/epe'));
-
-// 中国海洋大学
-// router.get('/ouc/it/:type?', lazyloadRouteHandler('./routes/universities/ouc/it'));
 
 // 大连大学
 router.get('/dlu/jiaowu/news', lazyloadRouteHandler('./routes/universities/dlu/jiaowu/news'));
@@ -716,22 +375,11 @@ router.get('/dlu/jiaowu/news', lazyloadRouteHandler('./routes/universities/dlu/j
 router.get('/dgut/jwc/:type?', lazyloadRouteHandler('./routes/universities/dgut/jwc'));
 router.get('/dgut/xsc/:type?', lazyloadRouteHandler('./routes/universities/dgut/xsc'));
 
-// 同济大学
-// router.get('/tju/sse/:type?', lazyloadRouteHandler('./routes/universities/tju/sse/notice'));
-
-// 华南理工大学
-// router.get('/scut/jwc/notice/:category?', lazyloadRouteHandler('./routes/universities/scut/jwc/notice'));
-// router.get('/scut/jwc/school/:category?', lazyloadRouteHandler('./routes/universities/scut/jwc/school'));
-// router.get('/scut/jwc/news', lazyloadRouteHandler('./routes/universities/scut/jwc/news'));
-
 // 温州商学院
 router.get('/wzbc/:type?', lazyloadRouteHandler('./routes/universities/wzbc/news'));
 
 // 河南大学
 router.get('/henu/:type?', lazyloadRouteHandler('./routes/universities/henu/news'));
-
-// 天津大学 migrated to v2
-// router.get('/tju/oaa/:type?', lazyloadRouteHandler('./routes/universities/tju/oaa'));
 
 // 南开大学
 router.get('/nku/jwc/:type?', lazyloadRouteHandler('./routes/universities/nku/jwc/index'));
@@ -742,27 +390,6 @@ router.get('/buaa/news/:type', lazyloadRouteHandler('./routes/universities/buaa/
 // 浙江工业大学
 router.get('/zjut/:type', lazyloadRouteHandler('./routes/universities/zjut/index'));
 router.get('/zjut/design/:type', lazyloadRouteHandler('./routes/universities/zjut/design'));
-
-// 上海大学
-// router.get('/shu/:type?', lazyloadRouteHandler('./routes/universities/shu/index'));
-// router.get('/shu/jwc/:type?', lazyloadRouteHandler('./routes/universities/shu/jwc'));
-// router.get('/shu/jwb/:type?', lazyloadRouteHandler('./routes/universities/shu/jwc'));
-
-// 北京科技大学天津学院
-// router.get('/ustb/tj/news/:type?', lazyloadRouteHandler('./routes/universities/ustb/tj/news'));
-
-// 深圳大学
-// router.get('/szu/yz/:type?', lazyloadRouteHandler('./routes/universities/szu/yz'));
-
-// 中国石油大学（华东）
-// router.get('/upc/main/:type?', lazyloadRouteHandler('./routes/universities/upc/main'));
-// router.get('/upc/jsj/:type?', lazyloadRouteHandler('./routes/universities/upc/jsj'));
-
-// 华北水利水电大学
-// router.get('/ncwu/notice', lazyloadRouteHandler('./routes/universities/ncwu/notice'));
-
-// 太原师范学院
-// router.get('/tynu', lazyloadRouteHandler('./routes/universities/tynu/tynu'));
 
 // 中北大学
 router.get('/nuc/:type', lazyloadRouteHandler('./routes/universities/nuc/index'));
@@ -796,51 +423,17 @@ router.get('/xmu/aero/:type', lazyloadRouteHandler('./routes/universities/xmu/ae
 // ifanr
 router.get('/ifanr/:channel?', lazyloadRouteHandler('./routes/ifanr/index'));
 
-// 果壳网
-// router.get('/guokr/scientific', lazyloadRouteHandler('./routes/guokr/scientific'));
-// router.get('/guokr/:channel', lazyloadRouteHandler('./routes/guokr/calendar'));
-
-// 联合早报 已经迁移至v2模板
-// router.get('/zaobao/realtime/:section?', require('./routes/zaobao/realtime'));
-// router.get('/zaobao/znews/:section?', require('./routes/zaobao/znews'));
-// router.get('/zaobao/:type/:section', lazyloadRouteHandler('./routes/zaobao/index'));
-// router.get('/zaobao/interactive-graphics', lazyloadRouteHandler('./routes/zaobao/interactive'));
-
 // IPSW.me
 router.get('/ipsw/index/:ptype/:pname', lazyloadRouteHandler('./routes/ipsw/index'));
 
 // Minecraft CurseForge
 router.get('/curseforge/files/:project', lazyloadRouteHandler('./routes/curseforge/files'));
 
-// 少数派 sspai migrated to v2
-// router.get('/sspai/index', lazyloadRouteHandler('./routes/sspai/index'));
-// router.get('/sspai/series', lazyloadRouteHandler('./routes/sspai/series'));
-// router.get('/sspai/shortcuts', lazyloadRouteHandler('./routes/sspai/shortcutsGallery'));
-// router.get('/sspai/matrix', lazyloadRouteHandler('./routes/sspai/matrix'));
-// router.get('/sspai/column/:id', lazyloadRouteHandler('./routes/sspai/column'));
-// router.get('/sspai/author/:id', lazyloadRouteHandler('./routes/sspai/author'));
-// router.get('/sspai/topics', lazyloadRouteHandler('./routes/sspai/topics'));
-// router.get('/sspai/topic/:id', lazyloadRouteHandler('./routes/sspai/topic'));
-// router.get('/sspai/tag/:keyword', lazyloadRouteHandler('./routes/sspai/tag'));
-// router.get('/sspai/activity/:slug', lazyloadRouteHandler('./routes/sspai/activity'));
-
 // 异次元软件世界
 router.get('/iplay/home', lazyloadRouteHandler('./routes/iplay/home'));
 
 // xclient.info
 router.get('/xclient/app/:name', lazyloadRouteHandler('./routes/xclient/app'));
-
-// 中国驻外使领事馆 migrated to v2
-// router.get('/embassy/:country/:city?', lazyloadRouteHandler('./routes/embassy/index'));
-
-// 澎湃新闻
-// router.get('/thepaper/featured', lazyloadRouteHandler('./routes/thepaper/featured'));
-// router.get('/thepaper/channel/:id', lazyloadRouteHandler('./routes/thepaper/channel'));
-// router.get('/thepaper/list/:id', lazyloadRouteHandler('./routes/thepaper/list'));
-
-// 澎湃美数课
-// router.get('/thepaper/839studio', lazyloadRouteHandler('./routes/thepaper/839studio/studio.js'));
-// router.get('/thepaper/839studio/:id', lazyloadRouteHandler('./routes/thepaper/839studio/category.js'));
 
 // 电影首发站
 router.get('/dysfz', lazyloadRouteHandler('./routes/dysfz/index'));
@@ -853,32 +446,14 @@ router.get('/kirara/news', lazyloadRouteHandler('./routes/kirara/news'));
 router.get('/dytt', lazyloadRouteHandler('./routes/dytt/index'));
 router.get('/dytt/index', lazyloadRouteHandler('./routes/dytt/index')); // 废弃
 
-// BT之家
-// router.get('/btzj/:type?', lazyloadRouteHandler('./routes/btzj/index'));
-
 // 人生05电影网
 router.get('/rs05/rs05', lazyloadRouteHandler('./routes/rs05/rs05'));
-
-// 人人影视 (评测推荐) migrated to v2
-// router.get('/rrys/review', lazyloadRouteHandler('./routes/rrys/review'));
-// 人人影视（每日更新）
-// router.get('/yyets/todayfilelist', lazyloadRouteHandler('./routes/yyets/todayfilelist'));
 
 // 趣头条
 router.get('/qutoutiao/category/:cid', lazyloadRouteHandler('./routes/qutoutiao/category'));
 
-// NHK NEW WEB EASY migrated to v2
-// router.get('/nhk/news_web_easy', lazyloadRouteHandler('./routes/nhk/news_web_easy'));
-
 // BBC
 router.get('/bbc/:site?/:channel?', lazyloadRouteHandler('./routes/bbc/index'));
-
-// Financial Times migrated to v2
-// router.get('/ft/myft/:key', lazyloadRouteHandler('./routes/ft/myft'));
-// router.get('/ft/:language/:channel?', lazyloadRouteHandler('./routes/ft/channel'));
-
-// The Verge
-// router.get('/verge', lazyloadRouteHandler('./routes/verge/index'));
 
 // 看雪
 router.get('/pediy/topic/:category?/:type?', lazyloadRouteHandler('./routes/pediy/topic'));
@@ -886,11 +461,6 @@ router.get('/pediy/topic/:category?/:type?', lazyloadRouteHandler('./routes/pedi
 // 知晓程序
 router.get('/miniapp/article/:category', lazyloadRouteHandler('./routes/miniapp/article'));
 router.get('/miniapp/store/newest', lazyloadRouteHandler('./routes/miniapp/store/newest'));
-
-// 后续
-// router.get('/houxu/live/:id/:timeline?', lazyloadRouteHandler('./routes/houxu/live'));
-// router.get('/houxu/events', lazyloadRouteHandler('./routes/houxu/events'));
-// router.get('/houxu/lives/:type', lazyloadRouteHandler('./routes/houxu/lives'));
 
 // 老司机
 router.get('/laosiji/hot', lazyloadRouteHandler('./routes/laosiji/hot'));
@@ -906,9 +476,6 @@ router.get('/99percentinvisible/transcript', lazyloadRouteHandler('./routes/99pe
 // 青空文庫
 router.get('/aozora/newbook/:count?', lazyloadRouteHandler('./routes/aozora/newbook'));
 
-// solidot migrated to v2
-// router.get('/solidot/:type?', lazyloadRouteHandler('./routes/solidot/main'));
-
 // Hermes UK
 router.get('/parcel/hermesuk/:tracking', lazyloadRouteHandler('./routes/parcel/hermesuk'));
 
@@ -923,22 +490,11 @@ router.get('/dgtle/trade/search/:keyword', lazyloadRouteHandler('./routes/dgtle/
 router.get('/chouti/top/:hour?', lazyloadRouteHandler('./routes/chouti/top'));
 router.get('/chouti/:subject?', lazyloadRouteHandler('./routes/chouti'));
 
-// 西安电子科技大学 migrated to v2
-// router.get('/xidian/jwc/:category?', lazyloadRouteHandler('./routes/universities/xidian/jwc'));
-
 // Westore
 router.get('/westore/new', lazyloadRouteHandler('./routes/westore/new'));
 
-// nHentai
-// router.get('/nhentai/search/:keyword/:mode?', lazyloadRouteHandler('./routes/nhentai/search'));
-// router.get('/nhentai/:key/:keyword/:mode?', lazyloadRouteHandler('./routes/nhentai/other'));
-
 // 龙腾网
 router.get('/ltaaa/:category?', lazyloadRouteHandler('./routes/ltaaa/index'));
-
-// AcFun migrated to v2
-// router.get('/acfun/bangumi/:id', lazyloadRouteHandler('./routes/acfun/bangumi'));
-// router.get('/acfun/user/video/:uid', lazyloadRouteHandler('./routes/acfun/video'));
 
 // Auto Trader
 router.get('/autotrader/:query', lazyloadRouteHandler('./routes/autotrader'));
@@ -993,19 +549,6 @@ router.get('/eeo/:column?/:category?', lazyloadRouteHandler('./routes/eeo/index'
 // 腾讯视频
 router.get('/tencentvideo/playlist/:id', lazyloadRouteHandler('./routes/tencent/video/playlist'));
 
-// 看漫画 migrated to v2
-// router.get('/manhuagui/comic/:id/:chapterCnt?', lazyloadRouteHandler('./routes/manhuagui/comic'));
-// router.get('/mhgui/comic/:id/:chapterCnt?', lazyloadRouteHandler('./routes/mhgui/comic'));
-// router.get('/twmanhuagui/comic/:id/:chapterCnt?', lazyloadRouteHandler('./routes/twmanhuagui/comic'));
-
-// 拷贝漫画
-// router.get('/copymanga/comic/:id/:chapterCnt?', lazyloadRouteHandler('./routes/copymanga/comic'));
-
-// 拷贝漫画
-// router.get('/copymanga/comic/:id', lazyloadRouteHandler('./routes/copymanga/comic'));
-
-// 動漫狂
-// router.get('/cartoonmad/comic/:id', lazyloadRouteHandler('./routes/cartoonmad/comic'));
 // Vol
 router.get('/vol/:mode?', lazyloadRouteHandler('./routes/vol/lastupdate'));
 // 咚漫
@@ -1020,10 +563,6 @@ router.get('/tits-guru/daily', lazyloadRouteHandler('./routes/titsguru/daily'));
 router.get('/tits-guru/category/:type', lazyloadRouteHandler('./routes/titsguru/category'));
 router.get('/tits-guru/model/:name', lazyloadRouteHandler('./routes/titsguru/model'));
 
-// typora
-// router.get('/typora/changelog', lazyloadRouteHandler('./routes/typora/changelog'));
-// router.get('/typora/changelog-dev/:os?', lazyloadRouteHandler('./routes/typora/changelog-dev'));
-
 // TSSstatus
 router.get('/tssstatus/:board/:build', lazyloadRouteHandler('./routes/tssstatus'));
 
@@ -1031,17 +570,11 @@ router.get('/tssstatus/:board/:build', lazyloadRouteHandler('./routes/tssstatus'
 router.get('/anime1/anime/:time/:name', lazyloadRouteHandler('./routes/anime1/anime'));
 router.get('/anime1/search/:keyword', lazyloadRouteHandler('./routes/anime1/search'));
 
-// Global UDN
-// router.get('/udn/global/:tid', lazyloadRouteHandler('./routes/udn/global'));
-
 // gitea
 router.get('/gitea/blog', lazyloadRouteHandler('./routes/gitea/blog'));
 
 // iDownloadBlog
 router.get('/idownloadblog', lazyloadRouteHandler('./routes/idownloadblog/index'));
-
-// 9to5
-// router.get('/9to5/:subsite/:tag?', lazyloadRouteHandler('./routes/9to5/subsite'));
 
 // TesterHome
 router.get('/testerhome/newest', lazyloadRouteHandler('./routes/testerhome/newest'));
@@ -1058,41 +591,9 @@ router.get('/coolbuy/newest', lazyloadRouteHandler('./routes/coolbuy/newest'));
 router.get('/miniflux/subscription/:parameters?', lazyloadRouteHandler('./routes/miniflux/get_feeds'));
 router.get('/miniflux/:feeds/:parameters?', lazyloadRouteHandler('./routes/miniflux/get_entries'));
 
-// NGA migrated to v2
-// router.get('/nga/forum/:fid/:recommend?', lazyloadRouteHandler('./routes/nga/forum'));
-// router.get('/nga/post/:tid', lazyloadRouteHandler('./routes/nga/post'));
-
-// Nautilus
-// router.get('/nautilus/topic/:tid', lazyloadRouteHandler('./routes/nautilus/topics'));
-
-// JavBus migrated to v2
-// router.get('/javbus/home', lazyloadRouteHandler('./routes/javbus/home'));
-// router.get('/javbus/genre/:gid', lazyloadRouteHandler('./routes/javbus/genre'));
-// router.get('/javbus/star/:sid', lazyloadRouteHandler('./routes/javbus/star'));
-// router.get('/javbus/series/:seriesid', lazyloadRouteHandler('./routes/javbus/series'));
-// router.get('/javbus/studio/:studioid', lazyloadRouteHandler('./routes/javbus/studio'));
-// router.get('/javbus/label/:labelid', lazyloadRouteHandler('./routes/javbus/label'));
-// router.get('/javbus/uncensored/home', lazyloadRouteHandler('./routes/javbus/uncensored/home'));
-// router.get('/javbus/uncensored/genre/:gid', lazyloadRouteHandler('./routes/javbus/uncensored/genre'));
-// router.get('/javbus/uncensored/star/:sid', lazyloadRouteHandler('./routes/javbus/uncensored/star'));
-// router.get('/javbus/uncensored/series/:seriesid', lazyloadRouteHandler('./routes/javbus/uncensored/series'));
-// router.get('/javbus/western/home', lazyloadRouteHandler('./routes/javbus/western/home'));
-// router.get('/javbus/western/genre/:gid', lazyloadRouteHandler('./routes/javbus/western/genre'));
-// router.get('/javbus/western/star/:sid', lazyloadRouteHandler('./routes/javbus/western/star'));
-// router.get('/javbus/western/series/:seriesid', lazyloadRouteHandler('./routes/javbus/western/series'));
-
-// 中山大学
-// router.get('/sysu/cse', lazyloadRouteHandler('./routes/universities/sysu/cse'));
-
 // 動畫瘋
 router.get('/anigamer/new_anime', lazyloadRouteHandler('./routes/anigamer/new_anime'));
 router.get('/anigamer/anime/:sn', lazyloadRouteHandler('./routes/anigamer/anime'));
-
-// Apkpure
-// router.get('/apkpure/versions/:region/:pkg', lazyloadRouteHandler('./routes/apkpure/versions'));
-
-// 豆瓣美女 migrated to v2
-// router.get('/dbmv/:category?', lazyloadRouteHandler('./routes/dbmv/index'));
 
 // 中国药科大学
 router.get('/cpu/home', lazyloadRouteHandler('./routes/universities/cpu/home'));
@@ -1105,16 +606,6 @@ router.get('/zimuzu/top/:range/:type', lazyloadRouteHandler('./routes/zimuzu/top
 
 // 字幕库
 router.get('/zimuku/:type?', lazyloadRouteHandler('./routes/zimuku/index'));
-
-// SubHD.tv
-// router.get('/subhd/newest', lazyloadRouteHandler('./routes/subhd/newest'));
-
-// 虎嗅 migrated to v2
-// router.get('/huxiu/tag/:id', lazyloadRouteHandler('./routes/huxiu/tag'));
-// router.get('/huxiu/search/:keyword', lazyloadRouteHandler('./routes/huxiu/search'));
-// router.get('/huxiu/author/:id', lazyloadRouteHandler('./routes/huxiu/author'));
-// router.get('/huxiu/article', lazyloadRouteHandler('./routes/huxiu/article'));
-// router.get('/huxiu/collection/:id', lazyloadRouteHandler('./routes/huxiu/collection'));
 
 // Steam
 router.get('/steam/search/:params', lazyloadRouteHandler('./routes/steam/search'));
@@ -1136,13 +627,6 @@ router.get('/bihu/activaties/:id', lazyloadRouteHandler('./routes/bihu/activatie
 router.get('/tingdiantz/nanjing', lazyloadRouteHandler('./routes/tingdiantz/nanjing'));
 router.get('/tingdiantz/95598/:province/:city/:district?', lazyloadRouteHandler('./routes/tingdiantz/95598'));
 
-// 36kr migrated to v2
-// router.get('/36kr/search/article/:keyword', lazyloadRouteHandler('./routes/36kr/search/article'));
-// router.get('/36kr/newsflashes', lazyloadRouteHandler('./routes/36kr/newsflashes'));
-// router.get('/36kr/news/:category?', lazyloadRouteHandler('./routes/36kr/news'));
-// router.get('/36kr/user/:uid', lazyloadRouteHandler('./routes/36kr/user'));
-// router.get('/36kr/motif/:mid', lazyloadRouteHandler('./routes/36kr/motif'));
-
 // PMCAFF
 router.get('/pmcaff/list/:typeid', lazyloadRouteHandler('./routes/pmcaff/list'));
 router.get('/pmcaff/feed/:typeid', lazyloadRouteHandler('./routes/pmcaff/feed'));
@@ -1159,13 +643,6 @@ router.get('/jingdong/zhongchou/:type/:status/:sort', lazyloadRouteHandler('./ro
 
 // All Poetry
 router.get('/allpoetry/:order?', lazyloadRouteHandler('./routes/allpoetry/order'));
-
-// 华尔街见闻
-// router.get('/wallstreetcn/news/global', lazyloadRouteHandler('./routes/wallstreetcn/news'));
-// router.get('/wallstreetcn/live/:channel?', lazyloadRouteHandler('./routes/wallstreetcn/live'));
-
-// 多抓鱼搜索
-// router.get('/duozhuayu/search/:wd', lazyloadRouteHandler('./routes/duozhuayu/search'));
 
 // 创业邦
 router.get('/cyzone/author/:id', lazyloadRouteHandler('./routes/cyzone/author'));
@@ -1186,9 +663,6 @@ router.get('/gov/xinwen/tujie/:caty', lazyloadRouteHandler('./routes/gov/xinwen/
 router.get('/gov/suzhou/news/:uid', lazyloadRouteHandler('./routes/gov/suzhou/news'));
 router.get('/gov/suzhou/doc', lazyloadRouteHandler('./routes/gov/suzhou/doc'));
 
-// 江苏
-// router.get('/gov/jiangsu/eea/:type?', lazyloadRouteHandler('./routes/gov/jiangsu/eea'));
-
 // 山西
 router.get('/gov/shanxi/rst/:category', lazyloadRouteHandler('./routes/gov/shanxi/rst'));
 
@@ -1197,15 +671,6 @@ router.get('/gov/hunan/notice/:type', lazyloadRouteHandler('./routes/gov/hunan/n
 
 // 中华人民共和国国家发展和改革委员会
 router.get('/gov/ndrc/xwdt/:caty?', lazyloadRouteHandler('./routes/gov/ndrc/xwdt'));
-
-// 中华人民共和国-海关总署 migrated to v2
-// router.get('/gov/customs/list/:gchannel', lazyloadRouteHandler('./routes/gov/customs/list'));
-
-// 中华人民共和国教育部
-// router.get('/gov/moe/:type', lazyloadRouteHandler('./routes/gov/moe/moe'));
-
-// 中华人民共和国外交部
-// router.get('/gov/fmprc/fyrbt', lazyloadRouteHandler('./routes/gov/fmprc/fyrbt'));
 
 // 中华人民共和国住房和城乡建设部
 router.get('/gov/mohurd/policy', lazyloadRouteHandler('./routes/gov/mohurd/policy'));
@@ -1229,9 +694,6 @@ router.get('/gov/guangdong/edu/:caty', lazyloadRouteHandler('./routes/gov/guangd
 // 广东省教育考试院
 router.get('/gov/guangdong/eea/:caty', lazyloadRouteHandler('./routes/gov/guangdong/eea'));
 
-// 广东省深圳市
-// router.get('/gov/shenzhen/xxgk/zfxxgj/:caty', lazyloadRouteHandler('./routes/gov/shenzhen/xxgk/zfxxgj'));
-
 // 日本国外務省記者会見
 router.get('/go.jp/mofa', lazyloadRouteHandler('./routes/go.jp/mofa/main'));
 
@@ -1242,25 +704,6 @@ router.get('/xiaoheihe/discount/:platform?', lazyloadRouteHandler('./routes/xiao
 
 // 惠誉评级
 router.get('/fitchratings/site/:type', lazyloadRouteHandler('./routes/fitchratings/site'));
-
-// 移动支付 migrated to v2
-// router.get('/mpaypass/news', lazyloadRouteHandler('./routes/mpaypass/news'));
-// router.get('/mpaypass/main/:type?', lazyloadRouteHandler('./routes/mpaypass/main'));
-
-// 新浪科技探索
-// router.get('/sina/discovery/:type', lazyloadRouteHandler('./routes/sina/discovery'));
-
-// 新浪科技滚动新闻
-// router.get('/sina/rollnews', lazyloadRouteHandler('./routes/sina/rollnews'));
-
-// 新浪体育
-// router.get('/sina/sports/:type', lazyloadRouteHandler('./routes/sina/sports'));
-
-// 新浪专栏创事记
-// router.get('/sina/csj', lazyloadRouteHandler('./routes/sina/chuangshiji'));
-
-// 新浪财经－国內
-// router.get('/sina/finance', lazyloadRouteHandler('./routes/sina/finance'));
 
 // Animen
 router.get('/animen/news/:type', lazyloadRouteHandler('./routes/animen/news'));
@@ -1283,13 +726,6 @@ router.get('/meipai/user/:uid', lazyloadRouteHandler('./routes/meipai/user'));
 // 多知网
 router.get('/duozhi', lazyloadRouteHandler('./routes/duozhi'));
 
-// 人人都是产品经理
-// router.get('/woshipm/popular', lazyloadRouteHandler('./routes/woshipm/popular'));
-// router.get('/woshipm/wen', lazyloadRouteHandler('./routes/woshipm/wen'));
-// router.get('/woshipm/bookmarks/:id', lazyloadRouteHandler('./routes/woshipm/bookmarks'));
-// router.get('/woshipm/user_article/:id', lazyloadRouteHandler('./routes/woshipm/user_article'));
-// router.get('/woshipm/latest', lazyloadRouteHandler('./routes/woshipm/latest'));
-
 // 高清电台
 router.get('/gaoqing/latest', lazyloadRouteHandler('./routes/gaoqing/latest'));
 
@@ -1297,30 +733,10 @@ router.get('/gaoqing/latest', lazyloadRouteHandler('./routes/gaoqing/latest'));
 router.get('/whalegogo/home', lazyloadRouteHandler('./routes/whalegogo/home'));
 router.get('/whalegogo/portal/:type_id/:tagid?', lazyloadRouteHandler('./routes/whalegogo/portal'));
 
-// 爱思想
-// router.get('/aisixiang/column/:id', lazyloadRouteHandler('./routes/aisixiang/column'));
-// router.get('/aisixiang/ranking/:type?/:range?', lazyloadRouteHandler('./routes/aisixiang/ranking'));
-// router.get('/aisixiang/thinktank/:name/:type?', lazyloadRouteHandler('./routes/aisixiang/thinktank'));
-
-// Hacker News
-// router.get('/hackernews/:section/:type?', lazyloadRouteHandler('./routes/hackernews/story'));
-
 // LeetCode
 // router.get('/leetcode/articles', lazyloadRouteHandler('./routes/leetcode/articles'));
 router.get('/leetcode/submission/us/:user', lazyloadRouteHandler('./routes/leetcode/check-us'));
 router.get('/leetcode/submission/cn/:user', lazyloadRouteHandler('./routes/leetcode/check-cn'));
-
-// 虎扑
-// router.get('/hupu/bxj/:id/:order?', lazyloadRouteHandler('./routes/hupu/bbs'));
-// router.get('/hupu/bbs/:id/:order?', lazyloadRouteHandler('./routes/hupu/bbs'));
-// router.get('/hupu/all/:caty', lazyloadRouteHandler('./routes/hupu/all'));
-// router.get('/hupu/dept/:dept', lazyloadRouteHandler('./routes/hupu/dept'));
-
-// 牛客网 migrated to v2
-// router.get('/nowcoder/discuss/:type/:order', lazyloadRouteHandler('./routes/nowcoder/discuss'));
-// router.get('/nowcoder/schedule/:propertyId?/:typeId?', lazyloadRouteHandler('./routes/nowcoder/schedule'));
-// router.get('/nowcoder/recommend', lazyloadRouteHandler('./routes/nowcoder/recommend'));
-// router.get('/nowcoder/jobcenter/:recruitType?/:city?/:type?/:order?/:latest?', lazyloadRouteHandler('./routes/nowcoder/jobcenter'));
 
 // Xiaomi.eu
 router.get('/xiaomieu/releases', lazyloadRouteHandler('./routes/xiaomieu/releases'));
@@ -1346,22 +762,8 @@ router.get('/instapaper/person/:name', lazyloadRouteHandler('./routes/instapaper
 router.get('/ui-cn/article', lazyloadRouteHandler('./routes/ui-cn/article'));
 router.get('/ui-cn/user/:id', lazyloadRouteHandler('./routes/ui-cn/user'));
 
-// Dcard
-// router.get('/dcard/:section/:type?', lazyloadRouteHandler('./routes/dcard/section'));
-
-// 北京天文馆每日一图
-// router.get('/bjp/apod', lazyloadRouteHandler('./routes/bjp/apod'));
-
-// 洛谷
-// router.get('/luogu/daily/:id?', lazyloadRouteHandler('./routes/luogu/daily'));
-// router.get('/luogu/contest', lazyloadRouteHandler('./routes/luogu/contest'));
-// router.get('/luogu/user/feed/:uid', lazyloadRouteHandler('./routes/luogu/userFeed'));
-
 // 决胜网
 router.get('/juesheng', lazyloadRouteHandler('./routes/juesheng'));
-
-// 播客IBCラジオ イヤーマイッタマイッタ
-// router.get('/maitta', lazyloadRouteHandler('./routes/maitta'));
 
 // 一些博客
 // 敬维-以认真的态度做完美的事情: https://jingwei.link/
@@ -1376,16 +778,8 @@ router.get('/blogs/wang54/:id?', lazyloadRouteHandler('./routes/blogs/wang54'));
 // WordPress
 router.get('/blogs/wordpress/:domain/:https?', lazyloadRouteHandler('./routes/blogs/wordpress'));
 
-// 裏垢女子まとめ migrated to v2
-// router.get('/uraaka-joshi', lazyloadRouteHandler('./routes/uraaka-joshi/uraaka-joshi'));
-// router.get('/uraaka-joshi/:id', lazyloadRouteHandler('./routes/uraaka-joshi/uraaka-joshi-user'));
-
 // 西祠胡同
 router.get('/xici/:id?', lazyloadRouteHandler('./routes/xici'));
-
-// 淘股吧论坛
-// router.get('/taoguba/index', lazyloadRouteHandler('./routes/taoguba/index'));
-// router.get('/taoguba/user/:uid', lazyloadRouteHandler('./routes/taoguba/user'));
 
 // 今日热榜
 router.get('/tophub/:id', lazyloadRouteHandler('./routes/tophub'));
@@ -1420,22 +814,9 @@ router.get('/dianping/user/:id?', lazyloadRouteHandler('./routes/dianping/user')
 router.get('/banyuetan/byt/:time?', lazyloadRouteHandler('./routes/banyuetan/byt'));
 router.get('/banyuetan/:name', lazyloadRouteHandler('./routes/banyuetan'));
 
-// 人民网
-// router.get('/people/opinion/:id', lazyloadRouteHandler('./routes/people/opinion'));
-// router.get('/people/env/:id', lazyloadRouteHandler('./routes/people/env'));
-// router.get('/people/xjpjh/:keyword?/:year?', lazyloadRouteHandler('./routes/people/xjpjh'));
-// router.get('/people/cpc/24h', lazyloadRouteHandler('./routes/people/cpc/24h'));
-
-// 北极星电力网 migrated to v2
-// router.get('/bjx/huanbao', lazyloadRouteHandler('./routes/bjx/huanbao'));
-
 // gamersky
 router.get('/gamersky/news', lazyloadRouteHandler('./routes/gamersky/news'));
 router.get('/gamersky/ent/:category', lazyloadRouteHandler('./routes/gamersky/ent'));
-
-// 游研社
-// router.get('/yystv/category/:category', lazyloadRouteHandler('./routes/yystv/category'));
-// router.get('/yystv/docs', lazyloadRouteHandler('./routes/yystv/docs'));
 
 // konami
 router.get('/konami/pesmobile/:lang?/:os?', lazyloadRouteHandler('./routes/konami/pesmobile'));
@@ -1448,31 +829,12 @@ router.get('/psnine/game', lazyloadRouteHandler('./routes/psnine/game'));
 router.get('/psnine/news/:order?', lazyloadRouteHandler('./routes/psnine/news'));
 router.get('/psnine/node/:id?/:order?', lazyloadRouteHandler('./routes/psnine/node'));
 
-// 浙江大学 migrated to v2
-// router.get('/zju/list/:type', lazyloadRouteHandler('./routes/universities/zju/list'));
-// router.get('/zju/physics/:type', lazyloadRouteHandler('./routes/universities/zju/physics'));
-// router.get('/zju/grs/:type', lazyloadRouteHandler('./routes/universities/zju/grs'));
-// router.get('/zju/career/:type', lazyloadRouteHandler('./routes/universities/zju/career'));
-// router.get('/zju/cst/:type', lazyloadRouteHandler('./routes/universities/zju/cst'));
-// router.get('/zju/cst/custom/:id', lazyloadRouteHandler('./routes/universities/zju/cst/custom'));
-
 // 浙江大学城市学院
 router.get('/zucc/news/latest', lazyloadRouteHandler('./routes/universities/zucc/news'));
 router.get('/zucc/cssearch/latest/:webVpn/:key', lazyloadRouteHandler('./routes/universities/zucc/cssearch'));
 
-// 华中师范大学
-// router.get('/ccnu/career', lazyloadRouteHandler('./routes/universities/ccnu/career'));
-
-// Infoq
-// router.get('/infoq/recommend', lazyloadRouteHandler('./routes/infoq/recommend'));
-// router.get('/infoq/topic/:id', lazyloadRouteHandler('./routes/infoq/topic'));
-
 // checkee
 router.get('/checkee/:dispdate', lazyloadRouteHandler('./routes/checkee/index'));
-
-// ZAKER migrated to v2
-// router.get('/zaker/:type/:id', lazyloadRouteHandler('./routes/zaker/source'));
-// router.get('/zaker/focusread', lazyloadRouteHandler('./routes/zaker/focusread'));
 
 // Matters
 router.get('/matters/latest/:type?', lazyloadRouteHandler('./routes/matters/latest'));
@@ -1502,17 +864,6 @@ router.get('/bupt/portal', lazyloadRouteHandler('./routes/universities/bupt/port
 router.get('/bupt/news', lazyloadRouteHandler('./routes/universities/bupt/news'));
 router.get('/bupt/funbox', lazyloadRouteHandler('./routes/universities/bupt/funbox'));
 
-// VOCUS 方格子
-// router.get('/vocus/publication/:id', lazyloadRouteHandler('./routes/vocus/publication'));
-// router.get('/vocus/user/:id', lazyloadRouteHandler('./routes/vocus/user'));
-
-// 一亩三分地 1point3acres
-// router.get('/1point3acres/blog/:category?', lazyloadRouteHandler('./routes/1point3acres/blog'));
-// router.get('/1point3acres/user/:id/threads', lazyloadRouteHandler('./routes/1point3acres/threads'));
-// router.get('/1point3acres/user/:id/posts', lazyloadRouteHandler('./routes/1point3acres/posts'));
-// router.get('/1point3acres/offer/:year?/:major?/:school?', lazyloadRouteHandler('./routes/1point3acres/offer'));
-// router.get('/1point3acres/post/:category', lazyloadRouteHandler('./routes/1point3acres/post'));
-
 // 广东海洋大学
 router.get('/gdoujwc', lazyloadRouteHandler('./routes/universities/gdou/jwc/jwtz'));
 
@@ -1531,21 +882,6 @@ router.get('/ps/:lang?/product/:gridName', lazyloadRouteHandler('./routes/ps/pro
 // Quanta Magazine
 router.get('/quantamagazine/archive', lazyloadRouteHandler('./routes/quantamagazine/archive'));
 
-// Nintendo migrated to v2
-// router.get('/nintendo/eshop/jp', lazyloadRouteHandler('./routes/nintendo/eshop_jp'));
-// router.get('/nintendo/eshop/hk', lazyloadRouteHandler('./routes/nintendo/eshop_hk'));
-// router.get('/nintendo/eshop/us', lazyloadRouteHandler('./routes/nintendo/eshop_us'));
-// router.get('/nintendo/eshop/cn', lazyloadRouteHandler('./routes/nintendo/eshop_cn'));
-// router.get('/nintendo/news', lazyloadRouteHandler('./routes/nintendo/news'));
-// router.get('/nintendo/news/china', lazyloadRouteHandler('./routes/nintendo/news_china'));
-// router.get('/nintendo/direct', lazyloadRouteHandler('./routes/nintendo/direct'));
-// router.get('/nintendo/system-update', lazyloadRouteHandler('./routes/nintendo/system-update'));
-
-// 世界卫生组织 migrated to v2
-// router.get('/who/news-room/:category?/:language?', lazyloadRouteHandler('./routes/who/news-room'));
-// router.get('/who/speeches/:language?', lazyloadRouteHandler('./routes/who/speeches'));
-// router.get('/who/news/:language?', lazyloadRouteHandler('./routes/who/news'));
-
 // 福利资源-met.red
 router.get('/metred/fuli', lazyloadRouteHandler('./routes/metred/fuli'));
 
@@ -1557,17 +893,9 @@ router.get('/mit/csail/news', lazyloadRouteHandler('./routes/universities/mit/cs
 // 毕马威
 router.get('/kpmg/insights', lazyloadRouteHandler('./routes/kpmg/insights'));
 
-// Saraba1st
-// router.get('/saraba1st/thread/:tid', lazyloadRouteHandler('./routes/saraba1st/thread'));
-
 // gradcafe
 router.get('/gradcafe/result/:type', lazyloadRouteHandler('./routes/gradcafe/result'));
 router.get('/gradcafe/result', lazyloadRouteHandler('./routes/gradcafe/result'));
-
-// The Economist migrated to v2
-// router.get('/the-economist/download', lazyloadRouteHandler('./routes/the-economist/download'));
-// router.get('/the-economist/gre-vocabulary', lazyloadRouteHandler('./routes/the-economist/gre-vocabulary'));
-// router.get('/the-economist/:endpoint', lazyloadRouteHandler('./routes/the-economist/full'));
 
 // 鼠绘漫画
 router.get('/shuhui/comics/:id', lazyloadRouteHandler('./routes/shuhui/comics'));
@@ -1575,9 +903,6 @@ router.get('/shuhui/comics/:id', lazyloadRouteHandler('./routes/shuhui/comics'))
 // 朝日新闻
 router.get('/asahi/area/:id', lazyloadRouteHandler('./routes/asahi/area'));
 router.get('/asahi/:genre?/:category?', lazyloadRouteHandler('./routes/asahi/index'));
-
-// 7x24小时快讯
-// router.get('/fx678/kx', lazyloadRouteHandler('./routes/fx678/kx'));
 
 // SoundCloud
 router.get('/soundcloud/tracks/:user', lazyloadRouteHandler('./routes/soundcloud/tracks'));
@@ -1603,17 +928,6 @@ router.get('/manhuadb/comics/:id', lazyloadRouteHandler('./routes/manhuadb/comic
 router.get('/zfrontier/postlist/:type', lazyloadRouteHandler('./routes/zfrontier/postlist'));
 router.get('/zfrontier/board/:boardId', lazyloadRouteHandler('./routes/zfrontier/board_postlist'));
 
-// 观察者网
-// router.get('/guancha/headline', lazyloadRouteHandler('./routes/guancha/headline'));
-// router.get('/guancha/topic/:id/:order?', lazyloadRouteHandler('./routes/guancha/topic'));
-// router.get('/guancha/member/:caty?', lazyloadRouteHandler('./routes/guancha/member'));
-// router.get('/guancha/personalpage/:uid', lazyloadRouteHandler('./routes/guancha/personalpage'));
-// router.get('/guancha/:caty?', lazyloadRouteHandler('./routes/guancha/index'));
-
-// router.get('/guanchazhe/topic/:id/:order?', lazyloadRouteHandler('./routes/guancha/topic'));
-// router.get('/guanchazhe/personalpage/:uid', lazyloadRouteHandler('./routes/guancha/personalpage'));
-// router.get('/guanchazhe/index/:caty?', lazyloadRouteHandler('./routes/guancha/index'));
-
 // Hpoi 手办维基
 router.get('/hpoi/info/:type?', lazyloadRouteHandler('./routes/hpoi/info'));
 router.get('/hpoi/:category/:words', lazyloadRouteHandler('./routes/hpoi'));
@@ -1628,20 +942,10 @@ router.get('/swufe/seie/:type?', lazyloadRouteHandler('./routes/universities/swu
 // Wired
 router.get('/wired/tag/:tag', lazyloadRouteHandler('./routes/wired/tag'));
 
-// 语雀文档
-// router.get('/yuque/doc/:repo_id', lazyloadRouteHandler('./routes/yuque/doc'));
-
 // 飞地
 router.get('/enclavebooks/category/:id?', lazyloadRouteHandler('./routes/enclavebooks/category'));
 router.get('/enclavebooks/user/:uid', lazyloadRouteHandler('./routes/enclavebooks/user.js'));
 router.get('/enclavebooks/collection/:uid', lazyloadRouteHandler('./routes/enclavebooks/collection.js'));
-
-// 色花堂
-// router.get('/dsndsht23/picture/:subforumid', lazyloadRouteHandler('./routes/dsndsht23/index'));
-// router.get('/dsndsht23/bt/:subforumid?', lazyloadRouteHandler('./routes/dsndsht23/index'));
-// router.get('/dsndsht23/:subforumid?/:type?', lazyloadRouteHandler('./routes/dsndsht23/index'));
-// router.get('/dsndsht23/:subforumid?', lazyloadRouteHandler('./routes/dsndsht23/index'));
-// router.get('/dsndsht23', lazyloadRouteHandler('./routes/dsndsht23/index'));
 
 // 数英网最新文章
 router.get('/digitaling/index', lazyloadRouteHandler('./routes/digitaling/index'));
@@ -1664,9 +968,6 @@ router.get('/ningmeng/song', lazyloadRouteHandler('./routes/ningmeng/song'));
 // 紫竹张先生
 router.get('/zzz/:category?/:language?', lazyloadRouteHandler('./routes/zzz'));
 
-// AEON
-// router.get('/aeon/:cid', lazyloadRouteHandler('./routes/aeon/category'));
-
 // AlgoCasts
 router.get('/algocasts', lazyloadRouteHandler('./routes/algocasts/all'));
 
@@ -1678,10 +979,6 @@ router.get('/maoyan/hot', lazyloadRouteHandler('./routes/maoyan/hot'));
 router.get('/maoyan/upcoming', lazyloadRouteHandler('./routes/maoyan/upcoming'));
 router.get('/maoyan/hotComplete/:orderby?/:ascOrDesc?/:top?', lazyloadRouteHandler('./routes/maoyan/hotComplete'));
 
-// cnBeta
-// router.get('/cnbeta', lazyloadRouteHandler('./routes/cnbeta/home'));
-// router.get('/cnbeta/topic/:topic_id', lazyloadRouteHandler('./routes/cnbeta/topic'));
-
 // 国家退伍士兵信息
 router.get('/gov/veterans/:type', lazyloadRouteHandler('./routes/gov/veterans/china'));
 
@@ -1690,9 +987,6 @@ router.get('/gov/veterans/hebei/:type', lazyloadRouteHandler('./routes/gov/veter
 
 // Dilbert Comic Strip
 router.get('/dilbert/strip', lazyloadRouteHandler('./routes/dilbert/strip'));
-
-// 游戏打折情报
-// router.get('/yxdzqb/:type', lazyloadRouteHandler('./routes/yxdzqb'));
 
 // 怪物猎人
 router.get('/monsterhunter/update', lazyloadRouteHandler('./routes/mhw/update'));
@@ -1708,23 +1002,11 @@ router.get('/polimi/news/:language?', lazyloadRouteHandler('./routes/polimi/news
 // dekudeals
 router.get('/dekudeals/:type', lazyloadRouteHandler('./routes/dekudeals'));
 
-// 直播吧 migrated to v2
-// router.get('/zhibo8/forum/:id', lazyloadRouteHandler('./routes/zhibo8/forum'));
-// router.get('/zhibo8/post/:id', lazyloadRouteHandler('./routes/zhibo8/post'));
-// router.get('/zhibo8/more/:category?', lazyloadRouteHandler('./routes/zhibo8/more'));
-
-// 东方网 migrated to v2
-// router.get('/eastday/sh', require('./routes/eastday/sh'));
-// router.get('/eastday/24/:category?', require('./routes/eastday/24'));
-
 // Metacritic
 router.get('/metacritic/release/:platform/:type/:sort?', lazyloadRouteHandler('./routes/metacritic/release'));
 
 // 快科技（原驱动之家）
 router.get('/kkj/news', lazyloadRouteHandler('./routes/kkj/news'));
-
-// Outage.Report
-// router.get('/outagereport/:name/:count?', lazyloadRouteHandler('./routes/outagereport/service'));
 
 // sixthtone
 router.get('/sixthtone/news', lazyloadRouteHandler('./routes/sixthtone/news'));
@@ -1735,29 +1017,12 @@ router.get('/aiyanxishe/:id/:sort?', lazyloadRouteHandler('./routes/aiyanxishe/h
 // 活动行
 router.get('/huodongxing/explore', lazyloadRouteHandler('./routes/hdx/explore'));
 
-// 飞客茶馆优惠信息
-// router.get('/flyert/preferential', lazyloadRouteHandler('./routes/flyert/preferential'));
-// router.get('/flyert/creditcard/:bank', lazyloadRouteHandler('./routes/flyert/creditcard'));
-// router.get('/flyertea/preferential', lazyloadRouteHandler('./routes/flyert/preferential'));
-// router.get('/flyertea/creditcard/:bank', lazyloadRouteHandler('./routes/flyert/creditcard'));
-
-// 中国广播
-// router.get('/radio/:channelname/:name', lazyloadRouteHandler('./routes/radio/radio'));
-
-// TOPYS
-// router.get('/topys/:category', lazyloadRouteHandler('./routes/topys/article'));
-
 // 巴比特作者专栏
 router.get('/8btc/:authorid', lazyloadRouteHandler('./routes/8btc/author'));
 router.get('/8btc/news/flash', lazyloadRouteHandler('./routes/8btc/news/flash'));
 
 // VueVlog
 router.get('/vuevideo/:userid', lazyloadRouteHandler('./routes/vuevideo/user'));
-
-// 证监会
-// router.get('/csrc/news/:suffix?', lazyloadRouteHandler('./routes/csrc/news'));
-// router.get('/csrc/fashenwei', lazyloadRouteHandler('./routes/csrc/fashenwei'));
-// router.get('/csrc/auditstatus/:apply_id', lazyloadRouteHandler('./routes/csrc/auditstatus'));
 
 // LWN.net Alerts
 router.get('/lwn/alerts/:distributor', lazyloadRouteHandler('./routes/lwn/alerts'));
@@ -1786,17 +1051,11 @@ router.get('/archdaily', lazyloadRouteHandler('./routes/archdaily/home'));
 // aptonic Dropzone actions
 router.get('/aptonic/action/:untested?', lazyloadRouteHandler('./routes/aptonic/action'));
 
-// 印记中文周刊
-// router.get('/docschina/jsweekly', lazyloadRouteHandler('./routes/docschina/jsweekly'));
-
 // im2maker
 router.get('/im2maker/:channel?', lazyloadRouteHandler('./routes/im2maker/index'));
 
 // 巨潮资讯
 router.get('/cninfo/announcement/:column/:code/:orgId/:category?/:search?', lazyloadRouteHandler('./routes/cninfo/announcement'));
-
-// 金十数据
-// router.get('/jinshi/index', lazyloadRouteHandler('./routes/jinshi/index'));
 
 // 中华人民共和国农业农村部
 router.get('/gov/moa/sjzxfb', lazyloadRouteHandler('./routes/gov/moa/sjzxfb'));
@@ -1830,19 +1089,8 @@ router.get('/afdian/dynamic/:uid', lazyloadRouteHandler('./routes/afdian/dynamic
 router.get('/simonsfoundation/articles', lazyloadRouteHandler('./routes/simonsfoundation/articles'));
 router.get('/simonsfoundation/recommend', lazyloadRouteHandler('./routes/simonsfoundation/recommend'));
 
-// 王者荣耀
-// router.get('/tencent/pvp/newsindex/:type', lazyloadRouteHandler('./routes/tencent/pvp/newsindex'));
-
-// 《明日方舟》游戏 (migrated to v2)
-// router.get('/arknights/news', lazyloadRouteHandler('./routes/arknights/news'));
-// アークナイツ(明日方舟日服) (migrated to v2)
-// router.get('/arknights/japan', lazyloadRouteHandler('./routes/arknights/japan'));
 // 塞壬唱片
 router.get('/siren/news', lazyloadRouteHandler('./routes/siren/index'));
-
-// ff14 migrated to v2
-// router.get('/ff14/ff14_zh/:type', lazyloadRouteHandler('./routes/ff14/ff14_zh'));
-// router.get('/ff14/ff14_global/:lang/:type', lazyloadRouteHandler('./routes/ff14/ff14_global'));
 
 // 学堂在线
 router.get('/xuetangx/course/:cid/:type', lazyloadRouteHandler('./routes/xuetangx/course_info'));
@@ -1859,16 +1107,6 @@ router.get('/getitfree/search/:keyword?', lazyloadRouteHandler('./routes/getitfr
 // 万联网
 router.get('/10000link/news/:category?', lazyloadRouteHandler('./routes/10000link/news'));
 
-// 站酷
-// router.get('/zcool/discover/:query?/:subCate?/:hasVideo?/:city?/:collage?/:recommendLevel?/:sort?', lazyloadRouteHandler('./routes/zcool/discover'));
-// router.get('/zcool/recommend/:query?/:subCate?/:hasVideo?/:city?/:collage?/:recommendLevel?/:sort?', lazyloadRouteHandler('./routes/zcool/discover')); // 兼容老版本
-// router.get('/zcool/top/:type', lazyloadRouteHandler('./routes/zcool/top'));
-// router.get('/zcool/top', lazyloadRouteHandler('./routes/zcool/top')); // 兼容老版本
-// router.get('/zcool/user/:uid', lazyloadRouteHandler('./routes/zcool/user'));
-
-// 第一财经
-// router.get('/yicai/brief', lazyloadRouteHandler('./routes/yicai/brief.js'));
-
 // 一兜糖
 router.get('/yidoutang/index', lazyloadRouteHandler('./routes/yidoutang/index.js'));
 router.get('/yidoutang/guide', lazyloadRouteHandler('./routes/yidoutang/guide.js'));
@@ -1878,11 +1116,6 @@ router.get('/yidoutang/case/:type', lazyloadRouteHandler('./routes/yidoutang/cas
 // 开眼
 router.get('/kaiyan/index', lazyloadRouteHandler('./routes/kaiyan/index'));
 
-// 龙空
-// router.get('/lkong/forum/:id/:digest?', lazyloadRouteHandler('./routes/lkong/forum'));
-// router.get('/lkong/thread/:id', lazyloadRouteHandler('./routes/lkong/thread'));
-// router.get('/lkong/user/:id', lazyloadRouteHandler('./routes/lkong/user'));
-
 // 坂道系列资讯
 // 坂道系列官网新闻
 router.get('/keyakizaka46/news', lazyloadRouteHandler('./routes/keyakizaka46/news'));
@@ -1890,15 +1123,6 @@ router.get('/keyakizaka46/news', lazyloadRouteHandler('./routes/keyakizaka46/new
 router.get('/keyakizaka46/blog', lazyloadRouteHandler('./routes/keyakizaka46/blog'));
 // router.get('/hinatazaka46/blog', lazyloadRouteHandler('./routes/hinatazaka46/blog'));
 // router.get('/sakurazaka46/blog', lazyloadRouteHandler('./routes/sakurazaka46/blog'));
-
-// 酷安 migrated to v2
-// router.get('/coolapk/tuwen/:type?', lazyloadRouteHandler('./routes/coolapk/tuwen'));
-// router.get('/coolapk/tuwen-xinxian', lazyloadRouteHandler('./routes/coolapk/tuwen'));
-// router.get('/coolapk/toutiao/:type?', lazyloadRouteHandler('./routes/coolapk/toutiao'));
-// router.get('/coolapk/huati/:tag', lazyloadRouteHandler('./routes/coolapk/huati'));
-// router.get('/coolapk/user/:uid/dynamic', lazyloadRouteHandler('./routes/coolapk/userDynamic'));
-// router.get('/coolapk/dyh/:dyhId', lazyloadRouteHandler('./routes/coolapk/dyh'));
-// router.get('/coolapk/hot/:type?/:period?', lazyloadRouteHandler('./routes/coolapk/hot'));
 
 // 模型网
 router.get('/moxingnet', lazyloadRouteHandler('./routes/moxingnet'));
@@ -1917,16 +1141,8 @@ router.get('/socialclub/events/:game?', lazyloadRouteHandler('./routes/socialclu
 router.get('/ctfhub/upcoming/:limit?', lazyloadRouteHandler('./routes/ctfhub/upcoming'));
 router.get('/ctfhub/search/:limit?/:form?/:class?/:title?', lazyloadRouteHandler('./routes/ctfhub/search'));
 
-// 阿里云 migrated to v2
-// router.get('/aliyun/database_month', lazyloadRouteHandler('./routes/aliyun/database_month'));
-// router.get('/aliyun/notice/:type?', lazyloadRouteHandler('./routes/aliyun/notice'));
-// router.get('/aliyun/developer/group/:type', lazyloadRouteHandler('./routes/aliyun/developer/group'));
-
 // 礼物说
 router.get('/liwushuo/index', lazyloadRouteHandler('./routes/liwushuo/index.js'));
-
-// 故事fm
-// router.get('/storyfm/index', lazyloadRouteHandler('./routes/storyfm/index.js'));
 
 // 中国日报
 router.get('/chinadaily/english/:category', lazyloadRouteHandler('./routes/chinadaily/english.js'));
@@ -1939,14 +1155,6 @@ router.get('/dhl/:id', lazyloadRouteHandler('./routes/dhl/shipment-tracking'));
 
 // Japanpost
 router.get('/japanpost/track/:reqCode/:locale?', lazyloadRouteHandler('./routes/japanpost/track'));
-
-// 中华人民共和国商务部 migrated to v2
-// router.get('/mofcom/article/:suffix', lazyloadRouteHandler('./routes/mofcom/article'));
-
-// 品玩
-// router.get('/pingwest/status', lazyloadRouteHandler('./routes/pingwest/status'));
-// router.get('/pingwest/tag/:tag/:type/:option?', lazyloadRouteHandler('./routes/pingwest/tag'));
-// router.get('/pingwest/user/:uid/:type?/:option?', lazyloadRouteHandler('./routes/pingwest/user'));
 
 // Hanime
 router.get('/hanime/video', lazyloadRouteHandler('./routes/hanime/video'));
@@ -2001,25 +1209,8 @@ router.get('/sans/summit_archive', lazyloadRouteHandler('./routes/sans/summit_ar
 // LaTeX 开源小屋
 router.get('/latexstudio/home', lazyloadRouteHandler('./routes/latexstudio/home'));
 
-// 上证债券信息网 - 可转换公司债券公告
-// router.get('/sse/convert/:query?', lazyloadRouteHandler('./routes/sse/convert'));
-// router.get('/sse/renewal', lazyloadRouteHandler('./routes/sse/renewal'));
-// router.get('/sse/inquire', lazyloadRouteHandler('./routes/sse/inquire'));
-
-// 上海证券交易所
-// router.get('/sse/disclosure/:query?', lazyloadRouteHandler('./routes/sse/disclosure'));
-
-// 深圳证券交易所
-// router.get('/szse/notice', lazyloadRouteHandler('./routes/szse/notice'));
-// router.get('/szse/inquire/:type', lazyloadRouteHandler('./routes/szse/inquire'));
-// router.get('/szse/projectdynamic/:type?/:stage?/:status?', lazyloadRouteHandler('./routes/szse/projectdynamic'));
-
 // 前端艺术家每日整理&&飞冰早报
 router.get('/jskou/:type?', lazyloadRouteHandler('./routes/jskou/index'));
-
-// 国家应急广播
-// router.get('/cneb/yjxx', lazyloadRouteHandler('./routes/cneb/yjxx'));
-// router.get('/cneb/guoneinews', lazyloadRouteHandler('./routes/cneb/guoneinews'));
 
 // 邮箱
 router.get('/mail/imap/:email', lazyloadRouteHandler('./routes/mail/imap'));
@@ -2030,23 +1221,15 @@ router.get('/network360/jobs', lazyloadRouteHandler('./routes/network360/jobs'))
 // 智联招聘
 router.get('/zhilian/:city/:keyword', lazyloadRouteHandler('./routes/zhilian/index'));
 
-// 电鸭社区
-// router.get('/eleduck/jobs', lazyloadRouteHandler('./routes/eleduck/jobs'));
-
 // 北华航天工业学院 - 新闻
 router.get('/nciae/news', lazyloadRouteHandler('./routes/universities/nciae/news'));
-
 // 北华航天工业学院 - 通知公告
 router.get('/nciae/tzgg', lazyloadRouteHandler('./routes/universities/nciae/tzgg'));
-
 // 北华航天工业学院 - 学术信息
 router.get('/nciae/xsxx', lazyloadRouteHandler('./routes/universities/nciae/xsxx'));
 
 // cfan
 router.get('/cfan/news', lazyloadRouteHandler('./routes/cfan/news'));
-
-// 腾讯企鹅号 migrated to v2
-// router.get('/tencent/news/author/:mid', lazyloadRouteHandler('./routes/tencent/news/author'));
 
 // 奈菲影视
 router.get('/nfmovies/:id?', lazyloadRouteHandler('./routes/nfmovies/index'));
@@ -2083,18 +1266,6 @@ router.get('/haimaoba/:id?', lazyloadRouteHandler('./routes/haimaoba/comics'));
 // 蒲公英
 router.get('/pgyer/:app?', lazyloadRouteHandler('./routes/pgyer/app'));
 
-// 微博个人时间线
-// router.get('/weibo/timeline/:uid/:feature?/:routeParams?', lazyloadRouteHandler('./routes/weibo/timeline'));
-
-// TAPTAP migrated to v2
-// router.get('/taptap/topic/:id/:label?', lazyloadRouteHandler('./routes/taptap/topic'));
-// router.get('/taptap/changelog/:id', lazyloadRouteHandler('./routes/taptap/changelog'));
-// router.get('/taptap/review/:id/:order?/:lang?', lazyloadRouteHandler('./routes/taptap/review'));
-
-// lofter migrated to v2
-// router.get('/lofter/tag/:name?/:type?', lazyloadRouteHandler('./routes/lofter/tag'));
-// router.get('/lofter/user/:name?', lazyloadRouteHandler('./routes/lofter/user'));
-
 // 米坛社区表盘
 router.get('/watchface/:watch_type?/:list_type?', lazyloadRouteHandler('./routes/watchface/update'));
 
@@ -2108,19 +1279,8 @@ router.get('/zhanqi/room/:id', lazyloadRouteHandler('./routes/zhanqi/room'));
 // 酒云网
 router.get('/wineyun/:category', lazyloadRouteHandler('./routes/wineyun'));
 
-// 小红书 migrated to v2
-// router.get('/xiaohongshu/user/:user_id/:category', lazyloadRouteHandler('./routes/xiaohongshu/user'));
-// router.get('/xiaohongshu/board/:board_id', lazyloadRouteHandler('./routes/xiaohongshu/board'));
-
-// 每经网
-// router.get('/nbd/daily', lazyloadRouteHandler('./routes/nbd/article'));
-// router.get('/nbd/:id?', lazyloadRouteHandler('./routes/nbd/index'));
-
 // 快知
 router.get('/kzfeed/topic/:id', lazyloadRouteHandler('./routes/kzfeed/topic'));
-
-// 腾讯新闻较真查证平台
-// router.get('/factcheck', lazyloadRouteHandler('./routes/tencent/factcheck'));
 
 // X-MOL化学资讯平台
 router.get('/x-mol/news/:tag?', lazyloadRouteHandler('./routes/x-mol/news.js'));
@@ -2153,12 +1313,6 @@ router.get('/kaggle/discussion/:forumId/:sort?', lazyloadRouteHandler('./routes/
 router.get('/kaggle/competitions/:category?', lazyloadRouteHandler('./routes/kaggle/competitions'));
 router.get('/kaggle/user/:user', lazyloadRouteHandler('./routes/kaggle/user'));
 
-// PubMed Trending
-// router.get('/pubmed/trending', lazyloadRouteHandler('./routes/pubmed/trending'));
-
-// 领科 (linkresearcher.com)
-// router.get('/linkresearcher/:params', lazyloadRouteHandler('./routes/linkresearcher/index'));
-
 // eLife [Sci Journal]
 router.get('/elife/:tid', lazyloadRouteHandler('./routes/elife/index'));
 
@@ -2172,35 +1326,12 @@ router.get('/ieee/author/:aid/:sortType/:count?', lazyloadRouteHandler('./routes
 router.get('/cell/cell/:category', lazyloadRouteHandler('./routes/cell/cell/index'));
 router.get('/cell/cover', lazyloadRouteHandler('./routes/cell/cover'));
 
-// nature + nature 子刊 [Sci Journal] migrated to v2
-// router.get('/nature/research/:journal?', lazyloadRouteHandler('./routes/nature/research'));
-// router.get('/nature/news-and-comment/:journal?', lazyloadRouteHandler('./routes/nature/news-and-comment'));
-// router.get('/nature/cover', lazyloadRouteHandler('./routes/nature/cover'));
-// router.get('/nature/news', lazyloadRouteHandler('./routes/nature/news'));
-// router.get('/nature/highlight/:year?', lazyloadRouteHandler('./routes/nature/highlight'));
-
-// science [Sci Journal]
-// router.get('/sciencemag/current/:journal?', lazyloadRouteHandler('./routes/sciencemag/current'));
-// router.get('/sciencemag/cover', lazyloadRouteHandler('./routes/sciencemag/cover'));
-// router.get('/sciencemag/early/science', lazyloadRouteHandler('./routes/sciencemag/early'));
-
-// dlsite
-// router.get('/dlsite/new/:type', lazyloadRouteHandler('./routes/dlsite/new'));
-// router.get('/dlsite/campaign/:type/:free?', lazyloadRouteHandler('./routes/dlsite/campaign'));
-
 // mcbbs
 router.get('/mcbbs/forum/:type', lazyloadRouteHandler('./routes/mcbbs/forum'));
 router.get('/mcbbs/post/:tid/:authorid?', lazyloadRouteHandler('./routes/mcbbs/post'));
 
 // Pocket
 router.get('/pocket/trending', lazyloadRouteHandler('./routes/pocket/trending'));
-
-// HK01
-// router.get('/hk01/zone/:id', lazyloadRouteHandler('./routes/hk01/zone'));
-// router.get('/hk01/channel/:id', lazyloadRouteHandler('./routes/hk01/channel'));
-// router.get('/hk01/issue/:id', lazyloadRouteHandler('./routes/hk01/issue'));
-// router.get('/hk01/tag/:id', lazyloadRouteHandler('./routes/hk01/tag'));
-// router.get('/hk01/hot', lazyloadRouteHandler('./routes/hk01/hot'));
 
 // 码农周刊
 router.get('/manong-weekly', lazyloadRouteHandler('./routes/manong-weekly/issues'));
@@ -2217,11 +1348,7 @@ router.get('/noi/rg-news', lazyloadRouteHandler('./routes/noi/rg-news'));
 // 中国国家认证认可监管管理员会
 router.get('/gov/cnca/jgdt', lazyloadRouteHandler('./routes/gov/cnca/jgdt'));
 router.get('/gov/cnca/hydt', lazyloadRouteHandler('./routes/gov/cnca/hydt'));
-
 router.get('/gov/cnca/zxtz', lazyloadRouteHandler('./routes/gov/cnca/zxtz'));
-
-// clickme
-// router.get('/clickme/:site/:grouping/:name', lazyloadRouteHandler('./routes/clickme'));
 
 // 文汇报
 router.get('/whb/:category', lazyloadRouteHandler('./routes/whb/zhuzhan'));
@@ -2254,18 +1381,8 @@ router.get('/remote-work/:caty?', lazyloadRouteHandler('./routes/remote-work/ind
 // China Times
 router.get('/chinatimes/:caty', lazyloadRouteHandler('./routes/chinatimes/index'));
 
-// TransferWise
-// router.get('/transferwise/pair/:source/:target', lazyloadRouteHandler('./routes/transferwise/pair'));
-
 // chocolatey
 router.get('/chocolatey/software/:name?', lazyloadRouteHandler('./routes/chocolatey/software'));
-
-// Nyaa migrated to v2
-// router.get('/nyaa/search/:query?', lazyloadRouteHandler('./routes/nyaa/search'));
-
-// 片源网 migrated to v2
-// router.get('/pianyuan/index/:media?', lazyloadRouteHandler('./routes/pianyuan/app'));
-// router.get('/pianyuan/indexers/pianyuan/results/search/api', lazyloadRouteHandler('./routes/pianyuan/search'));
 
 // 巴哈姆特
 router.get('/bahamut/creation/:author/:category?', lazyloadRouteHandler('./routes/bahamut/creation'));
@@ -2276,16 +1393,6 @@ router.get('/centbrowser/history', lazyloadRouteHandler('./routes/centbrowser/hi
 
 // 755
 router.get('/755/user/:username', lazyloadRouteHandler('./routes/755/user'));
-
-// IKEA
-// router.get('/ikea/uk/new', lazyloadRouteHandler('./routes/ikea/uk/new'));
-// router.get('/ikea/uk/offer', lazyloadRouteHandler('./routes/ikea/uk/offer'));
-
-// Mastodon
-// router.get('/mastodon/timeline/:site/:only_media?', lazyloadRouteHandler('./routes/mastodon/timeline_local'));
-// router.get('/mastodon/remote/:site/:only_media?', lazyloadRouteHandler('./routes/mastodon/timeline_remote'));
-// router.get('/mastodon/account_id/:site/:account_id/statuses/:only_media?', lazyloadRouteHandler('./routes/mastodon/account_id'));
-// router.get('/mastodon/acct/:acct/statuses/:only_media?', lazyloadRouteHandler('./routes/mastodon/acct'));
 
 // Kernel Aliyun
 router.get('/aliyun-kernel/index', lazyloadRouteHandler('./routes/aliyun-kernel/index'));
@@ -2312,17 +1419,11 @@ router.get('/chrome/webstore/extensions/:id', lazyloadRouteHandler('./routes/chr
 // RTHK
 router.get('/rthk-news/:lang/:category', lazyloadRouteHandler('./routes/rthk-news/index'));
 
-// yahoo
-// router.get('/yahoo-news/:region/:category?', lazyloadRouteHandler('./routes/yahoo-news/index'));
-
 // Yahoo!テレビ
 router.get('/yahoo-jp-tv/:query', lazyloadRouteHandler('./routes/yahoo-jp-tv/index'));
 
 // Yahoo! by Author
 router.get('/yahoo-author/:author', lazyloadRouteHandler('./routes/yahoo-author/index'));
-
-// 白鲸出海
-// router.get('/baijing', lazyloadRouteHandler('./routes/baijing'));
 
 // 低端影视
 router.get('/ddrk/update/:name/:season?', lazyloadRouteHandler('./routes/ddrk/index'));
@@ -2348,18 +1449,12 @@ router.get('/galaxylab', lazyloadRouteHandler('./routes/galaxylab/index'));
 // NOSEC 安全讯息平台
 router.get('/nosec/:keykind?', lazyloadRouteHandler('./routes/nosec/index'));
 
-// Hex-Rays News migrated to v2
-// router.get('/hex-rays/news', lazyloadRouteHandler('./routes/hex-rays/index'));
-
 // 新趣集
 router.get('/xinquji/today', lazyloadRouteHandler('./routes/xinquji/today'));
 router.get('/xinquji/today/internal', lazyloadRouteHandler('./routes/xinquji/internal'));
 
 // 英中协会
 router.get('/gbcc/trust', lazyloadRouteHandler('./routes/gbcc/trust'));
-
-// Associated Press
-// router.get('/apnews/topics/:topic', lazyloadRouteHandler('./routes/apnews/topics'));
 
 // CBC
 router.get('/cbc/topics/:topic?', lazyloadRouteHandler('./routes/cbc/topics'));
@@ -2378,9 +1473,6 @@ router.get('/ifnews/:cid', lazyloadRouteHandler('./routes/ifnews/column'));
 
 // Scala Blog
 router.get('/scala/blog/:part?', lazyloadRouteHandler('./routes/scala-blog/scala-blog'));
-
-// Minecraft Java版游戏更新
-// router.get('/minecraft/version', lazyloadRouteHandler('./routes/minecraft/version'));
 
 // 微信更新日志
 router.get('/weixin/miniprogram/release', lazyloadRouteHandler('./routes/tencent/wechat/miniprogram/framework')); // 基础库更新日志
@@ -2402,10 +1494,6 @@ router.get('/coronavirus/yahoo-japan/:tdfk?', lazyloadRouteHandler('./routes/cor
 // 南京林业大学教务处
 router.get('/njfu/jwc/:category?', lazyloadRouteHandler('./routes/universities/njfu/jwc'));
 
-// 日本経済新聞
-// router.get('/nikkei/index', lazyloadRouteHandler('./routes/nikkei/index'));
-// router.get('/nikkei/:category/:article_type?', lazyloadRouteHandler('./routes/nikkei/news'));
-
 // MQube
 router.get('/mqube/user/:user', lazyloadRouteHandler('./routes/mqube/user'));
 router.get('/mqube/tag/:tag', lazyloadRouteHandler('./routes/mqube/tag'));
@@ -2416,12 +1504,6 @@ router.get('/mqube/top', lazyloadRouteHandler('./routes/mqube/top'));
 router.get('/letterboxd/user/diary/:username', lazyloadRouteHandler('./routes/letterboxd/userdiary'));
 router.get('/letterboxd/user/followingdiary/:username', lazyloadRouteHandler('./routes/letterboxd/followingdiary'));
 
-// javlibrary
-// router.get('/javlibrary/users/:uid/:utype', lazyloadRouteHandler('./routes/javlibrary/users'));
-// router.get('/javlibrary/videos/:vtype', lazyloadRouteHandler('./routes/javlibrary/videos'));
-// router.get('/javlibrary/stars/:sid', lazyloadRouteHandler('./routes/javlibrary/stars'));
-// router.get('/javlibrary/bestreviews', lazyloadRouteHandler('./routes/javlibrary/bestreviews'));
-
 // Last.FM
 router.get('/lastfm/recent/:user', lazyloadRouteHandler('./routes/lastfm/recent'));
 router.get('/lastfm/loved/:user', lazyloadRouteHandler('./routes/lastfm/loved'));
@@ -2430,9 +1512,6 @@ router.get('/lastfm/top/:country?', lazyloadRouteHandler('./routes/lastfm/top'))
 // piapro
 router.get('/piapro/user/:pid', lazyloadRouteHandler('./routes/piapro/user'));
 router.get('/piapro/public/:type/:tag?/:category?', lazyloadRouteHandler('./routes/piapro/public'));
-
-// 凤凰网 migrated to v2
-// router.get('/ifeng/feng/:id/:type', lazyloadRouteHandler('./routes/ifeng/feng'));
 
 // 第一版主
 router.get('/novel/d1bz/:category/:id', lazyloadRouteHandler('./routes/d1bz/novel'));
@@ -2449,30 +1528,13 @@ router.get('/hackerone/search/:search', lazyloadRouteHandler('./routes/hackerone
 // 奶牛关
 router.get('/cowlevel/element/:id', lazyloadRouteHandler('./routes/cowlevel/element'));
 
-// 2048
-// router.get('/2048/bbs/:fid', lazyloadRouteHandler('./routes/2048/bbs'));
-
-// Google News
-// router.get('/google/news/:category/:locale', lazyloadRouteHandler('./routes/google/news'));
-
 // 虛詞
 router.get('/p-articles/section/:section', lazyloadRouteHandler('./routes/p-articles/section'));
 router.get('/p-articles/contributors/:author', lazyloadRouteHandler('./routes/p-articles/contributors'));
 
-// finviz
-
-// router.get('/finviz/news/:ticker', lazyloadRouteHandler('./routes/finviz/news'));
-
 // 好好住
 router.get('/haohaozhu/whole-house/:keyword?', lazyloadRouteHandler('./routes/haohaozhu/whole-house'));
 router.get('/haohaozhu/discover/:keyword?', lazyloadRouteHandler('./routes/haohaozhu/discover'));
-
-// 东北大学
-// router.get('/neu/news/:type', lazyloadRouteHandler('./routes/universities/neu/news'));
-
-// 快递100
-// router.get('/kuaidi100/track/:number/:id/:phone?', lazyloadRouteHandler('./routes/kuaidi100/index'));
-// router.get('/kuaidi100/company', lazyloadRouteHandler('./routes/kuaidi100/supported_company'));
 
 // 稻草人书屋
 router.get('/dcrsw/:name/:count?', lazyloadRouteHandler('./routes/novel/dcrsw'));
@@ -2485,13 +1547,6 @@ router.get('/magireco/event_banner', lazyloadRouteHandler('./routes/magireco/eve
 router.get('/wolley', lazyloadRouteHandler('./routes/wolley/index'));
 router.get('/wolley/user/:id', lazyloadRouteHandler('./routes/wolley/user'));
 router.get('/wolley/host/:host', lazyloadRouteHandler('./routes/wolley/host'));
-
-// 西安交大
-// router.get('/xjtu/gs/tzgg', lazyloadRouteHandler('./routes/universities/xjtu/gs/tzgg'));
-// router.get('/xjtu/dean/:subpath+', lazyloadRouteHandler('./routes/universities/xjtu/dean'));
-// router.get('/xjtu/international/:subpath+', lazyloadRouteHandler('./routes/universities/xjtu/international'));
-// router.get('/xjtu/job/:subpath?', lazyloadRouteHandler('./routes/universities/xjtu/job'));
-// router.get('/xjtu/ee/:id?', lazyloadRouteHandler('./routes/universities/xjtu/ee'));
 
 // booksource
 router.get('/booksource', lazyloadRouteHandler('./routes/booksource/index'));
@@ -2518,36 +1573,13 @@ router.get('/krankenkassen', lazyloadRouteHandler('./routes/krankenkassen'));
 // 桂林航天工业学院
 router.get('/guat/news/:type?', lazyloadRouteHandler('./routes/guat/news'));
 
-// NEEA
-// router.get('/neea/:type', lazyloadRouteHandler('./routes/neea'));
-
-// 中国农业大学
-// router.get('/cauyjs', lazyloadRouteHandler('./routes/universities/cauyjs/cauyjs'));
-
-// 南方科技大学
-// router.get('/sustyjs', lazyloadRouteHandler('./routes/universities/sustyjs/sustyjs'));
-// router.get('/sustech/newshub-zh', lazyloadRouteHandler('./routes/universities/sustech/newshub-zh'));
-// router.get('/sustech/bidding', lazyloadRouteHandler('./routes/universities/sustech/bidding'));
-
 // 广州航海学院
 router.get('/gzmtu/jwc', lazyloadRouteHandler('./routes/universities/gzmtu/jwc'));
 router.get('/gzmtu/tsg', lazyloadRouteHandler('./routes/universities/gzmtu/tsg'));
 
-// 广州大学
-// router.get('/gzyjs', lazyloadRouteHandler('./routes/universities/gzyjs/gzyjs'));
-
 // 暨南大学
 router.get('/jnu/xysx/:type', lazyloadRouteHandler('./routes/universities/jnu/xysx/index'));
 router.get('/jnu/yw/:type?', lazyloadRouteHandler('./routes/universities/jnu/yw/index'));
-
-// 深圳大学
-// router.get('/szuyjs', lazyloadRouteHandler('./routes/universities/szuyjs/szuyjs'));
-
-// 中国传媒大学
-// router.get('/cucyjs', lazyloadRouteHandler('./routes/universities/cucyjs/cucyjs'));
-
-// 中国农业大学信电学院
-// router.get('/cauele', lazyloadRouteHandler('./routes/universities/cauyjs/cauyjs'));
 
 // moxingfans
 router.get('/moxingfans', lazyloadRouteHandler('./routes/moxingfans'));
@@ -2555,72 +1587,11 @@ router.get('/moxingfans', lazyloadRouteHandler('./routes/moxingfans'));
 // Chiphell
 router.get('/chiphell/forum/:forumId?', lazyloadRouteHandler('./routes/chiphell/forum'));
 
-// 华东理工大学研究生院
-// router.get('/ecustyjs', lazyloadRouteHandler('./routes/universities/ecustyjs/ecustyjs'));
-
-// 同济大学研究生院
-// router.get('/tjuyjs', lazyloadRouteHandler('./routes/universities/tjuyjs/tjuyjs'));
-
-// 中国石油大学研究生院
-// router.get('/upcyjs', lazyloadRouteHandler('./routes/universities/upcyjs/upcyjs'));
-
-// 中国海洋大学研究生院
-// router.get('/outyjs', lazyloadRouteHandler('./routes/universities/outyjs/outyjs'));
-
-// 中科院人工智能所
-// router.get('/zkyai', lazyloadRouteHandler('./routes/universities/zkyai/zkyai'));
-
-// 中科院自动化所
-// router.get('/zkyyjs', lazyloadRouteHandler('./routes/universities/zkyyjs/zkyyjs'));
-
-// 中国海洋大学信电学院
-// router.get('/outele', lazyloadRouteHandler('./routes/universities/outele/outele'));
-
-// 华东师范大学研究生院 migrated to v2
-// router.get('/ecnuyjs', lazyloadRouteHandler('./routes/universities/ecnuyjs/ecnuyjs'));
-
 // 考研帮调剂信息
 router.get('/kaoyan', lazyloadRouteHandler('./routes/kaoyan/kaoyan'));
 
-// 华中科技大学研究生院
-// router.get('/hustyjs', lazyloadRouteHandler('./routes/universities/hustyjs/hustyjs'));
-
-// 华中师范大学研究生院
-// router.get('/ccnuyjs', lazyloadRouteHandler('./routes/universities/ccnu/ccnuyjs'));
-
-// 华中师范大学计算机学院
-// router.get('/ccnucs', lazyloadRouteHandler('./routes/universities/ccnu/ccnucs'));
-
-// 华中师范大学伍论贡学院
-// router.get('/ccnuwu', lazyloadRouteHandler('./routes/universities/ccnu/ccnuwu'));
-
 // WEEX
 router.get('/weexcn/news/:typeid', lazyloadRouteHandler('./routes/weexcn/index'));
-
-// 天天基金 migrated to v2
-// router.get('/eastmoney/ttjj/user/:uid', lazyloadRouteHandler('./routes/eastmoney/ttjj/user'));
-
-// 紳士漫畫
-// router.get('/ssmh', lazyloadRouteHandler('./routes/ssmh'));
-// router.get('/ssmh/category/:cid', lazyloadRouteHandler('./routes/ssmh/category'));
-
-// 华南师范大学研究生学院
-// router.get('/scnuyjs', lazyloadRouteHandler('./routes/universities/scnu/scnuyjs'));
-
-// 华南师范大学软件学院
-// router.get('/scnucs', lazyloadRouteHandler('./routes/universities/scnu/scnucs'));
-
-// 华南理工大学研究生院
-// router.get('/scutyjs', lazyloadRouteHandler('./routes/universities/scut/scutyjs'));
-
-// 华南农业大学研究生院通知公告
-// router.get('/scauyjs', lazyloadRouteHandler('./routes/universities/scauyjs/scauyjs'));
-
-// 北京大学研究生招生网通知公告 migrated to v2
-// router.get('/pkuyjs', lazyloadRouteHandler('./routes/universities/pku/pkuyjs'));
-
-// 北京理工大学研究生通知公告
-// router.get('/bityjs', lazyloadRouteHandler('./routes/universities/bit/bityjs'));
 
 // 湖南科技大学教务处
 router.get('/hnust/jwc', lazyloadRouteHandler('./routes/universities/hnust/jwc/index'));
@@ -2628,10 +1599,6 @@ router.get('/hnust/computer', lazyloadRouteHandler('./routes/universities/hnust/
 router.get('/hnust/art', lazyloadRouteHandler('./routes/universities/hnust/art/index'));
 router.get('/hnust/chem', lazyloadRouteHandler('./routes/universities/hnust/chem/index'));
 router.get('/hnust/graduate/:type?', lazyloadRouteHandler('./routes/universities/hnust/graduate/index'));
-
-// AGE动漫
-// router.get('/agefans/detail/:id', lazyloadRouteHandler('./routes/agefans/detail'));
-// router.get('/agefans/update', lazyloadRouteHandler('./routes/agefans/update'));
 
 // Checkra1n
 router.get('/checkra1n/releases', lazyloadRouteHandler('./routes/checkra1n/releases'));
@@ -2697,9 +1664,6 @@ router.get('/ptpress/book/:type?', lazyloadRouteHandler('./routes/ptpress/book')
 // uniqlo styling book
 router.get('/uniqlo/stylingbook/:category?', lazyloadRouteHandler('./routes/uniqlo/stylingbook'));
 
-// 本地宝焦点资讯
-// router.get('/bendibao/news/:city', lazyloadRouteHandler('./routes/bendibao/news'));
-
 // unit-image
 router.get('/unit-image/films/:type?', lazyloadRouteHandler('./routes/unit-image/films'));
 
@@ -2739,9 +1703,6 @@ router.get('/adquan/:type?', lazyloadRouteHandler('./routes/adquan/index'));
 // 齐鲁晚报
 router.get('/qlwb/news', lazyloadRouteHandler('./routes/qlwb/news'));
 router.get('/qlwb/city/:city', lazyloadRouteHandler('./routes/qlwb/city'));
-
-// 蜻蜓FM
-// router.get('/qingting/channel/:id', lazyloadRouteHandler('./routes/qingting/channel'));
 
 // 金色财经
 router.get('/jinse/lives', lazyloadRouteHandler('./routes/jinse/lives'));
@@ -2784,24 +1745,11 @@ router.get('/199it/tag/:tag', lazyloadRouteHandler('./routes/199it/tag'));
 router.get('/jijitang/article/:id', lazyloadRouteHandler('./routes/jijitang/article'));
 router.get('/jijitang/publication', lazyloadRouteHandler('./routes/jijitang/publication'));
 
-// 新闻联播
-// router.get('/xwlb', lazyloadRouteHandler('./routes/xwlb/index'));
-
-// 端传媒
-// router.get('/initium/:type?/:language?', lazyloadRouteHandler('./routes/initium/full'));
-// router.get('/theinitium/:model/:type?/:language?', lazyloadRouteHandler('./routes/initium/full'));
-
 // Grub Street
 router.get('/grubstreet', lazyloadRouteHandler('./routes/grubstreet/index'));
 
 // 漫画堆
 router.get('/manhuadui/manhua/:name/:serial?', lazyloadRouteHandler('./routes/manhuadui/manhua'));
-
-// 风之漫画
-// router.get('/fzdm/manhua/:id', lazyloadRouteHandler('./routes/fzdm/manhua'));
-
-// Aljazeera 半岛网
-// router.get('/aljazeera/news', lazyloadRouteHandler('./routes/aljazeera/news'));
 
 // CFD indices dividend adjustment
 router.get('/cfd/gbp_div', lazyloadRouteHandler('./routes/cfd/gbp_div'));
@@ -2851,9 +1799,6 @@ router.get('/law/jctd', lazyloadRouteHandler('./routes/law/jctd'));
 // 三星盖乐世社区
 router.get('/samsungmembers/latest', lazyloadRouteHandler('./routes/samsungmembers/latest'));
 
-// 东莞教研网
-// router.get('/dgjyw/:type', lazyloadRouteHandler('./routes/dgjyw/index'));
-
 // 中国信息通信研究院
 router.get('/gov/caict/bps', lazyloadRouteHandler('./routes/gov/caict/bps'));
 router.get('/gov/caict/qwsj', lazyloadRouteHandler('./routes/gov/caict/qwsj'));
@@ -2861,10 +1806,6 @@ router.get('/gov/caict/caictgd', lazyloadRouteHandler('./routes/gov/caict/caictg
 
 // 中证网
 router.get('/cs/news/:caty', lazyloadRouteHandler('./routes/cs/news'));
-
-// 财联社
-// router.get('/cls/depth/:category?', lazyloadRouteHandler('./routes/cls/depth'));
-// router.get('/cls/telegraph/:category?', lazyloadRouteHandler('./routes/cls/telegraph'));
 
 // hentai-cosplays
 router.get('/hentai-cosplays/:type?/:name?', lazyloadRouteHandler('./routes/hentai-cosplays/hentai-cosplays'));
@@ -2876,34 +1817,8 @@ router.get('/dcinside/board/:id', lazyloadRouteHandler('./routes/dcinside/board'
 // 企鹅电竞
 router.get('/egameqq/room/:id', lazyloadRouteHandler('./routes/tencent/egame/room'));
 
-// 国家税务总局 migrated to v2
-// router.get('/gov/chinatax/latest', lazyloadRouteHandler('./routes/gov/chinatax/latest'));
-
 // 荔枝FM
 router.get('/lizhi/user/:id', lazyloadRouteHandler('./routes/lizhi/user'));
-
-// 富途牛牛
-// router.get('/futunn/highlights', lazyloadRouteHandler('./routes/futunn/highlights'));
-
-// 即刻 migrated to v2
-// router.get('/jike/topic/:id', lazyloadRouteHandler('./routes/jike/topic'));
-// router.get('/jike/topic/text/:id', lazyloadRouteHandler('./routes/jike/topicText'));
-// router.get('/jike/user/:id', lazyloadRouteHandler('./routes/jike/user'));
-
-// 网易新闻
-// router.get('/netease/news/rank/:category?/:type?/:time?', lazyloadRouteHandler('./routes/netease/news/rank'));
-// router.get('/netease/news/special/:type?', lazyloadRouteHandler('./routes/netease/news/special'));
-
-// 网易 - 网易号
-// router.get('/netease/dy/:id', lazyloadRouteHandler('./routes/netease/dy'));
-// router.get('/netease/dy2/:id', lazyloadRouteHandler('./routes/netease/dy2'));
-
-// 网易大神
-// router.get('/netease/ds/:id', lazyloadRouteHandler('./routes/netease/ds'));
-
-// 网易公开课
-// router.get('/open163/vip', lazyloadRouteHandler('./routes/netease/open/vip'));
-// router.get('/open163/latest', lazyloadRouteHandler('./routes/netease/open/latest'));
 
 // Boston.com
 router.get('/boston/:tag?', lazyloadRouteHandler('./routes/boston/index'));
@@ -2911,9 +1826,6 @@ router.get('/boston/:tag?', lazyloadRouteHandler('./routes/boston/index'));
 // 场库
 router.get('/changku', lazyloadRouteHandler('./routes/changku/index'));
 router.get('/changku/cate/:postid', lazyloadRouteHandler('./routes/changku/index'));
-
-// SCMP
-// router.get('/scmp/:category_id', lazyloadRouteHandler('./routes/scmp/index'));
 
 // 上海市生态环境局
 router.get('/gov/shanghai/sthj', lazyloadRouteHandler('./routes/gov/shanghai/sthj'));
@@ -2938,9 +1850,6 @@ router.get('/amazfitwatchfaces/search/:model/:keyword?/:sortBy?', lazyloadRouteH
 router.get('/missevan/drama/latest', lazyloadRouteHandler('./routes/missevan/latest'));
 router.get('/missevan/drama/:id', lazyloadRouteHandler('./routes/missevan/drama'));
 
-// Go语言爱好者周刊
-// router.get('/go-weekly', lazyloadRouteHandler('./routes/go-weekly'));
-
 // popiask提问箱
 router.get('/popiask/:sharecode/:pagesize?', lazyloadRouteHandler('./routes/popiask/questions'));
 
@@ -2950,19 +1859,11 @@ router.get('/tapechat/questionbox/:sharecode/:pagesize?', lazyloadRouteHandler('
 // AMD
 router.get('/amd/graphicsdrivers/:id/:rid?', lazyloadRouteHandler('./routes/amd/graphicsdrivers'));
 
-// 二柄APP
-// router.get('/erbingapp/news', lazyloadRouteHandler('./routes/erbingapp/news'));
-
 // 电商报
 router.get('/dsb/area/:area', lazyloadRouteHandler('./routes/dsb/area'));
 
 // 靠谱新闻
 router.get('/kaopunews/:language?', lazyloadRouteHandler('./routes/kaopunews'));
-
-// 格隆汇 migrated to v2
-// router.get('/gelonghui/user/:id', lazyloadRouteHandler('./routes/gelonghui/user'));
-// router.get('/gelonghui/subject/:id', lazyloadRouteHandler('./routes/gelonghui/subject'));
-// router.get('/gelonghui/keyword/:keyword', lazyloadRouteHandler('./routes/gelonghui/keyword'));
 
 // 光谷社区
 router.get('/guanggoo/:category?', lazyloadRouteHandler('./routes/guanggoo/index'));
@@ -3005,50 +1906,17 @@ router.get('/liequtv/room/:id', lazyloadRouteHandler('./routes/liequtv/room'));
 // 北京物资学院
 router.get('/bwu/news', lazyloadRouteHandler('./routes/universities/bwu/news'));
 
-// 新榜
-// router.get('/newrank/wechat/:wxid', lazyloadRouteHandler('./routes/newrank/wechat'));
-// router.get('/newrank/douyin/:dyid', lazyloadRouteHandler('./routes/newrank/douyin'));
-
 // 漫小肆
 router.get('/manxiaosi/book/:id', lazyloadRouteHandler('./routes/manxiaosi/book'));
 
 // 吉林大学校内通知
 router.get('/jlu/oa', lazyloadRouteHandler('./routes/universities/jlu/oa'));
 
-// 小宇宙 migrated to v2
-// router.get('/xiaoyuzhou', lazyloadRouteHandler('./routes/xiaoyuzhou/pickup'));
-// router.get('/xiaoyuzhou/podcast/:id', lazyloadRouteHandler('./routes/xiaoyuzhou/podcast'));
-
 // 合肥工业大学
 router.get('/hfut/tzgg', lazyloadRouteHandler('./routes/universities/hfut/tzgg'));
 
-// Darwin Awards
-// router.get('/darwinawards/all', lazyloadRouteHandler('./routes/darwinawards/articles'));
-
-// 四川职业技术学院
-// router.get('/scvtc/xygg', lazyloadRouteHandler('./routes/universities/scvtc/xygg'));
-
-// 华南理工大学土木与交通学院
-// router.get('/scut/scet/notice', lazyloadRouteHandler('./routes/universities/scut/scet/notice'));
-
-// 华南理工大学电子与信息学院
-// router.get('/scut/seie/news_center', lazyloadRouteHandler('./routes/universities/scut/seie/news_center'));
-
 // OneJAV
 router.get('/onejav/:type/:key?', lazyloadRouteHandler('./routes/onejav/one'));
-
-// 141jav
-// router.get('/141jav/:type/:key?', lazyloadRouteHandler('./routes/141jav/141jav'));
-
-// 141ppv
-// router.get('/141ppv/:type/:key?', lazyloadRouteHandler('./routes/141ppv/141ppv'));
-
-// CuriousCat
-// router.get('/curiouscat/user/:id', lazyloadRouteHandler('./routes/curiouscat/user'));
-
-// Telecompaper
-// router.get('/telecompaper/news/:caty/:year?/:country?/:type?', lazyloadRouteHandler('./routes/telecompaper/news'));
-// router.get('/telecompaper/search/:keyword?/:company?/:sort?/:period?', lazyloadRouteHandler('./routes/telecompaper/search'));
 
 // 水木社区
 router.get('/newsmth/account/:id', lazyloadRouteHandler('./routes/newsmth/account'));
@@ -3059,9 +1927,6 @@ router.get('/kotaku/story/:type', lazyloadRouteHandler('./routes/kotaku/story'))
 
 // 梅斯医学
 router.get('/medsci/recommend', lazyloadRouteHandler('./routes/medsci/recommend'));
-
-// Wallpaperhub migrated to v2
-// router.get('/wallpaperhub', lazyloadRouteHandler('./routes/wallpaperhub/index'));
 
 // 悟空问答
 router.get('/wukong/user/:id/:type?', lazyloadRouteHandler('./routes/wukong/user'));
@@ -3078,20 +1943,8 @@ router.get('/bioon/latest', lazyloadRouteHandler('./routes/bioon/latest'));
 // soomal
 router.get('/soomal/topics/:category/:language?', lazyloadRouteHandler('./routes/soomal/topics'));
 
-// NASA
-// router.get('/nasa/apod', lazyloadRouteHandler('./routes/nasa/apod'));
-// router.get('/nasa/apod-ncku', lazyloadRouteHandler('./routes/nasa/apod-ncku'));
-// router.get('/nasa/apod-cn', lazyloadRouteHandler('./routes/nasa/apod-cn'));
-
-// 爱Q生活网
-// router.get('/iqshw/latest', lazyloadRouteHandler('./routes/3k8/latest'));
-// router.get('/3k8/latest', lazyloadRouteHandler('./routes/3k8/latest'));
-
 // JustRun
 router.get('/justrun', lazyloadRouteHandler('./routes/justrun/index'));
-
-// 上海电力大学 migrated to v2
-// router.get('/shiep/:type/:id?', lazyloadRouteHandler('./routes/universities/shiep/index'));
 
 // 福建新闻
 router.get('/fjnews/:city/:limit', lazyloadRouteHandler('./routes/fjnews/fznews'));
@@ -3106,9 +1959,6 @@ router.get('/kongfz/shop/:id/:cat?', lazyloadRouteHandler('./routes/kongfz/shop'
 
 // XMind
 router.get('/xmind/mindmap/:lang?', lazyloadRouteHandler('./routes/xmind/mindmap'));
-
-// 小刀娱乐网
-// router.get('/x6d/:id?', lazyloadRouteHandler('./routes/x6d/index'));
 
 // 思维导图社区
 router.get('/edrawsoft/mindmap/:classId?/:order?/:sort?/:lang?/:price?/:search?', lazyloadRouteHandler('./routes/edrawsoft/mindmap'));
@@ -3158,9 +2008,6 @@ router.get('/chuhaibiji', lazyloadRouteHandler('./routes/chuhaibiji/index'));
 // 建宁闲谈
 router.get('/blogs/jianning', lazyloadRouteHandler('./routes/blogs/jianning'));
 
-// 妖火网
-// router.get('/yaohuo/:type?', lazyloadRouteHandler('./routes/yaohuo/index'));
-
 // 互动吧
 router.get('/hudongba/:city/:id', lazyloadRouteHandler('./routes/hudongba/index'));
 
@@ -3172,9 +2019,6 @@ router.get('/1x/:category?', lazyloadRouteHandler('./routes/1x/index'));
 
 // 剑网3
 router.get('/jx3/:caty?', lazyloadRouteHandler('./routes/jx3/news'));
-
-// GQ
-// router.get('/gq/tw/:caty?/:subcaty?', lazyloadRouteHandler('./routes/gq/tw/index'));
 
 // 泉州市跨境电子商务协会
 router.get('/qzcea/:caty?', lazyloadRouteHandler('./routes/qzcea/index'));
@@ -3196,9 +2040,6 @@ router.get('/appsales/:caty?/:time?', lazyloadRouteHandler('./routes/appsales/in
 // Academy of Management
 router.get('/aom/journal/:id', lazyloadRouteHandler('./routes/aom/journal'));
 
-// 巴哈姆特電玩資訊站 migrated to v2
-// router.get('/gamer/hot/:bsn', lazyloadRouteHandler('./routes/gamer/hot'));
-
 // iCity
 router.get('/icity/:id', lazyloadRouteHandler('./routes/icity/index'));
 
@@ -3217,11 +2058,6 @@ router.get('/huawei/xinsheng/:caty?/:order?/:keyword?', lazyloadRouteHandler('./
 // 守望先锋
 router.get('/ow/patch', lazyloadRouteHandler('./routes/ow/patch'));
 
-// MM范
-// router.get('/95mm/tab/:tab?', lazyloadRouteHandler('./routes/95mm/tab'));
-// router.get('/95mm/tag/:tag', lazyloadRouteHandler('./routes/95mm/tag'));
-// router.get('/95mm/category/:category', lazyloadRouteHandler('./routes/95mm/category'));
-
 // 中国工程科技知识中心
 router.get('/cktest/app/:ctgroup?/:domain?', lazyloadRouteHandler('./routes/cktest/app'));
 router.get('/cktest/policy', lazyloadRouteHandler('./routes/cktest/policy'));
@@ -3232,19 +2068,6 @@ router.get('/mamibuy/:caty?/:age?/:sort?', lazyloadRouteHandler('./routes/mamibu
 // Mercari
 router.get('/mercari/:type/:id', lazyloadRouteHandler('./routes/mercari/index'));
 
-// notefolio
-// router.get('/notefolio/:caty?/:order?/:time?/:query?', lazyloadRouteHandler('./routes/notefolio/index'));
-
-// JavDB
-// router.get('/javdb/home/:category?/:sort?/:filter?', lazyloadRouteHandler('./routes/javdb'));
-// router.get('/javdb/search/:keyword?/:filter?', lazyloadRouteHandler('./routes/javdb/search'));
-// router.get('/javdb/tags/:query?/:caty?', lazyloadRouteHandler('./routes/javdb/tags'));
-// router.get('/javdb/actors/:id/:filter?', lazyloadRouteHandler('./routes/javdb/actors'));
-// router.get('/javdb/makers/:id/:filter?', lazyloadRouteHandler('./routes/javdb/makers'));
-// router.get('/javdb/series/:id/:filter?', lazyloadRouteHandler('./routes/javdb/series'));
-// router.get('/javdb/rankings/:caty?/:time?', lazyloadRouteHandler('./routes/javdb/rankings'));
-// router.get('/javdb/:category?/:sort?/:filter?', lazyloadRouteHandler('./routes/javdb'));
-
 // World Economic Forum
 router.get('/weforum/report/:lang?/:year?/:platform?', lazyloadRouteHandler('./routes/weforum/report'));
 
@@ -3254,13 +2077,6 @@ router.get('/nobelprize/:caty?', lazyloadRouteHandler('./routes/nobelprize/index
 // 中華民國國防部
 router.get('/gov/taiwan/mnd', lazyloadRouteHandler('./routes/gov/taiwan/mnd'));
 
-// 読売新聞 to v2
-// router.get('/yomiuri/:category', lazyloadRouteHandler('./routes/yomiuri/news'));
-
-// 巴哈姆特
-// GNN新闻 migrated to v2
-// router.get('/gamer/gnn/:category?', lazyloadRouteHandler('./routes/gamer/gnn_index'));
-
 // 中国人大网
 router.get('/npc/:caty', lazyloadRouteHandler('./routes/npc/index'));
 
@@ -3269,9 +2085,6 @@ router.get('/ofweek/news', lazyloadRouteHandler('./routes/ofweek/news'));
 
 // 八阕
 router.get('/popyard/:caty?', lazyloadRouteHandler('./routes/popyard/index'));
-
-// 原神 migrated to v2
-// router.get('/yuanshen/:location?/:category?', lazyloadRouteHandler('./routes/yuanshen/index'));
 
 // World Trade Organization
 router.get('/wto/dispute-settlement/:year?', lazyloadRouteHandler('./routes/wto/dispute-settlement'));
@@ -3287,11 +2100,6 @@ router.get('/allnow/column/:id', lazyloadRouteHandler('./routes/allnow/column'))
 router.get('/allnow/tag/:id', lazyloadRouteHandler('./routes/allnow/tag'));
 router.get('/allnow/user/:id', lazyloadRouteHandler('./routes/allnow/user'));
 router.get('/allnow', lazyloadRouteHandler('./routes/allnow/index'));
-
-// 证券时报网
-// router.get('/stcn/news/:id?', lazyloadRouteHandler('./routes/stcn/news'));
-// router.get('/stcn/data/:id?', lazyloadRouteHandler('./routes/stcn/data'));
-// router.get('/stcn/kuaixun/:id?', lazyloadRouteHandler('./routes/stcn/kuaixun'));
 
 // dev.to
 router.get('/dev.to/top/:period', lazyloadRouteHandler('./routes/dev.to/top'));
@@ -3327,9 +2135,6 @@ router.get('/liquipedia/dota2/matches/:id', lazyloadRouteHandler('./routes/liqui
 // 哈尔滨市科技局
 router.get('/gov/harbin/kjj', lazyloadRouteHandler('./routes/gov/harbin/kjj'));
 
-// WSJ migrated to v2
-// router.get('/wsj/:lang/:category?', lazyloadRouteHandler('./routes/wsj/index'));
-
 // China File
 router.get('/chinafile/:category?', lazyloadRouteHandler('./routes/chinafile/index'));
 
@@ -3346,24 +2151,11 @@ router.get('/nwpu/:column', lazyloadRouteHandler('./routes/nwpu/index'));
 // 美国联邦最高法院
 router.get('/us/supremecourt/argument_audio/:year?', lazyloadRouteHandler('./routes/us/supremecourt/argument_audio'));
 
-// 得到
-// router.get('/dedao/list/:caty?', lazyloadRouteHandler('./routes/dedao/list'));
-// router.get('/dedao/knowledge/:topic?/:type?', lazyloadRouteHandler('./routes/dedao/knowledge'));
-// router.get('/dedao/:caty?', lazyloadRouteHandler('./routes/dedao/index'));
-
 // 未名新闻
 router.get('/mitbbs/:caty?', lazyloadRouteHandler('./routes/mitbbs/index'));
 
-// 8kcos migrated to v2
-// router.get('/8kcos/', lazyloadRouteHandler('./routes/8kcos/latest'));
-// router.get('/8kcos/cat/:cat*', lazyloadRouteHandler('./routes/8kcos/cat'));
-// router.get('/8kcos/tag/:tag', lazyloadRouteHandler('./routes/8kcos/tag'));
-
 // 贾真的电商108将
 router.get('/jiazhen108', lazyloadRouteHandler('./routes/jiazhen108/index'));
-
-// Instagram
-// router.get('/instagram/:category/:key', lazyloadRouteHandler('./routes/instagram/index'));
 
 // 优设网
 router.get('/uisdc/talk/:sort?', lazyloadRouteHandler('./routes/uisdc/talk'));
@@ -3374,9 +2166,6 @@ router.get('/uisdc/topic/:title?/:sort?', lazyloadRouteHandler('./routes/uisdc/t
 
 // 中国劳工观察
 router.get('/chinalaborwatch/reports/:lang?/:industry?', lazyloadRouteHandler('./routes/chinalaborwatch/reports'));
-
-// Phoronix
-// router.get('/phoronix/:page/:queryOrItem?', lazyloadRouteHandler('./routes/phoronix/index'));
 
 // 美国中央情报局
 router.get('/cia/foia-annual-report', lazyloadRouteHandler('./routes/us/cia/foia-annual-report'));
@@ -3389,9 +2178,6 @@ router.get('/clb/commentary/:lang?', lazyloadRouteHandler('./routes/clb/commenta
 
 // 国际教育研究所
 router.get('/iie/blog', lazyloadRouteHandler('./routes/iie/blog'));
-
-// McKinsey Greater China
-// router.get('/mckinsey/:category?', lazyloadRouteHandler('./routes/mckinsey/index'));
 
 // 超理论坛
 router.get('/chaoli/:channel?', lazyloadRouteHandler('./routes/chaoli/index'));
@@ -3407,15 +2193,6 @@ router.get('/rescuetime/release-notes/:os?', lazyloadRouteHandler('./routes/resc
 
 // Total Commander
 router.get('/totalcommander/whatsnew', lazyloadRouteHandler('./routes/totalcommander/whatsnew'));
-
-// Blizzard
-// router.get('/blizzard/news/:language?/:category?', lazyloadRouteHandler('./routes/blizzard/news'));
-
-// DeepMind
-// router.get('/deepmind/blog/:category?', lazyloadRouteHandler('./routes/deepmind/blog'));
-
-// 东西智库
-// router.get('/dx2025/:type?/:category?', lazyloadRouteHandler('./routes/dx2025/index'));
 
 // DeepL
 router.get('/deepl/blog/:lang?', lazyloadRouteHandler('./routes/deepl/blog'));
@@ -3447,20 +2224,8 @@ router.get('/matataki/tags/:tagId/:tagName/posts/:ipfsFlag?', lazyloadRouteHandl
 // 收藏夹
 router.get('/matataki/users/:userId/favorites/:favoriteListId/posts/:ipfsFlag?', lazyloadRouteHandler('./routes/matataki/site/posts/favorite'));
 
-// SoBooks
-// router.get('/sobooks/tag/:id?', lazyloadRouteHandler('./routes/sobooks/tag'));
-// router.get('/sobooks/date/:date?', lazyloadRouteHandler('./routes/sobooks/date'));
-// router.get('/sobooks/:category?', lazyloadRouteHandler('./routes/sobooks/index'));
-
 // Zhimap 知识导图社区
 router.get('/zhimap/:categoryUuid?/:recommend?', lazyloadRouteHandler('./routes/zhimap/index'));
-
-// Fantia
-// router.get('/fantia/search/:type?/:caty?/:peroid?/:order?/:rating?/:keyword?', lazyloadRouteHandler('./routes/fantia/search'));
-// router.get('/fantia/user/:id', lazyloadRouteHandler('./routes/fantia/user'));
-
-// i-Cable
-// router.get('/icable/:category/:option?', lazyloadRouteHandler('./routes/icable/category'));
 
 // ProcessOn
 router.get('/processon/popular/:cate?/:sort?', lazyloadRouteHandler('./routes/processon/popular'));
@@ -3485,9 +2250,6 @@ router.get('/esquirehk/tag/:id', lazyloadRouteHandler('./routes/esquirehk/tag'))
 // 国家普通话测试 杭州市
 router.get('/putonghua', lazyloadRouteHandler('./routes/putonghua/hangzhou'));
 
-// 国家自学考试 上海市 migrated to v2 /shmeea/self-study
-// router.get('/self-study/shanghai', require('./routes/self-study/shanghai'));
-
 // 有道云笔记
 router.get('/youdao/xueba', lazyloadRouteHandler('./routes/youdao/xueba'));
 router.get('/youdao/latest', lazyloadRouteHandler('./routes/youdao/latest'));
@@ -3499,9 +2261,6 @@ router.get('/yinxiang/card/:id', lazyloadRouteHandler('./routes/yinxiang/card'))
 router.get('/yinxiang/personal/:id', lazyloadRouteHandler('./routes/yinxiang/personal'));
 router.get('/yinxiang/category/:id', lazyloadRouteHandler('./routes/yinxiang/category'));
 
-// 晚点LatePost
-// router.get('/latepost/:proma?', lazyloadRouteHandler('./routes/latepost/index'));
-
 // 遠見 gvm.com.tw
 router.get('/gvm/index/:category?', lazyloadRouteHandler('./routes/gvm/index'));
 
@@ -3510,9 +2269,6 @@ router.get('/chuapp/index/:category?', lazyloadRouteHandler('./routes/chuapp/ind
 
 // Deloitte
 router.get('/deloitte/industries/:category?', lazyloadRouteHandler('./routes/deloitte/industries'));
-
-// 特斯拉系统更新
-// router.get('/tesla/ota', lazyloadRouteHandler('./routes/tesla/update'));
 
 // 复旦大学继续教育学院
 router.get('/fudan/cce', lazyloadRouteHandler('./routes/universities/fudan/cce'));
@@ -3526,9 +2282,6 @@ router.get('/proletar/:type?/:id?', lazyloadRouteHandler('./routes/proletar/inde
 // QTTabBar
 router.get('/qttabbar/change-log', lazyloadRouteHandler('./routes/qttabbar/change-log'));
 
-// 酷18
-// router.get('/cool18/:id?/:type?/:keyword?', lazyloadRouteHandler('./routes/cool18/index'));
-
 // 美国贸易代表办公室
 router.get('/ustr/press-releases/:year?/:month?', lazyloadRouteHandler('./routes/us/ustr/press-releases'));
 
@@ -3537,9 +2290,6 @@ router.get('/vgn/:platform?', lazyloadRouteHandler('./routes/vgn/index'));
 
 // 国际能源署
 router.get('/iea/:category?', lazyloadRouteHandler('./routes/iea/index'));
-
-// 中国计算机学会
-// router.get('/ccf/news/:category?', lazyloadRouteHandler('./routes/ccf/news'));
 
 // The Brain
 router.get('/thebrain/:category?', lazyloadRouteHandler('./routes/thebrain/blog'));
@@ -3606,9 +2356,6 @@ router.get('/yicas/blog', lazyloadRouteHandler('./routes/yicas/blog'));
 // 九三学社
 router.get('/93/:category?', lazyloadRouteHandler('./routes/93/index'));
 
-// 科学网
-// router.get('/sciencenet/blog/:type?/:time?/:sort?', lazyloadRouteHandler('./routes/sciencenet/blog'));
-
 // DailyArt
 router.get('/dailyart/:language?', lazyloadRouteHandler('./routes/dailyart/index'));
 
@@ -3624,9 +2371,6 @@ router.get('/cppcc/:slug?', lazyloadRouteHandler('./routes/gov/cppcc/index'));
 // National Association of Colleges and Employers
 router.get('/nace/blog/:sort?', lazyloadRouteHandler('./routes/nace/blog'));
 
-// Caixin Latest
-// router.get('/caixin/latest', lazyloadRouteHandler('./routes/caixin/latest'));
-
 // Semiconductor Industry Association
 router.get('/semiconductors/latest-news', lazyloadRouteHandler('./routes/semiconductors/latest-news'));
 
@@ -3635,16 +2379,6 @@ router.get('/voa/day-photos', lazyloadRouteHandler('./routes/voa/day-photos'));
 
 // Voice of America
 router.get('/voa/:language/:channel?', lazyloadRouteHandler('./routes/voa/index'));
-
-// 留园网
-// router.get('/6park/:id?/:type?/:keyword?', lazyloadRouteHandler('./routes/6park/index'));
-
-// 哔嘀影视
-// router.get('/mp4er/:type?/:caty?/:area?/:year?/:order?', lazyloadRouteHandler('./routes/mp4er/index'));
-// router.get('/bde4/:type?/:caty?/:area?/:year?/:order?', lazyloadRouteHandler('./routes/mp4er/index'));
-
-// 上海证券交易所
-// router.get('/sse/sserules/:slug?', lazyloadRouteHandler('./routes/sse/sserules'));
 
 // 游戏葡萄
 router.get('/gamegrape/:id?', lazyloadRouteHandler('./routes/gamegrape/index'));
@@ -3664,16 +2398,8 @@ router.get('/mofish/:id', lazyloadRouteHandler('./routes/mofish/index'));
 // Mcdonalds
 router.get('/mcdonalds/:category', lazyloadRouteHandler('./routes/mcdonalds/news'));
 
-// Pincong 品葱 migrated to v2
-// router.get('/pincong/category/:category?/:sort?', lazyloadRouteHandler('./routes/pincong/index'));
-// router.get('/pincong/hot/:category?', lazyloadRouteHandler('./routes/pincong/hot'));
-// router.get('/pincong/topic/:topic', lazyloadRouteHandler('./routes/pincong/topic'));
-
 // GoComics
 router.get('/gocomics/:name', lazyloadRouteHandler('./routes/gocomics/index'));
-
-// Comics Kingdom
-// router.get('/comicskingdom/:name', lazyloadRouteHandler('./routes/comicskingdom/index'));
 
 // Media Digest
 router.get('/mediadigest/:range/:category?', lazyloadRouteHandler('./routes/mediadigest/category'));
@@ -3696,15 +2422,8 @@ router.get('/feed-the-beast/modpack/:modpackEntry', lazyloadRouteHandler('./rout
 router.get('/gab/user/:username', lazyloadRouteHandler('./routes/gab/user'));
 router.get('/gab/popular/:sort?', lazyloadRouteHandler('./routes/gab/explore'));
 
-// NEW 字幕组
-// router.get('/newzmz/view/:id', lazyloadRouteHandler('./routes/newzmz/view'));
-// router.get('/newzmz/:category?', lazyloadRouteHandler('./routes/newzmz/index'));
-
 // Phrack Magazine
 router.get('/phrack', lazyloadRouteHandler('./routes/phrack/index'));
-
-// 通識·現代中國
-// router.get('/chiculture/topic/:category?', lazyloadRouteHandler('./routes/chiculture/topic'));
 
 // CQUT News
 router.get('/cqut/news', lazyloadRouteHandler('./routes/universities/cqut/cqut-news'));
@@ -3718,9 +2437,6 @@ router.get('/thrillist/:tag?', lazyloadRouteHandler('./routes/thrillist/index'))
 
 // 丁香园
 router.get('/dxy/vaccine/:province?/:city?/:location?', lazyloadRouteHandler('./routes/dxy/vaccine'));
-
-// Wtu
-// router.get('/wtu/:type', lazyloadRouteHandler('./routes/universities/wtu'));
 
 // 中国庭审公开网
 router.get('/tingshen', lazyloadRouteHandler('./routes/tingshen/tingshen'));
@@ -3740,13 +2456,6 @@ router.get('/tianyancha/hot', lazyloadRouteHandler('./routes/tianyancha/hot'));
 // King Arthur
 router.get('/kingarthur/:type', lazyloadRouteHandler('./routes/kingarthur/index'));
 
-// 新华网
-// router.get('/news/whxw', lazyloadRouteHandler('./routes/news/whxw'));
-
-// 游讯网
-// router.get('/yxdown/recommend', lazyloadRouteHandler('./routes/yxdown/recommend'));
-// router.get('/yxdown/news/:category?', lazyloadRouteHandler('./routes/yxdown/news'));
-
 // BabeHub
 router.get('/babehub/search/:keyword?', lazyloadRouteHandler('./routes/babehub/search'));
 router.get('/babehub/:category?', lazyloadRouteHandler('./routes/babehub/index'));
@@ -3758,9 +2467,6 @@ router.get('/sznews/ranking', lazyloadRouteHandler('./routes/sznews/ranking'));
 // Shuax
 router.get('/shuax/project/:name?', lazyloadRouteHandler('./routes/shuax/project'));
 
-// BioOne
-// router.get('/bioone/featured', lazyloadRouteHandler('./routes/bioone/featured'));
-
 // Obsidian
 router.get('/obsidian/announcements', lazyloadRouteHandler('./routes/obsidian/announcements'));
 
@@ -3768,10 +2474,6 @@ router.get('/obsidian/announcements', lazyloadRouteHandler('./routes/obsidian/an
 router.get('/jlbtc/kyc/:category?', lazyloadRouteHandler('./routes/universities/jlbtc/kyc'));
 router.get('/jlbtc/jwc/:id?', lazyloadRouteHandler('./routes/universities/jlbtc/jwc'));
 router.get('/jlbtc/:category?', lazyloadRouteHandler('./routes/universities/jlbtc/index'));
-
-// DT 财经 migrated to v2
-// router.get('/dtcj/datahero/:category?', lazyloadRouteHandler('./routes/dtcj/datahero'));
-// router.get('/dtcj/datainsight/:id?', lazyloadRouteHandler('./routes/dtcj/datainsight'));
 
 // 劍心．回憶
 router.get('/kenshin/:category?/:type?', lazyloadRouteHandler('./routes/kenshin/index'));
@@ -3823,15 +2525,6 @@ router.get('/trakt/collection/:username/:type?', lazyloadRouteHandler('./routes/
 // 全球化智库
 router.get('/ccg/:category?', lazyloadRouteHandler('./routes/ccg/index'));
 
-// 少女前线
-// router.get('/gf-cn/news/:category?', lazyloadRouteHandler('./routes/gf-cn/news'));
-
-// Eagle
-// router.get('/eagle/changelog/:language?', lazyloadRouteHandler('./routes/eagle/changelog'));
-
-// ezone.hk
-// router.get('/ezone/:category?', lazyloadRouteHandler('./routes/ezone/index'));
-
 // 中国橡胶网
 router.get('/cria/news/:id?', lazyloadRouteHandler('./routes/cria/news'));
 
@@ -3854,13 +2547,6 @@ router.get('/liyuan-forums/threads/forum/:forum_id', lazyloadRouteHandler('./rou
 router.get('/liyuan-forums/threads/topic/:topic_id', lazyloadRouteHandler('./routes/liyuan-forums/threads'));
 router.get('/liyuan-forums/threads/user/:user_id', lazyloadRouteHandler('./routes/liyuan-forums/threads'));
 
-// 集思录
-// router.get('/jisilu/reply/:user', lazyloadRouteHandler('./routes/jisilu/reply'));
-// router.get('/jisilu/topic/:user', lazyloadRouteHandler('./routes/jisilu/topic'));
-
-// Constitutional Court of Baden-Württemberg (Germany) migrated to v2
-// router.get('/verfghbw/press/:keyword?', lazyloadRouteHandler('./routes/verfghbw/press'));
-
 // Topbook
 router.get('/topbook/overview/:id?', lazyloadRouteHandler('./routes/topbook/overview'));
 router.get('/topbook/today', lazyloadRouteHandler('./routes/topbook/today'));
@@ -3876,10 +2562,6 @@ router.get('/wanwansub/:id?', lazyloadRouteHandler('./routes/wanwansub/index'));
 router.get('/zimuxia/portfolio/:id', lazyloadRouteHandler('./routes/zimuxia/portfolio'));
 router.get('/zimuxia/:category?', lazyloadRouteHandler('./routes/zimuxia/index'));
 
-// Bandcamp migrated to v2
-// router.get('/bandcamp/tag/:tag?', lazyloadRouteHandler('./routes/bandcamp/tag'));
-// router.get('/bandcamp/weekly', lazyloadRouteHandler('./routes/bandcamp/weekly'));
-
 // Hugo 更新日志
 router.get('/hugo/releases', lazyloadRouteHandler('./routes/hugo/releases'));
 
@@ -3889,16 +2571,8 @@ router.get('/tongli/news/:type', lazyloadRouteHandler('./routes/tongli/news'));
 // OR
 router.get('/or/:id?', lazyloadRouteHandler('./routes/or'));
 
-// e-hentai migrated to v2
-// router.get('/ehentai/favorites/:favcat?/:order?/:page?/:routeParams?', lazyloadRouteHandler('./routes/ehentai/favorites'));
-// router.get('/ehentai/search/:params?/:page?/:routeParams?', lazyloadRouteHandler('./routes/ehentai/search'));
-// router.get('/ehentai/tag/:tag/:page?/:routeParams?', lazyloadRouteHandler('./routes/ehentai/tag'));
-
 // 字型故事
 router.get('/fontstory', lazyloadRouteHandler('./routes/fontstory/tw'));
-
-// HKEPC migrated to v2
-// router.get('/hkepc/:category?', lazyloadRouteHandler('./routes/hkepc/index'));
 
 // 海南大学
 router.get('/hainanu/ssszs', lazyloadRouteHandler('./routes/hainanu/ssszs'));
@@ -3911,9 +2585,6 @@ router.get('/macau-bolsas/:lang?', lazyloadRouteHandler('./routes/macau-bolsas/i
 
 // PotPlayer
 router.get('/potplayer/update/:language?', lazyloadRouteHandler('./routes/potplayer/update'));
-
-// 综艺秀
-// router.get('/zyshow/:name', lazyloadRouteHandler('./routes/zyshow'));
 
 // 加美财经
 router.get('/caus/:category?', lazyloadRouteHandler('./routes/caus'));
@@ -3948,9 +2619,6 @@ router.get('/partnershiponai/resources', lazyloadRouteHandler('./routes/partners
 // Common App
 router.get('/commonapp/blog', lazyloadRouteHandler('./routes/commonapp/blog'));
 
-// Sky Sports
-// router.get('/skysports/news/:team', lazyloadRouteHandler('./routes/skysports/news'));
-
 // Europa Press
 router.get('/europapress/:category?', lazyloadRouteHandler('./routes/europapress'));
 
@@ -3978,12 +2646,6 @@ router.get('/fnal/news/:category?', lazyloadRouteHandler('./routes/fnal/news'));
 
 // X410
 router.get('/x410/news', lazyloadRouteHandler('./routes/x410/news'));
-
-// 恩山无线论坛
-// router.get('/right/forum/:id?', lazyloadRouteHandler('./routes/right/forum'));
-
-// 香港經濟日報 migrated to v2
-// router.get('/hket/:category?', lazyloadRouteHandler('./routes/hket/index'));
 
 // micmicidol
 router.get('/micmicidol', lazyloadRouteHandler('./routes/micmicidol/latest'));
@@ -4016,20 +2678,8 @@ router.get('/netflix/newsroom/:category?/:region?', lazyloadRouteHandler('./rout
 // SBS
 router.get('/sbs/chinese/:category?/:id?/:dialect?/:language?', lazyloadRouteHandler('./routes/sbs/chinese'));
 
-// Asian to lick
-// router.get('/asiantolick/:category?/:keyword?', lazyloadRouteHandler('./routes/asiantolick'));
-
-// Research Gate
-// router.get('/researchgate/publications/:id', lazyloadRouteHandler('./routes/researchgate/publications'));
-
 // QuestMobile
 router.get('/questmobile/report/:category?/:label?', lazyloadRouteHandler('./routes/questmobile/report'));
-
-// 星球日报
-// router.get('/odaily/activity', lazyloadRouteHandler('./routes/odaily/activity'));
-// router.get('/odaily/newsflash', lazyloadRouteHandler('./routes/odaily/newsflash'));
-// router.get('/odaily/user/:id', lazyloadRouteHandler('./routes/odaily/user'));
-// router.get('/odaily/:id?', lazyloadRouteHandler('./routes/odaily/post'));
 
 // Fashion Network
 router.get('/fashionnetwork/news/:sectors?/:categories?/:language?', lazyloadRouteHandler('./routes/fashionnetwork/news.js'));
@@ -4037,19 +2687,8 @@ router.get('/fashionnetwork/news/:sectors?/:categories?/:language?', lazyloadRou
 // dykszx
 router.get('/dykszx/news/:type?', lazyloadRouteHandler('./routes/dykszx/news'));
 
-// 安全内参
-// router.get('/secrss/category/:category?', lazyloadRouteHandler('./routes/secrss/category'));
-// router.get('/secrss/author/:author?', lazyloadRouteHandler('./routes/secrss/author'));
-
 // Fashion Network
 router.get('/fashionnetwork/headline/:country?', lazyloadRouteHandler('./routes/fashionnetwork/headline.js'));
-
-// mirror.xyz
-// router.get('/mirror/:id', lazyloadRouteHandler('./routes/mirror/entries'));
-
-// KBS migrated to v2
-// router.get('/kbs/today/:language?', lazyloadRouteHandler('./routes/kbs/today'));
-// router.get('/kbs/news/:category?/:language?', lazyloadRouteHandler('./routes/kbs/news'));
 
 // Deprecated: DO NOT ADD ANY NEW ROUTES HERE
 

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "puppeteer-extra-plugin-user-preferences": "2.4.1",
     "query-string": "7.1.3",
     "rand-user-agent": "1.0.109",
-    "re2": "1.20.1",
+    "re2-wasm": "1.0.2",
     "require-all": "3.0.0",
     "rfc4648": "1.5.2",
     "rss-parser": "3.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ dependencies:
     version: 0.6.3
   instagram-private-api:
     specifier: 1.45.3
-    version: 1.45.3(re2@1.20.1)
+    version: 1.45.3
   ioredis:
     specifier: 5.3.2
     version: 5.3.2
@@ -158,9 +158,9 @@ dependencies:
   rand-user-agent:
     specifier: 1.0.109
     version: 1.0.109
-  re2:
-    specifier: 1.20.1
-    version: 1.20.1
+  re2-wasm:
+    specifier: 1.0.2
+    version: 1.0.2
   require-all:
     specifier: 3.0.0
     version: 3.0.0
@@ -713,18 +713,6 @@ packages:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
     dev: false
 
-  /@isaacs/cliui@8.0.2:
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: /string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: /strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: false
-
   /@istanbuljs/load-nyc-config@1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -1059,20 +1047,6 @@ packages:
     transitivePeerDependencies:
       - encoding
     dev: false
-
-  /@npmcli/fs@3.1.0:
-    resolution: {integrity: sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      semver: 7.5.4
-    dev: false
-
-  /@pkgjs/parseargs@0.11.0:
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@pkgr/utils@2.4.2:
     resolution: {integrity: sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==}
@@ -1577,6 +1551,7 @@ packages:
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    dev: true
 
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -1627,19 +1602,13 @@ packages:
       - supports-color
     dev: false
 
-  /agentkeepalive@4.5.0:
-    resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      humanize-ms: 1.2.1
-    dev: false
-
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+    dev: true
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1663,6 +1632,7 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
+    dev: true
 
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -1684,6 +1654,7 @@ packages:
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+    dev: true
 
   /any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1699,6 +1670,7 @@ packages:
 
   /aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
+    dev: true
 
   /are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
@@ -1707,14 +1679,6 @@ packages:
       delegates: 1.0.0
       readable-stream: 3.6.2
     dev: true
-
-  /are-we-there-yet@3.0.1:
-    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
-    dev: false
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1939,12 +1903,6 @@ packages:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  /brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-    dependencies:
-      balanced-match: 1.0.2
-    dev: false
-
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
@@ -2006,24 +1964,6 @@ packages:
     dependencies:
       run-applescript: 5.0.0
     dev: true
-
-  /cacache@17.1.3:
-    resolution: {integrity: sha512-jAdjGxmPxZh0IipMdR7fK/4sDSrHMLUV0+GvVUsjwyGNKHsh79kW/otg+GkbXwl6Uzvy9wsvHOX4nUoWldeZMg==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      '@npmcli/fs': 3.1.0
-      fs-minipass: 3.0.2
-      glob: 10.3.3
-      lru-cache: 7.18.3
-      minipass: 5.0.0
-      minipass-collect: 1.0.2
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      p-map: 4.0.0
-      ssri: 10.0.4
-      tar: 6.1.15
-      unique-filename: 3.0.0
-    dev: false
 
   /cache-content-type@1.0.1:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
@@ -2202,6 +2142,7 @@ packages:
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+    dev: true
 
   /chromium-bidi@0.4.20(devtools-protocol@0.0.1147663):
     resolution: {integrity: sha512-ruHgVZFEv00mAQMz1tQjfjdG63jiPWrQPF6HLlX2ucqLqVTJoWngeBEKHaJ6n1swV/HSvgnBNbtTRIlcVyW3Fw==}
@@ -2248,6 +2189,7 @@ packages:
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
+    dev: true
 
   /cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -2337,6 +2279,7 @@ packages:
   /color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
+    dev: true
 
   /color@3.2.1:
     resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
@@ -2389,6 +2332,7 @@ packages:
 
   /console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+    dev: true
 
   /content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -2469,6 +2413,7 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
 
   /crypto-js@4.1.1:
     resolution: {integrity: sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==}
@@ -2789,6 +2734,7 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: true
 
   /ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
@@ -2871,6 +2817,7 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: true
 
   /enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
@@ -2885,14 +2832,6 @@ packages:
     resolution: {integrity: sha512-++P0RhebUC8MJAwJOsT93dT+5oc5oPImp1HubZpAuCZ5kTLnhuuBhKHj2jJeO/Gj93idPBWmIuQ9QWMe5rX3pQ==}
     engines: {node: '>=8.10.0'}
     dev: false
-
-  /encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-    requiresBuild: true
-    dependencies:
-      iconv-lite: 0.6.3
-    dev: false
-    optional: true
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -2916,15 +2855,6 @@ packages:
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
-    dev: false
-
-  /env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /err-code@2.0.3:
-    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
     dev: false
 
   /error-ex@1.3.2:
@@ -3208,10 +3138,6 @@ packages:
       jest-util: 29.6.2
     dev: true
 
-  /exponential-backoff@3.1.1:
-    resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
-    dev: false
-
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -3377,14 +3303,6 @@ packages:
       for-in: 1.0.2
     dev: false
 
-  /foreground-child@3.1.1:
-    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
-    engines: {node: '>=14'}
-    dependencies:
-      cross-spawn: 7.0.3
-      signal-exit: 4.1.0
-    dev: false
-
   /forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
@@ -3473,13 +3391,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       minipass: 3.3.6
-
-  /fs-minipass@3.0.2:
-    resolution: {integrity: sha512-2GAfyfoaCDRrM6jaOS3UsBts8yJ55VioXdWcOL7dK9zdAuKT71+WBA4ifnNYqVjYv+4SsPxjK0JT4yIIn4cA/g==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      minipass: 5.0.0
-    dev: false
+    dev: true
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -3509,20 +3421,6 @@ packages:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
     dev: true
-
-  /gauge@4.0.4:
-    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      aproba: 2.0.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    dev: false
 
   /gaxios@6.1.0:
     resolution: {integrity: sha512-EIHuesZxNyIkUGcTQKQPMICyOpDD/bi+LJIJx+NLsSGmnS7N+xCLRX5bi4e9yAu9AlSZdVq+qlyWWVuTh/483w==}
@@ -3620,18 +3518,6 @@ packages:
     dependencies:
       is-glob: 4.0.3
     dev: true
-
-  /glob@10.3.3:
-    resolution: {integrity: sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
-    dependencies:
-      foreground-child: 3.1.1
-      jackspeak: 2.2.3
-      minimatch: 9.0.3
-      minipass: 5.0.0
-      path-scurry: 1.10.1
-    dev: false
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -3797,6 +3683,7 @@ packages:
 
   /has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+    dev: true
 
   /has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -3997,12 +3884,6 @@ packages:
     engines: {node: '>=14.18.0'}
     dev: true
 
-  /humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
-    dependencies:
-      ms: 2.1.3
-    dev: false
-
   /husky@8.0.3:
     resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
     engines: {node: '>=14'}
@@ -4061,10 +3942,12 @@ packages:
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+    dev: true
 
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+    dev: true
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -4079,7 +3962,7 @@ packages:
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  /instagram-private-api@1.45.3(re2@1.20.1):
+  /instagram-private-api@1.45.3:
     resolution: {integrity: sha512-IybVclR0Ahh01rn/4r9sxRn4vkfbfMXAXFVljsGk51mfL/EyyP6Yn+aWIxbG/JboArR1POJzaFI5bQOR99R3xA==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -4099,7 +3982,6 @@ packages:
       json-bigint: 1.0.0
       lodash: 4.17.21
       luxon: 1.28.1
-      re2: 1.20.1
       reflect-metadata: 0.1.13
       request: 2.88.2
       request-promise: 4.2.6(request@2.88.2)
@@ -4108,15 +3990,10 @@ packages:
       tough-cookie: 2.5.0
       ts-custom-error: 2.2.2
       ts-xor: 1.1.0
-      url-regex-safe: 3.0.0(re2@1.20.1)
+      url-regex-safe: 3.0.0
       utility-types: 3.10.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /install-artifact-from-github@1.3.3:
-    resolution: {integrity: sha512-x79SL0d8WOi1ZjXSTUqqs0GPQZ92YArJAN9O46wgU9wdH2U9ecyyhB9YGDbPe2OLV4ptmt6AZYRQZ2GydQZosQ==}
-    hasBin: true
     dev: false
 
   /interpret@1.4.0:
@@ -4264,10 +4141,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /is-lambda@1.0.1:
-    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
-    dev: false
-
   /is-localhost-ip@2.0.0:
     resolution: {integrity: sha512-vlgs2cSgMOfnKU8c1ewgKPyum9rVrjjLLW2HBdL5i0iAJjOs8NY55ZBd/hqUTaYR0EO9CKZd3hVSC2HlIbygTQ==}
     engines: {node: '>=12'}
@@ -4320,6 +4193,7 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
 
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -4374,15 +4248,6 @@ packages:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
     dev: true
-
-  /jackspeak@2.2.3:
-    resolution: {integrity: sha512-pF0kfjmg8DJLxDrizHoCZGUFz4P4czQ3HyfW4BU0ffebYkzAVlBywp5zaxW/TM+r0sGbmrQdi8EQQVTJFxnGsQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-    dev: false
 
   /jest-changed-files@29.5.0:
     resolution: {integrity: sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==}
@@ -5368,29 +5233,6 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /make-fetch-happen@11.1.1:
-    resolution: {integrity: sha512-rLWS7GCSTcEujjVBs2YqG7Y4643u8ucvCJeSRqiLYhesrDuzeuFIk37xREzAsfQaqzl8b9rNCE4m6J8tvX4Q8w==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      agentkeepalive: 4.5.0
-      cacache: 17.1.3
-      http-cache-semantics: 4.1.1
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-lambda: 1.0.1
-      lru-cache: 7.18.3
-      minipass: 5.0.0
-      minipass-fetch: 3.0.3
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.3
-      promise-retry: 2.0.1
-      socks-proxy-agent: 7.0.0
-      ssri: 10.0.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
     dependencies:
@@ -5655,61 +5497,17 @@ packages:
     dependencies:
       brace-expansion: 1.1.11
 
-  /minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: false
-
-  /minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: false
-
-  /minipass-fetch@3.0.3:
-    resolution: {integrity: sha512-n5ITsTkDqYkYJZjcRWzZt9qnZKCT7nKCosJhHoj7S7zD+BP4jVbWs+odsniw5TA3E0sLomhTKOKjF86wf11PuQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      minipass: 5.0.0
-      minipass-sized: 1.0.3
-      minizlib: 2.1.2
-    optionalDependencies:
-      encoding: 0.1.13
-    dev: false
-
-  /minipass-flush@1.0.5:
-    resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: false
-
-  /minipass-pipeline@1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: false
-
-  /minipass-sized@1.0.3:
-    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
-    engines: {node: '>=8'}
-    dependencies:
-      minipass: 3.3.6
-    dev: false
-
   /minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
     dependencies:
       yallist: 4.0.0
+    dev: true
 
   /minipass@5.0.0:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -5717,6 +5515,7 @@ packages:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+    dev: true
 
   /mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
@@ -5738,6 +5537,7 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+    dev: true
 
   /mockdate@3.0.5:
     resolution: {integrity: sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==}
@@ -5767,10 +5567,6 @@ packages:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
-    dev: false
-
-  /nan@2.17.0:
-    resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
     dev: false
 
   /natural-compare@1.4.0:
@@ -5825,26 +5621,6 @@ packages:
     hasBin: true
     dev: true
 
-  /node-gyp@9.4.0:
-    resolution: {integrity: sha512-dMXsYP6gc9rRbejLXmTbVRYjAHw7ppswsKyMxuxJxxOHzluIO1rGp9TOQgjFJ+2MCqcOcQTOPB/8Xwhr+7s4Eg==}
-    engines: {node: ^12.13 || ^14.13 || >=16}
-    hasBin: true
-    dependencies:
-      env-paths: 2.2.1
-      exponential-backoff: 3.1.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      make-fetch-happen: 11.1.1
-      nopt: 6.0.0
-      npmlog: 6.0.2
-      rimraf: 3.0.2
-      semver: 7.5.4
-      tar: 6.1.15
-      which: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
@@ -5890,14 +5666,6 @@ packages:
       abbrev: 1.1.1
     dev: true
 
-  /nopt@6.0.0:
-    resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      abbrev: 1.1.1
-    dev: false
-
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -5940,16 +5708,6 @@ packages:
       gauge: 3.0.2
       set-blocking: 2.0.0
     dev: true
-
-  /npmlog@6.0.2:
-    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      are-we-there-yet: 3.0.1
-      console-control-strings: 1.1.0
-      gauge: 4.0.4
-      set-blocking: 2.0.0
-    dev: false
 
   /nth-check@1.0.2:
     resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
@@ -6101,6 +5859,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       aggregate-error: 3.1.0
+    dev: true
 
   /p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -6217,6 +5976,7 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+    dev: true
 
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
@@ -6225,14 +5985,6 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
-  /path-scurry@1.10.1:
-    resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      lru-cache: 10.0.0
-      minipass: 5.0.0
-    dev: false
 
   /path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
@@ -6360,14 +6112,6 @@ packages:
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
-    dev: false
-
-  /promise-retry@2.0.1:
-    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
-    engines: {node: '>=10'}
-    dependencies:
-      err-code: 2.0.3
-      retry: 0.12.0
     dev: false
 
   /prompts@2.4.2:
@@ -6628,15 +6372,9 @@ packages:
     resolution: {integrity: sha512-mnAH0jDJQ0SJtEXjoW5aQILEc+33RwtKzKxwK9JG1a06M6nn8WDWheD+kmc5ucs+ux4FEWX3+PZuEB8r3x15yQ==}
     dev: false
 
-  /re2@1.20.1:
-    resolution: {integrity: sha512-JbzIoI5adNCqGUK8wHG1dMSyggvPyA4kx2hewt1lma5sP7/iWCfM15XKbCZlX2yvu5k80jSKAOQqJF7KC+2n8Q==}
-    requiresBuild: true
-    dependencies:
-      install-artifact-from-github: 1.3.3
-      nan: 2.17.0
-      node-gyp: 9.4.0
-    transitivePeerDependencies:
-      - supports-color
+  /re2-wasm@1.0.2:
+    resolution: {integrity: sha512-VXUdgSiUrE/WZXn6gUIVVIsg0+Hp6VPZPOaHCay+OuFKy6u/8ktmeNEf+U5qSA8jzGGFsg8jrDNu1BeHpz2pJA==}
+    engines: {node: '>=10'}
     dev: false
 
   /react-is@18.2.0:
@@ -6882,11 +6620,6 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
-    dev: false
-
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -6986,9 +6719,11 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    dev: true
 
   /setprototypeof@1.1.0:
     resolution: {integrity: sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==}
@@ -7013,10 +6748,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
+    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
 
   /shelljs@0.8.5:
     resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
@@ -7044,11 +6781,7 @@ packages:
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
-  /signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-    dev: false
+    dev: true
 
   /simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -7115,17 +6848,6 @@ packages:
       to-snake-case: 1.0.0
     dev: false
 
-  /socks-proxy-agent@7.0.0:
-    resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
-    engines: {node: '>= 10'}
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.3.4
-      socks: 2.7.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /socks-proxy-agent@8.0.1:
     resolution: {integrity: sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==}
     engines: {node: '>= 14'}
@@ -7189,13 +6911,6 @@ packages:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
-
-  /ssri@10.0.4:
-    resolution: {integrity: sha512-12+IR2CB2C28MMAw0Ncqwj5QbTcs0nGIhgJzYWzDkb21vWmfNI83KS4f3Ci6GI98WreIfG7o9UXp3C0qbpA8nQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      minipass: 5.0.0
-    dev: false
 
   /stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
@@ -7281,6 +6996,7 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+    dev: true
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -7298,6 +7014,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
+    dev: true
 
   /strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -7409,6 +7126,7 @@ packages:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+    dev: true
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -7675,20 +7393,6 @@ packages:
       vfile: 4.2.1
     dev: true
 
-  /unique-filename@3.0.0:
-    resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      unique-slug: 4.0.0
-    dev: false
-
-  /unique-slug@4.0.0:
-    resolution: {integrity: sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dependencies:
-      imurmurhash: 0.1.4
-    dev: false
-
   /unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
     dev: true
@@ -7760,7 +7464,7 @@ packages:
       requires-port: 1.0.0
     dev: false
 
-  /url-regex-safe@3.0.0(re2@1.20.1):
+  /url-regex-safe@3.0.0:
     resolution: {integrity: sha512-+2U40NrcmtWFVjuxXVt9bGRw6c7/MgkGKN9xIfPrT/2RX0LTkkae6CCEDp93xqUN0UKm/rr821QnHd2dHQmN3A==}
     engines: {node: '>= 10.12.0'}
     peerDependencies:
@@ -7770,7 +7474,6 @@ packages:
         optional: true
     dependencies:
       ip-regex: 4.3.0
-      re2: 1.20.1
       tlds: 1.242.0
     dev: false
 
@@ -7899,11 +7602,13 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
 
   /wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
       string-width: 4.2.3
+    dev: true
 
   /winston-transport@4.5.0:
     resolution: {integrity: sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==}
@@ -7952,15 +7657,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  /wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0
-    dev: false
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

Similar situation as #7111

## 路由地址示例 / Example for the Proposed Route(s)

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```routes
NOROUTE
```

## 说明 / Note

- f7b22ad1d4c6a0010d282282dec52a8cd83eedc9: Say goodbye to node-gyp.
`RE2` [only works in the Unicode mode](https://github.com/google/re2-wasm#unicode). The `u` flag must be passed to the `RE2` constructor.
- 85ccf99e412dd3af10f055b70ebf9019d0e51b68:
![image](https://github.com/DIYgod/RSSHub/assets/11386903/9d4aceb4-c73f-4625-b115-0346bd516c03)
- 260a34205ca9b40d4244fab7f7eb60e5b5a92c1a: add back wasm that was removed by `@vercel/nft`. Bump OS from debian 11 (bullseye) to debian 12 (bookworm)