### PR TITLE
feat(route): Science.org Blogs

### DIFF
--- a/docs/en/journal.md
+++ b/docs/en/journal.md
@@ -415,6 +415,14 @@ Including 'Science', 'Science Advances', 'Science Immunology', 'Science Robotics
 
 </RouteEn>
 
+### Blogs
+
+<RouteEn author="TomHodson" example="/science/blogs/pipeline" path="/science/blogs/:name?" :paramsDesc="['Short name for the blog, get this from the url. Defaults to pipeline']" anticrawler="1" puppeteer="1" radar="1" rssbud="1"/>
+
+To subscribe to IN THE PIPELINE by Derek Lowe’s at science.org/blogs/pipeline or the science editor's blog at science.org/blogs/editors-blog use the name parameter "pipeline" or "editors-blog".
+
+</RouteEn>
+
 ## ScienceDirect
 
 ### Journal

--- a/docs/en/journal.md
+++ b/docs/en/journal.md
@@ -419,7 +419,7 @@ Including 'Science', 'Science Advances', 'Science Immunology', 'Science Robotics
 
 <RouteEn author="TomHodson" example="/science/blogs/pipeline" path="/science/blogs/:name?" :paramsDesc="['Short name for the blog, get this from the url. Defaults to pipeline']" anticrawler="1" puppeteer="1" radar="1" rssbud="1">
 
-To subscribe to IN THE PIPELINE by Derek Lowe’s at science.org/blogs/pipeline or the science editor's blog at science.org/blogs/editors-blog use the name parameter "pipeline" or "editors-blog".
+To subscribe to [IN THE PIPELINE by Derek Lowe’s](https://science.org/blogs/pipeline) or the [science editor's blog](https://science.org/blogs/editors-blog), use the name parameter `pipeline` or `editors-blog`.
 
 </RouteEn>
 

--- a/docs/en/journal.md
+++ b/docs/en/journal.md
@@ -417,7 +417,7 @@ Including 'Science', 'Science Advances', 'Science Immunology', 'Science Robotics
 
 ### Blogs
 
-<RouteEn author="TomHodson" example="/science/blogs/pipeline" path="/science/blogs/:name?" :paramsDesc="['Short name for the blog, get this from the url. Defaults to pipeline']" anticrawler="1" puppeteer="1" radar="1" rssbud="1"/>
+<RouteEn author="TomHodson" example="/science/blogs/pipeline" path="/science/blogs/:name?" :paramsDesc="['Short name for the blog, get this from the url. Defaults to pipeline']" anticrawler="1" puppeteer="1" radar="1" rssbud="1">
 
 To subscribe to IN THE PIPELINE by Derek Lowe’s at science.org/blogs/pipeline or the science editor's blog at science.org/blogs/editors-blog use the name parameter "pipeline" or "editors-blog".
 

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -386,6 +386,14 @@ You can get all short name of a journal from <https://www.nature.com/siteindex> 
 
 </Route>
 
+### 博客
+
+<Route author="TomHodson" example="/science/blogs/pipeline" path="/science/blogs/:name?" :paramsDesc="['博客简称，可在 URL 找到。默认为 `pipeline`']" anticrawler="1" puppeteer="1" radar="1" rssbud="1">
+
+要订阅 Derek Lowe 在 <https://science.org/blogs/pipeline> 上 的 IN THE PIPELINE 或科学编辑的博客，请使用名称参数 `pipeline` 或 `editors-blog`。
+
+</Route>
+
 ## ScienceDirect
 
 ### Journal

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -390,7 +390,7 @@ You can get all short name of a journal from <https://www.nature.com/siteindex> 
 
 <Route author="TomHodson" example="/science/blogs/pipeline" path="/science/blogs/:name?" :paramsDesc="['博客简称，可在 URL 找到。默认为 `pipeline`']" anticrawler="1" puppeteer="1" radar="1" rssbud="1">
 
-要订阅 Derek Lowe 在 <https://science.org/blogs/pipeline> 上 的 IN THE PIPELINE 或科学编辑的博客，请使用名称参数 `pipeline` 或 `editors-blog`。
+要订阅 [Derek Lowe 的 IN THE PIPELINE](https://science.org/blogs/pipeline) 或 [科学编辑的博客](https://science.org/blogs/editors-blog)，请使用名称参数 `pipeline` 或 `editors-blog`。
 
 </Route>
 

--- a/lib/v2/science/blogs.js
+++ b/lib/v2/science/blogs.js
@@ -24,7 +24,7 @@ module.exports = async (ctx) => {
         page.close();
         browser.close();
         return response;
-    });
+    }, config.cache.routeExpire, false);
 
     const $ = cheerio.load(response, { xmlMode: true });
     const items = $('item')

--- a/lib/v2/science/blogs.js
+++ b/lib/v2/science/blogs.js
@@ -47,6 +47,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `Science Blogs: ${blog_name}`,
+        description: $('channel > description').text().slice(39, -67),
         image: `${baseUrl}/apple-touch-icon.png`,
         link: `${baseUrl}/blogs/${name}`,
         language: 'en-US',

