### PR TITLE
feat(route/reuters): Add **experimental** `sophi` API support.

### DIFF
--- a/lib/v2/reuters/common.js
+++ b/lib/v2/reuters/common.js
@@ -5,26 +5,37 @@ const { art } = require('@/utils/render');
 const path = require('path');
 
 module.exports = async (ctx) => {
+    const MUST_FETCH_BY_TOPICS = ['authors'];
+    const CAN_USE_SOPHI = ['world'];
+
     const category = ctx.params.category;
     const topic = ctx.params.topic ?? (category === 'authors' ? 'reuters' : '');
     const limit = ctx.query.limit ? parseInt(ctx.query.limit) : 20;
+    const useSophi = ctx.query.useSophi === 'yes' && 'topic' !== '' && CAN_USE_SOPHI.includes(category);
 
-    const MUST_FETCH_BY_TOPICS = ['authors'];
     const section_id = `/${category}/${topic ? `${topic}/` : ''}`;
     const { title, description, rootUrl, response } = await (async () => {
         if (!MUST_FETCH_BY_TOPICS.includes(category)) {
             const rootUrl = 'https://www.reuters.com/pf/api/v3/content/fetch/articles-by-section-alias-or-id-v1';
             const response = await got(rootUrl, {
                 searchParams: {
-                    query: JSON.stringify({
-                        offset: 0,
-                        size: limit,
-                        section_id,
-                        website: 'reuters',
-                        fetch_type: 'sophi',
-                        sophi_page: '*',
-                        sophi_widget: 'topic',
-                    }),
+                    query: JSON.stringify(
+                        Object.assign(
+                            {
+                                offset: 0,
+                                size: limit,
+                                section_id,
+                                website: 'reuters',
+                            },
+                            useSophi
+                                ? {
+                                      fetch_type: 'sophi',
+                                      sophi_page: '*',
+                                      sophi_widget: 'topic',
+                                  }
+                                : {}
+                        )
+                    ),
                 },
             }).json();
             return {
@@ -42,9 +53,6 @@ module.exports = async (ctx) => {
                         size: limit,
                         topic_url: section_id,
                         website: 'reuters',
-                        fetch_type: 'sophi',
-                        sophi_page: '*',
-                        sophi_widget: 'topic',
                     }),
                 },
             }).json();

--- a/lib/v2/reuters/common.js
+++ b/lib/v2/reuters/common.js
@@ -21,6 +21,9 @@ module.exports = async (ctx) => {
                         size: limit,
                         section_id,
                         website: 'reuters',
+                        fetch_type: 'sophi',
+                        sophi_page: '*',
+                        sophi_widget: 'topic',
                     }),
                 },
             }).json();
@@ -39,6 +42,9 @@ module.exports = async (ctx) => {
                         size: limit,
                         topic_url: section_id,
                         website: 'reuters',
+                        fetch_type: 'sophi',
+                        sophi_page: '*',
+                        sophi_widget: 'topic',
                     }),
                 },
             }).json();

--- a/lib/v2/reuters/common.js
+++ b/lib/v2/reuters/common.js
@@ -11,7 +11,7 @@ module.exports = async (ctx) => {
     const category = ctx.params.category;
     const topic = ctx.params.topic ?? (category === 'authors' ? 'reuters' : '');
     const limit = ctx.query.limit ? parseInt(ctx.query.limit) : 20;
-    const useSophi = ctx.query.useSophi === 'yes' && 'topic' !== '' && CAN_USE_SOPHI.includes(category);
+    const useSophi = ctx.query.sophi === 'yes' && 'topic' !== '' && CAN_USE_SOPHI.includes(category);
 
     const section_id = `/${category}/${topic ? `${topic}/` : ''}`;
     const { title, description, rootUrl, response } = await (async () => {

--- a/lib/v2/reuters/common.js
+++ b/lib/v2/reuters/common.js
@@ -19,23 +19,21 @@ module.exports = async (ctx) => {
             const rootUrl = 'https://www.reuters.com/pf/api/v3/content/fetch/articles-by-section-alias-or-id-v1';
             const response = await got(rootUrl, {
                 searchParams: {
-                    query: JSON.stringify(
-                        Object.assign(
-                            {
-                                offset: 0,
-                                size: limit,
-                                section_id,
-                                website: 'reuters',
-                            },
-                            useSophi
-                                ? {
-                                      fetch_type: 'sophi',
-                                      sophi_page: '*',
-                                      sophi_widget: 'topic',
-                                  }
-                                : {}
-                        )
-                    ),
+                    query: JSON.stringify({
+                        ...{
+                            offset: 0,
+                            size: limit,
+                            section_id,
+                            website: 'reuters',
+                        },
+                        ...(useSophi
+                            ? {
+                                  fetch_type: 'sophi',
+                                  sophi_page: '*',
+                                  sophi_widget: 'topic',
+                              }
+                            : {}),
+                    }),
                 },
             }).json();
             return {

--- a/lib/v2/reuters/common.js
+++ b/lib/v2/reuters/common.js
@@ -11,7 +11,7 @@ module.exports = async (ctx) => {
     const category = ctx.params.category;
     const topic = ctx.params.topic ?? (category === 'authors' ? 'reuters' : '');
     const limit = ctx.query.limit ? parseInt(ctx.query.limit) : 20;
-    const useSophi = ctx.query.sophi === 'yes' && 'topic' !== '' && CAN_USE_SOPHI.includes(category);
+    const useSophi = ctx.query.sophi === 'true' && 'topic' !== '' && CAN_USE_SOPHI.includes(category);
 
     const section_id = `/${category}/${topic ? `${topic}/` : ''}`;
     const { title, description, rootUrl, response } = await (async () => {

--- a/website/docs/routes/traditional-media.md
+++ b/website/docs/routes/traditional-media.md
@@ -490,6 +490,8 @@ Parameters can be obtained from the official website, for instance:
 
 :::
 
+You can use `sophi=yes` query parameter to invoke the **experimental** method, which can, if possible, fetch more articles(between 20 and 100) with `limit` given. But some articles from the old method might not be available.
+
 ### Category/Topic/Author {#reuters-lu-tou-she-category-topic-author}
 
 <Route author="HenryQW proletarius101 LyleLee nczitzk" example="/reuters/world/us" path="/reuters/:category/:topic?" paramsDesc={['find it in the URL, or tables below', 'find it in the URL, or tables below']}>

--- a/website/docs/routes/traditional-media.md
+++ b/website/docs/routes/traditional-media.md
@@ -490,7 +490,7 @@ Parameters can be obtained from the official website, for instance:
 
 :::
 
-You can use `sophi=yes` query parameter to invoke the **experimental** method, which can, if possible, fetch more articles(between 20 and 100) with `limit` given. But some articles from the old method might not be available.
+You can use `sophi=true` query parameter to invoke the **experimental** method, which can, if possible, fetch more articles(between 20 and 100) with `limit` given. But some articles from the old method might not be available.
 
 ### Category/Topic/Author {#reuters-lu-tou-she-category-topic-author}
 


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/reuters/world?limit=100&sophi=true
/reuters/world/africa
/reuters/business
/reuters/legal
/reuters/authors/jonathan-landay
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
  - [ ] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
`limit` parameter will not have effect if it's  larger than `20` for old API. The `sophi` type can solve the problem, but it comes with a lot of caveats, and the content is not exactly the same as the old API. Use with caution.