### PR TITLE
fix(route/twitter): readability and RT link

### DIFF
--- a/lib/v2/twitter/utils.js
+++ b/lib/v2/twitter/utils.js
@@ -31,9 +31,11 @@ const replaceBreak = (text) => text.replaceAll(/<br><br>|<br>/g, ' ');
 
 const formatText = (item) => {
     let text = item.full_text;
+    const id_str = item.id_str || item.conversation_id_str;
     const urls = item.entities.urls || [];
     for (const url of urls) {
-        text = text.replaceAll(url.url, url.expanded_url);
+        // trim link pointing to the tweet itself (usually appears when the tweet is truncated)
+        text = text.replaceAll(url.url, url.expanded_url.endsWith(id_str) ? '' : url.expanded_url);
     }
     const media = item.extended_entities?.media || [];
     for (const m of media) {
@@ -361,20 +363,27 @@ const ProcessFeed = (ctx, { data = [] }, params = {}) => {
         description += quote;
 
         if (readable) {
-            description += `<br clear='both' /><div style='clear: both'></div><hr>`;
+            description += `<br clear='both' /><div style='clear: both'></div>`;
         }
 
         if (showTimestampInDescription) {
+            if (readable) {
+                description += `<hr>`;
+            }
             description += `<small>${parseDate(item.created_at)}</small>`;
         }
 
         const authorName = originalItem.user.name;
+        const link =
+            originalItem.user.screen_name && (originalItem.id_str || originalItem.conversation_id_str)
+                ? `https://twitter.com/${originalItem.user.screen_name}/status/${originalItem.id_str || originalItem.conversation_id_str}`
+                : `https://twitter.com/${item.user.screen_name}/status/${item.id_str || item.conversation_id_str}`;
         return {
             title,
             author: authorName,
             description,
             pubDate: parseDate(item.created_at),
-            link: `https://twitter.com/${item.user.screen_name}/status/${item.id_str || item.conversation_id_str}`,
+            link,
 
             _extra:
                 (isRetweet && {


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/twitter/user/aboutrss/readable=1&authorNameBold=1&showAuthorInTitle=1&showEmojiForRetweetAndReply=1&showRetweetTextInTitle=0&addLinkForPics=1&showQuotedInTitle=1?filter_title=🔁
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
1. Trim link pointing to the tweet itself (usually appears when the tweet is truncated).
2. Only insert `<hr>` when both `showTimestampInDescription` and `readable` are enabled.
3. Make RT links point to the RT itself, instead of the original tweet.