### PR TITLE
fix(route): 修正141ppv中image获取问题

### DIFF
--- a/lib/v2/141ppv/index.js
+++ b/lib/v2/141ppv/index.js
@@ -42,7 +42,7 @@ module.exports = async (ctx) => {
             const onErrorAttr = item.find('.image').attr('onerror');
             const backupImageRegex = /this\.src='(.*?)'/;
             const match = backupImageRegex.exec(onErrorAttr);
-            const image = match ? match[1] : null;
+            const image = match ? match[1] : item.find('.image').attr('src');
 
             return {
                 title: `${id} ${size}`,

--- a/lib/v2/141ppv/index.js
+++ b/lib/v2/141ppv/index.js
@@ -39,7 +39,10 @@ module.exports = async (ctx) => {
                 .map((t) => $(t).text().trim());
             const magnet = item.find('a[title="Magnet torrent"]').attr('href');
             const link = item.find('a[title="Download .torrent"]').attr('href');
-            const image = item.find('.image').attr('src');
+            const onErrorAttr = item.find('.image').attr('onerror');
+            const backupImageRegex = /this\.src='(.*?)'/;
+            const match = backupImageRegex.exec(onErrorAttr);
+            const image = match ? match[1] : null;
 
             return {
                 title: `${id} ${size}`,


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/141ppv/popular/7
```
## Note / 说明

原来抓取的`src`值似乎是私有媒体存储库地址，无论是在本机访问还是通过RSS服务访问都会返回”Link expired“，其网页代码为

```
<img class="image" src="https://silverpic.com/img/uxhocjwud4y7ocgksyhc3fjtg6pqqfqxw2p4jpn2fe/****.jpg" onerror="this.onerror=null;this.src='https://www.141ppv.com/movies/****.jpg'">
```

现在改为直接获取`onerror`，然后正则匹配URL，将该值给`image`，如果没有则返回`null`。
