### PR TITLE
fix(egsea): pubDate Invalid Date

### DIFF
--- a/lib/routes/egsea/flash.js
+++ b/lib/routes/egsea/flash.js
@@ -17,7 +17,8 @@ module.exports = async (ctx) => {
     }
 
     const out = newsflashesList.map((item) => {
-        const pubDate = item.pageTime;
+        const pageTime = item.pageTime; // unix timestamp
+        const pubDate = new Date(pageTime * 1000).toUTCString();
         const link = 'https://www.egsea.com' + item.url;
         const title = item.title;
         const description = item.content;


### PR DESCRIPTION
the https://rsshub.app/egsea/flash response error pubDate

     <pubDate>Invalid Date</pubDate>

fixed

    <pubDate>Wed, 29 Nov 2023 09:03:35 GMT</pubDate>

