### PR TITLE
fix: request-rewriter proxy ignore loopback address and puppeteer ws …

### DIFF
--- a/lib/utils/request-rewriter/get.ts
+++ b/lib/utils/request-rewriter/get.ts
@@ -59,7 +59,14 @@ const getWrappedGet: <T extends Get>(origin: T) => T = (origin) =>
         if (!options.agent && proxy.agent) {
             const proxyRegex = new RegExp(proxy.proxyObj.url_regex);
 
-            if (proxyRegex.test(url.toString()) && url.protocol.startsWith('http') && url.host !== proxy.proxyUrlHandler?.host) {
+            if (
+                proxyRegex.test(url.toString()) &&
+                url.protocol.startsWith('http') &&
+                url.host !== proxy.proxyUrlHandler?.host &&
+                url.host !== 'localhost' &&
+                !url.host.startsWith('127.') &&
+                !(config.puppeteerWSEndpoint?.includes(url.host) ?? false)
+            ) {
                 options.agent = proxy.agent;
             }
         }


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
#
Request-rewriter should not add proxy when URL is loopback address and puppeteer endpoint.

https://github.com/DIYgod/RSSHub/blob/9b2af2920777f81b90302f8cf2ce4d448188aa4b/lib/utils/request-rewriter/index.ts#L17

Puppeter uses the node websocket module to connect, while the websocket module uses `http.request` to create actual connection.
Therefore, if rewrite `http.request` to set up an HTTP proxy for all requests, Puppeter's connection will also be affected. But I don't think this is expected. Therefore, I exclude setting a proxy for the connection of the Puppeter endpoint and the local loopback address (when the Puppeter endpoint is not set, Puppeter will be launched locally and connected using 127.0.0.1).