### PR TITLE
fix: Firefox release notes link for desktop

### DIFF
--- a/lib/routes/firefox/release.js
+++ b/lib/routes/firefox/release.js
@@ -8,7 +8,7 @@ module.exports = async (ctx) => {
         devicePlatform = '';
     }
 
-    const link = ['https://www.mozilla.org/en-US/firefox', devicePlatform, 'releasenotes/'].filter(x => x).join('/');
+    const link = ['https://www.mozilla.org/en-US/firefox', devicePlatform, 'releasenotes/'].filter((x) => x).join('/');
     const response = await got.get(link);
     const $ = cheerio.load(response.data);
     const version = $('.c-release-version').text();

--- a/lib/routes/firefox/release.js
+++ b/lib/routes/firefox/release.js
@@ -8,18 +8,18 @@ module.exports = async (ctx) => {
         devicePlatform = '';
     }
 
-    const link = `https://www.mozilla.org/en-US/firefox/${devicePlatform}/notes/`;
+    const link = ['https://www.mozilla.org/en-US/firefox', devicePlatform, 'releasenotes/'].filter(x => x).join('/');
     const response = await got.get(link);
     const $ = cheerio.load(response.data);
     const version = $('.c-release-version').text();
     const pubDate = new Date($('.c-release-date').text()).toUTCString();
 
     ctx.state.data = {
-        title: `Firefox ${platform} release note`,
+        title: `Firefox ${platform} release notes`,
         link,
         item: [
             {
-                title: `Firefox ${platform} ${version} release note`,
+                title: `Firefox ${platform} ${version} release notes`,
                 link,
                 description: $('.c-release-notes').html(),
                 guid: `${platform} ${version}`,


### PR DESCRIPTION
This PR fixes Firefox release notes feed link for desktop platform.

- Removes double slash
- Uses updated `/releasenotes/` path

---

Before this change, desktop link was `https://www.mozilla.org/en-US/firefox//notes/`.
After this change, desktop link is `https://www.mozilla.org/en-US/firefox/releasenotes/`.