### PR TITLE
fix(route/twitter): reply URL; threads when excludeReplies=1

### DIFF
--- a/lib/v2/twitter/web-api/twitter-api.js
+++ b/lib/v2/twitter/web-api/twitter-api.js
@@ -151,6 +151,7 @@ function gatherLegacyFromData(entries, filterNested, userId) {
                         continue;
                     }
                     t.legacy.user = t.core?.user_result?.result?.legacy || t.core?.user_results?.result?.legacy;
+                    t.legacy.id_str = t.rest_id; // avoid falling back to conversation_id_str elsewhere
                     const quote = t.quoted_status_result?.result;
                     if (quote) {
                         t.legacy.quoted_status = quote.legacy;
@@ -257,7 +258,11 @@ const getUserTweets = async (cache, id, params = {}) => {
     }
     const idSet = new Set();
     tweets = tweets
-        .filter((tweet) => !tweet.in_reply_to_screen_name) // exclude replies
+        .filter(
+            (tweet) =>
+                !tweet.in_reply_to_user_id_str || // exclude replies
+                tweet.in_reply_to_user_id_str === rest_id // but include replies to self (threads)
+        )
         .map((tweet) => {
             const id_str = tweet.id_str || tweet.conversation_id_str;
             return !idSet.has(id_str) && idSet.add(id_str) && tweet;


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/twitter/user/jia0kelvin/excludeReplies=1
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Without `legacy.id_str`, reply URLs would be constructed with conversion IDs, resulting in:
- wrong URLs: pointing to the first tweet in the conversion (thread)
- multiple items with the same guid: each tweet in a conversion (thread) had the same URL and thus guid

The bug was caused by the widely used temporary fix (legacy.id_str || legacy.conversation_id_str) after Twitter had upgraded their API. Thus, it is quite easy to fix it:
Refill legacy.id_str using the rest_id that resides in the container of legacy.

With it fixed, take a step further to include threads when excludeReplies=1 (simulating the behavior of Twitter Web/App).