### PR TITLE
fix: 微博内容中[查看图片]的链接支持被HOTLINK_TEMPLATE替换

### DIFF
--- a/lib/middleware/anti-hotlink.js
+++ b/lib/middleware/anti-hotlink.js
@@ -70,6 +70,7 @@ const process = (html, image_hotlink_template, multimedia_hotlink_template, wrap
     if (image_hotlink_template) {
         replaceUrls($, 'img, picture > source', image_hotlink_template);
         replaceUrls($, 'video[poster]', image_hotlink_template, 'poster');
+        replaceUrls($, '*[data-rsshub-image="href"]', image_hotlink_template, 'href');
     }
     if (multimedia_hotlink_template) {
         replaceUrls($, 'video, video > source, audio, audio > source', multimedia_hotlink_template);

--- a/lib/v2/weibo/utils.js
+++ b/lib/v2/weibo/utils.js
@@ -82,7 +82,10 @@ const weiboUtils = {
         htmlNewLineUnreplaced = htmlNewLineUnreplaced.replaceAll(/<a href="(.*?)">全文<\/a>/g, '');
 
         // 处理外部链接
-        htmlNewLineUnreplaced = htmlNewLineUnreplaced.replaceAll(/https:\/\/weibo\.cn\/sinaurl\/.*?&u=(http.*?")/g, (match, p1) => decodeURIComponent(p1));
+        htmlNewLineUnreplaced = htmlNewLineUnreplaced.replaceAll(/"https:\/\/weibo\.cn\/sinaurl.*?[&?]u=(http.*?)"/g, (match, p1) => `"${decodeURIComponent(p1)}"`);
+
+        // 处理图片的链接
+        htmlNewLineUnreplaced = htmlNewLineUnreplaced.replaceAll(/<a\s+href="https?:\/\/.+\.(jpg|png|gif)"/g, (match) => `${match} data-rsshub-image="href"`);
 
         let html = htmlNewLineUnreplaced.replaceAll('\n', '<br>');
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #12314 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/weibo/user/1401527553
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

### 外部链接

例子如下，之前只能匹配最后一个，目前微博大部分是第一个

```
"https://weibo.cn/sinaurl?u=http://xx"
"https://weibo.cn/sinaurl/?u=http://xx"
"https://weibo.cn/sinaurl?q=xx&u=http://xx"
"https://weibo.cn/sinaurl/?q=xx&u=http://xx"
```

### 图片链接替换

内容中会出现`a`链接的`查看图片`，这里面的链接希望被替换，以绕过防盗链

```html
<a href="https://tvax4.sinaimg.cn/large/53899d01gy1hmckcfvlh1j20soc4je82.jpg" data-hide=""><span class="url-icon"><img style="width: 1rem;height: 1rem" src="https://api.xlab.app/img-proxy/?url=https%3A%2F%2Fh5.sinaimg.cn%2Fupload%2F2015%2F01%2F21%2F20%2Ftimeline_card_small_photo_default.png" referrerpolicy="no-referrer"></span><span class="surl-text">查看图片</span></a>
```

> 原始href是如上的外部链接，被替换后得到真实图片链接

单独在微博处理时给`a`标签加属性，以便在hotlink替换时处理