### PR TITLE
feat(route): add author in gcores

### DIFF
--- a/lib/routes/gcores/category.ts
+++ b/lib/routes/gcores/category.ts
@@ -77,7 +77,10 @@ async function handler(ctx) {
                 const itemPage = itemRes.data;
                 const $ = load(itemPage);
 
-                let articleData = await got(`https://www.gcores.com/gapi/v1${item.url}?include=media`);
+                let articleData = await got(`https://www.gcores.com/gapi/v1${item.url}?include=media,category,user`);
+                // assign value before replace
+                const articleMeta = articleData.data.included[0];
+                const author = articleMeta.attributes.nickname;
 
                 articleData = articleData.data.data;
                 let cover;
@@ -127,6 +130,7 @@ async function handler(ctx) {
                     description: cover + content,
                     link: articleUrl,
                     guid: articleUrl,
+                    author,
                     pubDate: new Date(articleData.attributes['published-at']),
                 };
                 return category === 'news' ? basicItem : { ...basicItem, category: item.category };

--- a/lib/routes/gcores/category.ts
+++ b/lib/routes/gcores/category.ts
@@ -77,12 +77,11 @@ async function handler(ctx) {
                 const itemPage = itemRes.data;
                 const $ = load(itemPage);
 
-                let articleData = await got(`https://www.gcores.com/gapi/v1${item.url}?include=media,category,user`);
-                // assign value before replace
-                const articleMeta = articleData.data.included[0];
+                const articleRaw = await got(`https://www.gcores.com/gapi/v1${item.url}?include=media,category,user`);
+                const articleData = articleRaw.data.data;
+                const articleMeta = articleRaw.data.included.find((i) => i.type === 'users' && i.id === articleData.relationships.user.data.id);
                 const author = articleMeta.attributes.nickname;
 
-                articleData = articleData.data.data;
                 let cover;
                 if (articleData.attributes.cover) {
                     cover = `<img src="https://image.gcores.com/${articleData.attributes.cover}" />`;


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/gcores/category/articles
/gcores/category/news
/gcores/category/videos
/gcores/category/radios
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/gcores/category/articles
/gcores/category/news
/gcores/category/videos
/gcores/category/radios
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

只对资讯、文章的路由进行了测试，有两个问题：
1. 作者输出带有日期

我想要的是 `无名氏` 这样的输出，实际输出是 `无名氏24分钟前`，`无名氏B3天前`这样的。

主要是我没太懂 cheerio 这个是怎么选择元素的。网页上应该是 `.avatar_text > .me-2`，但是我尝试了下面几种方式在输出的 RSS 里直接不显示 author 参数，只有 `.avatar_text` 能正常显示
    - `.avatar_text > .me-2`
    - `.avatar_text>.me-2`
    - `.me-2>.avatar_text`

2. author 这行写了两遍

当我尝试 RSSHub 文档中 [制作路由](https://docs.rsshub.app/zh/joinus/new-rss/start-code#生成-rss-源-1) 的这部分代码，直接在 `const basicItem =` 这个代码块添加 `author: item.find('.avatar_text').text(),`，访问路由会提示报错:

```js
❯ pnpm dev

> rsshub@1.0.0 dev .../RSSHub
> cross-env NODE_ENV=dev tsx watch --no-cache lib/index.ts

info: 🎉 RSSHub is running on port 1200! Cheers!
info: 💖 Can you help keep this open source project alive? Please sponsor 👉 https://docs.rsshub.app/sponsor
info: 🔗 Local: 👉 http://localhost:1200
info: 🔗 Network: 👉 http://xxx:1200
info: <-- GET /gcores/category/articles
error: Error in /gcores/category/articles: TypeError: item.find is not a function
    at .../RSSHub/lib/routes/gcores/category.ts:4:2423
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.tryGet (.../RSSHub/lib/utils/cache/index.ts:2:2693)
    at async Promise.all (index 0)
    at async Object.handler (.../RSSHub/lib/routes/gcores/category.ts:4:852)
    at async wrapedHandler (file://.../RSSHub/lib/registry.ts:1:2076)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async middleware (file://.../RSSHub/lib/middleware/cache.ts:1:980)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async middleware (file://.../RSSHub/lib/middleware/parameter.ts:1:1423)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async middleware (file://.../RSSHub/lib/middleware/anti-hotlink.ts:1:2325)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async middleware (file://.../RSSHub/lib/middleware/header.ts:1:759)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async middleware (file://.../RSSHub/lib/middleware/template.tsx:1:440)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async middleware (file://.../RSSHub/lib/middleware/debug.ts:1:366)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async middleware (file://.../RSSHub/lib/middleware/access-control.ts:1:706)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async middleware (file://.../RSSHub/lib/middleware/sentry.ts:1:479)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async middleware (file://.../RSSHub/lib/middleware/logger.ts:1:834)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
    at async compress2 (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/middleware/compress/index.js:5:5)
    at async dispatch (file://.../RSSHub/node_modules/.pnpm/hono@4.1.5/node_modules/hono/dist/compose.js:29:17)
info: --> GET /gcores/category/articles 503 3s
info: <-- GET /logo.png
info: --> GET /logo.png 200 3ms
info: <-- GET /favicon.ico
info: --> GET /favicon.ico 200 3ms
```

PS：只要能实现功能就行，可以直接commit然后把这个PR关了