### PR TITLE
fix(route): zhubai/top20&zhubai/posts/:id

### DIFF
--- a/lib/routes/zhubai/index.ts
+++ b/lib/routes/zhubai/index.ts
@@ -5,9 +5,9 @@ import { parseDate } from '@/utils/parse-date';
 import { isValidHost } from '@/utils/valid-host';
 
 export const route: Route = {
-    path: '/:id',
+    path: '/posts/:id',
     categories: ['blog'],
-    example: '/zhubai/via',
+    example: '/zhubai/posts/via',
     parameters: { id: '`id` 为竹白主页 url 中的三级域名，如 via.zhubai.love 的 `id` 为 `via`' },
     features: {
         requireConfig: false,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #14931

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zhubai/posts/via
/zhubai/top20
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
because the top20 route `/top20` will hit the original article route `/:id`,  it needs to be distinguished by adding  `posts` before the article route