### PR TITLE
fix(route): Epic Games Store - items containing non-free games

### DIFF
--- a/lib/v2/epicgames/index.js
+++ b/lib/v2/epicgames/index.js
@@ -24,7 +24,9 @@ module.exports = async (ctx) => {
             (item) =>
                 item.promotions &&
                 item.promotions.promotionalOffers &&
-                item.promotions.promotionalOffers[0] &&
+                item.promotions.promotionalOffers.length &&
+                item.promotions.promotionalOffers[0].promotionalOffers[0].discountSetting.discountType === 'PERCENTAGE' &&
+                item.promotions.promotionalOffers[0].promotionalOffers[0].discountSetting.discountPercentage === 0 &&
                 dayjs(item.promotions.promotionalOffers[0].promotionalOffers[0].startDate) <= now &&
                 dayjs(item.promotions.promotionalOffers[0].promotionalOffers[0].endDate) > now
         )
@@ -32,15 +34,11 @@ module.exports = async (ctx) => {
             let link = `${rootUrl}/${locale}/p/`;
             let contentUrl = `${contentBaseUrl}/products/`;
             let isBundles = false;
-            item.categories.some((category) => {
-                if (category.path === 'bundles') {
-                    link = `${rootUrl}/${locale}/bundles/`;
-                    isBundles = true;
-                    contentUrl = `${contentBaseUrl}/bundles/`;
-                    return true;
-                }
-                return false;
-            });
+            if (item.categories.some((category) => category.path === 'bundles')) {
+                link = `${rootUrl}/${locale}/bundles/`;
+                isBundles = true;
+                contentUrl = `${contentBaseUrl}/bundles/`;
+            }
             const linkSlug = item.catalogNs.mappings.length > 0 ? item.catalogNs.mappings[0].pageSlug : item.offerMappings.length > 0 ? item.offerMappings[0].pageSlug : item.productSlug ? item.productSlug : item.urlSlug;
             link += linkSlug;
             contentUrl += linkSlug;
@@ -61,6 +59,7 @@ module.exports = async (ctx) => {
                 }
                 return false;
             });
+            const endDate = dayjs(item.promotions.promotionalOffers[0].promotionalOffers[0].endDate).toISOString();
             return {
                 title: item.title,
                 author: item.seller.name,
@@ -68,6 +67,7 @@ module.exports = async (ctx) => {
                 description: art(path.join(__dirname, 'templates/description.art'), {
                     description,
                     image,
+                    endDate,
                 }),
                 pubDate: parseDate(item.promotions.promotionalOffers[0].promotionalOffers[0].startDate),
             };

--- a/lib/v2/epicgames/templates/description.art
+++ b/lib/v2/epicgames/templates/description.art
@@ -1,2 +1,3 @@
 <p>{{ description }}</p>
 <img src="{{ image }}">
+<p>Free Now to {{ endDate }}</p>


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/epicgames/freegames
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
  - [ ] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
fix items containing non-free games
