### PR TITLE
fix(route): 知乎时间线 (#9485)

### DIFF
--- a/lib/routes/zhihu/timeline.ts
+++ b/lib/routes/zhihu/timeline.ts
@@ -30,17 +30,20 @@ export const route: Route = {
   :::`,
 };
 
-async function handler() {
+async function handler(ctx) {
     const cookie = config.zhihu.cookies;
     if (cookie === undefined) {
         throw new Error('缺少知乎用户登录后的 Cookie 值');
     }
-
     const response = await got({
         method: 'get',
-        url: `https://www.zhihu.com/api/v3/moments?desktop=true&limit=100`,
+        url: `https://www.zhihu.com/api/v3/moments`,
         headers: {
             Cookie: cookie,
+        },
+        searchParams: {
+            desktop: true,
+            limit: ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 15,
         },
     });
     const feeds = response.data.data;
@@ -111,7 +114,7 @@ async function handler() {
     };
 
     const out = feeds
-        .filter((e) => e && e.verb && e.verb !== 'MEMBER_VOTEUP_ARTICLE' && e.verb !== 'MEMBER_VOTEUP_ANSWER')
+        .filter((e) => e.verb && e.verb !== 'MEMBER_VOTEUP_ARTICLE' && e.verb !== 'MEMBER_VOTEUP_ANSWER')
         .map((e) => {
             if (e && e.type && e.type === 'feed_group') {
                 // A feed group contains a list of feeds whose structure is the same as a single feed

--- a/lib/routes/zhihu/utils.ts
+++ b/lib/routes/zhihu/utils.ts
@@ -15,8 +15,12 @@ export default {
             const href = $(elem).attr('href');
             if (href?.startsWith('https://link.zhihu.com/?target=')) {
                 const url = new URL(href);
-                const target = url.searchParams.get('target');
-                $(elem).attr('href', decodeURIComponent(target));
+                const target = url.searchParams.get('target') || '';
+                try {
+                    $(elem).attr('href', decodeURIComponent(target));
+                } catch {
+                    // sometimes the target is not a valid url
+                }
             }
         });
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #9485 

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zhihu/timeline
```

## Note / 说明

Zhihu API use `verb` instead of `type`(default `feed`) to classify feeds. `verbs` includes:

```python
{('', '{}关注了问题'),
 ('MEMBER_ANSWER_QUESTION', '{}回答了问题'),
 ('MEMBER_ASK_QUESTION', '{}添加了问题'),
 ('MEMBER_COLLECT_ARTICLE', '{}收藏了文章'),
 ('MEMBER_CREATE_ARTICLE', '{}发表了文章'),
 ('MEMBER_CREATE_PIN', '{}发布了想法'),
 ('MEMBER_VOTEUP_ANSWER', '{}赞同了回答'),
 ('MEMBER_VOTEUP_ARTICLE', '{}赞同了文章'),
 (None, None) # advertisement
}
```

I excluded categories about votes but don't know if `MEMBER_CREATE_PIN`(想法) should be included. demo see [private temp rsshub](http://18.189.188.195:1200/zhihu/timeline?key=ernest)