### PR TITLE
fix: fix sse disclosure

### DIFF
--- a/lib/v2/sse/disclosure.js
+++ b/lib/v2/sse/disclosure.js
@@ -29,13 +29,13 @@ module.exports = async (ctx) => {
         },
     });
 
-    const pdf_host = 'https://static.sse.com.cn';
+    const pdfHost = 'https://static.sse.com.cn';
 
     const items = response.data.result.map((item) => ({
         title: item.TITLE,
-        description: `${pdf_host}${item.URL}`,
+        description: `${pdfHost}${item.URL}`,
         pubDate: parseDate(item.ADDDATE),
-        link: `${pdf_host}${item.URL}`,
+        link: `${pdfHost}${item.URL}`,
         author: item.SECURITY_NAME,
     }));
 

--- a/lib/v2/sse/disclosure.js
+++ b/lib/v2/sse/disclosure.js
@@ -3,7 +3,6 @@ const { parseDate } = require('@/utils/parse-date');
 
 module.exports = async (ctx) => {
     const query = ctx.params.query ?? ''; // beginDate=2018-08-18&endDate=2020-09-01&productId=600696
-    const host = 'https://www.sse.com.cn';
     const queries = query.split('&').reduce((acc, cur) => {
         const [key, value] = cur.split('=');
         acc[key] = value;
@@ -30,11 +29,13 @@ module.exports = async (ctx) => {
         },
     });
 
+    const pdf_host = 'https://static.sse.com.cn';
+
     const items = response.data.result.map((item) => ({
         title: item.TITLE,
-        description: `${host}${item.URL}`,
+        description: `${pdf_host}${item.URL}`,
         pubDate: parseDate(item.ADDDATE),
-        link: `${host}${item.URL}`,
+        link: `${pdf_host}${item.URL}`,
         author: item.SECURITY_NAME,
     }));
 


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close https://github.com/DIYgod/RSSHub/issues/13981

## Example for the Proposed Route(s) / 路由地址示例

```routes
/sse/disclosure/beginDate=2023-08-18&endDate=2023-09-01&productId=600696
/sse/disclosure/beginDate=2023-08-18&endDate=2023-09-01&productId=600133
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
