### PR TITLE
feat(route): add 吉首大学相关通知公告

### DIFF
--- a/website/docs/routes/university.mdx
+++ b/website/docs/routes/university.mdx
@@ -3651,3 +3651,33 @@ jsjxy.hbut.edu.cn 证书链不全，自建 RSSHub 可设置环境变量 NODE\_TL
   | -------- | -------- | -------- | -------- |
   | results  | papers   | writings | policy   |
 </Route>
+
+## 吉首大学 {#ji-shou-da-xue}
+
+### 吉首大学 - 通知公告 {#ji-shou-da-xue-tong-zhi-gong-gao}
+
+<Route author="wenjia03" example="/jsu/notice" path="/jsu/notice"/>
+
+### 吉首大学计算机科学与工程学院 - 通知公告 {#ji-shou-da-xue-ji-suan-ji-ke-xue-yu-gong-cheng-xue-yuan}
+
+<Route author="wenjia03" example="/jsu/rjxy" path="/jsu/rjxy"/>
+
+### 教务处 {#ji-shou-da-xue-jiao-wu-chu}
+
+<Route author="wenjia03" example="/jsu/jwc/jwdt" path="/jsu/jwc/:types?" paramsDesc={['通知分类 默认为`jwtz`']}>
+    | 教务通知 | 教务动态 |
+    | ---- | ---- |
+    | jwtz | jwdt |
+</Route>
+
+### 数学与统计学院 - 通知公告{#ji-shou-da-xue-shu-xue-yu-tong-ji-xue-yuan}
+
+<Route author="wenjia03" example="/jsu/stxy" path="/jsu/stxy"/>
+
+### 创新中心 {#ji-shou-da-xue-chuang-xin-zhong-xin}
+
+<Route author="wenjia03" example="/cxzx/xkjs" path="/cxzx/:types?" paramsDesc={['通知分类 默认为`xkjs`']}>
+    | 通知公告 | 学科竞赛公告 | 创新项目公告 | 竞赛新闻 | 竞赛通知 |
+    | ------ | ----------- | ---------- | ------ | ------- |
+    | tzgg | xkjs | cxtz | jsxw | jstz |
+</Route>


### PR DESCRIPTION
* feat(route): add 吉首大学计算机科学与工程学院、吉首大学数统学院、吉首大学主站、创新中心通知公告、教务处教务动态、教务通知


## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/jsu/rjxy
/jsu/stxy
/jsu/notice
/jsu/jwc
/jsu/jwc/jwdt
/jsu/jwc/jwtz
/jsu/cxzx
/jsu/cxzx/tzgg
/jsu/cxzx/xkjs
/jsu/cxzx/cxtz
/jsu/cxzx/jsxw
/jsu/cxzx/jstz
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [v2 Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [v2 路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
- [x] Full text / 全文获取
  - [x] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

地址URL使用拼音简评跟随网站对应的域，以便于后续增加Rader支持。

完成了吉首大学学校通知、教务处通知和动态、计算机科学与工程学院、数学与统计学院通知和创新中心较多常用通知板块的通知。