### PR TITLE
fix: use path param with regex for npm package feed

### DIFF
--- a/lib/routes/npm/package.js
+++ b/lib/routes/npm/package.js
@@ -3,7 +3,7 @@ import { art } from '@/utils/render';
 import * as path from 'node:path';
 
 export default async (ctx) => {
-    const name = ctx.req.url.split('package/')[1];
+    const name = ctx.req.param('name');
     const packageDownloadLastMonthAPI = `https://api.npmjs.org/downloads/point/last-month/${name}`; // 按月统计
     const packageDownloadLastWeekAPI = `https://api.npmjs.org/downloads/point/last-week/${name}`; // 按周统计
     const packageDownloadLastDayAPI = `https://api.npmjs.org/downloads/point/last-day/${name}`; // 按天统计

--- a/lib/routes/npm/package.js
+++ b/lib/routes/npm/package.js
@@ -15,14 +15,12 @@ export default async (ctx) => {
     const packageVersionRes = await got(packageVersionAPI).json();
 
     const packageVersion = packageVersionRes.time;
-    const packageVersionList = [];
-    for (const key in packageVersion) {
-        packageVersionList.push({
+    const packageVersionList = Object.keys(packageVersion)
+        .map((key) => ({
             version: key,
             time: packageVersion[key],
-        });
-    }
-    packageVersionList.reverse();
+        }))
+        .toReversed();
 
     ctx.set('data', {
         title: `${name} - npm`,

--- a/lib/routes/npm/router.js
+++ b/lib/routes/npm/router.js
@@ -1,3 +1,4 @@
 export default (router) => {
-    router.get('package/*', './package');
+    // https://github.com/dword-design/package-name-regex/blob/master/src/index.js
+    router.get('package/:name{(@[a-z0-9-~][a-z0-9-._~]*\\/)?[a-z0-9-~][a-z0-9-._~]*}', './package');
 };


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

#9575, #9578

## Example for the Proposed Route(s) / 路由地址示例

```routes
/npm/package/lodash
/npm/package/lodash?key=access_key
/npm/package/@package/copy
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

1.  Don't include query params like `?code` in the package name.
2.  Handle special cases when the org name of the package ends with `package`, i.e. the package name is something like `@*package/*`.