### PR TITLE
fix(route): fix redundant '/' in stats.gov.cn

### DIFF
--- a/lib/routes/gov/stats/index.ts
+++ b/lib/routes/gov/stats/index.ts
@@ -13,9 +13,26 @@ import * as path from 'node:path';
 
 export const route: Route = {
     path: '/stats/*',
-    name: 'Unknown',
-    maintainers: [],
+    name: '国家统计局 通用',
+    url: 'www.stats.gov.cn',
+    categories: ['government'],
+    maintainers: ['bigfei', 'nczitzk'],
+    example: '/stats/sj/zxfb',
     handler,
+    radar: [
+        {
+            title: '国家统计局 通用',
+            source: ['www.stats.gov.cn/*path'],
+            target: '/gov/stats/*path',
+        },
+    ],
+    description: `::: tip
+    路径处填写对应页面 URL 中 \`http://www.stats.gov.cn/\` 后的字段。下面是一个例子。
+
+    若订阅 [数据 > 数据解读](http://www.stats.gov.cn/sj/sjjd/) 则将对应页面 URL \`http://www.stats.gov.cn/sj/sjjd/\` 中 \`http://www.stats.gov.cn/\` 后的字段 \`sj/sjjd\` 作为路径填入。此时路由为 [\`/gov/stats/sj/sjjd\`](https://rsshub.app/gov/stats/sj/sjjd)
+
+    若订阅 [新闻 > 时政要闻 > 中央精神](http://www.stats.gov.cn/xw/szyw/zyjs/) 则将对应页面 URL \`http://www.stats.gov.cn/xw/szyw/zyjs/\` 中 \`http://www.stats.gov.cn/\` 后的字段 \`xw/szyw/zyjs\` 作为路径填入。此时路由为 [\`/gov/stats/xw/szyw/zyjs\`](https://rsshub.app/gov/stats/xw/szyw/zyjs)
+    :::`,
 };
 
 async function handler(ctx) {

--- a/lib/routes/gov/stats/index.ts
+++ b/lib/routes/gov/stats/index.ts
@@ -20,11 +20,10 @@ export const route: Route = {
 
 async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 15;
-
-    const defaultPath = '/sj/zxfb/';
-
     const rootUrl = 'http://www.stats.gov.cn';
-    const currentUrl = `${rootUrl}${getSubPath(ctx) === '/stats' ? defaultPath : getSubPath(ctx).replace(/^\/stats(.*)/, '$1/')}`;
+
+    const pathname = getSubPath(ctx) === '/stats' ? '/sj/zxfb/' : getSubPath(ctx).replace(/^\/stats(.*)/, '$1');
+    const currentUrl = `${rootUrl}${pathname.endsWith('/') ? pathname : pathname + '/'}`;
 
     let response = await got({
         method: 'get',


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue
Close #https://github.com/DIYgod/RSSHub/issues/14794

## Example for the Proposed Route(s) / 路由地址示例


<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/gov/stats/sj/zxfb/
```

