### PR TITLE
docs: fix path of zh configuration

### DIFF
--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/install/README.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/install/README.md
@@ -140,7 +140,7 @@ $ docker run -d --name rsshub -p 1200:1200 -e CACHE_EXPIRE=3600 -e GITHUB_ACCESS
 
 该部署方式不包括 puppeteer（除非改用 `diygod/rsshub:chromium-bundled`）和 redis 依赖，如有需要请改用 Docker Compose 部署方式或自行部署外部依赖
 
-更多配置项请看 [#配置](#pei-zhi)
+更多配置项请看 [#配置](/zh/install/config)
 
 ## Kubernetes 部署 (Helm)
 
@@ -385,7 +385,7 @@ CACHE_EXPIRE=600
 
 该部署方式不包括 redis 依赖，如有需要请改用 Docker Compose 部署方式或自行部署外部依赖
 
-更多配置项请看 [#配置](#pei-zhi)
+更多配置项请看 [#配置](/zh/install/config)
 
 ### 更新
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

No Issue.

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

在文档看到[手动安装添加配置](https://docs.rsshub.app/zh/install/#%E6%B7%BB%E5%8A%A0%E9%85%8D%E7%BD%AE-2)时发现路由跳转失效，找了一会才发现需要点左侧导航栏里的[配置](https://docs.rsshub.app/zh/install/config)，于是想开个 PR 改一下。
但本地运行 website 时，zh 部分是 404，也没找到什么地方能看到效果，于是先 push 上来看看会不会有测试用的部署。

顺带一问，文档问题我从 [discussions](https://github.com/DIYgod/RSSHub/discussions/9944) 看到 [issue](https://github.com/DIYgod/RSSHub/issues/6198)，但之后貌似没有 i18n 的进度了。这部分的进度是另有重要的特性而搁置了还是？

最后一个问题是，#pei-zhi-bu-fen-rss-mo-kuai-pei-zhi 这玩意在哪?