### PR TITLE
feat(route): id param for shmeea

### DIFF
--- a/lib/v2/shmeea/index.js
+++ b/lib/v2/shmeea/index.js
@@ -4,7 +4,7 @@ const timezone = require('@/utils/timezone');
 const { parseDate } = require('@/utils/parse-date');
 
 module.exports = async (ctx) => {
-    const id = ctx.params.id;
+    const id = ctx.params.id ?? '08000';
     const baseURL = 'https://www.shmeea.edu.cn';
     const link = `${baseURL}/page/${id}/index.html`;
 
@@ -27,7 +27,11 @@ module.exports = async (ctx) => {
     const items = await Promise.all(
         list.map((item) =>
             ctx.cache.tryGet(item.link, async () => {
-                const result = await got.get(item.link);
+                if (!item.link.endsWith('.html') || new URL(item.link).hostname !== new URL(baseURL).hostname) {
+                    return item;
+                }
+
+                const result = await got(item.link);
                 const $ = cheerio.load(result.data);
 
                 const description = $('#ivs_content').html();

--- a/lib/v2/shmeea/index.js
+++ b/lib/v2/shmeea/index.js
@@ -1,44 +1,49 @@
 const got = require('@/utils/got');
 const cheerio = require('cheerio');
+const timezone = require('@/utils/timezone');
+const { parseDate } = require('@/utils/parse-date');
 
 module.exports = async (ctx) => {
-    const baseURL = 'http://www.shmeea.edu.cn';
-    const rootUrl = baseURL + '/page/08000/index.html';
-    const response = await got({
-        method: 'get',
-        url: rootUrl,
-    });
+    const id = ctx.params.id;
+    const baseURL = 'https://www.shmeea.edu.cn';
+    const link = `${baseURL}/page/${id}/index.html`;
 
-    const data = response.data;
+    const response = await got(link);
+    const $ = cheerio.load(response.data);
 
-    const $ = cheerio.load(data);
+    const title = `上海市教育考试院-${$('#main .pageh4-tit').text().trim()}`;
 
-    const list = $('#main .pageList li');
+    const list = $('#main .pageList li')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            return {
+                title: item.find('a').attr('title') || item.find('a').text(),
+                link: new URL(item.find('a').attr('href'), baseURL).href,
+                pubDate: parseDate(item.find('.listTime').text().trim(), 'YYYY-MM-DD'),
+            };
+        });
 
     const items = await Promise.all(
-        list.map(async (i, item) => {
-            item = $(item);
-            const link = baseURL + item.find('a').attr('href');
-            const description = await ctx.cache.tryGet(link, async () => {
-                const result = await got.get(link);
-
+        list.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const result = await got.get(item.link);
                 const $ = cheerio.load(result.data);
 
-                return $('#ivs_content').html();
-            });
-            return {
-                title: item.find('a').text(),
-                pubDate: new Date(item.find('.listTime').text()),
-                link,
-                description,
-            };
-        })
+                const description = $('#ivs_content').html();
+                const pbTimeText = $('#ivs_title .PBtime').text().trim();
+
+                item.description = description;
+                item.pubDate = pbTimeText ? timezone(parseDate(pbTimeText, 'YYYY-MM-DD HH:mm:ss'), +8) : item.pubDate;
+
+                return item;
+            })
+        )
     );
 
     ctx.state.data = {
-        title: '上海市教育考试院',
-        description: '消息速递',
-        link: baseURL,
+        title,
+        link,
         item: items,
     };
 };

--- a/lib/v2/shmeea/maintainer.js
+++ b/lib/v2/shmeea/maintainer.js
@@ -1,4 +1,4 @@
 module.exports = {
-    '/:id': ['jialinghui', 'Misaka13514'],
+    '/:id?': ['jialinghui', 'Misaka13514'],
     '/self-study': ['h2ws'],
 };

--- a/lib/v2/shmeea/maintainer.js
+++ b/lib/v2/shmeea/maintainer.js
@@ -1,4 +1,4 @@
 module.exports = {
-    '/': ['jialinghui'],
+    '/:id': ['jialinghui', 'Misaka13514'],
     '/self-study': ['h2ws'],
 };

--- a/lib/v2/shmeea/radar.js
+++ b/lib/v2/shmeea/radar.js
@@ -5,10 +5,10 @@ module.exports = {
             {
                 title: '消息',
                 docs: 'https://docs.rsshub.app/routes/study#shang-hai-shi-jiao-yu-kao-shi-yuan',
-                source: ['/page/:id/index.html'],
+                source: ['/page/:id?/index.html'],
                 target: (params, url, document) => {
                     const li = document.querySelector('#main .pageList li');
-                    return li ? '/shmeea/:id' : '';
+                    return li ? '/shmeea/:id?' : '';
                 },
             },
             {

--- a/lib/v2/shmeea/radar.js
+++ b/lib/v2/shmeea/radar.js
@@ -13,7 +13,7 @@ module.exports = {
             },
             {
                 title: '自学考试通知公告',
-                docs: 'https://docs.rsshub.app/routes/other#shang-hai-shi-jiao-yu-kao-shi-yuan',
+                docs: 'https://docs.rsshub.app/routes/study#shang-hai-shi-jiao-yu-kao-shi-yuan',
                 source: ['/page/04000/index.html', '/'],
                 target: '/shmeea/self-study',
             },

--- a/lib/v2/shmeea/radar.js
+++ b/lib/v2/shmeea/radar.js
@@ -3,10 +3,13 @@ module.exports = {
         _name: '上海市教育考试院',
         www: [
             {
-                title: '消息速递',
-                docs: 'https://docs.rsshub.app/routes/other#shang-hai-shi-jiao-yu-kao-shi-yuan',
-                source: ['/'],
-                target: '/shmeea',
+                title: '消息',
+                docs: 'https://docs.rsshub.app/routes/study#shang-hai-shi-jiao-yu-kao-shi-yuan',
+                source: ['/page/:id/index.html'],
+                target: (params, url, document) => {
+                    const li = document.querySelector('#main .pageList li');
+                    return li ? '/shmeea/:id' : '';
+                },
             },
             {
                 title: '自学考试通知公告',

--- a/lib/v2/shmeea/router.js
+++ b/lib/v2/shmeea/router.js
@@ -1,4 +1,4 @@
 module.exports = function (router) {
-    router.get('/', require('./index'));
     router.get('/self-study', require('./self-study'));
+    router.get('/:id', require('./index'));
 };

--- a/lib/v2/shmeea/router.js
+++ b/lib/v2/shmeea/router.js
@@ -1,4 +1,4 @@
 module.exports = function (router) {
     router.get('/self-study', require('./self-study'));
-    router.get('/:id', require('./index'));
+    router.get('/:id?', require('./index'));
 };

--- a/website/docs/routes/study.mdx
+++ b/website/docs/routes/study.mdx
@@ -335,11 +335,19 @@
 
 ## 上海市教育考试院 {#shang-hai-shi-jiao-yu-kao-shi-yuan}
 
-### 消息速递 {#shang-hai-shi-jiao-yu-kao-shi-yuan-xiao-xi-su-di}
+官方网址：[https://www.shmeea.edu.cn](https://www.shmeea.edu.cn)
 
-官方网址：[http://www.shmeea.edu.cn](http://www.shmeea.edu.cn)
+### 消息 {#shang-hai-shi-jiao-yu-kao-shi-yuan-xiao-xi}
 
-<Route author="jialinghui" example="/shmeea" path="/shmeea" radar="1" />
+<Route author="jialinghui Misaka13514" example="/shmeea/08000" path="/shmeea/:id" radar="1" paramsDesc={['页面 ID，可在 URL 中找到']}>
+  :::tip
+  例如：消息速递的网址为 `https://www.shmeea.edu.cn/page/08000/index.html`，则页面 ID 为 `08000`。
+  :::
+
+  :::warning
+  暂不支持大类分类和[院内动态](https://www.shmeea.edu.cn/page/19000/index.html)
+  :::
+</Route>
 
 ### 自学考试通知公告 {#shang-hai-shi-jiao-yu-kao-shi-yuan-zi-xue-kao-shi-tong-zhi-gong-gao}
 

--- a/website/docs/routes/study.mdx
+++ b/website/docs/routes/study.mdx
@@ -339,7 +339,7 @@
 
 ### 消息 {#shang-hai-shi-jiao-yu-kao-shi-yuan-xiao-xi}
 
-<Route author="jialinghui Misaka13514" example="/shmeea/08000" path="/shmeea/:id" radar="1" paramsDesc={['页面 ID，可在 URL 中找到']}>
+<Route author="jialinghui Misaka13514" example="/shmeea/08000" path="/shmeea/:id?" radar="1" paramsDesc={['页面 ID，可在 URL 中找到，默认为消息速递']}>
   :::tip
   例如：消息速递的网址为 `https://www.shmeea.edu.cn/page/08000/index.html`，则页面 ID 为 `08000`。
   :::


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/shmeea/08000
/shmeea/09000
/shmeea/02200
/shmeea/03200
/shmeea/05100
/shmeea/04100
/shmeea/05400
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
- [x] Full text / 全文获取
  - [x] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

因[当前 shmeea 路由](https://rsshub.app/shmeea)不工作![](https://img.shields.io/website.svg?label=&url=https%3A%2F%2Frsshub.app%2Fshmeea&cacheSeconds=7200)，修复路由的同时为其添加 id 参数。

- 添加 id 参数，完成相应 Radar 规则
- 尝试获取精确发布时间，并校正时区
- 修复 L41 不精确的 `link: baseURL`

CC @jialinghui