### PR TITLE
fix(core): string-type categories only

### DIFF
--- a/lib/middleware/parameter.js
+++ b/lib/middleware/parameter.js
@@ -136,6 +136,13 @@ module.exports = async (ctx, next) => {
                     });
                 }
             }
+
+            // handle category
+            if (item.category) {
+                // convert single string to array, and filter only string type category
+                Array.isArray(item.category) || (item.category = [item.category]);
+                item.category = item.category.filter((e) => typeof e === 'string');
+            }
             return item;
         };
 
@@ -172,8 +179,7 @@ module.exports = async (ctx, next) => {
                     const title = item.title || '';
                     const description = item.description || title;
                     const author = item.author || '';
-                    const categoryArray = Array.isArray(item.category) ? item.category : [item.category];
-                    const category = item.category ? categoryArray : [];
+                    const category = item.category || [];
                     const isFilter =
                         engine === 're2'
                             ? regex.matcher(title).find() || regex.matcher(description).find() || regex.matcher(author).find() || category.some((c) => regex.matcher(c).find())
@@ -189,8 +195,7 @@ module.exports = async (ctx, next) => {
                     const title = item.title || '';
                     const description = item.description || title;
                     const author = item.author || '';
-                    const categoryArray = Array.isArray(item.category) ? item.category : [item.category];
-                    const category = item.category ? categoryArray : [];
+                    const category = item.category || [];
                     let isFilter = true;
 
                     const titleRegex = makeRegex(ctx.query.filter_title);
@@ -216,8 +221,7 @@ module.exports = async (ctx, next) => {
                     const title = item.title;
                     const description = item.description || title;
                     const author = item.author || '';
-                    const categoryArray = Array.isArray(item.category) ? item.category : [item.category];
-                    const category = item.category ? categoryArray : [];
+                    const category = item.category || [];
                     let isFilter = true;
 
                     const titleRegex = makeRegex(ctx.query.filterout_title);

--- a/lib/v2/test/index.js
+++ b/lib/v2/test/index.js
@@ -42,6 +42,15 @@ module.exports = async (ctx) => {
                 category: 'Category3',
             },
         ];
+    } else if (ctx.params.id === 'filter-illegal-category') {
+        item.push({
+            title: 'TitleIllegal',
+            description: 'DescriptionIllegal',
+            pubDate: new Date(`2019-3-1`).toUTCString(),
+            link: `https://github.com/DIYgod/RSSHub/issues/1`,
+            author: `DIYgod0`,
+            category: [1, 'CategoryIllegal', true, null, undefined, { type: 'object' }],
+        });
     } else if (ctx.params.id === 'long') {
         item.push({
             title: `Long Title `.repeat(50),

--- a/test/middleware/parameter.js
+++ b/test/middleware/parameter.js
@@ -112,6 +112,14 @@ describe('filter', () => {
         expect(parsed.items[0].title).toBe('Filter Title3');
     });
 
+    it(`filter_category illegal_category`, async () => {
+        const response = await request.get('/test/filter-illegal-category?filter_category=CategoryIllegal');
+        const parsed = await parser.parseString(response.text);
+        expect(parsed.items.length).toBe(1);
+        expect(parsed.items[0].categories.length).toBe(1);
+        expect(parsed.items[0].categories[0]).toBe('CategoryIllegal');
+    });
+
     it(`filter_time`, async () => {
         const response = await request.get('/test/current_time?filter_time=25');
         const parsed = await parser.parseString(response.text);


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #13451 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/test/filter-illegal-category?filter_category=CategoryIllegal
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
  - [ ] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
The issue doesn't provide a route, so I use the test one.
This is meant to keep only string-type categories, so that the program doesn't crash with null category.