### PR TITLE
feat: opentelementry support

### DIFF
--- a/lib/app.ts
+++ b/lib/app.ts
@@ -12,6 +12,7 @@ import debug from '@/middleware/debug';
 import header from '@/middleware/header';
 import antiHotlink from '@/middleware/anti-hotlink';
 import parameter from '@/middleware/parameter';
+import trace from '@/middleware/trace';
 
 import logger from '@/utils/logger';
 
@@ -27,6 +28,7 @@ const app = new Hono();
 app.use(compress());
 
 app.use(mLogger);
+app.use(trace);
 app.use(sentry);
 app.use(accessControl);
 app.use(debug);

--- a/lib/errors/index.tsx
+++ b/lib/errors/index.tsx
@@ -9,6 +9,8 @@ import RequestInProgressError from './request-in-progress';
 import RejectError from './reject';
 import NotFoundError from './not-found';
 
+import { requestMetric } from '@/utils/otel';
+
 export const errorHandler: ErrorHandler = (error, ctx) => {
     const requestPath = ctx.req.path;
     const matchedRoute = ctx.req.routePath;
@@ -61,6 +63,7 @@ export const errorHandler: ErrorHandler = (error, ctx) => {
     }
 
     logger.error(`Error in ${requestPath}: ${message}`);
+    requestMetric.error({ path: requestPath, method: ctx.req.method, status: ctx.res.status });
 
     return config.isPackage ? ctx.json({
         error: {

--- a/lib/init-routes.ts
+++ b/lib/init-routes.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import index from '@/routes/index';
 import robotstxt from '@/routes/robots.txt';
 import test from '@/routes/test/router';
+import metrics from '@/routes/metrics';
 
 import { getCurrentPath } from '@/utils/helpers';
 const __dirname = getCurrentPath(import.meta.url);
@@ -54,6 +55,7 @@ export default function (app: Hono) {
     // routes without rss data
     app.get('/', index);
     app.get('/robots.txt', robotstxt);
+    app.get('/metrics', metrics);
 
     app.use(
         '/*',

--- a/lib/middleware/access-control.ts
+++ b/lib/middleware/access-control.ts
@@ -12,7 +12,7 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
     const accessKey = ctx.req.query('key');
     const accessCode = ctx.req.query('code');
 
-    if (requestPath === '/' || requestPath === '/robots.txt') {
+    if (requestPath === '/' || requestPath === '/robots.txt' || requestPath === '/metrics') {
         await next();
     } else {
         if (config.accessKey && !(config.accessKey === accessKey || accessCode === md5(requestPath + config.accessKey))) {

--- a/lib/middleware/logger.ts
+++ b/lib/middleware/logger.ts
@@ -1,3 +1,4 @@
+import { requestMetric } from '@/utils/otel';
 import { MiddlewareHandler } from 'hono';
 import logger from '@/utils/logger';
 import { getPath, time } from '@/utils/helpers';
@@ -34,7 +35,10 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
 
     await next();
 
-    logger.info(`${LogPrefix.Outgoing} ${method} ${path} ${colorStatus(ctx.res.status)} ${time(start)}`);
+    const status = ctx.res.status;
+
+    logger.info(`${LogPrefix.Outgoing} ${method} ${path} ${colorStatus(status)} ${time(start)}`);
+    requestMetric.success(Date.now() - start, { path, method, status });
 };
 
 export default middleware;

--- a/lib/middleware/trace.ts
+++ b/lib/middleware/trace.ts
@@ -1,0 +1,18 @@
+import { MiddlewareHandler } from 'hono';
+import { getPath } from '@/utils/helpers';
+import { tracer } from '@/utils/otel';
+
+const middleware: MiddlewareHandler = async (ctx, next) => {
+    const { method, raw } = ctx.req;
+    const path = getPath(raw);
+
+    const span = tracer.startSpan(`${method} ${path}`, {
+        kind: 1, // server
+        attributes: {},
+    });
+    span.addEvent('invoking handleRequest');
+    await next();
+    span.end();
+};
+
+export default middleware;

--- a/lib/routes/metrics.ts
+++ b/lib/routes/metrics.ts
@@ -1,0 +1,12 @@
+import type { Handler } from 'hono';
+import { getContext } from '@/utils/otel';
+
+const handler: Handler = (ctx) =>
+    getContext()
+        .then((val) => ctx.text(val))
+        .catch((error) => {
+            ctx.status(500);
+            ctx.json({ error });
+        });
+
+export default handler;

--- a/lib/utils/otel/index.ts
+++ b/lib/utils/otel/index.ts
@@ -1,0 +1,2 @@
+export * from './metric';
+export * from './trace';

--- a/lib/utils/otel/metric.ts
+++ b/lib/utils/otel/metric.ts
@@ -1,0 +1,66 @@
+import { Resource } from '@opentelemetry/resources';
+import { PrometheusExporter, PrometheusSerializer } from '@opentelemetry/exporter-prometheus';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { Attributes } from '@opentelemetry/api';
+
+interface IMetricAttributes extends Attributes {
+    method: string;
+    path: string;
+    status: number;
+}
+
+interface IHistogramAttributes extends IMetricAttributes {
+    unit: string;
+}
+
+const metric_prefix = 'rsshub';
+
+const exporter = new PrometheusExporter({});
+
+const provider = new MeterProvider({
+    resource: new Resource({
+        [SEMRESATTRS_SERVICE_NAME]: 'rsshub',
+    }),
+    readers: [exporter],
+});
+
+const serializer = new PrometheusSerializer();
+
+const meter = provider.getMeter('rsshub');
+
+const request_total = meter.createCounter<IMetricAttributes>(`${metric_prefix}_request_total`);
+const request_error_total = meter.createCounter<IMetricAttributes>(`${metric_prefix}_request_error_total`);
+const request_duration_seconds_bucket = meter.createHistogram<IHistogramAttributes>(`${metric_prefix}_request_duration_seconds_bucket`, {
+    advice: {
+        explicitBucketBoundaries: [0.01, 0.1, 1, 2, 5, 15, 30, 60],
+    },
+});
+const request_duration_milliseconds_bucket = meter.createHistogram<IHistogramAttributes>(`${metric_prefix}_request_duration_milliseconds_bucket`, {
+    advice: {
+        explicitBucketBoundaries: [10, 20, 50, 100, 250, 500, 1000, 5000, 15000],
+    },
+});
+
+export const requestMetric = {
+    success: (value: number, attributes: IMetricAttributes) => {
+        request_total.add(1, attributes);
+        request_duration_milliseconds_bucket.record(value, { unit: 'millisecond', ...attributes });
+        request_duration_seconds_bucket.record(value / 1000, { unit: 'second', ...attributes });
+    },
+    error: (attributes: IMetricAttributes) => {
+        request_error_total.add(1, attributes);
+    },
+};
+
+export const getContext = () =>
+    new Promise<string>((resolve, reject) => {
+        exporter
+            .collect()
+            .then((value) => {
+                resolve(serializer.serialize(value.resourceMetrics));
+            })
+            .finally(() => {
+                reject('');
+            });
+    });

--- a/lib/utils/otel/trace.ts
+++ b/lib/utils/otel/trace.ts
@@ -1,0 +1,28 @@
+import { Resource } from '@opentelemetry/resources';
+import { BasicTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+
+const provider = new BasicTracerProvider({
+    resource: new Resource({
+        [SEMRESATTRS_SERVICE_NAME]: 'rsshub',
+    }),
+});
+
+const exporter = new OTLPTraceExporter({
+    // optional OTEL_EXPORTER_OTLP_ENDPOINT=https://localhost:4318
+});
+
+provider.addSpanProcessor(
+    new BatchSpanProcessor(exporter, {
+        // The maximum queue size. After the size is reached spans are dropped.
+        maxQueueSize: 4096,
+        // The interval between two consecutive exports
+        scheduledDelayMillis: 30000,
+    })
+);
+
+provider.register();
+
+export const tracer = provider.getTracer('rsshub');
+export const mainSpan = tracer.startSpan('main');

--- a/package.json
+++ b/package.json
@@ -51,6 +51,13 @@
   "dependencies": {
     "@hono/node-server": "1.8.2",
     "@notionhq/client": "2.2.14",
+    "@opentelemetry/api": "^1.8.0",
+    "@opentelemetry/exporter-prometheus": "^0.49.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.49.1",
+    "@opentelemetry/resources": "^1.22.0",
+    "@opentelemetry/sdk-metrics": "^1.22.0",
+    "@opentelemetry/sdk-trace-base": "^1.22.0",
+    "@opentelemetry/semantic-conventions": "^1.22.0",
     "@postlight/parser": "2.2.3",
     "@sentry/node": "7.105.0",
     "@tonyrl/rand-user-agent": "2.0.53",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,27 @@ dependencies:
   '@notionhq/client':
     specifier: 2.2.14
     version: 2.2.14
+  '@opentelemetry/api':
+    specifier: ^1.8.0
+    version: 1.8.0
+  '@opentelemetry/exporter-prometheus':
+    specifier: ^0.49.1
+    version: 0.49.1(@opentelemetry/api@1.8.0)
+  '@opentelemetry/exporter-trace-otlp-http':
+    specifier: ^0.49.1
+    version: 0.49.1(@opentelemetry/api@1.8.0)
+  '@opentelemetry/resources':
+    specifier: ^1.22.0
+    version: 1.22.0(@opentelemetry/api@1.8.0)
+  '@opentelemetry/sdk-metrics':
+    specifier: ^1.22.0
+    version: 1.22.0(@opentelemetry/api@1.8.0)
+  '@opentelemetry/sdk-trace-base':
+    specifier: ^1.22.0
+    version: 1.22.0(@opentelemetry/api@1.8.0)
+  '@opentelemetry/semantic-conventions':
+    specifier: ^1.22.0
+    version: 1.22.0
   '@postlight/parser':
     specifier: 2.2.3
     version: 2.2.3
@@ -2033,6 +2054,132 @@ packages:
       - encoding
     dev: false
 
+  /@opentelemetry/api-logs@0.49.1:
+    resolution: {integrity: sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+    dev: false
+
+  /@opentelemetry/api@1.8.0:
+    resolution: {integrity: sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
+  /@opentelemetry/core@1.22.0(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/semantic-conventions': 1.22.0
+    dev: false
+
+  /@opentelemetry/exporter-prometheus@0.49.1(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-FgzGl6OH22f+Wb1dh/TnoQSnZE2SCADhHx06nMqxivSqRJ9t3AhUdMsEOFt2IMjZClE705pcsLHk10BCJ79vsA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-metrics': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/exporter-trace-otlp-http@0.49.1(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/otlp-exporter-base@0.49.1(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/otlp-transformer@0.49.1(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-metrics': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/resources@1.22.0(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    dev: false
+
+  /@opentelemetry/sdk-logs@0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.9.0'
+      '@opentelemetry/api-logs': '>=0.39.1'
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/sdk-metrics@1.22.0(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      lodash.merge: 4.6.2
+    dev: false
+
+  /@opentelemetry/sdk-trace-base@1.22.0(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    dev: false
+
+  /@opentelemetry/semantic-conventions@1.22.0:
+    resolution: {integrity: sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==}
+    engines: {node: '>=14'}
+    dev: false
+
   /@otplib/core@12.0.1:
     resolution: {integrity: sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==}
     dev: false
@@ -2202,6 +2349,7 @@ packages:
     resolution: {integrity: sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2210,6 +2358,7 @@ packages:
     resolution: {integrity: sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -2218,6 +2367,7 @@ packages:
     resolution: {integrity: sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2226,6 +2376,7 @@ packages:
     resolution: {integrity: sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2234,6 +2385,7 @@ packages:
     resolution: {integrity: sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true

--- a/scripts/workflow/build-radar.ts
+++ b/scripts/workflow/build-radar.ts
@@ -8,7 +8,7 @@ const targetJson = path.join(__dirname, '../../assets/build/radar-rules.json');
 const dirname = path.join(__dirname + '../../../lib/routes');
 
 // Namespaces that do not require radar.ts
-const allowNamespace = new Set(['discourse', 'discuz', 'ehentai', 'lemmy', 'mail', 'test', 'index.tsx', 'robots.txt.ts']);
+const allowNamespace = new Set(['discourse', 'discuz', 'ehentai', 'lemmy', 'mail', 'test', 'index.tsx', 'robots.txt.ts', 'metrics.ts']);
 // Check if a radar.ts file is exist under each folder of dirname
 for (const dir of fs.readdirSync(dirname)) {
     const dirPath = path.join(dirname, dir);

--- a/website/docs/install/config.md
+++ b/website/docs/install/config.md
@@ -158,6 +158,16 @@ Access code is the md5 generated based on the access key + route, eg:
 
 `SENTRY_ROUTE_TIMEOUT`: Report Sentry if route execution takes more than this milliseconds, default to `3000`
 
+## Opentelementry Config
+
+`OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`: The maximum waiting time, in milliseconds, allowed to send each OTLP trace batch. Default is 10000.
+
+`OTEL_EXPORTER_OTLP_TIMEOUT`: The maximum waiting time, in milliseconds, allowed to send each OTLP trace and metric batch. Default is 10000.
+
+`OTEL_EXPORTER_OTLP_ENDPOINT`:  Target URL to which the exporter is going to send spans, metrics, or logs. The implementation MUST honor the following URL components: Default: `http://localhost:4318`
+
+For more details, see [OpenTelemetry Specification on Protocol Exporter.](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options)
+
 ## Image Processing
 
 :::tip New Config Format


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
- [ ] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [x] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Implement opentelementry feature `metrics` and `trace`

### Metrics
metrics endpoint with `/metrics`
labels:
- `method` http method (example: GET/POST)
- `path` request path
- `status` response return status code
- `unit` only for bucket (example: second/millisecond)

The following metric name supported for now.
- `request_total` record request with  params
- `request_error_total` record request error with params
- `request_duration_seconds_bucket` record request second with params
- `request_duration_milliseconds_bucket` record request millisecond with params

### trace
trace with opentelementry OTLP exporter, which could be collected by jaeger (for example)
endpoint follow [OpenTelemetry Specification on Protocol Exporter.](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options)
