### PR TITLE
feat(route)(telegram/channel): support for video stickers

### DIFF
--- a/lib/routes/telegram/channel.ts
+++ b/lib/routes/telegram/channel.ts
@@ -29,7 +29,7 @@ const LOCATION = 'LOCATION';
 const CONTACT = 'CONTACT';
 const STICKER = 'STICKER';
 const ANIMATED_STICKER = 'ANIMATED_STICKER';
-// const VIDEO_STICKER = 'VIDEO_STICKER';  // not supported yet by t.me
+const VIDEO_STICKER = 'VIDEO_STICKER';
 const UNSUPPORTED = 'UNSUPPORTED';
 const PARTIALLY_UNSUPPORTED = 'PARTIALLY_UNSUPPORTED';
 
@@ -50,7 +50,7 @@ const mediaTagDict = {
     CONTACT: ['[Contact]', '📱'],
     STICKER: ['[Sticker]', '[Sticker]'],
     ANIMATED_STICKER: ['[Animated Sticker]', '[Animated Sticker]'],
-    // VIDEO_STICKER: ['[Video Sticker]', '[Video Sticker]'],  // not supported yet by t.me
+    VIDEO_STICKER: ['[Video Sticker]', '[Video Sticker]'],
     UNSUPPORTED: ['[Unsupported]', '🚫'],
     PARTIALLY_UNSUPPORTED: ['', ''],
 };
@@ -224,6 +224,9 @@ async function handler(ctx) {
                     if (item.find('.tgme_widget_message_tgsticker').length) {
                         msgTypes.push(ANIMATED_STICKER);
                     }
+                    if (item.find('.tgme_widget_message_videosticker').length) {
+                        msgTypes.push(VIDEO_STICKER);
+                    }
                     if (item.find('.message_media_not_supported').length) {
                         if (item.find('.media_supported_cont').length) {
                             msgTypes.unshift(PARTIALLY_UNSUPPORTED);
@@ -369,6 +372,12 @@ async function handler(ctx) {
                                     tag_media += $(source).toString();
                                 });
                                 tag_media += '</picture>';
+                            } else if (node.attribs && node.attribs.class && node.attribs.class.search(/(^|\s)tgme_widget_message_videosticker(\s|$)/) !== -1) {
+                                // video sticker
+                                const videoLink = $node.find('.js-videosticker_video').attr('src');
+                                tag_media += art(path.join(__dirname, 'templates/video.art'), {
+                                    source: videoLink,
+                                });
                             } else if (node.name === 'img') {
                                 // unknown
                                 tag_media += $node.toString();
@@ -403,7 +412,9 @@ async function handler(ctx) {
                         return tag_media_all;
                     };
                     // ordinary message photos, service message photos, stickers, animated stickers, video
-                    const messageMedia = generateMedia('.tgme_widget_message_photo_wrap,.tgme_widget_message_service_photo,.tgme_widget_message_sticker,.tgme_widget_message_tgsticker,.tgme_widget_message_video_player');
+                    const messageMedia = generateMedia(
+                        '.tgme_widget_message_photo_wrap,.tgme_widget_message_service_photo,.tgme_widget_message_sticker,.tgme_widget_message_tgsticker,.tgme_widget_message_videosticker,.tgme_widget_message_video_player'
+                    );
 
                     /* location */
                     const location = () => {


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->


## Involved routes

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/telegram/channel/thisismegatest
```



## Note / 说明

Now t.me supports videostickers and I've added it to rsshub

Here is parsed example
first message is video and another is videosticker:
https://pastebin.com/raw/46XX4rWr


<img width="1244" alt="image" src="https://github.com/DIYgod/RSSHub/assets/33029221/40259d98-953f-40bb-b1ac-74eaed903d0b">
