### PR TITLE
fix(route): 18comic add cover image

### DIFF
--- a/lib/routes/18comic/templates/description.art
+++ b/lib/routes/18comic/templates/description.art
@@ -1,3 +1,6 @@
+{{ if cover }}
+<img src="{{ cover }}">
+{{ /if }}
 <p>{{ introduction }}</p>
 {{ each images image }}
 <img src="{{ image }}">

--- a/lib/routes/18comic/utils.ts
+++ b/lib/routes/18comic/utils.ts
@@ -49,6 +49,7 @@ const ProcessItems = async (ctx, currentUrl, rootUrl) => {
                 const content = load(detailResponse.data);
 
                 item.pubDate = parseDate(content('div[itemprop="datePublished"]').first().attr('content'));
+                item.updated = parseDate(content('div[itemprop="datePublished"]').last().attr('content'));
                 item.category = content('span[data-type="tags"]')
                     .first()
                     .find('a')
@@ -65,6 +66,7 @@ const ProcessItems = async (ctx, currentUrl, rootUrl) => {
                     images: content('.img_zoom_img img')
                         .toArray()
                         .map((image) => content(image).attr('data-original')),
+                    cover: content('.thumb-overlay img').first().attr('src'),
                 });
 
                 return item;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/18comic/all/a/mv
/18comic/all/a/mv?domain=jmcomic1.me
/18comic/all/a/mv?domain=jm-comic3.art
/18comic/all/a/mv?domain=jm-comic.club
/18comic/all/a/mv?domain=jm-comic2.ark
/18comic/all/a/mv?domain=18comic.org
/18comic/all/a/mv?domain=18comic.vip
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
