### PR TITLE
fix: PornHub pubDate

### DIFF
--- a/lib/v2/pornhub/utils.js
+++ b/lib/v2/pornhub/utils.js
@@ -1,6 +1,7 @@
 const { art } = require('@/utils/render');
 const { join } = require('path');
 const { parseRelativeDate } = require('@/utils/parse-date');
+const dayjs = require('dayjs');
 
 const defaultDomain = 'https://www.pornhub.com';
 
@@ -10,6 +11,10 @@ const headers = {
 };
 
 const renderDescription = (data) => art(join(__dirname, 'templates/description.art'), data);
+const extractDateFromImageUrl = (imageUrl) => {
+    const matchResult = imageUrl.match(/(\d{6})\/(\d{2})/);
+    return matchResult ? matchResult.slice(1, 3).join('') : null;
+};
 
 const parseItems = (e) => ({
     title: e.find('span.title a').text().trim(),
@@ -19,7 +24,7 @@ const parseItems = (e) => ({
         previewVideo: e.find('img').data('mediabook'),
     }),
     author: e.find('.usernameWrap a').text(),
-    pubDate: parseRelativeDate(e.find('.added').text()),
+    pubDate: dayjs(extractDateFromImageUrl(e.find('img').data('mediumthumb'))) || parseRelativeDate(e.find('.added').text()),
 });
 
 module.exports = {


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/pornhub/users/pornhubmodels
/pornhub/model/stacy-starando
/pornhub/pornstar/june-liu
/pornhub/category_url/video%3Fc%3D15%26o%3Dmv%26t%3Dw%26cc%3Djp
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

PornHub 时间解析出错，替换为封面图片 URL 中携带的时间参数

更改前
![image](https://github.com/DIYgod/RSSHub/assets/41602338/2dff0630-1b90-4138-8695-4244362feea3)

更改后
![image](https://github.com/DIYgod/RSSHub/assets/41602338/c0100b93-8aa4-4aeb-b667-d48d2431010f)

