### PR TITLE
fix: encode tag name in lofter request's form

### DIFF
--- a/lib/v2/lofter/tag.js
+++ b/lib/v2/lofter/tag.js
@@ -23,7 +23,7 @@ module.exports = async (ctx) => {
             'c0-scriptName': 'TagBean',
             'c0-methodName': 'search',
             'c0-id': '0',
-            'c0-param0': `string:${name}`,
+            'c0-param0': `string:${encodeURI(name)}`,
             'c0-param1': 'number:0',
             'c0-param2': 'string:',
             'c0-param3': `string:${type}`,


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/lofter/tag/i
/lofter/tag/i/new
/lofter/tag/边狱巴士
/lofter/tag/边狱巴士/new
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

The name must be encoded in request's form, otherwise Chinese characters won't be recognized.