### PR TITLE
Feature: add new route honghq/blog-posts

### DIFF
--- a/lib/v2/konghq/blog-posts.js
+++ b/lib/v2/konghq/blog-posts.js
@@ -1,0 +1,64 @@
+// Get the lastest blog posts of https://konghq.com/
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+
+const BASE_URL = 'https://konghq.com';
+const BLOG_POSTS_URL = `${BASE_URL}/blog`;
+
+module.exports = async (ctx) => {
+    // Always get the posts on the first page.
+    const url = `${BLOG_POSTS_URL}/page/1`;
+
+    const { data: response } = await got(url);
+    const $ = cheerio.load(response);
+    // Request and parse the index page to get the posts
+    const posts = $('div[class^="card-styles_inner"]')
+        .toArray()
+        .map((_item) => {
+            const item = $(_item);
+
+            const titleElem = item.find('a:has(h1)').first();
+            const title = titleElem.find('h1').text();
+            const author = item.find('div[class^="Author_name"]').text();
+            const category = item.find('div[class^="Eyebrow_eyebrow"]>a').text();
+
+            let link = titleElem.attr('href');
+            // The link value is a related path, concat it with the base url
+            link = `${BASE_URL}${link}`;
+
+            const pubDateText = item.find('div[class^="Eyebrow_eyebrow"]>div').text();
+            const pubDate = parseDate(pubDateText);
+            return {
+                title,
+                link,
+                pubDate,
+                author,
+                category,
+            };
+        });
+
+    // Request each post to get the details content as "description"
+    const items = await Promise.all(
+        posts.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const { data: response } = await got(item.link);
+                const $ = cheerio.load(response);
+
+                // Update the description to post's main content
+                let content = $('div[class*="RichTextBlock_content"]').first().html();
+                if (!content) {
+                    content = $('section[class^="blog_sections"]').first().html();
+                }
+                item.description = content;
+                return item;
+            })
+        )
+    );
+
+    ctx.state.data = {
+        title: `Kong Inc(konghq.com) blog posts`,
+        link: BLOG_POSTS_URL,
+        item: items,
+    };
+};

--- a/lib/v2/konghq/blog-posts.js
+++ b/lib/v2/konghq/blog-posts.js
@@ -10,9 +10,9 @@ module.exports = async (ctx) => {
     // Always get the posts on the first page.
     const url = `${BLOG_POSTS_URL}/page/1`;
 
+    // Request and parse the index page to get the posts
     const { data: response } = await got(url);
     const $ = cheerio.load(response);
-    // Request and parse the index page to get the posts
     const posts = $('div[class^="card-styles_inner"]')
         .toArray()
         .map((_item) => {

--- a/lib/v2/konghq/maintainer.js
+++ b/lib/v2/konghq/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/blog-posts': ['piglei'],
+};

--- a/lib/v2/konghq/router.js
+++ b/lib/v2/konghq/router.js
@@ -1,0 +1,3 @@
+module.exports = (router) => {
+    router.get('/blog-posts', require('./blog-posts'));
+};

--- a/website/docs/routes/programming.mdx
+++ b/website/docs/routes/programming.mdx
@@ -502,6 +502,14 @@ Subscribe to the updates (threads and submission) from a paritcular Hacker News 
 
 <Route author="running-grass" radar="1" example="/issuehunt/funded/DIYgod/RSSHub" path="/issuehunt/funded/:username/:repo" paramsDesc={['Github user/org','Repository name']} />
 
+## Kong API 网关平台 {#kong-api-wang-guan-ping-tai}
+
+[Kong](https://konghq.com/) 是一家开源的 API 网关服务商，此处收集其官网的最新博客文章。
+
+### 博客最新文章 {#kong-api-wang-guan-ping-tai-bo-ke-zui-xin-wen-zhang}
+
+<Route author="piglei" example="/konghq/blog-posts" path="/konghq/blog-posts" />
+
 ## LeetCode {#leetcode}
 
 ### Articles {#leetcode-articles}


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```route
/konghq/blog-posts
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
- [x] Full text / 全文获取
  - [x] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Kong is an open source API gateway provider, this PR adds a route that collects the latest blog posts on [the official website](https://konghq.com/blog/page/1), the posts include product news and API gateway related technical articles. 