### PR TITLE
fix(route): Update the kemono route to point at the new canonical URL

### DIFF
--- a/lib/v2/kemono/index.js
+++ b/lib/v2/kemono/index.js
@@ -8,7 +8,7 @@ module.exports = async (ctx) => {
     const source = ctx.params.source ?? '';
     const id = ctx.params.id;
 
-    const rootUrl = 'https://kemono.party';
+    const rootUrl = 'https://kemono.su';
     const apiUrl = `${rootUrl}/api/v1/discord/channel/lookup/${id}`;
     const currentUrl = `${rootUrl}/${source ? `${source}/${source === 'discord' ? `server/${id}` : `user/${id}`}` : 'posts'}`;
 

--- a/lib/v2/kemono/index.js
+++ b/lib/v2/kemono/index.js
@@ -87,6 +87,7 @@ module.exports = async (ctx) => {
                         item.description = content('.post__body').html();
                         item.author = content('.post__user-name').text();
                         item.title = content('.post__title span').first().text();
+                        item.guid = item.link.replace('kemono.su', 'kemono.party');
                         item.pubDate = parseDate(content('.timestamp').attr('datetime'));
 
                         return item;

--- a/lib/v2/kemono/radar.js
+++ b/lib/v2/kemono/radar.js
@@ -1,5 +1,5 @@
 module.exports = {
-    'kemono.party': {
+    'kemono.su': {
         _name: 'Kemono',
         '.': [
             {


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

Every kemono route, but:

```routes
/kemono/patreon/44261000
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
There is no new route in this PR.

## Note / 说明

kemono.party redirects to kemono.su now, and the website was proactively telling people to update their bookmarks for a while.