### PR TITLE
fix(route): fix pubDate timezone for route e-hentai

### DIFF
--- a/lib/v2/ehentai/ehapi.js
+++ b/lib/v2/ehentai/ehapi.js
@@ -77,7 +77,7 @@ async function parsePage(cache, data, get_bittorrent = false, embed_thumb = fals
     async function parseElement(cache, element) {
         const el = $(element);
         const title = el.find('div.glink').html();
-        const rawDate = el.find('div[id^="posted_"]').html();
+        const rawDate = el.find('div[id^="posted_"]').text();
         const pubDate = rawDate ? timezone(rawDate, 0) : rawDate;
         let el_a;
         let el_img;

--- a/lib/v2/ehentai/ehapi.js
+++ b/lib/v2/ehentai/ehapi.js
@@ -1,5 +1,6 @@
 const got = require('@/utils/got');
 const logger = require('@/utils/logger');
+const timezone = require('@/utils/timezone');
 const cheerio = require('cheerio');
 const path = require('path');
 const config = require('@/config').value.ehentai;
@@ -76,7 +77,8 @@ async function parsePage(cache, data, get_bittorrent = false, embed_thumb = fals
     async function parseElement(cache, element) {
         const el = $(element);
         const title = el.find('div.glink').html();
-        const pubDate = el.find('div[id^="posted_"]').html();
+        const rawDate = el.find('div[id^="posted_"]').html();
+        const pubDate = rawDate ? timezone(rawDate, 0) : rawDate;
         let el_a;
         let el_img;
         // match layout


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

#6795

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/ehentai/tag/language:chinese
/ehentai/search
/ehentai/search/f_search=artist%3Ahiten%24
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
  - [ ] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
The posted time returned by e-hentai is always GMT. This PR is aimed to fix the wrong timezone for non-GMT servers.