### PR TITLE
fix: import routes directory path error

### DIFF
--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -11,7 +11,7 @@ type Root = {
 };
 
 const imports = directoryImport({
-    targetDirectoryPath: './v2',
+    targetDirectoryPath: path.join(__dirname, 'v2'),
     importPattern: /router\.js$/,
 });
 


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

无

## Note / 说明

修复 `npm run dev` 启动失败，提示导入路由目录错误

<img width="680" alt="image" src="https://github.com/DIYgod/RSSHub/assets/15377484/afcfee11-fa29-4415-8593-074b8db8a54d">
