### PR TITLE
fix(core): buffer responseType

### DIFF
--- a/lib/routes/baidu/tieba/search.ts
+++ b/lib/routes/baidu/tieba/search.ts
@@ -29,7 +29,7 @@ export const route: Route = {
     description: `| 键           | 含义                                                       | 接受的值      | 默认值 |
   | ------------ | ---------------------------------------------------------- | ------------- | ------ |
   | kw           | 在名为 kw 的贴吧中搜索                                     | 任意名称 / 无 | 无     |
-  | only\_thread | 只看主题帖，默认为 0 关闭                                  | 0/1           | 0      |
+  | only_thread  | 只看主题帖，默认为 0 关闭                                  | 0/1           | 0      |
   | rn           | 返回条目的数量                                             | 1-20          | 20     |
   | sm           | 排序方式，0 为按时间顺序，1 为按时间倒序，2 为按相关性顺序 | 0/1/2         | 1      |
 
@@ -41,7 +41,7 @@ async function handler(ctx) {
     const query = new URLSearchParams(ctx.req.param('routeParams'));
     query.set('ie', 'utf-8');
     query.set('qw', qw);
-    query.set('rn', query.get('rn') || 20); // Number of returned items
+    query.set('rn', query.get('rn') || '20'); // Number of returned items
     const link = `https://tieba.baidu.com/f/search/res?${query.toString()}`;
 
     const response = await got.get(link, {

--- a/lib/utils/got.test.ts
+++ b/lib/utils/got.test.ts
@@ -48,4 +48,12 @@ describe('got', () => {
         expect(response.body).toBe('{"test":"rsshub"}');
         expect(response.data.test).toBe('rsshub');
     });
+
+    it('buffer-get', async () => {
+        const response = await got.get('http://example.com', {
+            responseType: 'buffer',
+        });
+        expect(response.body instanceof Buffer).toBe(true);
+        expect(response.data instanceof Buffer).toBe(true);
+    });
 });


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #15042, Close #15076, Close #15077

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/ncc-cma/cmdp/image
/c114/roll
/txrjy/fornumtopic/1
/baidu/tieba/search/neuro
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
`buffer` responseType is not supported in the new `got.ts`, so all the routes are parsed as string, which results in encoding error. I add support for `buffer` responseType in this commit.