### PR TITLE
fix: Update metacritic API root URL

### DIFF
--- a/lib/v2/metacritic/index.js
+++ b/lib/v2/metacritic/index.js
@@ -11,7 +11,7 @@ module.exports = async (ctx) => {
     const limit = ctx.query.limit ? Number.parseInt(ctx.query.limit, 10) : 50;
 
     const rootUrl = 'https://www.metacritic.com';
-    const rootApiUrl = 'https://fandom-prod.apigee.net';
+    const rootApiUrl = 'https://internal-prod.apigee.fandom.net';
     const apiUrl = new URL('v1/xapi/finder/metacritic/web', rootApiUrl).href;
 
     const currentUrlObject = new URL(`/browse/${type}/all/all/all-time/${sort}/${filter ? `?${filter}` : ''}`, rootUrl);


### PR DESCRIPTION
This updates the metacritic.com API endpoint to the new URL.
See #14474 for details.

Fixes #14474 


