### PR TITLE
fix(route): bilibili webgl signature

### DIFF
--- a/lib/v2/bilibili/video.js
+++ b/lib/v2/bilibili/video.js
@@ -16,7 +16,12 @@ module.exports = async (ctx) => {
     //         Cookie: cookie,
     //     },
     // });
-    const params = utils.addVerifyInfo(`mid=${uid}&ps=30&tid=0&pn=1&keyword=&order=pubdate&platform=web&web_location=1550101&order_avoided=true`, verifyString);
+    const params = utils.addVerifyInfo(
+        `mid=${uid}&ps=30&tid=0&pn=1&keyword=&order=pubdate&platform=web&web_location=1550101&order_avoided=true&dm_img_list=[]&dm_img_str=${Buffer.from('no webgl').toString('base64')}&dm_cover_img_str=${Buffer.from(
+            'no webgl'
+        ).toString('base64')}`,
+        verifyString
+    );
     const response = await got(`https://api.bilibili.com/x/space/wbi/arc/search?${params}`, {
         headers: {
             Referer: `https://space.bilibili.com/${uid}/video?tid=0&page=1&keyword=&order=pubdate`,


### PR DESCRIPTION
<!-- 
Reference: https://docs.rsshub.app/joinus/new-rss/submit-route
如有疑问，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/bilibili/user/video/2267573
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
  - [ ] EN / 英文文档
  - [ ] CN / 中文文档
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制 
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

```js
        var ha, va, _a = ["ZG1faW1nX2xpc3Q=", "ZG1faW1nX3N0cg==", "ZG1fY292ZXJfaW1nX3N0cg=="].map((function(t) {
            return atob(t)
        }
        )), ba = new fa.a({
            activityEvents: ["mousemove", "click"],
            logStackMaxLength: 50,
            samplingTime: 100,
            obfuscate: !0,
            logConfig: {
                valueMap: {
                    userLogStr: _a[0],
                    webglStr: _a[1],
                    webglVendorAndRenderer: _a[2]
                }
            }
        })
```

```js
{
            key: "getUserWebglInfo",
            value: function() {
                var t = document.createElement("canvas")
                  , e = t.getContext("webgl");
                if (!e)
                    return this.webglVendorAndRenderer = "no webgl",
                    void (this.webglStr = "no webgl");
                this.webglStr = e.getParameter(e.VERSION);
                var n = null == e ? void 0 : e.getExtension("WEBGL_debug_renderer_info");
                if (n) {
                    var r = e.getParameter(n.UNMASKED_RENDERER_WEBGL)
                      , o = e.getParameter(n.UNMASKED_VENDOR_WEBGL);
                    this.webglVendorAndRenderer = r + o
                } else
                    this.webglVendorAndRenderer = "no webgl extension";
                t.remove()
            }
```