### PR TITLE
docs: change html example to use items variable instead of item

### DIFF
--- a/website/docs/joinus/new-rss/start-code.md
+++ b/website/docs/joinus/new-rss/start-code.md
@@ -320,7 +320,7 @@ Next, we'll use Cheerio selectors to select the relevant HTML elements, parse th
     // We use a Cheerio selector to select all 'div' elements with the class name 'js-navigation-container'
     // that contain child elements with the class name 'flex-auto'.
     // highlight-start
-    const item = $('div.js-navigation-container .flex-auto')
+    const items = $('div.js-navigation-container .flex-auto')
         // We use the `toArray()` method to retrieve all the DOM elements selected as an array.
         .toArray()
         // We use the `map()` method to traverse the array and parse the data we need from each element.
@@ -366,7 +366,7 @@ module.exports = async (ctx) => {
     const { data: response } = await got(`${baseUrl}/${user}/${repo}/issues`);
     const $ = cheerio.load(response);
 
-    const item = $('div.js-navigation-container .flex-auto')
+    const items = $('div.js-navigation-container .flex-auto')
         .toArray()
         .map((item) => {
             item = $(item);

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/joinus/new-rss/start-code.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/joinus/new-rss/start-code.md
@@ -317,7 +317,7 @@ module.exports = async (ctx) => {
     // 我们使用 Cheerio 选择器选择所有带类名“js-navigation-container”的“div”元素，
     // 其中包含带类名“flex-auto”的子元素。
     // highlight-start
-    const item = $('div.js-navigation-container .flex-auto')
+    const items = $('div.js-navigation-container .flex-auto')
         // 使用“toArray()”方法将选择的所有 DOM 元素以数组的形式返回。
         .toArray()
         // 使用“map()”方法遍历数组，并从每个元素中解析需要的数据。
@@ -363,7 +363,7 @@ module.exports = async (ctx) => {
     const { data: response } = await got(`${baseUrl}/${user}/${repo}/issues`);
     const $ = cheerio.load(response);
 
-    const item = $('div.js-navigation-container .flex-auto')
+    const items = $('div.js-navigation-container .flex-auto')
         .toArray()
         .map((item) => {
             item = $(item);


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
The existing example for HTML retrieval documentation uses 'item' variable to store array of the retrieved articles, but the final rss output refers to the 'items' variable. This results in undefined variable 'items' for anyone who directly uses the example code.