### PR TITLE
feat(routes): Add more routes related to Minecraft

### DIFF
--- a/lib/routes/minecraft/blockedservers.ts
+++ b/lib/routes/minecraft/blockedservers.ts
@@ -34,6 +34,11 @@ async function handler() {
         method: 'get',
         url: 'https://sessionserver.mojang.com/blockedservers',
         responseType: 'text',
+        headers: {
+            // I don't know why but without this Mojang returns HTTP 403
+            //   -- xtex
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0',
+        },
     });
 
     const data = (response.data.toString() as string).split('\n').filter((str) => str !== '');

--- a/lib/routes/minecraft/blockedservers.ts
+++ b/lib/routes/minecraft/blockedservers.ts
@@ -1,0 +1,53 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/blockedservers',
+    categories: ['game'],
+    example: '/minecraft/blockedservers',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['minecraft.net/'],
+        },
+    ],
+    name: 'Java Blocked Servers',
+    maintainers: ['xtexChooser'],
+    handler,
+    url: 'minecraft.net/',
+    description: `Java 版中被 Mojang 通过 sessionserver 阻止的服务器域名的 SHA-1 散列`,
+    zh: {
+        name: 'Java版被阻止的服务器域名散列',
+    },
+};
+
+async function handler() {
+    const response: any = await got({
+        method: 'get',
+        url: 'https://sessionserver.mojang.com/blockedservers',
+        responseType: 'text',
+    });
+
+    const data = (response.data.toString() as string).split('\n').filter((str) => str !== '');
+
+    const title = `Minecraft Java版被阻止的服务器域名散列`;
+
+    return {
+        title,
+        link: `https://sessionserver.mojang.com/blockedservers`,
+        description: title,
+        item: data.map((item) => ({
+            title: item,
+            description: `域名散列 ${item} 被阻止`,
+            guid: item,
+        })),
+    };
+}

