### PR TITLE
fix: doc link

### DIFF
--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -80,7 +80,7 @@ In addition to the two functions of generating RSS and obtaining data, RSSHub al
 
 ### Configuration file
 
-Radar has two types of configuration files, one is a full-featured [js file](https://github.com/DIYgod/RSSHub/blob/gh-pages/build/radar-rules.js), and the other is a simplified [json file]((https://github.com/DIYgod/RSSHub/blob/gh-pages/build/radar-rules.json)).
+Radar has two types of configuration files, one is a full-featured [js file](https://github.com/DIYgod/RSSHub/blob/gh-pages/build/radar-rules.js), and the other is a simplified [json file](https://github.com/DIYgod/RSSHub/blob/gh-pages/build/radar-rules.json).
 
 ### Usage
 


### PR DESCRIPTION
## Note / 说明

Previously the modified field leads to a broken link: 
https://docs.rsshub.app/(https://github.com/DIYgod/RSSHub/blob/gh-pages/build/radar-rules.json)

Now I follow the style of other functioning link to remove the redundant parenthesis.
