### PR TITLE
fix: zhihu timeline

### DIFF
--- a/lib/v2/zhihu/timeline.js
+++ b/lib/v2/zhihu/timeline.js
@@ -53,13 +53,28 @@ module.exports = async (ctx) => {
         return actors.map((e) => e.name).join(', ');
     };
 
+    const getContent = (content) => {
+        if (!content || !Array.isArray(content)) {
+            return content;
+        }
+        // content can be a string or an array of objects
+        return (
+            content
+                .map((e) => e.content)
+                .filter((e) => e instanceof String && !!e)
+                // some content may not be wrapped in tag, it will cause error when parsing
+                .map((e) => `<div>${e}</div>`)
+                .join('')
+        );
+    };
+
     const buildItem = (e) => {
         if (!e || !e.target) {
             return {};
         }
         return {
             title: `${e.action_text_tpl.replace('{}', buildActors(e))}: ${getOne([e.target.title, e.target.question ? e.target.question.title : ''])}`,
-            description: utils.ProcessImage(`<div>${getOne([e.target.content, e.target.detail, e.target.excerpt, ''])}</div>`),
+            description: utils.ProcessImage(`<div>${getOne([getContent(e.target.content), e.target.detail, e.target.excerpt, ''])}</div>`),
             pubDate: parseDate(e.updated_time * 1000),
             link: buildLink(e),
             author: e.target.author ? e.target.author.name : '',

--- a/lib/v2/zhihu/timeline.js
+++ b/lib/v2/zhihu/timeline.js
@@ -74,7 +74,7 @@ module.exports = async (ctx) => {
         }
         return {
             title: `${e.action_text_tpl.replace('{}', buildActors(e))}: ${getOne([e.target.title, e.target.question ? e.target.question.title : ''])}`,
-            description: utils.ProcessImage(`<div>${getOne([getContent(e.target.content), e.target.detail, e.target.excerpt, ''])}</div>`),
+            description: utils.ProcessImage(`<div>${getOne([e.target.content_html, getContent(e.target.content), e.target.detail, e.target.excerpt, ''])}</div>`),
             pubDate: parseDate(e.updated_time * 1000),
             link: buildLink(e),
             author: e.target.author ? e.target.author.name : '',

--- a/lib/v2/zhihu/timeline.js
+++ b/lib/v2/zhihu/timeline.js
@@ -59,7 +59,7 @@ module.exports = async (ctx) => {
         }
         return {
             title: `${e.action_text_tpl.replace('{}', buildActors(e))}: ${getOne([e.target.title, e.target.question ? e.target.question.title : ''])}`,
-            description: utils.ProcessImage(getOne([e.target.content, e.target.detail, e.target.excerpt, ''])),
+            description: utils.ProcessImage(`<div>${getOne([e.target.content, e.target.detail, e.target.excerpt, ''])}</div>`),
             pubDate: parseDate(e.updated_time * 1000),
             link: buildLink(e),
             author: e.target.author ? e.target.author.name : '',


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/zhihu/timeline
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This PR fix the following error:

```
Route requested: /zhihu/timeline
Error message: Cannot read properties of undefined (reading 'substring')
Helpful Information to provide when opening issue:
Path: /zhihu/timeline
Node version: v20.10.0
Git Hash: 3bf9dd2
```

Caused by modules taking following html (as example) as text node:

```html
some text <span>123</span> some text
```

It also:
- deal with `content` inside an array
- adopts `content_html` if exists.

Looks good to me.
