### PR TITLE
feat(route): 添加 dm_img_list 字段防止被 Bilibili 识别

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -121,6 +121,7 @@ const calculateValue = () => {
         // Route-specific Configurations
         bilibili: {
             cookies: bilibili_cookies,
+            dmImgList: envs.BILIBILI_DM_IMG_LIST,
         },
         bitbucket: {
             username: envs.BITBUCKET_USERNAME,

--- a/lib/config.js
+++ b/lib/config.js
@@ -121,7 +121,6 @@ const calculateValue = () => {
         // Route-specific Configurations
         bilibili: {
             cookies: bilibili_cookies,
-            dmImgList: envs.BILIBILI_DM_IMG_LIST,
         },
         bitbucket: {
             username: envs.BITBUCKET_USERNAME,

--- a/lib/v2/bilibili/cache.js
+++ b/lib/v2/bilibili/cache.js
@@ -55,8 +55,8 @@ module.exports = {
             return cookie.join('; ');
         });
     },
-    getVerifyString: (ctx) => {
-        const key = 'bili-verify-string';
+    getWbiVerifyString: (ctx) => {
+        const key = 'bili-wbi-verify-string';
         return ctx.cache.tryGet(key, async () => {
             const cookie = await module.exports.getCookie(ctx);
             const { data: navResponse } = await got('https://api.bilibili.com/x/web-interface/nav', {
@@ -97,14 +97,14 @@ module.exports = {
         const key = 'bili-username-from-uid-' + uid;
         return ctx.cache.tryGet(key, async () => {
             const cookie = await module.exports.getCookie(ctx);
-            const verifyString = await module.exports.getVerifyString(ctx);
+            const wbiVerifyString = await module.exports.getWbiVerifyString(ctx);
             // await got(`https://space.bilibili.com/${uid}/`, {
             //     headers: {
             //         Referer: 'https://www.bilibili.com/',
             //         Cookie: cookie,
             //     },
             // });
-            const params = utils.addVerifyInfo(`mid=${uid}&token=&platform=web&web_location=1550101`, verifyString);
+            const params = utils.addWbiVerifyInfo(`mid=${uid}&token=&platform=web&web_location=1550101`, wbiVerifyString);
             const { data: nameResponse } = await got(`https://api.bilibili.com/x/space/wbi/acc/info?${params}`, {
                 headers: {
                     Referer: `https://space.bilibili.com/${uid}/`,
@@ -121,14 +121,14 @@ module.exports = {
         let face = await ctx.cache.get(faceKey);
         if (!name || !face) {
             const cookie = await module.exports.getCookie(ctx);
-            const verifyString = await module.exports.getVerifyString(ctx);
+            const wbiVerifyString = await module.exports.getWbiVerifyString(ctx);
             // await got(`https://space.bilibili.com/${uid}/`, {
             //     headers: {
             //         Referer: `https://www.bilibili.com/`,
             //         Cookie: cookie,
             //     },
             // });
-            const params = utils.addVerifyInfo(`mid=${uid}&token=&platform=web&web_location=1550101`, verifyString);
+            const params = utils.addWbiVerifyInfo(`mid=${uid}&token=&platform=web&web_location=1550101`, wbiVerifyString);
             const { data: nameResponse } = await got(`https://api.bilibili.com/x/space/wbi/acc/info?${params}`, {
                 headers: {
                     Referer: `https://space.bilibili.com/${uid}/`,

--- a/lib/v2/bilibili/hotSearch.js
+++ b/lib/v2/bilibili/hotSearch.js
@@ -3,8 +3,8 @@ const cache = require('./cache');
 const utils = require('./utils');
 
 module.exports = async (ctx) => {
-    const verifyString = await cache.getVerifyString(ctx);
-    const params = utils.addVerifyInfo('limit=10&platform=web', verifyString);
+    const wbiVerifyString = await cache.getWbiVerifyString(ctx);
+    const params = utils.addWbiVerifyInfo('limit=10&platform=web', wbiVerifyString);
     const url = `https://api.bilibili.com/x/web-interface/wbi/search/square?${params}`;
     const response = await got({
         method: 'get',

--- a/lib/v2/bilibili/liveSearch.js
+++ b/lib/v2/bilibili/liveSearch.js
@@ -17,9 +17,9 @@ module.exports = async (ctx) => {
             orderTitle = '人气直播';
             break;
     }
-    const verifyString = await cache.getVerifyString(ctx);
+    const wbiVerifyString = await cache.getWbiVerifyString(ctx);
     let params = `__refresh__=true&_extra=&context=&page=1&page_size=42&order=${order}&duration=&from_source=&from_spmid=333.337&platform=pc&highlight=1&single_column=0&keyword=${urlEncodedKey}&ad_resource=&source_tag=3&gaia_vtoken=&category_id=&search_type=live&dynamic_offset=0&web_location=1430654`;
-    params = utils.addVerifyInfo(params, verifyString);
+    params = utils.addWbiVerifyInfo(params, wbiVerifyString);
 
     const response = await got({
         method: 'get',

--- a/lib/v2/bilibili/router.js
+++ b/lib/v2/bilibili/router.js
@@ -32,6 +32,7 @@ module.exports = (router) => {
     router.get('/user/followers/:uid/:loginUid', require('./followers'));
     router.get('/user/followings/:uid/:loginUid', require('./followings'));
     router.get('/user/video/:uid/:disableEmbed?', require('./video'));
+    router.get('/user/video-all/:uid/:disableEmbed?', require('./video-all'));
     router.get('/video/danmaku/:bvid/:pid?', require('./danmaku'));
     router.get('/video/page/:bvid/:disableEmbed?', require('./page'));
     router.get('/video/reply/:bvid', require('./reply'));

--- a/lib/v2/bilibili/utils.js
+++ b/lib/v2/bilibili/utils.js
@@ -1,4 +1,3 @@
-const config = require('@/config').value;
 const md5 = require('@/utils/md5');
 const CryptoJS = require('crypto-js');
 
@@ -75,11 +74,30 @@ function addWbiVerifyInfo(params, wbiVerifyString) {
     return `${params}&w_rid=${w_rid}&wts=${wts}`;
 }
 
+// https://github.com/errcw/gaussian/blob/master/lib/box-muller.js
+function generateGaussianInteger(mean, std) {
+    const _2PI = Math.PI * 2;
+    const u1 = Math.random();
+    const u2 = Math.random();
+
+    const z0 = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(_2PI * u2);
+
+    return Math.round(z0 * std + mean);
+}
+
 function getDmImgList() {
-    if (typeof (config.bilibili.dmImgList) === 'undefined') {
-        return '[{"x":2721,"y":615,"z":0,"timestamp":29,"type":0}]';    // This is true data from browser
-    }
-    return config.bilibili.dmImgList;
+    const x = Math.max(generateGaussianInteger(720, 20), 0);
+    const y = Math.max(generateGaussianInteger(480, 20), 0);
+    const path = [
+        {
+            x: 3 * x + 2 * y,
+            y: 4 * x - 5 * y,
+            z: 0,
+            timestamp: Math.max(generateGaussianInteger(40, 5), 0),
+            type: 0,
+        },
+    ];
+    return JSON.stringify(path);
 }
 
 function addDmVerifyInfo(params, dmImgList) {

--- a/lib/v2/bilibili/utils.js
+++ b/lib/v2/bilibili/utils.js
@@ -1,3 +1,4 @@
+const config = require('@/config').value;
 const md5 = require('@/utils/md5');
 const CryptoJS = require('crypto-js');
 
@@ -65,13 +66,26 @@ function hexsign(e) {
     return o;
 }
 
-function addVerifyInfo(params, verifyString) {
+function addWbiVerifyInfo(params, wbiVerifyString) {
     const searchParams = new URLSearchParams(params);
     searchParams.sort();
     const verifyParam = searchParams.toString();
     const wts = Math.round(Date.now() / 1000);
-    const w_rid = md5(`${verifyParam}&wts=${wts}${verifyString}`);
+    const w_rid = md5(`${verifyParam}&wts=${wts}${wbiVerifyString}`);
     return `${params}&w_rid=${w_rid}&wts=${wts}`;
+}
+
+function getDmImgList() {
+    if (typeof (config.bilibili.dmImgList) === 'undefined') {
+        return '[{"x":2721,"y":615,"z":0,"timestamp":29,"type":0}]';    // This is true data from browser
+    }
+    return config.bilibili.dmImgList;
+}
+
+function addDmVerifyInfo(params, dm_img_list) {
+    const dm_img_str = Buffer.from('no webgl').toString('base64').slice(0, -2);
+    const dm_cover_img_str = Buffer.from('no webgl').toString('base64').slice(0, -2);
+    return `${params}&dm_img_list=${dm_img_list}&dm_img_str=${dm_img_str}&dm_cover_img_str=${dm_cover_img_str}`;
 }
 
 module.exports = {
@@ -79,6 +93,8 @@ module.exports = {
     lsid,
     _uuid,
     hexsign,
-    addVerifyInfo,
+    addWbiVerifyInfo,
+    getDmImgList,
+    addDmVerifyInfo,
     bvidTime: 1589990400,
 };

--- a/lib/v2/bilibili/utils.js
+++ b/lib/v2/bilibili/utils.js
@@ -82,10 +82,10 @@ function getDmImgList() {
     return config.bilibili.dmImgList;
 }
 
-function addDmVerifyInfo(params, dm_img_list) {
-    const dm_img_str = Buffer.from('no webgl').toString('base64').slice(0, -2);
-    const dm_cover_img_str = Buffer.from('no webgl').toString('base64').slice(0, -2);
-    return `${params}&dm_img_list=${dm_img_list}&dm_img_str=${dm_img_str}&dm_cover_img_str=${dm_cover_img_str}`;
+function addDmVerifyInfo(params, dmImgList) {
+    const dmImgStr = Buffer.from('no webgl').toString('base64').slice(0, -2);
+    const dmCoverImgStr = Buffer.from('no webgl').toString('base64').slice(0, -2);
+    return `${params}&dm_img_list=${dmImgList}&dm_img_str=${dmImgStr}&dm_cover_img_str=${dmCoverImgStr}`;
 }
 
 module.exports = {

--- a/lib/v2/bilibili/video-all.js
+++ b/lib/v2/bilibili/video-all.js
@@ -1,0 +1,75 @@
+const got = require('@/utils/got');
+const cache = require('./cache');
+const utils = require('./utils');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const uid = ctx.params.uid;
+    const disableEmbed = ctx.params.disableEmbed;
+    const cookie = await cache.getCookie(ctx);
+    const wbiVerifyString = await cache.getWbiVerifyString(ctx);
+    const dmImgList = utils.getDmImgList();
+    const [name, face] = await cache.getUsernameAndFaceFromUID(ctx, uid);
+
+    await got(`https://space.bilibili.com/${uid}/video?tid=0&page=1&keyword=&order=pubdate`, {
+        headers: {
+            Referer: `https://space.bilibili.com/${uid}/`,
+            Cookie: cookie,
+        },
+    });
+    const params = utils.addWbiVerifyInfo(utils.addDmVerifyInfo(`mid=${uid}&ps=30&tid=0&pn=1&keyword=&order=pubdate&platform=web&web_location=1550101&order_avoided=true`, dmImgList), wbiVerifyString);
+    const response = await got(`https://api.bilibili.com/x/space/wbi/arc/search?${params}`, {
+        headers: {
+            Referer: `https://space.bilibili.com/${uid}/video?tid=0&page=1&keyword=&order=pubdate`,
+            Cookie: cookie,
+        },
+    });
+
+    const vlist = [...response.data.data.list.vlist];
+    const pageTotal = Math.ceil(response.data.data.page.count / response.data.data.page.ps);
+
+    const getPage = async (pageId) => {
+        const cookie = await cache.getCookie(ctx);
+        await got(`https://space.bilibili.com/${uid}/video?tid=0&page=${pageId}&keyword=&order=pubdate`, {
+            headers: {
+                Referer: `https://space.bilibili.com/${uid}/`,
+                Cookie: cookie,
+            },
+        });
+        const params = utils.addWbiVerifyInfo(utils.addDmVerifyInfo(`mid=${uid}&ps=30&tid=0&pn=${pageId}&keyword=&order=pubdate&platform=web&web_location=1550101&order_avoided=true`, dmImgList), wbiVerifyString);
+        return got(`https://api.bilibili.com/x/space/wbi/arc/search?${params}`, {
+            headers: {
+                Referer: `https://space.bilibili.com/${uid}/video?tid=0&page=${pageId}&keyword=&order=pubdate`,
+                Cookie: cookie,
+            },
+        });
+    };
+
+    const promises = [];
+
+    if (pageTotal > 1) {
+        for (let i = 2; i <= pageTotal; i++) {
+            promises.push(getPage(i));
+        }
+        const rets = await Promise.all(promises);
+        rets.forEach((ret) => {
+            vlist.push(...ret.data.data.list.vlist);
+        });
+    }
+
+    ctx.state.data = {
+        title: name,
+        link: `https://space.bilibili.com/${uid}/video`,
+        description: `${name} 的 bilibili 所有视频`,
+        logo: face,
+        icon: face,
+        item: vlist.map((item) => ({
+            title: item.title,
+            description: `${item.description}${!disableEmbed ? `<br><br>${utils.iframe(item.aid)}` : ''}<br><img src="${item.pic}">`,
+            pubDate: parseDate(item.created, 'X'),
+            link: item.created > utils.bvidTime && item.bvid ? `https://www.bilibili.com/video/${item.bvid}` : `https://www.bilibili.com/video/av${item.aid}`,
+            author: name,
+            comments: item.comment,
+        })),
+    };
+};

--- a/lib/v2/bilibili/video.js
+++ b/lib/v2/bilibili/video.js
@@ -7,7 +7,8 @@ module.exports = async (ctx) => {
     const uid = ctx.params.uid;
     const disableEmbed = ctx.params.disableEmbed;
     const cookie = await cache.getCookie(ctx);
-    const verifyString = await cache.getVerifyString(ctx);
+    const wbiVerifyString = await cache.getWbiVerifyString(ctx);
+    const dmImgList = utils.getDmImgList();
     const [name, face] = await cache.getUsernameAndFaceFromUID(ctx, uid);
 
     // await got(`https://space.bilibili.com/${uid}/video?tid=0&page=1&keyword=&order=pubdate`, {
@@ -16,14 +17,7 @@ module.exports = async (ctx) => {
     //         Cookie: cookie,
     //     },
     // });
-    const params = utils.addVerifyInfo(
-        `mid=${uid}&ps=30&tid=0&pn=1&keyword=&order=pubdate&platform=web&web_location=1550101&order_avoided=true&dm_img_list=[]&dm_img_str=${Buffer.from('no webgl').toString('base64').slice(0, -2)}&dm_cover_img_str=${Buffer.from(
-            'no webgl'
-        )
-            .toString('base64')
-            .slice(0, -2)}`,
-        verifyString
-    );
+    const params = utils.addWbiVerifyInfo(utils.addDmVerifyInfo(`mid=${uid}&ps=30&tid=0&pn=1&keyword=&order=pubdate&platform=web&web_location=1550101&order_avoided=true`, dmImgList), wbiVerifyString);
     const response = await got(`https://api.bilibili.com/x/space/wbi/arc/search?${params}`, {
         headers: {
             Referer: `https://space.bilibili.com/${uid}/video?tid=0&page=1&keyword=&order=pubdate`,


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/bilibili/user/video/12590
/bilibili/user/video-all/12590
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
我在请求参数中添加了非空的 `dm_img_list` 字段

`/bilibili/user/video-all` 仍然可用，我重新添加了它

代码中 `'[{"x":2721,"y":615,"z":0,"timestamp":29,"type":0}]'` 是我从浏览器中获取的一串可能的数据

也可以通过 `BILIBILI_DM_IMG_LIST` 环境变量自行添加

尽管它可以工作，我仍然不清楚 `dm_img_list` 的含义

它也许和鼠标移动有关，因为当我不移动鼠标时其值为 `[]` (空列表)

我无法随机生成它来欺骗系统，Bilibili 也许引入了机器学习来分辨人类与机器