### PR TITLE
fix(route): fix `/nytimes` paragraph division

### DIFF
--- a/lib/v2/nytimes/index.js
+++ b/lib/v2/nytimes/index.js
@@ -81,10 +81,7 @@ module.exports = async (ctx) => {
             // Match 感谢|謝.*?cn.letters@nytimes.com。
             const ending = /&#x611F;(&#x8C22|&#x8B1D);.*?cn\.letters@nytimes\.com&#x3002;/g;
 
-            const matching = '<div class="article-paragraph">';
-            const formatted = '<br>' + matching;
-
-            single.description = result.description.replace(ending, '').split(matching).join(formatted);
+            single.description = result.description?.replace(ending, '');
 
             if (hasEnVersion) {
                 single.title = result.title;

--- a/lib/v2/nytimes/utils.js
+++ b/lib/v2/nytimes/utils.js
@@ -79,6 +79,11 @@ const ProcessFeed = (data, hasEnVersion = false) => {
             $(e).remove();
         });
 
+        // divide paragraphs with <p>
+        content.find('div.article-paragraph').each((i, e) => {
+            $(e).html(`<p>${$(e).html()}</p>`);
+        });
+
         if ($('figure.article-span-photo').length > 0) {
             // there is a cover photo
             const cover = $('figure.article-span-photo');


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #12896 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/nytimes
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
  - [ ] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Change paragraph division from `<br>` to `<p>`.