### PR TITLE
feat(route): add GitHub Pulse

### DIFF
--- a/lib/v2/github/maintainer.js
+++ b/lib/v2/github/maintainer.js
@@ -7,6 +7,7 @@ module.exports = {
     '/issue/:user/:repo/:state?/:labels?': ['HenryQW', 'AndreyMZ'],
     '/notifications': ['zhzy0077'],
     '/pull/:user/:repo/:state?': ['hashman', 'TonyRL'],
+    '/pulse/:user/:repo/:period?': ['jameschensmith'],
     '/repos/:user': ['DIYgod'],
     '/search/:query/:sort?/:order?': ['LogicJake'],
     '/starred_repos/:user': ['LanceZhu'],

--- a/lib/v2/github/pulse.js
+++ b/lib/v2/github/pulse.js
@@ -1,6 +1,8 @@
 const cheerio = require('cheerio');
 const path = require('path');
 const got = require('@/utils/got');
+const md5 = require('@/utils/md5');
+const { parseDate } = require('@/utils/parse-date');
 const { art } = require('@/utils/render');
 
 module.exports = async (ctx) => {
@@ -16,7 +18,7 @@ module.exports = async (ctx) => {
     const $mainSections = $('main .Layout-main').children();
 
     const $subheading = $mainSections.eq(0);
-    const periodHeading = $subheading.find('h2').text();
+    const [periodFrom, periodTo] = $subheading.find('h2').text().split('–');
 
     const $overview = $mainSections.eq(1);
     const overviewItems = $overview
@@ -52,9 +54,12 @@ module.exports = async (ctx) => {
                         .map((_, item) => {
                             const $item = $(item);
                             const $link = $item.find('a');
+                            const $details = $item.find('p');
+                            const $relativeTime = $details.find('relative-time');
+                            $relativeTime.replaceWith($relativeTime.attr('datetime'));
                             return {
                                 link: { text: $link.text(), url: $link.attr('href') },
-                                details: $item.find('p').text(),
+                                details: $details.text(),
                             };
                         })
                         .toArray(),
@@ -68,13 +73,14 @@ module.exports = async (ctx) => {
         link,
         item: [
             {
-                title: periodHeading,
+                guid: md5(`${user}${repo}${period}${periodFrom}${periodTo}`),
+                title: `${periodFrom} - ${periodTo}`,
                 description: art(path.join(__dirname, 'templates/pulse-description.art'), {
                     overviewItems,
                     commitActivity,
                     githubActivity,
                 }),
-                pubDate: new Date().toUTCString(),
+                pubDate: parseDate(periodTo),
             },
         ],
     };

--- a/lib/v2/github/pulse.js
+++ b/lib/v2/github/pulse.js
@@ -1,0 +1,81 @@
+const cheerio = require('cheerio');
+const path = require('path');
+const got = require('@/utils/got');
+const { art } = require('@/utils/render');
+
+module.exports = async (ctx) => {
+    const { user, repo, period } = ctx.params;
+
+    const periods = ['daily', 'halfweekly', 'weekly', 'monthly'];
+    const pulsePeriod = periods.includes(period) ? period : periods[2];
+
+    const link = `https://github.com/${user}/${repo}/pulse/${pulsePeriod}`;
+    const { data: pulsePage } = await got(link);
+    const $ = cheerio.load(pulsePage);
+
+    const $mainSections = $('main .Layout-main').children();
+
+    const $subheading = $mainSections.eq(0);
+    const periodHeading = $subheading.find('h2').text();
+
+    const $overview = $mainSections.eq(1);
+    const overviewItems = $overview
+        .find('ul ul li')
+        .map((_, el) => $(el).text())
+        .toArray();
+
+    const $commitActivity = $mainSections.eq(2);
+    let commitActivity;
+    const $contributionData = $commitActivity.find('.js-pulse-contribution-data');
+    if ($contributionData.length) {
+        const summaryUrl = $contributionData.attr('data-pulse-diffstat-summary-url');
+        commitActivity = (await got(`https://github.com${summaryUrl}`)).data;
+    } else {
+        commitActivity = $commitActivity.text();
+    }
+
+    const $githubActivity = $mainSections.eq(3);
+    let githubActivity;
+    const $sections = $githubActivity.find('h3');
+    if ($sections.length) {
+        githubActivity = $sections
+            .map((_, section) => {
+                const $section = $(section);
+                const $sectionSiblings = $section.nextUntil('h3');
+                const $paragraph = $section.nextUntil('ul');
+                const $list = $sectionSiblings.last();
+                return {
+                    heading: $section.text(),
+                    paragraph: $paragraph.length > 0 ? $paragraph.text() : undefined,
+                    items: $list
+                        .children()
+                        .map((_, item) => {
+                            const $item = $(item);
+                            const $link = $item.find('a');
+                            return {
+                                link: { text: $link.text(), url: $link.attr('href') },
+                                details: $item.find('p').text(),
+                            };
+                        })
+                        .toArray(),
+                };
+            })
+            .toArray();
+    }
+
+    ctx.state.data = {
+        title: `${user}/${repo} ${pulsePeriod} Pulse`,
+        link,
+        item: [
+            {
+                title: periodHeading,
+                description: art(path.join(__dirname, 'templates/pulse-description.art'), {
+                    overviewItems,
+                    commitActivity,
+                    githubActivity,
+                }),
+                pubDate: new Date().toUTCString(),
+            },
+        ],
+    };
+};

--- a/lib/v2/github/radar.js
+++ b/lib/v2/github/radar.js
@@ -45,6 +45,12 @@ module.exports = {
                 target: '/github/pull/:user/:repo',
             },
             {
+                title: 'Pulse',
+                docs: 'https://docs.rsshub.app/routes/programming#github',
+                source: ['/:user/:repo/pulse', '/:user/:repo/pulse/:period'],
+                target: '/github/pulse/:user/:repo/:period?',
+            },
+            {
                 title: '用户仓库',
                 docs: 'https://docs.rsshub.app/routes/programming#github',
                 source: '/:user',

--- a/lib/v2/github/router.js
+++ b/lib/v2/github/router.js
@@ -8,6 +8,7 @@ module.exports = function (router) {
     router.get('/issue/:user/:repo/:state?/:labels?', require('./issue'));
     router.get('/notifications', require('./notifications'));
     router.get('/pull/:user/:repo/:state?/:labels?', require('./pulls'));
+    router.get('/pulse/:user/:repo/:period?', require('./pulse'));
     router.get('/repos/:user', require('./repos'));
     router.get('/search/:query/:sort?/:order?', require('./search'));
     router.get('/starred_repos/:user', require('./starred_repos'));

--- a/lib/v2/github/templates/pulse-description.art
+++ b/lib/v2/github/templates/pulse-description.art
@@ -1,0 +1,24 @@
+<h2>Overview</h2>
+
+<ul>
+{{each overviewItems item}}
+    <li>{{item}}</li>
+{{/each}}
+</ul>
+
+{{@ commitActivity}}
+
+{{each githubActivity activity}}
+    <h2>{{activity.heading}}</h2>
+    {{if activity.paragraph}}
+        <p>{{activity.paragraph}}</p>
+    {{/if}}
+    <ul>
+    {{each activity.items item}}
+        <li>
+            <a href="{{item.link.url}}">{{item.link.text}}</a>
+            <p>{{item.details}}</p>
+        </li>
+    {{/each}}
+    </ul>
+{{/each}}

--- a/website/docs/routes/programming.md
+++ b/website/docs/routes/programming.md
@@ -316,6 +316,10 @@ For instance, the `/github/topics/framework/l=php&o=desc&s=stars` route will gen
 
 <Route author="hashman TonyRL" example="/github/pull/DIYgod/RSSHub" path="/github/pull/:user/:repo/:state?/:labels?" paramsDesc={['User name', 'Repo name', 'the state of pull requests. Can be either `open`, `closed`, or `all`. Default: `open`.', 'a list of comma separated label names']} radar="1" rssbud="1"/>
 
+### Repo Pulse {#github-repo-pulse}
+
+<Route author="jameschensmith" example="/github/pulse/DIYgod/RSSHub" path="/pulse/:user/:repo/:period?" paramsDesc={['User name', 'Repo name', 'Time frame, selected from a repository\'s Pulse/Insights page. Possible values are: `daily`, `halfweekly`, `weekly`, or `monthly`. Default: `weekly`.']} radar="1" rssbud="1"/>
+
 ### User Followers {#github-user-followers}
 
 <Route author="HenryQW" path="/github/user/followers/:user" example="/github/user/followers/HenryQW" paramsDesc={['GitHub username']} radar="1" rssbud="1"/>

--- a/website/docs/routes/programming.md
+++ b/website/docs/routes/programming.md
@@ -318,7 +318,7 @@ For instance, the `/github/topics/framework/l=php&o=desc&s=stars` route will gen
 
 ### Repo Pulse {#github-repo-pulse}
 
-<Route author="jameschensmith" example="/github/pulse/DIYgod/RSSHub" path="/pulse/:user/:repo/:period?" paramsDesc={['User name', 'Repo name', 'Time frame, selected from a repository\'s Pulse/Insights page. Possible values are: `daily`, `halfweekly`, `weekly`, or `monthly`. Default: `weekly`.']} radar="1" rssbud="1"/>
+<Route author="jameschensmith" example="/github/pulse/DIYgod/RSSHub" path="/github/pulse/:user/:repo/:period?" paramsDesc={['User name', 'Repo name', 'Time frame, selected from a repository\'s Pulse/Insights page. Possible values are: `daily`, `halfweekly`, `weekly`, or `monthly`. Default: `weekly`. If your RSS client supports it, consider aligning the polling frequency of the feed to the period.']} radar="1" rssbud="1"/>
 
 ### User Followers {#github-user-followers}
 


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Not Applicable.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/github/pulse/ziglang/zig
/github/pulse/DIYgod/RSSHub/daily
/github/pulse/DIYgod/RSSHub/halfweekly
/github/pulse/DIYgod/RSSHub/weekly
/github/pulse/DIYgod/RSSHub/monthly
/github/pulse/DIYgod/RSSHub/should-default-to-weekly
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
  - [x] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

For [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date), I use the current date / time the pulse page was called since the page records details from the current date. If there are other suggestions on what to do here, I welcome all feedback. Thanks! Excited to be contributing this ☺️ 