### PR TITLE
feat(core/utils/wechat-mp): major rewrite

### DIFF
--- a/lib/errors/index.test.ts
+++ b/lib/errors/index.test.ts
@@ -66,13 +66,13 @@ describe('route throws an error', () => {
                     expect(value).toBe('9');
                     break;
                 case 'Hot Routes:':
-                    expect(value).toBe('6 /test/:id<br>');
+                    expect(value).toBe('6 /test/:id/:params?<br>');
                     break;
                 case 'Hot Paths:':
                     expect(value).toBe('2 /test/error<br>2 /test/slow<br>1 /test/httperror<br>1 /test/config-not-found-error<br>1 /test/invalid-parameter-error<br>1 /thisDoesNotExist<br>1 /<br>');
                     break;
                 case 'Hot Error Routes:':
-                    expect(value).toBe('5 /test/:id<br>');
+                    expect(value).toBe('5 /test/:id/:params?<br>');
                     break;
                 case 'Hot Error Paths:':
                     expect(value).toBe('2 /test/error<br>1 /test/httperror<br>1 /test/slow<br>1 /test/config-not-found-error<br>1 /test/invalid-parameter-error<br>1 /thisDoesNotExist<br>');

--- a/lib/routes/test/index.ts
+++ b/lib/routes/test/index.ts
@@ -3,13 +3,14 @@ import { config } from '@/config';
 import got from '@/utils/got';
 import wait from '@/utils/wait';
 import cache from '@/utils/cache';
+import { fetchArticle } from '@/utils/wechat-mp';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
 import InvalidParameterError from '@/errors/types/invalid-parameter';
 
 let cacheIndex = 0;
 
 export const route: Route = {
-    path: '/:id',
+    path: '/:id/:params?',
     name: 'Unknown',
     maintainers: ['DIYgod', 'NeverBehave'],
     handler,
@@ -382,6 +383,15 @@ async function handler(ctx) {
                 link: 'https://m.thepaper.cn/newsDetail_forward_4059298',
             },
         ];
+    }
+
+    if (ctx.req.param('id') === 'wechat-mp') {
+        const params = ctx.req.param('params');
+        if (!params) {
+            throw new InvalidParameterError('Invalid parameter');
+        }
+        const mpUrl = 'https:/mp.weixin.qq.com/s' + (params.includes('&') ? '?' : '/') + params;
+        item = [await fetchArticle(mpUrl)];
     }
 
     return {

--- a/lib/setup.test.ts
+++ b/lib/setup.test.ts
@@ -2,6 +2,29 @@ import { afterAll, afterEach } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 
+const genWeChatMpPage = (rich_media_content: string, scripts: string[] | string) => {
+    if (!Array.isArray(scripts)) {
+        scripts = [scripts];
+    }
+    let pageHtml = `
+<meta name="description" content="summary" />
+<meta name="author" content="author" />
+<meta property="og:title" content="title" />
+<meta property="og:image" content="https://mmbiz.qpic.cn/rsshub_test/og_img_1/0?wx_fmt=jpeg" />
+<meta property="twitter:card" content="summary" />
+<div class="rich_media_content" id="js_content" style="visibility: hidden;">
+${rich_media_content}
+</div>
+<div class="wx_follow_nickname">mpName</div>`;
+    for (const script of scripts) {
+        pageHtml += `
+<script type="text/javascript" nonce="000000000">
+${script}
+</script>`;
+    }
+    return pageHtml;
+};
+
 const server = setupServer(
     http.post(`https://api.openai.mock/v1/chat/completions`, () =>
         HttpResponse.json({
@@ -33,21 +56,106 @@ const server = setupServer(
             </ul>
         </div>`)
     ),
-    http.get(`https://mp.weixin.qq.com/rsshub_test/wechatMp_fetchArticle`, () =>
+    http.get(`https://mp.weixin.qq.com/rsshub_test/appMsg`, () =>
         HttpResponse.text(
-            '\n' +
-                '<meta name="description" content="summary" />\n' +
-                '<meta name="author" content="author" />\n' +
-                '<meta property="og:title" content="title" />\n' +
-                '<meta property="twitter:card" content="summary" />\n' +
-                '<div class="rich_media_content" id="js_content" style="visibility: hidden;">description</div>\n' +
-                '<div class="profile_inner"><strong class="profile_nickname">mpName</strong></div>\n' +
-                '<script type="text/javascript" nonce="000000000">\n' +
-                'var appmsg_type = "9";\n' +
-                `var ct = "${1_636_626_300}";\n` +
-                '</script>'
+            genWeChatMpPage(
+                `
+description
+<iframe class="video_iframe rich_pages" data-ratio="1.7777777777777777" data-w="864"data-src="https://v.qq.com/rsshub_test/?vid=fake"></iframe>
+<mpvoice name="title" voice_encode_fileid="rsshub_test"></mpvoice>
+`,
+                `
+var item_show_type = "0";
+var real_item_show_type = "0";
+var appmsg_type = "9";
+var ct = "${1_636_626_300}";
+var msg_source_url = "https://mp.weixin.qq.com/rsshub_test/fake";
+window.ip_wording = {
+  countryName: '中国',
+  countryId: '156',
+  provinceName: '福建',
+  provinceId: '',
+  cityName: '',
+  cityId: ''
+};`
+            )
         )
     ),
+    http.get(`https://mp.weixin.qq.com/rsshub_test/img`, () =>
+        HttpResponse.text(
+            genWeChatMpPage('fake_description', [
+                `
+var item_show_type = "8";
+var real_item_show_type = "8";
+var appmsg_type = "9";
+var ct = "${1_636_626_300}";
+`,
+                `
+window.picture_page_info_list = [
+{
+  cdn_url: 'https://mmbiz.qpic.cn/rsshub_test/fake_img_1/0?wx_fmt=jpeg',
+},
+{
+  cdn_url: 'https://mmbiz.qpic.cn/rsshub_test/fake_img_2/0?wx_fmt=jpeg',
+},
+].slice(0, 20);
+`,
+            ])
+        )
+    ),
+    http.get(`https://mp.weixin.qq.com/rsshub_test/audio`, () =>
+        HttpResponse.text(
+            genWeChatMpPage('fake_description', [
+                `
+var item_show_type = "7";
+var real_item_show_type = "7";
+var appmsg_type = "9";
+var ct = "${1_636_626_300}";
+`,
+                `
+reportOpt = {
+  voiceid: "",
+  uin: "",
+  biz: "",
+  mid: "",
+  idx: ""
+};
+window.cgiData = {
+  voiceid: "rsshub_test_voiceid_1",
+  duration: "6567" * 1,
+};
+`,
+            ])
+        )
+    ),
+    http.get(`https://mp.weixin.qq.com/rsshub_test/video`, () =>
+        HttpResponse.text(
+            genWeChatMpPage(
+                'fake_description',
+                `
+var item_show_type = "5";
+var real_item_show_type = "5";
+var appmsg_type = "9";
+var ct = "${1_636_626_300}";
+`
+            )
+        )
+    ),
+    http.get(`https://mp.weixin.qq.com/rsshub_test/fallback`, () =>
+        HttpResponse.text(
+            genWeChatMpPage(
+                'fake_description',
+                `
+var item_show_type = "99988877";
+var real_item_show_type = "99988877";
+var appmsg_type = "9";
+var ct = "${1_636_626_300}";
+`
+            )
+        )
+    ),
+    http.get(`https://mp.weixin.qq.com/s/rsshub_test`, () => HttpResponse.text(genWeChatMpPage('', ''))),
+    http.get(`https://mp.weixin.qq.com/s?__biz=rsshub_test&mid=1&idx=1&sn=1`, () => HttpResponse.text(genWeChatMpPage('', ''))),
     http.get(`http://rsshub.test/headers`, ({ request }) =>
         HttpResponse.json({
             ...Object.fromEntries(request.headers.entries()),

--- a/lib/utils/wechat-mp.test.ts
+++ b/lib/utils/wechat-mp.test.ts
@@ -36,13 +36,7 @@ const genScriptHtmlStr = (script: string) => `
         </script>
     </html>
 `;
-const testFetchArticleFinishArticleItem = async (
-    path: string,
-    finishArticleItemParams = {
-        setMpNameAsAuthor: false,
-        skipLink: false,
-    }
-) => {
+const testFetchArticleFinishArticleItem = async (path: string, { setMpNameAsAuthor = false, skipLink = false } = {}) => {
     const ct = 1_636_626_300;
     const httpsUrl = `https://mp.weixin.qq.com/rsshub_test${path}`;
     const httpUrl = 'http' + httpsUrl.slice(5);
@@ -60,10 +54,10 @@ const testFetchArticleFinishArticleItem = async (
 
     const ToBeFinishedArticleItem = { link: httpUrl };
     const expectedFinishedArticleItem = { ...fetchArticleItem };
-    expectedFinishedArticleItem.author = finishArticleItemParams.setMpNameAsAuthor ? <string>expectedFinishedArticleItem.mpName : expectedFinishedArticleItem.author;
-    expectedFinishedArticleItem.link = finishArticleItemParams.skipLink ? ToBeFinishedArticleItem.link : expectedFinishedArticleItem.link;
+    expectedFinishedArticleItem.author = setMpNameAsAuthor ? <string>expectedFinishedArticleItem.mpName : expectedFinishedArticleItem.author;
+    expectedFinishedArticleItem.link = skipLink ? ToBeFinishedArticleItem.link : expectedFinishedArticleItem.link;
 
-    const finishedArticleItem = await finishArticleItem(ToBeFinishedArticleItem, finishArticleItemParams.setMpNameAsAuthor, finishArticleItemParams.skipLink);
+    const finishedArticleItem = await finishArticleItem(ToBeFinishedArticleItem, setMpNameAsAuthor, skipLink);
     expect(compareDate(finishedArticleItem.pubDate, fetchArticleItem.pubDate)).toBe(true);
     delete expectedFinishedArticleItem.pubDate;
     expect(finishedArticleItem).toMatchObject(expectedFinishedArticleItem);

--- a/lib/utils/wechat-mp.test.ts
+++ b/lib/utils/wechat-mp.test.ts
@@ -1,6 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { load } from 'cheerio';
-import { fixArticleContent, fetchArticle, finishArticleItem, normalizeUrl } from '@/utils/wechat-mp';
+import Parser from 'rss-parser';
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import { exportedForTestingOnly, fetchArticle, finishArticleItem, fixArticleContent, normalizeUrl } from '@/utils/wechat-mp';
+const { ExtractMetadata, showTypeMapReverse } = exportedForTestingOnly;
+
+vi.mock('@/utils/request-rewriter', () => ({ default: null }));
+const { default: app } = await import('@/app');
+const parser = new Parser();
+
+const expectedItem: {
+    title: string;
+    summary: string;
+    author: string;
+    mpName: string;
+    link: string;
+} = {
+    title: 'title',
+    summary: 'summary',
+    author: 'author',
+    mpName: 'mpName',
+    link: '', // to be filled
+};
 
 // date from the cache will be an ISO8601 string, so we need to use this function
 const compareDate = (date1, date2) => {
@@ -8,8 +29,233 @@ const compareDate = (date1, date2) => {
     date2 = typeof date2 === 'string' ? new Date(date2) : date2;
     return date1.getTime() === date2.getTime();
 };
+const genScriptHtmlStr = (script: string) => `
+    <html lang="">
+        <script type="text/javascript" nonce="123456789">
+        ${script}
+        </script>
+    </html>
+`;
+const testFetchArticleFinishArticleItem = async (
+    path: string,
+    finishArticleItemParams = {
+        setMpNameAsAuthor: false,
+        skipLink: false,
+    }
+) => {
+    const ct = 1_636_626_300;
+    const httpsUrl = `https://mp.weixin.qq.com/rsshub_test${path}`;
+    const httpUrl = 'http' + httpsUrl.slice(5);
+
+    const expectedDate = new Date(ct * 1000);
+
+    const expectedItem_ = {
+        ...expectedItem,
+        link: httpsUrl,
+    };
+
+    const fetchArticleItem = await fetchArticle(httpUrl);
+    expect(compareDate(fetchArticleItem.pubDate, expectedDate)).toBe(true);
+    expect(fetchArticleItem).toMatchObject(expectedItem_);
+
+    const ToBeFinishedArticleItem = { link: httpUrl };
+    const expectedFinishedArticleItem = { ...fetchArticleItem };
+    expectedFinishedArticleItem.author = finishArticleItemParams.setMpNameAsAuthor ? <string>expectedFinishedArticleItem.mpName : expectedFinishedArticleItem.author;
+    expectedFinishedArticleItem.link = finishArticleItemParams.skipLink ? ToBeFinishedArticleItem.link : expectedFinishedArticleItem.link;
+
+    const finishedArticleItem = await finishArticleItem(ToBeFinishedArticleItem, finishArticleItemParams.setMpNameAsAuthor, finishArticleItemParams.skipLink);
+    expect(compareDate(finishedArticleItem.pubDate, fetchArticleItem.pubDate)).toBe(true);
+    delete expectedFinishedArticleItem.pubDate;
+    expect(finishedArticleItem).toMatchObject(expectedFinishedArticleItem);
+
+    return fetchArticleItem;
+};
 
 describe('wechat-mp', () => {
+    it('ExtractMetadata.common', () => {
+        expect(ExtractMetadata.common(load(''))).toStrictEqual({});
+
+        expect(
+            ExtractMetadata.common(
+                load(
+                    genScriptHtmlStr(`
+            window.fake_item_show_type = '5' || '';
+            window.fake_real_item_show_type = '5' || '';
+            window.fake_ct = '1713009660' || '';
+        `)
+                )
+            )
+        ).toMatchObject({});
+
+        expect(
+            ExtractMetadata.common(
+                load(
+                    genScriptHtmlStr(`
+            window.item_show_type = '5' || '';
+            window.real_item_show_type = '5' || '';
+            window.ct = '1713009660' || '';
+        `)
+                )
+            )
+        ).toMatchObject({
+            showType: showTypeMapReverse['5'],
+            realShowType: showTypeMapReverse['5'],
+            createTime: '1713009660',
+        });
+
+        expect(
+            ExtractMetadata.common(
+                load(
+                    genScriptHtmlStr(`
+            var item_show_type = "5";
+            var real_item_show_type = "5";
+            var ct = "1713009660";
+            var msg_source_url = 'https://mp.weixin.qq.com/rsshub_test/fake';
+        `)
+                )
+            )
+        ).toMatchObject({
+            showType: showTypeMapReverse['5'],
+            realShowType: showTypeMapReverse['5'],
+            createTime: '1713009660',
+            sourceUrl: 'https://mp.weixin.qq.com/rsshub_test/fake',
+        });
+
+        expect(
+            ExtractMetadata.common(
+                load(
+                    genScriptHtmlStr(`
+            var item_show_type = "998877665544332211";
+            var real_item_show_type = "112233445566778899";
+            var ct = "1713009660";
+        `)
+                )
+            )
+        ).toMatchObject({
+            showType: '998877665544332211',
+            realShowType: '112233445566778899',
+            createTime: '1713009660',
+        });
+    });
+    it('ExtractMetadata.img', () => {
+        expect(ExtractMetadata.img(load(''))).toStrictEqual({});
+
+        expect(
+            ExtractMetadata.img(
+                load(
+                    genScriptHtmlStr(`
+            window.picture_page_info_list = [
+            {
+              cdn_url: 'https://mmbiz.qpic.cn/rsshub_test/fake_img_1/0?wx_fmt=jpeg',
+            },
+            {
+              cdn_url: 'https://mmbiz.qpic.cn/rsshub_test/fake_img_2/0?wx_fmt=jpeg',
+            },
+            ].slice(0, 20);
+        `)
+                )
+            )
+        ).toMatchObject({
+            imgUrls: ['https://mmbiz.qpic.cn/rsshub_test/fake_img_1/0?wx_fmt=jpeg', 'https://mmbiz.qpic.cn/rsshub_test/fake_img_2/0?wx_fmt=jpeg'],
+        });
+    });
+    it('ExtractMetadata.audio', () => {
+        expect(ExtractMetadata.audio(load(''))).toStrictEqual({});
+
+        expect(
+            ExtractMetadata.audio(
+                load(
+                    genScriptHtmlStr(`
+            reportOpt = {
+              voiceid: "",
+              uin: "",
+              biz: "",
+              mid: "",
+              idx: ""
+            };
+        `)
+                )
+            )
+        ).toMatchObject({});
+
+        expect(
+            ExtractMetadata.audio(
+                load(
+                    genScriptHtmlStr(`
+            window.cgiData = {
+              voiceid: "rsshub_test_voiceid_1",
+              duration: "6567" * 1,
+            };
+        `)
+                )
+            )
+        ).toMatchObject({
+            voiceId: 'rsshub_test_voiceid_1',
+            duration: '6567',
+        });
+
+        expect(
+            ExtractMetadata.audio(
+                load(
+                    genScriptHtmlStr(`
+            window.cgiData = {
+              voiceid: "rsshub_test_voiceid_1",
+            };
+        `)
+                )
+            )
+        ).toMatchObject({
+            voiceId: 'rsshub_test_voiceid_1',
+            duration: null,
+        });
+
+        expect(
+            ExtractMetadata.audio(
+                load(
+                    genScriptHtmlStr(`
+            reportOpt = {
+              voiceid: "",
+              uin: "",
+              biz: "",
+              mid: "",
+              idx: ""
+            };
+            window.cgiData = {
+              voiceid: "rsshub_test_voiceid_1",
+              duration: "6567" * 1,
+            };
+        `)
+                )
+            )
+        ).toMatchObject({
+            voiceId: 'rsshub_test_voiceid_1',
+            duration: '6567',
+        });
+    });
+    it('ExtractMetadata.location', () => {
+        expect(ExtractMetadata.location(load(''))).toStrictEqual({});
+
+        expect(
+            ExtractMetadata.location(
+                load(
+                    genScriptHtmlStr(`
+            window.ip_wording = {
+              countryName: '中国',
+              countryId: '156',
+              provinceName: '广东',
+              provinceId: '',
+              cityName: '',
+              cityId: ''
+            };
+        `)
+                )
+            )
+        ).toMatchObject({
+            countryName: '中国',
+            provinceName: '广东',
+            cityName: '',
+        });
+    });
     it('fixArticleContent', () => {
         const divHeader = '<div class="rich_media_content " id="js_content">';
         const divFooter = '</div>';
@@ -88,37 +334,105 @@ describe('wechat-mp', () => {
         expect(normalizeUrl(notWechatMp, true)).toBe(notWechatMp);
     });
 
-    it('fetchArticle_&_finishArticleItem', async () => {
-        const ct = 1_636_626_300;
-        const httpsUrl = 'https://mp.weixin.qq.com/rsshub_test/wechatMp_fetchArticle';
-        const httpUrl = httpsUrl.replace(/^https:\/\//, 'http://');
-
-        const expectedItem: {
-            title: string;
-            summary: string;
-            author: string;
-            description: string;
-            mpName?: string;
-            link: string;
-        } = {
+    it('fetchArticle_&_finishArticleItem_appMsg', async () => {
+        const fetchArticleItem = await testFetchArticleFinishArticleItem('/appMsg');
+        const $ = load(fetchArticleItem.description);
+        expect($('iframe').attr()).toMatchObject({
+            src:
+                'https://v.qq.com/txp/iframe/player.html?origin=https%3A%2F%2Fmp.weixin.qq.com' +
+                '&containerId=js_tx_video_container_0.3863487104715233&vid=fake&width=677&height=380.8125' +
+                '&autoplay=false&allowFullScreen=true&chid=17&full=true&show1080p=false&isDebugIframe=false',
+            width: '677',
+            height: '380.8125',
+        });
+        expect($('audio').attr()).toMatchObject({
+            src: 'https://res.wx.qq.com/voice/getvoice?mediaid=rsshub_test',
             title: 'title',
-            summary: 'summary',
-            author: 'author',
-            description: 'description',
-            mpName: 'mpName',
-            link: httpsUrl,
+        });
+        expect($('a').attr()).toMatchObject({
+            href: 'https://mp.weixin.qq.com/rsshub_test/fake',
+        });
+        expect(fetchArticleItem.description).toContain('description');
+        expect(fetchArticleItem.description).toContain('📍发表于：中国 福建');
+        expect(fetchArticleItem.description).toContain('🔗️ 阅读原文');
+    });
+
+    it('fetchArticle_&_finishArticleItem_img', async () => {
+        const fetchArticleItem = await testFetchArticleFinishArticleItem('/img');
+        const $ = load(fetchArticleItem.description);
+        expect($.text()).toBe('summary');
+        expect($('img:nth-of-type(1)').attr()).toMatchObject({
+            src: 'https://mmbiz.qpic.cn/rsshub_test/fake_img_1/0?wx_fmt=jpeg',
+        });
+        expect($('img:nth-of-type(2)').attr()).toMatchObject({
+            src: 'https://mmbiz.qpic.cn/rsshub_test/fake_img_2/0?wx_fmt=jpeg',
+        });
+    });
+
+    it('fetchArticle_&_finishArticleItem_audio', async () => {
+        const fetchArticleItem = await testFetchArticleFinishArticleItem('/audio');
+        const $ = load(fetchArticleItem.description);
+        expect($.text()).toBe('summary');
+        expect($('audio').attr()).toMatchObject({
+            controls: '',
+            src: 'https://res.wx.qq.com/voice/getvoice?mediaid=rsshub_test_voiceid_1',
+            style: 'width:100%',
+            title: 'title',
+        });
+        expect(fetchArticleItem).toMatchObject({
+            enclosure_type: 'audio/mp3',
+            enclosure_url: 'https://res.wx.qq.com/voice/getvoice?mediaid=rsshub_test_voiceid_1',
+            itunes_duration: '6567',
+        });
+    });
+
+    it('fetchArticle_&_finishArticleItem_video', async () => {
+        const fetchArticleItem = await testFetchArticleFinishArticleItem('/video');
+        const $ = load(fetchArticleItem.description);
+        expect($.text()).toBe('summary');
+        expect($('img').attr()).toMatchObject({
+            src: 'https://mmbiz.qpic.cn/rsshub_test/og_img_1/0?wx_fmt=jpeg',
+        });
+    });
+
+    it('fetchArticle_&_finishArticleItem_fallback', async () => {
+        const fetchArticleItem = await testFetchArticleFinishArticleItem('/fallback');
+        const $ = load(fetchArticleItem.description);
+        expect($.text()).toBe('summary');
+        expect($('img').attr()).toMatchObject({
+            src: 'https://mmbiz.qpic.cn/rsshub_test/og_img_1/0?wx_fmt=jpeg',
+        });
+    });
+
+    it('finishArticleItem_param', async () => {
+        await testFetchArticleFinishArticleItem('/fallback', { setMpNameAsAuthor: false, skipLink: false });
+        await testFetchArticleFinishArticleItem('/fallback', { setMpNameAsAuthor: true, skipLink: false });
+        await testFetchArticleFinishArticleItem('/fallback', { setMpNameAsAuthor: false, skipLink: true });
+        await testFetchArticleFinishArticleItem('/fallback', { setMpNameAsAuthor: true, skipLink: true });
+    });
+
+    it('route_test', async () => {
+        try {
+            await app.request('/test/wechat-mp');
+        } catch (error) {
+            expect(error).toBeInstanceOf(InvalidParameterError);
+        }
+
+        const responseShort = await app.request('/test/wechat-mp/rsshub_test');
+        const parsedShort = await parser.parseString(await responseShort.text());
+        const expectedItemShort = {
+            author: expectedItem.author,
+            title: expectedItem.title,
+            link: 'https://mp.weixin.qq.com/s/rsshub_test',
         };
-        const expectedDate = new Date(ct * 1000);
+        expect(parsedShort.items[0]).toMatchObject(expectedItemShort);
 
-        const fetchArticleItem = await fetchArticle(httpUrl);
-        expect(compareDate(fetchArticleItem.pubDate, expectedDate)).toBe(true);
-        delete fetchArticleItem.pubDate;
-        expect(fetchArticleItem).toEqual(expectedItem);
-
-        delete expectedItem.mpName;
-        const finishedArticleItem = await finishArticleItem({ link: httpUrl });
-        expect(compareDate(finishedArticleItem.pubDate, expectedDate)).toBe(true);
-        delete finishedArticleItem.pubDate;
-        expect(finishedArticleItem).toEqual(expectedItem);
+        const responseLong = await app.request('/test/wechat-mp/__biz=rsshub_test&mid=1&idx=1&sn=1');
+        const parsedLong = await parser.parseString(await responseLong.text());
+        const expectedItemLong = {
+            ...expectedItemShort,
+            link: 'https://mp.weixin.qq.com/s?__biz=rsshub_test&mid=1&idx=1&sn=1',
+        };
+        expect(parsedLong.items[0]).toMatchObject(expectedItemLong);
     });
 });

--- a/lib/utils/wechat-mp.ts
+++ b/lib/utils/wechat-mp.ts
@@ -43,9 +43,8 @@ const replaceReturnNewline = (() => {
     return (text: string, replaceReturnWith = '', replaceNewlineWith = '<br>') => text.replaceAll(returnRegExp, replaceReturnWith).replaceAll(newlineRegExp, replaceNewlineWith);
 })();
 const fixUrl = (() => {
-    const hex26RegExp = /\\x26/g;
-    const ampRegExp = /&amp;/g;
-    return (text: string) => text.replaceAll(hex26RegExp, '&').replaceAll(ampRegExp, '&');
+    const ampRegExp = /(&|\\x26)amp;/g;
+    return (text: string) => text.replaceAll(ampRegExp, '&');
 })();
 
 class LoopContinue extends Error {

--- a/lib/utils/wechat-mp.ts
+++ b/lib/utils/wechat-mp.ts
@@ -156,7 +156,7 @@ class ExtractMetadata {
             $,
             (script) => {
                 const scriptText = $(script).text();
-                const metadataExtracted = <Record<string, string>>this.doExtract(this.commonMetadataToBeExtracted, scriptText);
+                const metadataExtracted = <Record<string, string>> this.doExtract(this.commonMetadataToBeExtracted, scriptText);
                 const showType = showTypeMapReverse[metadataExtracted.showType];
                 const realShowType = showTypeMapReverse[metadataExtracted.realShowType];
                 metadataExtracted.sourceUrl = metadataExtracted.sourceUrl && fixUrl(metadataExtracted.sourceUrl);
@@ -191,7 +191,7 @@ class ExtractMetadata {
             $,
             (script) => {
                 const scriptText = $(script).text();
-                const metadataExtracted = <Record<string, string>>this.doExtract(this.audioMetadataToBeExtracted, scriptText);
+                const metadataExtracted = <Record<string, string>> this.doExtract(this.audioMetadataToBeExtracted, scriptText);
                 throw new LoopReturn(metadataExtracted);
             },
             {},
@@ -207,7 +207,7 @@ class ExtractMetadata {
             $,
             (script) => {
                 const scriptText = $(script).text();
-                const metadataExtracted = <Record<string, string[]>>this.doExtract(this.imgMetadataToBeExtracted, scriptText);
+                const metadataExtracted = <Record<string, string[]>> this.doExtract(this.imgMetadataToBeExtracted, scriptText);
                 if (Array.isArray(metadataExtracted.imgUrls)) {
                     metadataExtracted.imgUrls = metadataExtracted.imgUrls.map((url) => fixUrl(url));
                 }

--- a/lib/utils/wechat-mp.ts
+++ b/lib/utils/wechat-mp.ts
@@ -26,9 +26,216 @@
  */
 
 import ofetch from '@/utils/ofetch';
-import { load, type Cheerio, type Element } from 'cheerio';
+import { type Cheerio, type CheerioAPI, type Element, load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
 import cache from '@/utils/cache';
+import logger from '@/utils/logger';
+
+const MAINTAINERS = ['Rongronggg9'];
+
+const warn = (reason: string, details: string) =>
+    logger.warn(`wechat-mp: ${reason}: ${details},
+consider raise an issue (mentioning ${MAINTAINERS.join(', ')}) with the article URL for further investigation`);
+
+const replaceReturnNewline = (() => {
+    const returnRegExp = /\r|\\(r|x0d)/g;
+    const newlineRegExp = /\n|\\(n|x0a)/g;
+    return (text: string, replaceReturnWith = '', replaceNewlineWith = '<br>') => text.replaceAll(returnRegExp, replaceReturnWith).replaceAll(newlineRegExp, replaceNewlineWith);
+})();
+const fixUrl = (() => {
+    const hex26RegExp = /\\x26/g;
+    const ampRegExp = /&amp;/g;
+    return (text: string) => text.replaceAll(hex26RegExp, '&').replaceAll(ampRegExp, '&');
+})();
+
+class LoopContinue extends Error {
+    constructor() {
+        super('');
+        this.name = 'LoopContinue';
+    }
+}
+
+class LoopReturn extends Error {
+    to_return: any;
+
+    constructor(to_return: any) {
+        super('');
+        this.name = 'LoopReturn';
+        this.to_return = to_return;
+    }
+}
+
+const forEachScript = ($: CheerioAPI | string, callback: (script) => void, defaultReturn: any = null, selector = 'script[nonce][type="text/javascript"]') => {
+    const scripts = typeof $ === 'string' ? [$] : $(selector).toArray();
+    for (const script of scripts) {
+        try {
+            callback(script);
+        } catch (error) {
+            if (error instanceof LoopReturn) {
+                return error.to_return;
+            } else if (error instanceof LoopContinue) {
+                continue;
+            }
+            throw error;
+        }
+    }
+    return defaultReturn;
+};
+
+// view-source a *_SHARE_PAGE type article and search for `ITEM_SHOW_TYPE_MAP`
+// Please update the comments below if you find new types or new examples
+const showTypeMap = {
+    // "Article".
+    // May be combined with media, but type won't change
+    // Combined with audio and iframe: https://mp.weixin.qq.com/s/FnjcMXZ1xdS-d6n-pUUyyw
+    APP_MSG_PAGE: '0',
+    // https://mp.weixin.qq.com/s?__biz=Mzg4NTA1MTkwNA==&mid=2247532942&idx=1&sn=a84e4adbe49fdb39e4d4c1b5c12a4c3f
+    VIDEO_SHARE_PAGE: '5',
+    MUSIC_SHARE_PAGE: '6',
+    // https://mp.weixin.qq.com/s/FY6yQC_e4NMAxK0FBr6jwQ
+    AUDIO_SHARE_PAGE: '7',
+    // https://mp.weixin.qq.com/s/4p5YmYuASiQSYFiy7KqydQ
+    // https://mp.weixin.qq.com/s?__biz=Mzg4NTA1MTkwNA==&mid=2247532936&idx=4&sn=624054c20ded6ee85c6632f419c6f758
+    IMG_SHARE_PAGE: '8',
+    TEXT_SHARE_PAGE: '10',
+    SHORT_CONTENT_PAGE: '17',
+};
+const showTypeMapReverse = Object.fromEntries(Object.entries(showTypeMap).map(([k, v]) => [v, k]));
+
+class ExtractMetadata {
+    private static genAssignmentRegExp = (varName: string, valuePattern: string, assignPattern: string) => RegExp(`\\b${varName}\\s*${assignPattern}\\s*(?<quote>["'])(?<value>${valuePattern})\\k<quote>`, 'mg');
+
+    private static genExtractFunc = (
+        varName: string,
+        {
+            valuePattern = '\\w+',
+            assignPattern = '=',
+            allowNotFound = false,
+            multiple = false,
+        }: {
+            valuePattern?: string;
+            assignPattern?: string;
+            allowNotFound?: boolean;
+            multiple?: boolean;
+        }
+    ) => {
+        const regExp = this.genAssignmentRegExp(varName, valuePattern, assignPattern);
+        return (str: string) => {
+            const values: string[] = [];
+            for (const match of str.matchAll(regExp)) {
+                const value = <string>match.groups?.value;
+                if (!multiple) {
+                    return value;
+                }
+                values.push(value);
+            }
+            if (!allowNotFound && values.length === 0) {
+                throw new LoopContinue();
+            }
+            return multiple ? values : null;
+        };
+    };
+
+    private static doExtract = (metadataToBeExtracted: Record<string, (str: string) => string | string[] | null | undefined>, scriptText: string) => {
+        const metadataExtracted: Record<string, string | string[]> = {};
+        for (const [key, extractFunc] of Object.entries(metadataToBeExtracted)) {
+            metadataExtracted[key] = <string>extractFunc(scriptText);
+        }
+        metadataExtracted._extractedFrom = scriptText;
+        return metadataExtracted;
+    };
+
+    private static commonMetadataToBeExtracted = {
+        showType: this.genExtractFunc('item_show_type', { valuePattern: '\\d+' }),
+        realShowType: this.genExtractFunc('real_item_show_type', { valuePattern: '\\d+' }),
+        createTime: this.genExtractFunc('ct', { valuePattern: '\\d+' }),
+        sourceUrl: this.genExtractFunc('msg_source_url', { valuePattern: `https?://[^'"]*`, allowNotFound: true }),
+    };
+
+    static common = ($: CheerioAPI) =>
+        forEachScript(
+            $,
+            (script) => {
+                const scriptText = $(script).text();
+                const metadataExtracted = <Record<string, string>>this.doExtract(this.commonMetadataToBeExtracted, scriptText);
+                const showType = showTypeMapReverse[metadataExtracted.showType];
+                const realShowType = showTypeMapReverse[metadataExtracted.realShowType];
+                metadataExtracted.sourceUrl = metadataExtracted.sourceUrl && fixUrl(metadataExtracted.sourceUrl);
+                if (showType) {
+                    metadataExtracted.showType = showType;
+                } else {
+                    warn('showType not found', `item_show_type=${metadataExtracted.showType}`);
+                }
+                if (realShowType) {
+                    metadataExtracted.realShowType = realShowType;
+                } else {
+                    warn('realShowType not found', `real_item_show_type=${metadataExtracted.realShowType}`);
+                }
+                if (metadataExtracted.showType !== metadataExtracted.realShowType) {
+                    // never seen this happen, waiting for examples
+                    warn('showType mismatch', `item_show_type=${metadataExtracted.showType}, real_item_show_type=${metadataExtracted.realShowType}`);
+                }
+                throw new LoopReturn(metadataExtracted);
+            },
+            {},
+            'script[nonce][type="text/javascript"]:contains("real_item_show_type")'
+        );
+
+    private static audioMetadataToBeExtracted = {
+        voiceId: this.genExtractFunc('voiceid', { assignPattern: ':' }),
+        duration: this.genExtractFunc('duration', { valuePattern: '\\d*', assignPattern: ':', allowNotFound: true }),
+    };
+
+    // never seen a audio article containing multiple audio, waiting for examples
+    static audio = ($: CheerioAPI) =>
+        forEachScript(
+            $,
+            (script) => {
+                const scriptText = $(script).text();
+                const metadataExtracted = <Record<string, string>>this.doExtract(this.audioMetadataToBeExtracted, scriptText);
+                throw new LoopReturn(metadataExtracted);
+            },
+            {},
+            'script[nonce][type="text/javascript"]:contains("voiceid")'
+        );
+
+    private static imgMetadataToBeExtracted = {
+        imgUrls: this.genExtractFunc('cdn_url', { valuePattern: `https?://[^'"]*`, assignPattern: ':', multiple: true }),
+    };
+
+    static img = ($: CheerioAPI) =>
+        forEachScript(
+            $,
+            (script) => {
+                const scriptText = $(script).text();
+                const metadataExtracted = <Record<string, string[]>>this.doExtract(this.imgMetadataToBeExtracted, scriptText);
+                if (Array.isArray(metadataExtracted.imgUrls)) {
+                    metadataExtracted.imgUrls = metadataExtracted.imgUrls.map((url) => fixUrl(url));
+                }
+                throw new LoopReturn(metadataExtracted);
+            },
+            {},
+            'script[nonce][type="text/javascript"]:contains("picture_page_info_list")'
+        );
+
+    private static locationMetadataToBeExtracted = {
+        countryName: this.genExtractFunc('countryName', { valuePattern: `[^'"]*`, assignPattern: ':' }),
+        provinceName: this.genExtractFunc('provinceName', { valuePattern: `[^'"]*`, assignPattern: ':' }),
+        cityName: this.genExtractFunc('cityName', { valuePattern: `[^'"]*`, assignPattern: ':' }),
+    };
+
+    static location = ($: CheerioAPI) =>
+        forEachScript(
+            $,
+            (script) => {
+                const scriptText = $(script).text();
+                const metadataExtracted = this.doExtract(this.locationMetadataToBeExtracted, scriptText);
+                throw new LoopReturn(metadataExtracted);
+            },
+            {},
+            'script[nonce][type="text/javascript"]:contains("countryName")'
+        );
+}
 
 const replaceTag = ($, oldTag, newTagName) => {
     oldTag = $(oldTag);
@@ -55,15 +262,23 @@ const detectOriginalArticleUrl = ($) => {
     return null;
 };
 
-const detectSourceUrl = ($) => {
-    const matchs = $.root()
-        .html()
-        .match(/msg_source_url = '(.+)';/);
-
-    if (matchs) {
-        return matchs[1];
-    }
-    return null;
+const genAudioSrc = (voiceId: string) => `https://res.wx.qq.com/voice/getvoice?mediaid=${voiceId}`;
+const genAudioTag = (src: string, title: string) => `<audio controls src="${src}" title="${title}" style="width:100%"/>`;
+const genVideoSrc = (videoId: string) => {
+    const newSearchParams = new URLSearchParams({
+        origin: 'https://mp.weixin.qq.com',
+        containerId: 'js_tx_video_container_0.3863487104715233',
+        vid: videoId,
+        width: '677',
+        height: '380.8125',
+        autoplay: 'false',
+        allowFullScreen: 'true',
+        chid: '17',
+        full: 'true',
+        show1080p: 'false',
+        isDebugIframe: 'false',
+    });
+    return `https://v.qq.com/txp/iframe/player.html?${newSearchParams.toString()}`;
 };
 
 /**
@@ -99,6 +314,33 @@ const fixArticleContent = (html?: string | Cheerio<Element>, skipImg = false) =>
             }
         });
     }
+    // fix audio: https://mp.weixin.qq.com/s/FnjcMXZ1xdS-d6n-pUUyyw
+    $('mpvoice[voice_encode_fileid]').each((_, voice) => {
+        const $voice = $(voice);
+        const voiceId = $voice.attr('voice_encode_fileid');
+        if (voiceId) {
+            const title = $voice.attr('name') || 'Audio';
+            $voice.replaceWith(genAudioTag(genAudioSrc(voiceId), title));
+        }
+    });
+    // fix iframe: https://mp.weixin.qq.com/s/FnjcMXZ1xdS-d6n-pUUyyw
+    $('iframe.video_iframe[data-src]').each((_, iframe) => {
+        const $iframe = $(iframe);
+        const dataSrc = <string>$iframe.attr('data-src');
+        const srcUrlObj = new URL(dataSrc);
+        if (srcUrlObj.host === 'v.qq.com' && srcUrlObj.searchParams.has('vid')) {
+            const newSrc = genVideoSrc(<string>srcUrlObj.searchParams.get('vid'));
+            $iframe.attr('src', newSrc);
+            $iframe.removeAttr('data-src');
+            const width = $iframe.attr('data-w');
+            const ratio = $iframe.attr('data-ratio');
+            if (width && ratio) {
+                const width_ = Math.min(Number.parseInt(width), 677);
+                $iframe.attr('width', width_.toString());
+                $iframe.attr('height', (width_ / Number.parseFloat(ratio)).toString());
+            }
+        } // else {} FIXME: https://mp.weixin.qq.com/s?__biz=Mzg5Mjk3MzE4OQ==&mid=2247549515&idx=2&sn=a608fca597f0589c1aebd6d0b82ff6e9
+    });
     // fix section
     $('section').each((_, section) => {
         const $section = $(section);
@@ -121,17 +363,6 @@ const fixArticleContent = (html?: string | Cheerio<Element>, skipImg = false) =>
 
     // clear line index tags in code section
     $('.code-snippet__line-index').remove();
-
-    // fix single picture article
-    // example: https://mp.weixin.qq.com/s/4p5YmYuASiQSYFiy7KqydQ
-    $('script').each((_, script) => {
-        const $script = $(script);
-        const matchs = $script.html()?.match(/document\.getElementById\('js_image_desc'\)\.innerHTML = "(.*)"\.replace/);
-
-        if (matchs) {
-            $script.replaceWith(matchs[1].replaceAll('\r', '').replaceAll('\n', '<br>').replaceAll('\\x0d', '').replaceAll('\\x0a', '<br>'));
-        }
-    });
 
     // clean scripts
     $('script').remove();
@@ -184,51 +415,124 @@ const normalizeUrl = (url, bypassHostCheck = false) => {
     return urlObj.href;
 };
 
+class PageParsers {
+    private static common = ($: CheerioAPI, commonMetadata: Record<string, string>) => {
+        const title = replaceReturnNewline($('meta[property="og:title"]').attr('content') || '', '', ' ');
+        const author = replaceReturnNewline($('meta[name=author]').attr('content') || '', '', ' ');
+        const pubDate = commonMetadata.createTime ? parseDate(Number.parseInt(commonMetadata.createTime) * 1000) : undefined;
+        const mpName = $('.wx_follow_nickname').first().text()?.trim();
+
+        let summary = replaceReturnNewline($('meta[name=description]').attr('content') || '');
+        const description = summary;
+        summary = summary.replaceAll('<br>', ' ') === title ? '' : summary;
+
+        return { title, author, description, summary, pubDate, mpName } as {
+            title: string;
+            author: string;
+            description: string;
+            summary: string;
+            pubDate?: Date;
+            mpName?: string;
+            enclosure_url?: string;
+            itunes_duration?: string | number;
+            enclosure_type?: string;
+        };
+    };
+    private static appMsg = async ($: CheerioAPI, commonMetadata: Record<string, string>) => {
+        const page = PageParsers.common($, commonMetadata);
+        page.description = fixArticleContent($('#js_content'));
+        const originalArticleUrl = detectOriginalArticleUrl($);
+        if (originalArticleUrl) {
+            // No article or article is too short, try to fetch the description from the original article
+            const data = await ofetch(normalizeUrl(originalArticleUrl));
+            const original$ = load(data);
+            page.description += fixArticleContent(original$('#js_content'));
+        }
+        return page;
+    };
+    private static img = ($: CheerioAPI, commonMetadata: Record<string, string>) => {
+        const page = PageParsers.common($, commonMetadata);
+        const imgUrls = ExtractMetadata.img($)?.imgUrls;
+        let imgHtml = '';
+        if (Array.isArray(imgUrls) && imgUrls.length > 0) {
+            for (const imgUrl of imgUrls) {
+                imgHtml += `<br><br><img src="${imgUrl}" />`;
+            }
+        }
+        page.description += imgHtml;
+        return page;
+    };
+    private static audio = ($: CheerioAPI, commonMetadata: Record<string, string>) => {
+        const page = PageParsers.common($, commonMetadata);
+        const audioMetadata = ExtractMetadata.audio($);
+        const audioUrl = genAudioSrc(audioMetadata.voiceId);
+        page.enclosure_url = audioUrl;
+        page.itunes_duration = audioMetadata.duration;
+        page.enclosure_type = 'audio/mp3'; // FIXME: may it be other types?
+        page.description += '<br><br>' + genAudioTag(audioUrl, page.title);
+        return page;
+    };
+    private static fallback = ($: CheerioAPI, commonMetadata: Record<string, string>) => {
+        const page = PageParsers.common($, commonMetadata);
+        const image = $('meta[property="og:image"]').attr('content');
+        if (image) {
+            page.description += `<br><br><img src="${image}" />`;
+        }
+        return page;
+    };
+    static dispatch = async ($: CheerioAPI) => {
+        const commonMetadata = ExtractMetadata.common($);
+        let page: Record<string, any>;
+        switch (commonMetadata.showType) {
+            case 'APP_MSG_PAGE':
+                page = await PageParsers.appMsg($, commonMetadata);
+                break;
+            case 'AUDIO_SHARE_PAGE':
+                page = PageParsers.audio($, commonMetadata);
+                break;
+            case 'IMG_SHARE_PAGE':
+                page = PageParsers.img($, commonMetadata);
+                break;
+            case 'VIDEO_SHARE_PAGE':
+                page = PageParsers.fallback($, commonMetadata);
+                break;
+            default:
+                warn('new showType, trying fallback method', `showType=${commonMetadata.showType}`);
+                page = PageParsers.fallback($, commonMetadata);
+        }
+        const locationMetadata = ExtractMetadata.location($);
+        let location = '';
+        for (const loc of [locationMetadata.countryName, locationMetadata.provinceName, locationMetadata.cityName]) {
+            if (loc) {
+                location += loc + ' ';
+            }
+        }
+        location = location.trim();
+        if (location) {
+            page.description += `<p>📍发表于：${location}</p>`;
+        }
+        if (commonMetadata.sourceUrl) {
+            page.description += `<p><a href="${commonMetadata.sourceUrl}">🔗️ 阅读原文</a></p>`;
+        }
+        return page;
+    };
+}
+
 /**
  * Fetch article and its metadata from WeChat MP (mp.weixin.qq.com).
  *
  * If you use this function, no need to call `fixArticleContent`
- * @param {object} ctx - The context object.
- * @param {string} url - The url of the article.
- * @param {boolean} bypassHostCheck - Whether to bypass host check.
- * @return {Promise<object>} - An object containing the article and its metadata.
+ * @param url - The url of the article.
+ * @param bypassHostCheck - Whether to bypass host check.
+ * @return - An object containing the article and its metadata.
  */
-const fetchArticle = (url, bypassHostCheck = false) => {
+const fetchArticle = (url: string, bypassHostCheck: boolean = false) => {
     url = normalizeUrl(url, bypassHostCheck);
     return cache.tryGet(url, async () => {
         const data = await ofetch(url);
         const $ = load(data);
-
-        const title = ($('meta[property="og:title"]').attr('content') || '').replaceAll('\\r', '').replaceAll('\\n', ' ');
-        const author = $('meta[name=author]').attr('content');
-        let summary = $('meta[name=description]').attr('content');
-        summary = summary === title ? '' : summary;
-        let description = fixArticleContent($('#js_content'));
-        // No article get or article is too short, try the original url
-        const originalUrl = detectOriginalArticleUrl($);
-        if (originalUrl) {
-            // try to fetch the description from the original article
-            const data = await ofetch(normalizeUrl(originalUrl, bypassHostCheck));
-            const original$ = load(data);
-            description += fixArticleContent(original$('#js_content'));
-        }
-
-        const sourceUrl = detectSourceUrl($);
-        if (sourceUrl) {
-            description += `<a href="${sourceUrl}">阅读原文</a>`;
-        }
-
-        let pubDate;
-        const publish_time_script = $('script[nonce][type="text/javascript"]:contains("var ct")').text();
-        const publish_time_match = publish_time_script && publish_time_script.match(/var ct *= *"?(\d{10})"?/);
-        const publish_timestamp = publish_time_match && publish_time_match[1];
-        if (publish_timestamp) {
-            pubDate = parseDate(Number.parseInt(publish_timestamp) * 1000);
-        }
-
-        let mpName = $('.profile_nickname').first().text();
-        mpName = mpName && mpName.trim();
-        return { title, author, description, summary, pubDate, mpName, link: url };
+        const page = await PageParsers.dispatch($);
+        return { ...page, link: url };
     }) as Promise<{
         title: string;
         author: string;
@@ -237,6 +541,9 @@ const fetchArticle = (url, bypassHostCheck = false) => {
         pubDate?: Date;
         mpName?: string;
         link: string;
+        enclosure_type?: string;
+        enclosure_url?: string;
+        itunes_duration?: string | number;
     }>;
 };
 
@@ -257,18 +564,23 @@ const fetchArticle = (url, bypassHostCheck = false) => {
  * @return {Promise<object>} - The incoming `item` object, with the article and its metadata filled in.
  */
 const finishArticleItem = async (item, setMpNameAsAuthor = false, skipLink = false) => {
-    const { title, author, description, summary, pubDate, mpName, link } = await fetchArticle(item.link);
-    item.title = title || item.title;
-    item.description = description || item.description;
-    item.summary = summary || item.summary;
-    item.pubDate = pubDate || item.pubDate;
-    item.author = setMpNameAsAuthor
-        ? mpName || item.author // the Official Account itself. if your route return articles from different accounts, you may want to use this
-        : author || item.author; // the real author of the article. if your route return articles from a certain account, use this
-    if (!skipLink) {
-        item.link = link || item.link;
+    const fetchedItem = await fetchArticle(item.link);
+    for (const key in fetchedItem) {
+        switch (key) {
+            case 'author':
+                item.author = setMpNameAsAuthor
+                    ? fetchedItem.mpName || item.author // the Official Account itself. if your route return articles from different accounts, you may want to use this
+                    : fetchedItem.author || item.author; // the real author of the article. if your route return articles from a certain account, use this
+                break;
+            case 'link':
+                item.link = skipLink ? item.link : (item.link = fetchedItem.link || item.link);
+                break;
+            default:
+                item[key] = item[key] || fetchedItem[key];
+        }
     }
     return item;
 };
 
-export { fixArticleContent, fetchArticle, finishArticleItem, normalizeUrl };
+const exportedForTestingOnly = { ExtractMetadata, showTypeMapReverse };
+export { exportedForTestingOnly, fixArticleContent, fetchArticle, finishArticleItem, normalizeUrl };

--- a/lib/utils/wechat-mp.ts
+++ b/lib/utils/wechat-mp.ts
@@ -572,7 +572,7 @@ const finishArticleItem = async (item, setMpNameAsAuthor = false, skipLink = fal
                     : fetchedItem.author || item.author; // the real author of the article. if your route return articles from a certain account, use this
                 break;
             case 'link':
-                item.link = skipLink ? item.link : (item.link = fetchedItem.link || item.link);
+                item.link = skipLink ? item.link : fetchedItem.link || item.link;
                 break;
             default:
                 item[key] = item[key] || fetchedItem[key];


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

#9674

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/test/wechat-mp/__biz=Mzg4NTA1MTkwNA==&mid=2247533067&idx=1&sn=778653e5fee2c949581b552c38d4fd8f
/test/wechat-mp/FnjcMXZ1xdS-d6n-pUUyyw
/test/wechat-mp/__biz=Mzg4NTA1MTkwNA==&mid=2247532942&idx=1&sn=a84e4adbe49fdb39e4d4c1b5c12a4c3f
/test/wechat-mp/FY6yQC_e4NMAxK0FBr6jwQ
/test/wechat-mp/__biz=Mzg4NTA1MTkwNA==&mid=2247532936&idx=1&sn=7a98b4381483b61fd7832cea4eb67bec
```

```
APP_MSG_PAGE
APP_MSG_PAGE (w/ audio and video)
VIDEO_SHARE_PAGE
AUDIO_SHARE_PAGE
IMG_SHARE_PAGE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
```
feat(core/utils/wechat-mp): major rewrite

* Support more `item_show_type`: `APP_MSG_PAGE`, `VIDEO_SHARE_PAGE`,
`AUDIO_SHARE_PAGE`, and `IMG_SHARE_PAGE`. Previously only the first one
could be parsed properly. There are still some other known types waiting
for live examples for further adaptation. If this is the case, a
fallback method will try to generate entries using mostly OpenGraph
metadata. Meanwhile, the administrator of self-hosted instances will see
warnings in the log, asking them to report the URL as a new live
example. Still, `VIDEO_SHARE_PAGE` explicitly uses the fallback method
without any warning, as there is no possible approach to generate a
video/iframe URL from page metadata.

* Show audio and videos in `APP_MSG_PAGE`. However, not all videos
can be shown due to the same reason as `VIDEO_SHARE_PAGE`.

* Show the location where the article is sent.

* Some bugs, mostly due to outdated cheerio selector, are fixed.

* Add a new sub-route `wechat-mp` to `/test` to make things easier.

* All changes are well-tested.

Signed-off-by: Rongrong <i@rong.moe>
```