### PR TITLE
feat: expose server URLs in the CLI

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,12 +1,18 @@
 import { serve } from '@hono/node-server';
 import logger from '@/utils/logger';
+import { getLocalhostAddress } from '@/utils/common-utils';
 import { config } from '@/config';
 import app from '@/app';
 
 const port = config.connect.port;
+const hostIPList = getLocalhostAddress();
 
 logger.info(`🎉 RSSHub is running on port ${port}! Cheers!`);
 logger.info('💖 Can you help keep this open source project alive? Please sponsor 👉 https://docs.rsshub.app/support');
+logger.info(`🔗 Local: 👉 http://localhost:${port}`);
+for (const ip of hostIPList) {
+    logger.info(`🔗 Network: 👉 http://${ip}:${port}`);
+}
 
 const server = serve({
     fetch: app.fetch,

--- a/lib/utils/common-utils.test.ts
+++ b/lib/utils/common-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { toTitleCase, collapseWhitespace, convertDateToISO8601 } from '@/utils/common-utils';
+import { toTitleCase, collapseWhitespace, convertDateToISO8601, getLocalhostAddress } from '@/utils/common-utils';
 
 describe('common-utils', () => {
     it('toTitleCase', () => {
@@ -33,5 +33,9 @@ describe('common-utils', () => {
         expect(collapseWhitespace('   \n\n\n    ')).toBe('');
         expect(collapseWhitespace('a string already collapsed')).toBe('a string already collapsed');
         expect(collapseWhitespace(' \n  a lot of     whitespaces   and \n\n\n\n linebreaks   \n\n ')).toBe('a lot of whitespaces and linebreaks');
+    });
+
+    it('getLocalhostAddress', () => {
+        expect(getLocalhostAddress()).toBeInstanceOf(Array);
     });
 });

--- a/lib/utils/common-utils.ts
+++ b/lib/utils/common-utils.ts
@@ -32,7 +32,7 @@ const getSubPath = (ctx) => {
     return subPath;
 };
 
-function getLocalhostAddress() {
+const getLocalhostAddress = () => {
     const interfaces = os.networkInterfaces();
     const address = Object.keys(interfaces)
         .flatMap((name) => interfaces[name] ?? [])
@@ -40,6 +40,6 @@ function getLocalhostAddress() {
         .map((iface) => iface?.address)
         .filter(Boolean);
     return address;
-}
+};
 
 export { toTitleCase, collapseWhitespace, convertDateToISO8601, getSubPath, getLocalhostAddress };

--- a/lib/utils/common-utils.ts
+++ b/lib/utils/common-utils.ts
@@ -1,5 +1,6 @@
 import { parseDate } from '@/utils/parse-date';
 import title from 'title';
+import os from 'os';
 
 // convert a string into title case
 const toTitleCase = (str: string) => title(str);
@@ -31,4 +32,14 @@ const getSubPath = (ctx) => {
     return subPath;
 };
 
-export { toTitleCase, collapseWhitespace, convertDateToISO8601, getSubPath };
+function getLocalhostAddress() {
+    const interfaces = os.networkInterfaces();
+    const address = Object.keys(interfaces)
+        .flatMap((name) => interfaces[name] ?? [])
+        .filter((iface) => iface?.family === 'IPv4' && !iface.internal)
+        .map((iface) => iface?.address)
+        .filter(Boolean);
+    return address;
+}
+
+export { toTitleCase, collapseWhitespace, convertDateToISO8601, getSubPath, getLocalhostAddress };


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
```
having to manually enter the address in the browser every time you start the project is inconvenient, isn't it?

this PR enables the direct exposure of all available server URLs from within the CLI.

offering some development conveniences.
```