### PR TITLE
feat(route): /minecraft/version, add version type filter and wiki link generator

### DIFF
--- a/lib/routes/minecraft/version.ts
+++ b/lib/routes/minecraft/version.ts
@@ -1,11 +1,15 @@
 import { Route } from '@/types';
 import got from '@/utils/got';
+import { Context } from 'hono';
 
 export const route: Route = {
-    path: '/version',
+    path: '/version/:versionType?/:linkType?',
     categories: ['game'],
     example: '/minecraft/version',
-    parameters: {},
+    parameters: {
+        versionType: `Game version type, \`all\` by default`,
+        linkType: `Link added to feed, \`official\` by default`,
+    },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -20,39 +24,113 @@ export const route: Route = {
         },
     ],
     name: 'Java Game Update',
-    maintainers: ['TheresaQWQ'],
+    maintainers: ['TheresaQWQ', 'xtexChooser'],
     handler,
     url: 'minecraft.net/',
+    description: `
+| Version                    | versionType |
+| -------------------------- | ----------- |
+| 正式版                     | release     |
+| 快照                       | snapshot    |
+| Alpha 及更早的版本         | old_alpha  |
+| Beta 版                    | old_beta   |
+| Target                     | linkType    |
+| -------------------------- | --------    |
+| minecraft.net              | official    |
+| 英文 Minecraft Wiki 版本页 | enwiki      |
+| 中文 Minecraft Wiki 版本页 | zhwiki      |
+`,
+    zh: {
+        name: 'Java版游戏更新',
+    },
 };
 
-async function handler() {
-    const url = 'https://launchermeta.mojang.com/mc/game/version_manifest.json';
+interface VersionInManifest {
+    id: string;
+    type: string;
+    releaseTime: string;
+}
 
-    const response = await got({
+const typeName = {
+    release: '正式版',
+    snapshot: '快照',
+    old_alpha: 'Alpha及更早的版本',
+    old_beta: 'Beta版',
+};
+
+const linkFormatter: any = {
+    official: () => `https://www.minecraft.net`,
+    enwiki: (item: VersionInManifest) => {
+        let id = item.id;
+        if (item.type === 'old_beta' && id.startsWith('b')) {
+            id = `Beta ${id.substring(1)}`;
+        }
+        if (item.type === 'old_alpha') {
+            if (id.startsWith('a')) {
+                id = `Alpha ${id.substring(1)}`;
+            } else if (id.startsWith('c')) {
+                id = `Classic ${id.substring(1)}`;
+            } else if (id.startsWith('inf-')) {
+                id = `Infdev`;
+            } else if (id.startsWith('rd-')) {
+                id = `pre-Classic ${id}`;
+            }
+        }
+        return `https://minecraft.wiki/w/Java Edition ${id}`;
+    },
+    zhwiki: (item: VersionInManifest) => {
+        let id = item.id;
+        if (item.type === 'release') {
+            id = `Java版${id}`;
+        }
+        if (item.type === 'old_beta' && id.startsWith('b')) {
+            id = `Java版Beta ${id.substring(1)}`;
+        }
+        if (item.type === 'old_alpha') {
+            if (id.startsWith('a')) {
+                id = `Java版Alpha ${id.substring(1)}`;
+            } else if (id.startsWith('c')) {
+                id = `Java版Classic ${id.substring(1)}`;
+            } else if (id.startsWith('inf-')) {
+                id = `Java版Infdev`;
+            } else if (id.startsWith('rd-')) {
+                id = `Java版pre-Classic ${id}`;
+            }
+        }
+        return `https://zh.minecraft.wiki/w/${id}`;
+    },
+};
+
+async function handler(ctx?: Context) {
+    const url = ctx?.req.query('mcmanifest') ?? 'https://piston-meta.mojang.com/mc/game/version_manifest_v2.json';
+
+    const response: any = await got({
         method: 'get',
         url,
+        responseType: 'json',
     });
 
-    const typeMap = {
-        release: '正式版',
-        snapshot: '快照',
-        old_alpha: '过时的预览版',
-        old_beta: '过时的测试版',
-    };
+    let data: VersionInManifest[] = response.data.versions;
 
-    const data = response.data.versions;
+    const versionType = ctx?.req.param('versionType') ?? 'all';
+    const linkType = ctx?.req.param('linkType') ?? 'official';
+    const linker = linkFormatter[linkType] ?? linkFormatter.official;
 
-    const title = `Minecraft Java版游戏更新`;
+    if (versionType !== 'all') {
+        data = data.filter((item) => item.type === versionType);
+    }
+
+    const title = `Minecraft Java版${versionType === 'all' ? '' : typeName[versionType] ?? versionType}游戏更新`;
 
     return {
         title,
         link: `https://www.minecraft.net/`,
         description: title,
         item: data.map((item) => ({
-            title: `${item.id} ${typeMap[item.type] || ''}更新`,
-            description: `${item.id} ${typeMap[item.type] || ''}更新`,
+            title: `${item.id} ${typeName[item.type] || ''}更新`,
+            description: `${item.id} ${typeName[item.type] || ''}更新`,
             pubDate: new Date(item.releaseTime).toUTCString(),
-            link: `https://www.minecraft.net`,
+            link: linker(item),
             guid: item.id + item.type,
         })),
     };


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
/minecraft/version
/minecraft/version/all
/minecraft/version/all/zhwiki
/minecraft/version/release/official
/minecraft/version/snapshot/enwiki
/minecraft/version/old_beta/zhwiki
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Switch to `piston-meta.mojang.com` (2022 June 15 (UTC+8), Mojang changed the host for version manifests to the new one)
- Switch to version manifest V2 (`sha1` and `complianceLevel` are added, though they are not used by RSSHub)
- Change "过时的预览版" to "Beta版"
- Change "过时的测试版" to "Alpha及更早的版本"
- Add version type filter
- Allow set links to EN/ZH Minecraft Wiki version pages