--- a/lib/v2/science/blogs.js
+++ b/lib/v2/science/blogs.js
@@ -1,7 +1,5 @@
 const cheerio = require('cheerio');
-const logger = require('@/utils/logger');
 const { parseDate } = require('@/utils/parse-date');
-
 const { baseUrl } = require('./utils');
 
 module.exports = async (ctx) => {
@@ -9,29 +7,20 @@ module.exports = async (ctx) => {
     const link = `${baseUrl}/blogs/${name}/feed`;
 
     const response = await ctx.cache.tryGet(link, async () => {
-        // require puppeteer utility class and initialise a browser instance
         const browser = await require('@/utils/puppeteer')();
-        // open a new tab
         const page = await browser.newPage();
-        // intercept all requests
         await page.setRequestInterception(true);
-        // only allow certain types of requests to proceed
+
         page.on('request', (request) => {
-            // in this case, we only allow document requests to proceed
             request.resourceType() === 'document' ? request.continue() : request.abort();
         });
-        // visit the target link
-        // got requests will be logged automatically
-        // but puppeteer requests are not
-        // so we need to log them manually
-        logger.debug(`Requesting ${link}`);
+
         await page.goto(link, {
-            // specify how long to wait for the page to load
             waitUntil: 'domcontentloaded',
         });
-        // retrieve the HTML content of the page
+
         const response = await page.content();
-        // close the tab
+
         page.close();
         browser.close();
         return response;
@@ -51,14 +40,13 @@ module.exports = async (ctx) => {
             };
         });
 
-    ctx.state.json = {
-        response,
-        // $,
-        items,
-    };
+    // The RSS feed is implemented by a keyword search on the science.org end
+    // so the description field of the feed looks like this:
+    const name_re = /Keyword search result for Blog Series: (?<blog_name>[^-]+) --/;
+    const { blog_name = 'Unknown Title' } = $('channel > description').text().match(name_re).groups;
 
     ctx.state.data = {
-        title: `Science Blogs: ${name}`,
+        title: `Science Blogs: ${blog_name}`,
         image: `${baseUrl}/apple-touch-icon.png`,
         link: `${baseUrl}/blogs/${name}`,
         language: 'en-US',

--- a/lib/v2/science/blogs.js
+++ b/lib/v2/science/blogs.js
@@ -1,0 +1,67 @@
+const cheerio = require('cheerio');
+const logger = require('@/utils/logger');
+const { parseDate } = require('@/utils/parse-date');
+
+const { baseUrl } = require('./utils');
+
+module.exports = async (ctx) => {
+    const { name = 'pipeline' } = ctx.params;
+    const link = `${baseUrl}/blogs/${name}/feed`;
+
+    const response = await ctx.cache.tryGet(link, async () => {
+        // require puppeteer utility class and initialise a browser instance
+        const browser = await require('@/utils/puppeteer')();
+        // open a new tab
+        const page = await browser.newPage();
+        // intercept all requests
+        await page.setRequestInterception(true);
+        // only allow certain types of requests to proceed
+        page.on('request', (request) => {
+            // in this case, we only allow document requests to proceed
+            request.resourceType() === 'document' ? request.continue() : request.abort();
+        });
+        // visit the target link
+        // got requests will be logged automatically
+        // but puppeteer requests are not
+        // so we need to log them manually
+        logger.debug(`Requesting ${link}`);
+        await page.goto(link, {
+            // specify how long to wait for the page to load
+            waitUntil: 'domcontentloaded',
+        });
+        // retrieve the HTML content of the page
+        const response = await page.content();
+        // close the tab
+        page.close();
+        browser.close();
+        return response;
+    });
+
+    const $ = cheerio.load(response, { xmlMode: true });
+    const items = $('item')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            return {
+                title: item.find('title').text().trim(),
+                link: item.find('link').text().trim(),
+                author: item.find('dc\\:creator').text().trim(),
+                pubDate: parseDate(item.find('pubDate').text().trim()),
+                description: item.find('content\\:encoded').text().trim(),
+            };
+        });
+
+    ctx.state.json = {
+        response,
+        // $,
+        items,
+    };
+
+    ctx.state.data = {
+        title: `Science Blogs: ${name}`,
+        image: `${baseUrl}/apple-touch-icon.png`,
+        link: `${baseUrl}/blogs/${name}`,
+        language: 'en-US',
+        item: items,
+    };
+};

--- a/lib/v2/science/blogs.js
+++ b/lib/v2/science/blogs.js
@@ -1,30 +1,36 @@
 const cheerio = require('cheerio');
 const { parseDate } = require('@/utils/parse-date');
 const { baseUrl } = require('./utils');
+const config = require('@/config').value;
 
 module.exports = async (ctx) => {
     const { name = 'pipeline' } = ctx.params;
     const link = `${baseUrl}/blogs/${name}/feed`;
 
-    const response = await ctx.cache.tryGet(link, async () => {
-        const browser = await require('@/utils/puppeteer')();
-        const page = await browser.newPage();
-        await page.setRequestInterception(true);
+    const response = await ctx.cache.tryGet(
+        link,
+        async () => {
+            const browser = await require('@/utils/puppeteer')();
+            const page = await browser.newPage();
+            await page.setRequestInterception(true);
 
-        page.on('request', (request) => {
-            request.resourceType() === 'document' ? request.continue() : request.abort();
-        });
+            page.on('request', (request) => {
+                request.resourceType() === 'document' ? request.continue() : request.abort();
+            });
 
-        await page.goto(link, {
-            waitUntil: 'domcontentloaded',
-        });
+            await page.goto(link, {
+                waitUntil: 'domcontentloaded',
+            });
 
-        const response = await page.content();
+            const response = await page.content();
 
-        page.close();
-        browser.close();
-        return response;
-    }, config.cache.routeExpire, false);
+            page.close();
+            browser.close();
+            return response;
+        },
+        config.cache.routeExpire,
+        false
+    );
 
     const $ = cheerio.load(response, { xmlMode: true });
     const items = $('item')
@@ -47,7 +53,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title: `Science Blogs: ${blog_name}`,
-        description: $('channel > description').text().slice(39, -67),
+        description: `A Science.org blog called ${blog_name}`,
         image: `${baseUrl}/apple-touch-icon.png`,
         link: `${baseUrl}/blogs/${name}`,
         language: 'en-US',

--- a/lib/v2/science/maintainer.js
+++ b/lib/v2/science/maintainer.js
@@ -1,6 +1,6 @@
 module.exports = {
+    '/blogs/:name?': ['TomHodson'],
     '/cover': ['y9c', 'TonyRL'],
     '/current/:journal?': ['y9c', 'TonyRL'],
     '/early/:journal?': ['y9c', 'TonyRL'],
-    '/blogs/:name?': ['TomHodson'],
 };

--- a/lib/v2/science/maintainer.js
+++ b/lib/v2/science/maintainer.js
@@ -2,4 +2,5 @@ module.exports = {
     '/cover': ['y9c', 'TonyRL'],
     '/current/:journal?': ['y9c', 'TonyRL'],
     '/early/:journal?': ['y9c', 'TonyRL'],
+    '/blogs/:name?': ['TomHodson'],
 };

--- a/lib/v2/science/radar.js
+++ b/lib/v2/science/radar.js
@@ -20,6 +20,12 @@ module.exports = {
                 source: ['/journal/:journal', '/toc/:journal/0/0'],
                 target: '/science/early/:journal',
             },
+            {
+                title: 'Science Blogs',
+                docs: 'https://docs.rsshub.app/journal.html#science-xi-lie',
+                source: ['/blogs/:name'],
+                target: '/science/blogs/:name',
+            },
         ],
     },
 };

