### PR TITLE
fix(core): misc fixes of disabling cache

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -348,7 +348,7 @@ const calculateValue = () => {
         allowOrigin: envs.ALLOW_ORIGIN,
         // cache
         cache: {
-            type: envs.CACHE_TYPE || 'memory', // 缓存类型，支持 'memory' 和 'redis'，设为空可以禁止缓存
+            type: envs.CACHE_TYPE || (envs.CACHE_TYPE === '' ? '' : 'memory'), // 缓存类型，支持 'memory' 和 'redis'，设为空可以禁止缓存
             requestTimeout: toInt(envs.CACHE_REQUEST_TIMEOUT, 60),
             routeExpire: toInt(envs.CACHE_EXPIRE, 5 * 60), // 路由缓存时间，单位为秒
             contentExpire: toInt(envs.CACHE_CONTENT_EXPIRE, 1 * 60 * 60), // 不变内容缓存时间，单位为秒

--- a/lib/middleware/cache.test.ts
+++ b/lib/middleware/cache.test.ts
@@ -25,6 +25,8 @@ const noCacheTestFunc = async () => {
 
     expect(parsed1.items[0].content).toBe('Cache1');
     expect(parsed2.items[0].content).toBe('Cache2');
+
+    expect(parsed1.ttl).toEqual('1');
 };
 
 describe('cache', () => {
@@ -48,6 +50,8 @@ describe('cache', () => {
 
         expect(response2.status).toBe(200);
         expect(response2.headers.get('rsshub-cache-status')).toBe('HIT');
+
+        expect(parsed1.ttl).toEqual('1');
 
         await wait(1 * 1000 + 100);
         const response3 = await app.request('/test/cache');
@@ -96,6 +100,8 @@ describe('cache', () => {
 
         expect(response2.status).toBe(200);
         expect(response2.headers.get('rsshub-cache-status')).toBe('HIT');
+
+        expect(parsed1.ttl).toEqual('1');
 
         await wait(1 * 1000 + 100);
         const response3 = await app.request('/test/cache');
@@ -161,5 +167,23 @@ describe('cache', () => {
         } catch (error: any) {
             expect(error.message).toContain('Cache key must be a string');
         }
+    });
+
+    it('RSS TTL (no cache)', async () => {
+        process.env.CACHE_TYPE = '';
+        process.env.CACHE_EXPIRE = '600';
+        const app = (await import('@/app')).default;
+        const response = await app.request('/test/cache');
+        const parsed = await parser.parseString(await response.text());
+        expect(parsed.ttl).toEqual('1');
+    });
+
+    it('RSS TTL (w/ cache)', async () => {
+        process.env.CACHE_TYPE = 'memory';
+        process.env.CACHE_EXPIRE = '600';
+        const app = (await import('@/app')).default;
+        const response = await app.request('/test/cache');
+        const parsed = await parser.parseString(await response.text());
+        expect(parsed.ttl).toEqual('10');
     });
 });

--- a/lib/middleware/template.tsx
+++ b/lib/middleware/template.tsx
@@ -8,6 +8,13 @@ import { Data } from '@/types';
 import { getCurrentPath } from '@/utils/helpers';
 const __dirname = getCurrentPath(import.meta.url);
 
+// Set RSS <ttl> (minute) according to the availability of cache
+// * available: max(config.cache.routeExpire / 60, 1)
+// * unavailable: 1
+// The minimum <ttl> is limited to 1 minute to prevent potential misuse
+import cacheModule from '@/utils/cache/index';
+const ttl = (cacheModule.status.available && Math.trunc(config.cache.routeExpire / 60)) || 1;
+
 const middleware: MiddlewareHandler = async (ctx, next) => {
     await next();
 
@@ -74,7 +81,7 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
     const result = {
         lastBuildDate: currentDate.toUTCString(),
         updated: currentDate.toISOString(),
-        ttl: Math.trunc(config.cache.routeExpire / 60),
+        ttl,
         atomlink: ctx.req.url,
         ...data,
     };


### PR DESCRIPTION
<!--如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
```
fix(core): false RSS <ttl> when cache unavailable

Some RSS readers may probe <ttl> to determine the minimum interval of
polling. However, it is always set to `config.cache.routeExpire / 60`
even when cache is unavailable. This may not be expected when the cache
is explicitly disabled.

Set it to 1 (minute) under such a circumstance. The minimum <ttl> (when
cache is available) is also limited to 1 to avoid potential misuse.

The Cache-Control header remains untouched as caching can be done by a
reverse proxy.

Signed-off-by: Rongrong <i@rong.moe>


fix(core): CACHE_TYPE='' does not disable cache

The documentation of config always states that CACHE_TYPE being empty
will disable the cache.

The regression was introduced in 847724ca. The corresponding test case
was mistakenly "fixed" in 719af907.

Signed-off-by: Rongrong <i@rong.moe>
```