### PR TITLE
fix: use access token for all Mastodon routes

### DIFF
--- a/lib/routes/mastodon/timeline-local.js
+++ b/lib/routes/mastodon/timeline-local.js
@@ -11,7 +11,7 @@ export default async (ctx) => {
 
     const url = `http://${site}/api/v1/timelines/public?local=true&only_media=${only_media}`;
 
-    const response = await got.get(url);
+    const response = await got.get(url, { headers: utils.apiHeaders() });
     const list = response.data;
 
     ctx.set('data', {

--- a/lib/routes/mastodon/timeline-remote.js
+++ b/lib/routes/mastodon/timeline-remote.js
@@ -11,7 +11,7 @@ export default async (ctx) => {
 
     const url = `http://${site}/api/v1/timelines/public?remote=true&only_media=${only_media}`;
 
-    const response = await got.get(url);
+    const response = await got.get(url, { headers: utils.apiHeaders() });
     const list = response.data;
 
     ctx.set('data', {

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -5,9 +5,10 @@ import { config } from '@/config';
 
 const allowSiteList = ['mastodon.social', 'pawoo.net'];
 
-const apiHeaders = () => {
-    const { accessToken } = config.mastodon;
-    return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+const apiHeaders = (site) => {
+    const { accessToken, apiHost } = config.mastodon;
+    // avoid sending API token to other sites
+    return accessToken && site === apiHost ? { Authorization: `Bearer ${accessToken}` } : {};
 };
 
 const mediaParse = (media_attachments) =>
@@ -64,7 +65,7 @@ async function getAccountStatuses(site, account_id, only_media) {
     const statuses_response = await got({
         method: 'get',
         url: statuses_url,
-        headers: apiHeaders(),
+        headers: apiHeaders(site),
     });
     const data = statuses_response.data;
 
@@ -76,7 +77,7 @@ async function getAccountStatuses(site, account_id, only_media) {
         const account_response = await got({
             method: 'get',
             url: account_url,
-            headers: apiHeaders(),
+            headers: apiHeaders(site),
         });
         account_data = account_response.data;
     }
@@ -102,7 +103,7 @@ async function getAccountIdByAcct(acct) {
         const search_response = await got({
             method: 'get',
             url: search_url,
-            headers: apiHeaders(),
+            headers: apiHeaders(site),
             searchParams: {
                 q: acct,
                 type: 'accounts',

--- a/lib/routes/mastodon/utils.js
+++ b/lib/routes/mastodon/utils.js
@@ -5,6 +5,11 @@ import { config } from '@/config';
 
 const allowSiteList = ['mastodon.social', 'pawoo.net'];
 
+const apiHeaders = () => {
+    const { accessToken } = config.mastodon;
+    return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+};
+
 const mediaParse = (media_attachments) =>
     media_attachments
         .map((item) => {
@@ -59,6 +64,7 @@ async function getAccountStatuses(site, account_id, only_media) {
     const statuses_response = await got({
         method: 'get',
         url: statuses_url,
+        headers: apiHeaders(),
     });
     const data = statuses_response.data;
 
@@ -70,6 +76,7 @@ async function getAccountStatuses(site, account_id, only_media) {
         const account_response = await got({
             method: 'get',
             url: account_url,
+            headers: apiHeaders(),
         });
         account_data = account_response.data;
     }
@@ -95,9 +102,7 @@ async function getAccountIdByAcct(acct) {
         const search_response = await got({
             method: 'get',
             url: search_url,
-            headers: {
-                ...(mastodonConfig.accessToken ? { Authorization: `Bearer ${mastodonConfig.accessToken}` } : {}),
-            },
+            headers: apiHeaders(),
             searchParams: {
                 q: acct,
                 type: 'accounts',
@@ -123,6 +128,7 @@ async function getAccountIdByAcct(acct) {
 }
 
 module.exports = {
+    apiHeaders,
     parseStatuses,
     getAccountStatuses,
     getAccountIdByAcct,


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
/mastodon/acct/CatWhitney@mastodon.social/statuses
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

获取 account statuses 以及 timeline 时也使用 Mastodon access token，且只向设置的 API host 发送 token。