### PR TITLE
feat(routes): Add censorbib

### DIFF
--- a/lib/routes/nymity/censorbib.ts
+++ b/lib/routes/nymity/censorbib.ts
@@ -1,0 +1,51 @@
+import { DataItem, Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+const url = 'https://censorbib.nymity.ch/';
+
+export const route: Route = {
+    path: '/censorbib',
+    categories: ['journal'],
+    example: '/nymity/censorbib',
+    radar: [
+        {
+            source: ['censorbib.nymity.ch/'],
+        },
+    ],
+    name: 'CensorBib Updates',
+    maintainers: ['xtexChooser'],
+    handler,
+    url: 'censorbib.nymity.ch/',
+};
+
+async function handler() {
+    const resp = await got.get(url);
+
+    const $ = load(resp.data);
+    const items = $('#container ul li')
+        .toArray()
+        .map((item): DataItem => {
+            const c = $(item);
+            const id = c.attr('id')!;
+            const title = c.find('span.paper').text().trim();
+            const author = c.find('span.author').text().trim();
+            const other = c.find('span.other').text().trim();
+            const download = c.find("img.icon[title='Download paper']").parent().attr('href');
+            const downloadBibTex = c.find("img.icon[title='Download BibTeX']").parent().attr('href');
+            const linkToPaper = c.find("img.icon[title='Link to paper']").parent().attr('href');
+            return {
+                title,
+                description: `${other}<br/><br/><a href='${download}'>Download</a>\n<a href='${downloadBibTex}'>Download BibTex</a>`,
+                author,
+                guid: id,
+                link: linkToPaper,
+            };
+        });
+
+    return {
+        title: 'CensorBib',
+        link: url,
+        description: 'CensorBib Updates',
+        item: items,
+    };
+}

--- a/lib/routes/nymity/censorbib.ts
+++ b/lib/routes/nymity/censorbib.ts
@@ -35,7 +35,7 @@ async function handler() {
             const linkToPaper = c.find("img.icon[title='Link to paper']").parent().attr('href');
             return {
                 title,
-                description: `${other}<br/><br/><a href='${download}'>Download</a>\n<a href='${downloadBibTex}'>Download BibTex</a>`,
+                description: `${other}<br/><br/><a href='${download}'>Download</a><br/><a href='${downloadBibTex}'>Download BibTex</a>`,
                 author,
                 guid: id,
                 link: linkToPaper,

--- a/lib/routes/nymity/namespace.ts
+++ b/lib/routes/nymity/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'nymity',
+    url: 'censorbib.nymity.ch',
+};

--- a/lib/utils/got.ts
+++ b/lib/utils/got.ts
@@ -52,12 +52,12 @@ const getFakeGot = (defaultOptions?: any) => {
         return gotofetch(request, options);
     };
 
-    fakeGot.get = (request, options) => fakeGot(request, { ...options, method: 'GET' });
-    fakeGot.post = (request, options) => fakeGot(request, { ...options, method: 'POST' });
-    fakeGot.put = (request, options) => fakeGot(request, { ...options, method: 'PUT' });
-    fakeGot.patch = (request, options) => fakeGot(request, { ...options, method: 'PATCH' });
-    fakeGot.head = (request, options) => fakeGot(request, { ...options, method: 'HEAD' });
-    fakeGot.delete = (request, options) => fakeGot(request, { ...options, method: 'DELETE' });
+    fakeGot.get = (request, options?) => fakeGot(request, { ...options, method: 'GET' });
+    fakeGot.post = (request, options?) => fakeGot(request, { ...options, method: 'POST' });
+    fakeGot.put = (request, options?) => fakeGot(request, { ...options, method: 'PUT' });
+    fakeGot.patch = (request, options?) => fakeGot(request, { ...options, method: 'PATCH' });
+    fakeGot.head = (request, options?) => fakeGot(request, { ...options, method: 'HEAD' });
+    fakeGot.delete = (request, options?) => fakeGot(request, { ...options, method: 'DELETE' });
     fakeGot.extend = (options) => getFakeGot(options);
 
     return fakeGot;


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/nymity/censorbib
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

https://github.com/NullHypothesis/censorbib/issues/8