### PR TITLE
feat(route): add apple podcast route

### DIFF
--- a/lib/routes/apple/podcast.ts
+++ b/lib/routes/apple/podcast.ts
@@ -1,0 +1,64 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/podcast/:id',
+    categories: ['multimedia'],
+    example: '/apple/podcast/id1559695855',
+    parameters: { id: '播客id，可以在 Apple 播客app 内分享的播客的 URL 中找到' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['podcasts.apple.com/cn/podcast/:id'],
+        },
+    ],
+    name: '播客',
+    maintainers: ['Acring'],
+    handler,
+    url: 'https://www.apple.com.cn/apple-podcasts/',
+};
+
+async function handler(ctx) {
+    const link = `https://podcasts.apple.com/cn/podcast/${ctx.req.param('id')}`;
+    const response = await got({
+        method: 'get',
+        url: link,
+    });
+
+    const $ = load(response.data);
+
+    const page_data = JSON.parse($('#shoebox-media-api-cache-amp-podcasts').text());
+
+    const data = JSON.parse(page_data[Object.keys(page_data)[0]]).d[0];
+    const attributes = data.attributes;
+
+    const episodes = data.relationships.episodes.data.map((item) => {
+        const attr = item.attributes;
+        return {
+            title: attr.name,
+            enclosure_url: attr.assetUrl,
+            itunes_duration: attr.durationInMilliseconds / 1000,
+            enclosure_type: 'audio/mp4',
+            link: attr.url,
+            pubDate: parseDate(attr.releaseDateTime),
+            description: attr.description.standard,
+        };
+    });
+
+    return {
+        title: attributes.name,
+        link: attributes.url,
+        itunes_author: attributes.artistName,
+        item: episodes,
+        description: attributes.description.standard,
+    };
+}

--- a/lib/routes/apple/podcast.ts
+++ b/lib/routes/apple/podcast.ts
@@ -50,7 +50,7 @@ async function handler(ctx) {
             enclosure_type: 'audio/mp4',
             link: attr.url,
             pubDate: parseDate(attr.releaseDateTime),
-            description: attr.description.standard,
+            description: attr.description.standard.replaceAll('\n', '<br>'),
         };
     });
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例


```routes
/apple/podcast/id1559695855
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

新增 apple 播客 路由