--- a/lib/v2/science/router.js
+++ b/lib/v2/science/router.js
@@ -1,6 +1,6 @@
 module.exports = (router) => {
+    router.get('/blogs/:name?', require('./blogs'));
     router.get('/cover', require('./cover'));
     router.get('/current/:journal?', require('./current'));
     router.get('/early/:journal?', require('./early'));
-    router.get('/blogs/:name?', require('./blogs'));
 };

--- a/lib/v2/science/router.js
+++ b/lib/v2/science/router.js
@@ -2,4 +2,5 @@ module.exports = (router) => {
     router.get('/cover', require('./cover'));
     router.get('/current/:journal?', require('./current'));
     router.get('/early/:journal?', require('./early'));
+    router.get('/blogs/:name?', require('./blogs'));
 };


### PR DESCRIPTION
<!-- 
如有疑问，请参考 https://docs.rsshub.app/joinus/new-rss/submit-route.html
Reference: https://docs.rsshub.app/en/joinus/new-rss/submit-route.html
-->

## 该 PR 相关 Issue / Involved Issue

This [rss feed](https://www.science.org/blogs/pipeline/feed) for [this blog](https://www.science.org/blogs/pipeline) is behind some kind of browser check so my RSS reader (miniflux) could not GET it. The RSS feed also has poor metadata, the title is wrong. This route uses pupeteer to download the RSS feed and expose it through RSShub.

## 路由地址示例 / Example for the Proposed Route(s)

```routes
/science/blogs/pipeline
/science/blogs/editors-blog
```

## 新 RSS 路由检查表 / New RSS Route Checklist
  
- [x] 新的路由 New Route
  - [x] 跟随 [v2 路由规范](https://docs.rsshub.app/joinus/script-standard.html) Follows [v2 Script Standard](https://docs.rsshub.app/en/joinus/script-standard.html)
- [x] 文档说明 Documentation
  - [ ] 中文文档 CN
  - [x] 英文文档 EN
- [x] 全文获取 fulltext
  - [x] 使用缓存 Use Cache
- [x] 反爬/频率限制 anti-bot or rate limit?
  - [x] 如果有, 是否有对应的措施? If yes, do your code reflect this sign?
- [x] [日期和时间](https://docs.rsshub.app/joinus/pub-date.html) [date and time](https://docs.rsshub.app/en/joinus/pub-date.html)
  - [X] 可以解析 Parsed
  - [X] 时区调整 Correct TimeZone
- [ ] 添加了新的包 New package added
- [X] `Puppeteer`

## 说明 / Note