--- a/lib/routes/minecraft/blockedservers.ts
+++ b/lib/routes/minecraft/blockedservers.ts
@@ -33,12 +33,6 @@ async function handler() {
     const response: any = await got({
         method: 'get',
         url: 'https://sessionserver.mojang.com/blockedservers',
-        responseType: 'text',
-        headers: {
-            // I don't know why but without this Mojang returns HTTP 403
-            //   -- xtex
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0',
-        },
     });
 
     const data = (response.data.toString() as string).split('\n').filter((str) => str !== '');
@@ -47,7 +41,7 @@ async function handler() {
 
     return {
         title,
-        link: `https://sessionserver.mojang.com/blockedservers`,
+        link: 'https://sessionserver.mojang.com/blockedservers',
         description: title,
         item: data.map((item) => ({
             title: item,

--- a/lib/routes/minecraft/java-runtime.ts
+++ b/lib/routes/minecraft/java-runtime.ts
@@ -89,8 +89,8 @@ function generateArch(arch: string, data: any, javaType: string): DataItem[] {
     return items;
 }
 
-async function handler(ctx?: Context) {
-    const url = ctx?.req.query('mcmanifest') ?? 'https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json';
+async function handler(ctx: Context) {
+    const url = 'https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json';
 
     const response: any = await got({
         method: 'get',
@@ -100,8 +100,8 @@ async function handler(ctx?: Context) {
 
     const data: any = response.data;
 
-    const arch = ctx?.req.param('arch') ?? 'all';
-    const javaType = ctx?.req.param('javaType') ?? 'all';
+    const arch = ctx.req.param('arch') ?? 'all';
+    const javaType = ctx.req.param('javaType') ?? 'all';
 
     let items: DataItem[] = [];
 
@@ -115,13 +115,12 @@ async function handler(ctx?: Context) {
     } else {
         items = [...items, ...generateArch(arch, data[arch], javaType)];
     }
-    items = items.sort((a, b) => new Date(a.pubDate!).getTime() - new Date(b.pubDate!).getTime());
 
-    const title = `Minecraft Java运行时`;
+    const title = 'Minecraft Java运行时';
 
     return {
         title,
-        link: `https://www.minecraft.net/`,
+        link: 'https://www.minecraft.net/',
         description: title,
         item: items,
     };

--- a/lib/routes/minecraft/java-runtime.ts
+++ b/lib/routes/minecraft/java-runtime.ts
@@ -1,0 +1,128 @@
+import { DataItem, Route } from '@/types';
+import got from '@/utils/got';
+import { Context } from 'hono';
+
+export const route: Route = {
+    path: '/java-runtime/:arch?/:javaType?',
+    categories: ['game'],
+    example: '/minecraft/java-runtime',
+    parameters: {
+        arch: `Arch, \`all\` by default`,
+        javaType: `Java runtime type, \`all\` by default`,
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['minecraft.net/'],
+        },
+    ],
+    name: 'Java Runtimes',
+    maintainers: ['xtexChooser'],
+    handler,
+    url: 'minecraft.net/',
+    description: `
+arch:
+
+- gamecore (Currently not used by Mojang)
+- linux
+- linux-i386
+- mac-os
+- mac-os-arm64
+- windows-arm64
+- windows-x64
+- windows-x86
+
+javaType:
+
+- java-runtime-alpha
+- java-runtime-beta
+- java-runtime-delta
+- java-runtime-gamma
+- java-runtime-gamma-snapshot
+- jre-legacy
+- minecraft-java-exe (Only on Windows)
+`,
+    zh: {
+        name: 'Java运行时',
+    },
+};
+
+interface RuntimeInManifest {
+    manifest: { url: string };
+    version: { name: string; released: string };
+}
+
+function generateJava(arch: string, javaType: string, data: RuntimeInManifest): DataItem {
+    return {
+        title: `${arch} ${javaType} 更新了 ${data.version.name}`,
+        description: `${arch} ${javaType} 更新了 ${data.version.name}`,
+        pubDate: new Date(data.version.released).toUTCString(),
+        link: data.manifest.url,
+        guid: arch + javaType + data.version.name,
+    };
+}
+
+function generateJavas(arch: string, javaType: string, data: RuntimeInManifest[]): DataItem[] {
+    return data.map((item) => generateJava(arch, javaType, item));
+}
+
+function generateArch(arch: string, data: any, javaType: string): DataItem[] {
+    let items: DataItem[] = [];
+
+    if (javaType === 'all') {
+        for (const k in data) {
+            if (!(k in data)) {
+                continue;
+            }
+            items = [...items, ...generateJavas(arch, k, data[k])];
+        }
+    } else {
+        items = [...items, ...generateJavas(arch, javaType, data[javaType])];
+    }
+    return items;
+}
+
+async function handler(ctx?: Context) {
+    const url = ctx?.req.query('mcmanifest') ?? 'https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json';
+
+    const response: any = await got({
+        method: 'get',
+        url,
+        responseType: 'json',
+    });
+
+    const data: any = response.data;
+
+    const arch = ctx?.req.param('arch') ?? 'all';
+    const javaType = ctx?.req.param('javaType') ?? 'all';
+
+    let items: DataItem[] = [];
+
+    if (arch === 'all') {
+        for (const k in data) {
+            if (!(k in data)) {
+                continue;
+            }
+            items = [...items, ...generateArch(k, data[k], javaType)];
+        }
+    } else {
+        items = [...items, ...generateArch(arch, data[arch], javaType)];
+    }
+    items = items.sort((a, b) => new Date(a.pubDate!).getTime() - new Date(b.pubDate!).getTime());
+
+    const title = `Minecraft Java运行时`;
+
+    return {
+        title,
+        link: `https://www.minecraft.net/`,
+        description: title,
+        item: items,
+    };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
/minecraft/blockedservers
/minecraft/java-runtime
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Based on #14941