### PR TITLE
fix: 豆瓣榜单与集合支持分页处理

### DIFF
--- a/lib/v2/douban/other/list.js
+++ b/lib/v2/douban/other/list.js
@@ -8,40 +8,54 @@ module.exports = async (ctx) => {
     const routeParams = Object.fromEntries(new URLSearchParams(ctx.params.routeParams));
     const playable = fallback(undefined, queryToInteger(routeParams.playable), 0);
     const score = fallback(undefined, queryToInteger(routeParams.score), 0);
-    const url = `https://m.douban.com/rexxar/api/v2/subject_collection/${type}/items?playable=${playable}`;
-    const response = await got({
-        method: 'get',
-        url,
-        headers: {
-            Referer: `https://m.douban.com/subject_collection/${type}`,
-        },
-    });
-    const description = response.data.subject_collection.description;
-    const items = response.data.subject_collection_items
-        .filter((item) => {
-            const rate = item.rating ? item.rating.value : 0;
-            return rate >= score; // 保留rate大于等于score的项and过滤无评分项
-        })
-        .map((item) => {
-            const title = item.title;
-            const link = item.url;
-            const description = art(path.join(__dirname, '../templates/list_description.art'), {
-                ranking_value: item.ranking_value,
-                title,
-                original_title: item.original_title,
-                rate: item.rating ? item.rating.value : null,
-                card_subtitle: item.card_subtitle,
-                description: item.cards ? item.cards[0].content : item.abstract,
-                cover: item.cover_url || item.cover?.url,
-            });
-            return {
-                title,
-                link,
-                description,
-            };
+    let start = 0;
+    const count = 50;
+    let items = [];
+    let title = '';
+    let description = '';
+    let total = null;
+    while (total === null || start < total) {
+        const url = `https://m.douban.com/rexxar/api/v2/subject_collection/${type}/items?playable=${playable}&start=${start}&count=${count}`;
+        // eslint-disable-next-line no-await-in-loop
+        const response = await got({
+            method: 'get',
+            url,
+            headers: {
+                Referer: `https://m.douban.com/subject_collection/${type}`,
+            },
         });
+        title = response.data.subject_collection.name;
+        description = response.data.subject_collection.description;
+        total = response.data.total;
+        const newItems = response.data.subject_collection_items
+            .filter((item) => {
+                const rate = item.rating ? item.rating.value : 0;
+                return rate >= score; // 保留rate大于等于score的项and过滤无评分项
+            })
+            .map((item) => {
+                const title = item.title;
+                const link = item.url;
+                const description = art(path.join(__dirname, '../templates/list_description.art'), {
+                    ranking_value: item.ranking_value,
+                    title,
+                    original_title: item.original_title,
+                    rate: item.rating ? item.rating.value : null,
+                    card_subtitle: item.card_subtitle,
+                    description: item.cards ? item.cards[0].content : item.abstract,
+                    cover: item.cover_url || item.cover?.url,
+                });
+                return {
+                    title,
+                    link,
+                    description,
+                };
+            });
+        items = [...items, ...newItems];
+        start += count;
+    }
+
     ctx.state.data = {
-        title: `豆瓣 - ${response.data.subject_collection.name}`,
+        title: `豆瓣 - ${title}`,
         link: `https://m.douban.com/subject_collection/${type}`,
         item: items,
         description,


### PR DESCRIPTION
在此之前，豆瓣电影Top250只能返回部分电影。修改后可以返回全部250部电影。

测试路由：`/douban/list/movie_top250`。

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/douban/list/movie_top250
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
