### PR TITLE
feat: add PwC Strategy& Sustainability route

### DIFF
--- a/lib/v2/pwc/maintainer.js
+++ b/lib/v2/pwc/maintainer.js
@@ -1,3 +1,3 @@
 module.exports = {
-    '/pwc/strategyand/sustainability': ['mintyfrankie'],
+    '/strategyand/sustainability': ['mintyfrankie'],
 };

--- a/lib/v2/pwc/maintainer.js
+++ b/lib/v2/pwc/maintainer.js
@@ -1,0 +1,3 @@
+module.exports = {
+    '/pwc/strategyand/sustainability': ['mintyfrankie'],
+};

--- a/lib/v2/pwc/radar.js
+++ b/lib/v2/pwc/radar.js
@@ -1,0 +1,11 @@
+module.exports = {
+    'pwc.com': {
+        _name: 'PwC',
+        strategyand: [
+            {
+                title: 'PwC Strategy& - Sustainability',
+                docs: 'https://docs.rsshub.app/routes/other#pwc-strategyand',
+            },
+        ],
+    },
+};

--- a/lib/v2/pwc/radar.js
+++ b/lib/v2/pwc/radar.js
@@ -1,10 +1,12 @@
 module.exports = {
     'pwc.com': {
-        _name: 'PwC',
+        _name: 'PwC Strategy&',
         strategyand: [
             {
-                title: 'PwC Strategy& - Sustainability',
-                docs: 'https://docs.rsshub.app/routes/other#pwc-strategyand',
+                title: 'Sustainability',
+                docs: 'https://docs.rsshub.app/routes/other#pwc-strategy',
+                source: ['/at/en/functions/sustainability-strategy/publications.html', '/'],
+                target: '/pwc/strategyand/sustainability',
             },
         ],
     },

--- a/lib/v2/pwc/router.js
+++ b/lib/v2/pwc/router.js
@@ -1,0 +1,3 @@
+module.exports = (router) => {
+    router.get('/strategyand/sustainability', require('./sustainability'));
+};

--- a/lib/v2/pwc/sustainability.js
+++ b/lib/v2/pwc/sustainability.js
@@ -10,8 +10,12 @@ module.exports = async (ctx) => {
     const browser = await require('@/utils/puppeteer')();
     const page = await browser.newPage();
     logger.http(`Requesting ${baseUrl}`);
+    await page.setRequestInterception(true);
+    page.on('request', (request) => {
+        request.resourceType() === 'document' || request.resourceType() === 'script' ? request.continue() : request.abort();
+    });
     await page.goto(baseUrl, {
-        waitUntil: 'networkidle0',
+        waitUntil: 'domcontentloaded',
     });
     const response = await page.content();
     page.close();

--- a/lib/v2/pwc/sustainability.js
+++ b/lib/v2/pwc/sustainability.js
@@ -1,0 +1,51 @@
+const got = require('@/utils/got');
+const cheerio = require('cheerio');
+const { parseDate } = require('@/utils/parse-date');
+
+module.exports = async (ctx) => {
+    const baseUrl = 'https://www.strategyand.pwc.com/at/en/functions/sustainability-strategy/publications.html';
+
+    const { data: response } = await got.get(baseUrl);
+    const $ = cheerio.load(response);
+
+    const list = $('article')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const a = item.find('a').first();
+            const div = item.find('div.collection-item__content').first();
+
+            const link = a.attr('href');
+            const title = div.find('h4').find('span').text();
+            const description = div.find('p').text();
+
+            return {
+                title,
+                link,
+                description,
+            };
+        });
+
+    const items = await Promise.all(
+        list.map((item) =>
+            ctx.cache.tryGet(item.link, async () => {
+                const { data } = await got.get(item.link);
+                const $ = cheerio.load(data);
+
+                const pubDate = parseDate($('div.hero-card__secondary').find('li').second().text());
+                const author = $('div.summary-text').find('p').first().text();
+
+                item.pubDate = pubDate;
+                item.author = author;
+
+                return item;
+            })
+        )
+    );
+
+    ctx.state.data = {
+        title: 'PwC Strategy& - Sustainability Publications',
+        link: baseUrl,
+        item: items,
+    };
+};

--- a/lib/v2/pwc/sustainability.js
+++ b/lib/v2/pwc/sustainability.js
@@ -1,51 +1,54 @@
-const got = require('@/utils/got');
 const cheerio = require('cheerio');
+const logger = require('@/utils/logger');
 const { parseDate } = require('@/utils/parse-date');
 
 module.exports = async (ctx) => {
     const baseUrl = 'https://www.strategyand.pwc.com/at/en/functions/sustainability-strategy/publications.html';
+    const feedLang = 'en';
+    const feedDescription = 'Sustainability Publications from PwC Strategy&';
 
-    const { data: response } = await got.get(baseUrl);
+    const browser = await require('@/utils/puppeteer')();
+    const page = await browser.newPage();
+    logger.http(`Requesting ${baseUrl}`);
+    await page.goto(baseUrl, {
+        waitUntil: 'networkidle0',
+    });
+    const response = await page.content();
+    page.close();
+
     const $ = cheerio.load(response);
 
-    const list = $('article')
+    const list = $('div#wrapper article')
         .toArray()
         .map((item) => {
             item = $(item);
             const a = item.find('a').first();
-            const div = item.find('div.collection-item__content').first();
+            const div = item.find('div.collection__item-content').first();
 
             const link = a.attr('href');
             const title = div.find('h4').find('span').text();
-            const description = div.find('p').text();
+            const pubDate = parseDate(div.find('time').attr('datetime'), 'DD/MM/YY');
+            const description = div.find('p.paragraph').text();
 
             return {
                 title,
                 link,
+                pubDate,
                 description,
             };
         });
 
-    const items = await Promise.all(
-        list.map((item) =>
-            ctx.cache.tryGet(item.link, async () => {
-                const { data } = await got.get(item.link);
-                const $ = cheerio.load(data);
+    const items = list;
 
-                const pubDate = parseDate($('div.hero-card__secondary').find('li').second().text());
-                const author = $('div.summary-text').find('p').first().text();
+    // TODO: Add full text support
 
-                item.pubDate = pubDate;
-                item.author = author;
-
-                return item;
-            })
-        )
-    );
+    browser.close();
 
     ctx.state.data = {
         title: 'PwC Strategy& - Sustainability Publications',
         link: baseUrl,
+        language: feedLang,
+        description: feedDescription,
         item: items,
     };
 };

--- a/website/docs/routes/other.mdx
+++ b/website/docs/routes/other.mdx
@@ -424,6 +424,12 @@ It is recommended to use with clipping tools such as Notion Web Clipper.
 
 <Route author="miaoyafeng Fatpandac" example="/producthunt/today" path="/producthunt/today" />
 
+## PwC Strategy& {#pwc-strategy}
+
+### Sustainability {#pwc-strategy-sustainability}
+
+<Route author="mintyfrankie" example="/pwc/strategyand/sustainability" path="/pwc/strategyand/sustainability" puppeteer="1" />
+
 ## Remote.work {#remote-work}
 
 ### Remote.work Job Information {#remote-work-remote-work-job-information}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

add PwC Strategy& Sustainability route

## Example for the Proposed Route(s) / 路由地址示例
```routes
/pwc/strategyand/sustainability
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [X] New Route / 新的路由
  - [X] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [X] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [X] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [X] Parsed / 可以解析
  - [X] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [X] `Puppeteer`

## Note / 说明
PwC Strategy& Sustainability is a blog on the thought leadership about subjects like sustainability or ESG.


