### PR TITLE
fix: update bilibili dynamic API to v2 from v1

### DIFF
--- a/lib/routes/bilibili/dynamic.ts
+++ b/lib/routes/bilibili/dynamic.ts
@@ -117,7 +117,7 @@ async function handler(ctx) {
 
     const response = await got({
         method: 'get',
-        url: `https://api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr/space_history?host_uid=${uid}`,
+        url: `https://api.vc.bilibili.com/dynamic_svr/v2/dynamic_svr/space_history?host_uid=${uid}`,
         headers: {
             Referer: `https://space.bilibili.com/${uid}/`,
         },


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #14952

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bilibili/user/dynamic/31009079/disableEmbed=1
/bilibili/user/dynamic/5017882/disableEmbed=1
/bilibili/user/dynamic/40366538
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

It seems like `v1` is a deprecated API, and they removed it today.

Replacing it with `v2` could get a valid response, but some fields have minor changes. It shouldn't cause problems with RSSHub. However, I haven't tested it, hopefully the CI can do it for me (if there is one?).
