### PR TITLE
fix(route): 处理大麦网查询结果为空的情况

### DIFF
--- a/lib/routes/damai/activity.js
+++ b/lib/routes/damai/activity.js
@@ -12,7 +12,7 @@ module.exports = async (ctx) => {
 
     const response = await got.get(url);
     const data = response.data;
-    const list = data.pageData.resultData;
+    const list = data.pageData.resultData || [];
 
     ctx.state.data = {
         title: `大麦网票务 - ${city ? city : '全国'} - ${category ? category : '全部分类'}${subcategory ? ' - ' + subcategory : ''}${keyword ? ' - ' + keyword : ''}`,


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #14201

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/damai/activity/:city/:category/:subcategory/:keyword?
```

## Note / 说明

简单修复，加了个短路运算符。