### PR TITLE
fix(route): zimuxia portfolio.js compatible for old stype and support ed2k baidu et.al

### DIFF
--- a/lib/v2/zimuxia/portfolio.js
+++ b/lib/v2/zimuxia/portfolio.js
@@ -3,6 +3,7 @@ const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
     const id = ctx.params.id;
+    let linktype = ctx.query.linktype ?? 'magnet';
 
     const rootUrl = 'https://www.zimuxia.cn';
     const currentUrl = `${rootUrl}/portfolio/${id}`;
@@ -17,16 +18,13 @@ module.exports = async (ctx) => {
     const $ = cheerio.load(response.data);
 
     const items = $('a')
-        .filter((_, el) => $(el).attr('href')?.startsWith('magnet:'))
+        .filter((_, el) => $(el).attr('href')?.match(RegExp(linktype)))
         .toArray()
         .map((item) => {
             item = $(item);
-            const title = item
-                .parent()
-                .contents()
-                .filter((_, el) => el.type === 'text')
-                .text()
-                .trim();
+            const tmpstr2match = $.html(item.parent().children()[item.prevAll("br").first().index()+1]);
+            const tmphtml = item.parent().contents().toArray().map((item) => { return $.html($(item)) });
+            const title = tmphtml[tmphtml.indexOf(tmpstr2match)-1].trim().replace(/\s.*|&nbsp;.*/,"");
 
             return {
                 link: currentUrl,

--- a/lib/v2/zimuxia/portfolio.js
+++ b/lib/v2/zimuxia/portfolio.js
@@ -3,7 +3,7 @@ const cheerio = require('cheerio');
 
 module.exports = async (ctx) => {
     const id = ctx.params.id;
-    let linktype = ctx.query.linktype ?? 'magnet';
+    const linktype = ctx.query.linktype ?? 'magnet';
 
     const rootUrl = 'https://www.zimuxia.cn';
     const currentUrl = `${rootUrl}/portfolio/${id}`;
@@ -22,9 +22,9 @@ module.exports = async (ctx) => {
         .toArray()
         .map((item) => {
             item = $(item);
-            const tmpstr2match = $.html(item.parent().children()[item.prevAll("br").first().index()+1]);
+            const tmpstr2match = $.html(item.parent().children()[item.prevAll("br").first().index() + 1]);
             const tmphtml = item.parent().contents().toArray().map((item) => { return $.html($(item)) });
-            const title = tmphtml[tmphtml.indexOf(tmpstr2match)-1].trim().replace(/\s.*|&nbsp;.*/,"");
+            const title = tmphtml[tmphtml.indexOf(tmpstr2match) - 1].trim().replace(/\s.*|&nbsp;.*/,"");
 
             return {
                 link: currentUrl,


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

#7412

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/zimuxia/portfolio/9号秘事
/zimuxia/portfolio/9号秘事?linktype=ed2k
/zimuxia/portfolio/9号秘事?linktype=pan.baidu
/zimuxia/portfolio/9号秘事?linktype=115.com
/zimuxia/portfolio/9号秘事?linktype=quark
/zimuxia/portfolio/9号秘事?linktype=subhd
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [x] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
  - [ ] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
The new v2 version is great but 
old page like https://www.zimuxia.cn/portfolio/9%E5%8F%B7%E7%A7%98%E4%BA%8B the links were not always wrap in div or p for the same episode, instead they seperated by <br>, this cause the title mess up such as start from S05E01 
https://rsshub.app/zimuxia/portfolio/9%E5%8F%B7%E7%A7%98%E4%BA%8B

this version tried matching the closest link after <br>, seems work good in a few tests. 