### PR TITLE
feat(route): Retrieve avatars from kemono pages and use them as feed images

### DIFF
--- a/lib/v2/kemono/index.js
+++ b/lib/v2/kemono/index.js
@@ -23,7 +23,8 @@ module.exports = async (ctx) => {
     });
 
     let items = [],
-        title = '';
+        title = '',
+        image = undefined;
 
     if (source === 'discord') {
         title = `Posts of ${id} from Discord | Kemono`;
@@ -56,6 +57,7 @@ module.exports = async (ctx) => {
         const $ = cheerio.load(response.data);
 
         title = $('title').text();
+        image = $('.user-header__avatar img[src]').attr('src');
 
         items = await Promise.all(
             $('.card-list__items')
@@ -97,6 +99,7 @@ module.exports = async (ctx) => {
 
     ctx.state.data = {
         title,
+        image,
         link: currentUrl,
         item: items,
     };


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

Any non-discord kemono URL (discord URLs leave the image as `undefined`):

```routes
/kemono/patreon/26889925
```