### PR TITLE
fix(route): Epic Games Store - Cannot read properties of null (reading 'length')

### DIFF
--- a/lib/v2/epicgames/index.js
+++ b/lib/v2/epicgames/index.js
@@ -39,7 +39,7 @@ module.exports = async (ctx) => {
                 isBundles = true;
                 contentUrl = `${contentBaseUrl}/bundles/`;
             }
-            const linkSlug = item.catalogNs.mappings.length > 0 ? item.catalogNs.mappings[0].pageSlug : item.offerMappings.length > 0 ? item.offerMappings[0].pageSlug : item.productSlug ? item.productSlug : item.urlSlug;
+            const linkSlug = item.catalogNs.mappings && item.catalogNs.mappings.length > 0 ? item.catalogNs.mappings[0].pageSlug : item.offerMappings && item.offerMappings.length > 0 ? item.offerMappings[0].pageSlug : item.productSlug ? item.productSlug : item.urlSlug;
             link += linkSlug;
             contentUrl += linkSlug;
             let description = item.description;

--- a/website/docs/routes/game.md
+++ b/website/docs/routes/game.md
@@ -111,7 +111,7 @@ Language codes
 
 ### Free games {#epic-games-store-free-games}
 
-<Route author="Zyx-A nczitzk  KotaHv" example="/epicgames/freegames" path="/epicgames/freegames/:locale?/:country?" paramsDesc={['Locale, en_US by default', 'Country, en_US by default']}/>
+<Route author="Zyx-A nczitzk  KotaHv" example="/epicgames/freegames" path="/epicgames/freegames/:locale?/:country?" paramsDesc={['Locale, en_US by default', 'Country, US by default']}/>
 
 ## Fate Grand Order {#fate-grand-order}
 


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #13548 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/epicgames/freegames
/epicgames/freegames/zh_CN
/epicgames/freegames/zh_CN/CN
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
  - [ ] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
See #13548 , when item.catalogNs.mappings and item.offerMappings are null, it wouldn't be able to tell if the length of the value was greater than 0 and report an error, so I put an extra judgement in front of the