### PR TITLE
fix(route): fix `/iqiyi/user/video`

### DIFF
--- a/lib/v2/iqiyi/maintainer.js
+++ b/lib/v2/iqiyi/maintainer.js
@@ -1,4 +1,4 @@
 module.exports = {
     '/album/:id': ['TonyRL'],
-    '/user/video/:uid': ['talengu'],
+    '/user/video/:uid': ['talengu', 'JimenezLi'],
 };

--- a/lib/v2/iqiyi/video.js
+++ b/lib/v2/iqiyi/video.js
@@ -1,43 +1,45 @@
-const got = require('@/utils/got');
 const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+const logger = require('@/utils/logger');
 // /iqiyi/user/video/:uid
 // http://localhost:1200/iqiyi/user/video/2289191062
 module.exports = async (ctx) => {
     const uid = ctx.params.uid;
+    const link = `https://www.iqiyi.com/u/${uid}/videos`;
 
-    const response = await got({
-        method: 'get',
-        url: `http://www.iqiyi.com/u/${uid}/v`,
-        headers: {
-            Host: 'www.iqiyi.com',
-            Referer: `http://www.iqiyi.com/u/${uid}/v`,
-        },
+    // Use puppeteer because iqiyi page has a delay.
+    const browser = await require('@/utils/puppeteer')();
+    const data = await ctx.cache.tryGet(link, async () => {
+        const page = await browser.newPage();
+        await page.setRequestInterception(true);
+        page.on('request', (request) => {
+            request.resourceType() === 'document' || request.resourceType() === 'script' ? request.continue() : request.abort();
+        });
+        logger.debug(`Requesting ${link}`);
+        await page.goto(link, {
+            waitUntil: 'domcontentloaded',
+        });
+        await page.waitForSelector('li.pic-txt-li');
+        return await page.content();
     });
+    browser.close();
 
-    const data = response.data;
     const $ = cheerio.load(data);
-    const description = '';
+    const list = $('li.pic-txt-li');
 
-    const list = $('li[j-delegate="colitem"]');
-
+    // The description returns an invalid image, I cannot fix it now
     ctx.state.data = {
         title: $('title').text(),
-        link: `http://www.iqiyi.com/u/${uid}/v`,
-        description,
+        link,
         item:
             list &&
             list
-                .map((index, item) => {
-                    const title = $(item).find('.site-piclist_pic a').attr('data-title');
-
-                    return {
-                        title,
-                        description: `<img src="${$(item).find('.site-piclist_pic img').attr('src')}">`,
-                        pubDate: new Date($(item).find('.playTimes_status.tl').text().substring(0, 10).replace(/-/g, '/')).toUTCString(),
-                        link: $(item).find('.site-piclist_pic a').attr('href'),
-                    };
-                })
+                .map((index, item) => ({
+                    title: $(item).attr('title'),
+                    // description: `<img src="${$(item).find('.li-pic img').attr('src')}">`,
+                    pubDate: parseDate($(item).find('.li-sub span.sub-date').text(), 'YYYY-MM-DD'),
+                    link: $(item).find('.li-dec a').attr('href'),
+                }))
                 .get(),
-        // .reverse(),
     };
 };

--- a/lib/v2/iqiyi/video.js
+++ b/lib/v2/iqiyi/video.js
@@ -1,4 +1,5 @@
 const cheerio = require('cheerio');
+const config = require('@/config').value;
 const { parseDate } = require('@/utils/parse-date');
 const logger = require('@/utils/logger');
 // /iqiyi/user/video/:uid
@@ -9,37 +10,43 @@ module.exports = async (ctx) => {
 
     // Use puppeteer because iqiyi page has a delay.
     const browser = await require('@/utils/puppeteer')();
-    const data = await ctx.cache.tryGet(link, async () => {
-        const page = await browser.newPage();
-        await page.setRequestInterception(true);
-        page.on('request', (request) => {
-            request.resourceType() === 'document' || request.resourceType() === 'script' ? request.continue() : request.abort();
-        });
-        logger.debug(`Requesting ${link}`);
-        await page.goto(link, {
-            waitUntil: 'domcontentloaded',
-        });
-        await page.waitForSelector('li.pic-txt-li');
-        return await page.content();
-    });
+    const data = await ctx.cache.tryGet(
+        link,
+        async () => {
+            const page = await browser.newPage();
+            await page.setRequestInterception(true);
+            page.on('request', (request) => {
+                request.resourceType() === 'document' || request.resourceType() === 'script' ? request.continue() : request.abort();
+            });
+            logger.debug(`Requesting ${link}`);
+            await page.goto(link, {
+                waitUntil: 'domcontentloaded',
+            });
+            await page.waitForSelector('li.pic-txt-li');
+            const html = await page.content();
+
+            const $ = cheerio.load(html);
+            const list = $('li.pic-txt-li');
+
+            return {
+                title: $('title').text(),
+                link,
+                item:
+                    list &&
+                    list
+                        .map((index, item) => ({
+                            title: $(item).attr('title'),
+                            // description: `<img src="${$(item).find('.li-pic img').attr('src')}">`,
+                            pubDate: parseDate($(item).find('.li-sub span.sub-date').text(), 'YYYY-MM-DD'),
+                            link: $(item).find('.li-dec a').attr('href'),
+                        }))
+                        .get(),
+            };
+        },
+        config.cache.routeExpire,
+        false
+    );
     browser.close();
 
-    const $ = cheerio.load(data);
-    const list = $('li.pic-txt-li');
-
-    // The description returns an invalid image, I cannot fix it now
-    ctx.state.data = {
-        title: $('title').text(),
-        link,
-        item:
-            list &&
-            list
-                .map((index, item) => ({
-                    title: $(item).attr('title'),
-                    // description: `<img src="${$(item).find('.li-pic img').attr('src')}">`,
-                    pubDate: parseDate($(item).find('.li-sub span.sub-date').text(), 'YYYY-MM-DD'),
-                    link: $(item).find('.li-dec a').attr('href'),
-                }))
-                .get(),
-    };
+    ctx.state.data = data;
 };


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #12916 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/iqiyi/user/video/1462574210099259
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
  - [ ] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明
I have to use `Puppeteer` because the `got` method cannot get contents due to iqiyi delay load.
All images in description is this invalid one, and I have no idea.
![iqiyi_invalid_image](https://www.iqiyipic.com/common/fix/personal_space_images/qy-mod-img_179_101.png)