### PR TITLE
fix(core/utils/wechat-mp): empty description when request blocked by WAF

### DIFF
--- a/lib/setup.test.ts
+++ b/lib/setup.test.ts
@@ -185,6 +185,8 @@ var ct = "${1_636_626_300}";
         )
     ),
     http.get(`https://mp.weixin.qq.com/s/rsshub_test_hit_waf`, () => HttpResponse.redirect(`https://mp.weixin.qq.com/mp/rsshub_test/waf`)),
+    http.get(`https://mp.weixin.qq.com/s/rsshub_test_redirect_no_location`, () => HttpResponse.text('', { status: 302 })),
+    http.get(`https://mp.weixin.qq.com/s/rsshub_test_recursive_redirect`, () => HttpResponse.redirect(`https://mp.weixin.qq.com/s/rsshub_test_recursive_redirect`)),
     http.get(`http://rsshub.test/headers`, ({ request }) =>
         HttpResponse.json({
             ...Object.fromEntries(request.headers.entries()),

--- a/lib/setup.test.ts
+++ b/lib/setup.test.ts
@@ -154,8 +154,26 @@ var ct = "${1_636_626_300}";
             )
         )
     ),
-    http.get(`https://mp.weixin.qq.com/s/rsshub_test`, () => HttpResponse.text(genWeChatMpPage('', ''))),
-    http.get(`https://mp.weixin.qq.com/s?__biz=rsshub_test&mid=1&idx=1&sn=1`, () => HttpResponse.text(genWeChatMpPage('', ''))),
+    http.get(`https://mp.weixin.qq.com/s/rsshub_test`, () => HttpResponse.redirect(`https://mp.weixin.qq.com/rsshub_test/fallback`)),
+    http.get(`https://mp.weixin.qq.com/s?__biz=rsshub_test&mid=1&idx=1&sn=1`, () => HttpResponse.redirect(`https://mp.weixin.qq.com/rsshub_test/fallback`)),
+    http.get(`https://mp.weixin.qq.com/mp/rsshub_test/waf`, () =>
+        HttpResponse.text(
+            `<html><body>
+<div class="weui-msg">
+    <div class="weui-msg__text-area pc-area">
+        <h2 class="weui-msg__title">环境异常</h2>
+        <p class="weui-msg__desc">当前环境异常，完成验证后即可继续访问。</p>
+    </div>
+    <div class="weui-msg__opr-area">
+      <p class="weui-btn-area">
+        <a class="weui-btn weui-btn_primary" id="js_verify">去验证</a>
+      </p>
+    </div>
+</div>
+</body></html>`
+        )
+    ),
+    http.get(`https://mp.weixin.qq.com/s/rsshub_test_hit_waf`, () => HttpResponse.redirect(`https://mp.weixin.qq.com/mp/rsshub_test/waf`)),
     http.get(`http://rsshub.test/headers`, ({ request }) =>
         HttpResponse.json({
             ...Object.fromEntries(request.headers.entries()),

--- a/lib/setup.test.ts
+++ b/lib/setup.test.ts
@@ -158,8 +158,19 @@ var ct = "${1_636_626_300}";
     http.get(`https://mp.weixin.qq.com/s?__biz=rsshub_test&mid=1&idx=1&sn=1`, () => HttpResponse.redirect(`https://mp.weixin.qq.com/rsshub_test/fallback`)),
     http.get(`https://mp.weixin.qq.com/mp/rsshub_test/waf`, () =>
         HttpResponse.text(
-            `<html><body>
+            `<html>
+<head>
+<title>Title</title>
+<script>console.log</script>
+</head>
+<body class="zh_CN " ontouchstart="">
+<script>console.log</script>
+<style>.style{}</style>
 <div class="weui-msg">
+  <div id="tips" style="display:none;" class="top_tips warning"></div>
+        <div class="weui-msg__icon-area">
+      <i class="weui-icon-info-circle weui-icon_msg"></i>
+    </div>
     <div class="weui-msg__text-area pc-area">
         <h2 class="weui-msg__title">环境异常</h2>
         <p class="weui-msg__desc">当前环境异常，完成验证后即可继续访问。</p>

--- a/lib/setup.test.ts
+++ b/lib/setup.test.ts
@@ -201,6 +201,22 @@ Unknown paragraph
 </body></html>`
         )
     ),
+    http.get(`https://mp.weixin.qq.com/s/deleted_page`, () =>
+        HttpResponse.text(
+            `<html>
+<head>
+<title>Title</title>
+<script>console.log</script>
+</head>
+<body class="zh_CN " ontouchstart="">
+<script>console.log</script>
+<style>.style{}</style>
+<p>
+该内容已被发布者删除
+</p>
+</body></html>`
+        )
+    ),
     http.get(`https://mp.weixin.qq.com/s/rsshub_test_redirect_no_location`, () => HttpResponse.text('', { status: 302 })),
     http.get(`https://mp.weixin.qq.com/s/rsshub_test_recursive_redirect`, () => HttpResponse.redirect(`https://mp.weixin.qq.com/s/rsshub_test_recursive_redirect`)),
     http.get(`http://rsshub.test/headers`, ({ request }) =>

--- a/lib/setup.test.ts
+++ b/lib/setup.test.ts
@@ -185,6 +185,22 @@ var ct = "${1_636_626_300}";
         )
     ),
     http.get(`https://mp.weixin.qq.com/s/rsshub_test_hit_waf`, () => HttpResponse.redirect(`https://mp.weixin.qq.com/mp/rsshub_test/waf`)),
+    http.get(`https://mp.weixin.qq.com/s/unknown_page`, () =>
+        HttpResponse.text(
+            `<html>
+<head>
+<title>Title</title>
+<script>console.log</script>
+</head>
+<body class="zh_CN " ontouchstart="">
+<script>console.log</script>
+<style>.style{}</style>
+<p>
+Unknown paragraph
+</p>
+</body></html>`
+        )
+    ),
     http.get(`https://mp.weixin.qq.com/s/rsshub_test_redirect_no_location`, () => HttpResponse.text('', { status: 302 })),
     http.get(`https://mp.weixin.qq.com/s/rsshub_test_recursive_redirect`, () => HttpResponse.redirect(`https://mp.weixin.qq.com/s/rsshub_test_recursive_redirect`)),
     http.get(`http://rsshub.test/headers`, ({ request }) =>

--- a/lib/utils/wechat-mp.test.ts
+++ b/lib/utils/wechat-mp.test.ts
@@ -340,6 +340,9 @@ describe('wechat-mp', () => {
         expect(normalizeUrl(unknownPath)).toBe(unknownPath);
         toggleWerror(true);
         expect(() => normalizeUrl(unknownPath, true)).toThrow('WarningAsError: unknown URL path');
+
+        const ampEscapedUrl = longUrl.replaceAll('&', '&amp;');
+        expect(normalizeUrl(ampEscapedUrl)).toBe(longUrlShortened);
     });
 
     it('fetchArticle_&_finishArticleItem_appMsg', async () => {

--- a/lib/utils/wechat-mp.test.ts
+++ b/lib/utils/wechat-mp.test.ts
@@ -430,10 +430,27 @@ describe('wechat-mp', () => {
             expect(error).toBeInstanceOf(WeChatMpError);
             expect((<WeChatMpError>error).message).not.toContain('console.log');
             expect((<WeChatMpError>error).message).not.toContain('.style');
-            expect((<WeChatMpError>error).message).toContain('unknown page');
+            expect((<WeChatMpError>error).message).not.toContain('Consider raise an issue');
+            expect((<WeChatMpError>error).message).toContain('request blocked by WAF:');
             expect((<WeChatMpError>error).message).toContain('/mp/rsshub_test/waf');
             expect((<WeChatMpError>error).message).toContain('Title');
             expect((<WeChatMpError>error).message).toContain('环境异常');
+        }
+    });
+
+    it('unknown_page', async () => {
+        const unknownPageUrl = 'https://mp.weixin.qq.com/s/unknown_page';
+        try {
+            await fetchArticle(unknownPageUrl);
+            expect.unreachable('Should throw an error');
+        } catch (error) {
+            expect(error).toBeInstanceOf(WeChatMpError);
+            expect((<WeChatMpError>error).message).not.toContain('console.log');
+            expect((<WeChatMpError>error).message).not.toContain('.style');
+            expect((<WeChatMpError>error).message).toContain('Consider raise an issue');
+            expect((<WeChatMpError>error).message).toContain('unknown page,');
+            expect((<WeChatMpError>error).message).toContain('Title Unknown paragraph');
+            expect((<WeChatMpError>error).message).toContain(unknownPageUrl);
         }
     });
 

--- a/lib/utils/wechat-mp.test.ts
+++ b/lib/utils/wechat-mp.test.ts
@@ -411,7 +411,10 @@ describe('wechat-mp', () => {
             expect.unreachable('Should throw an error');
         } catch (error) {
             expect(error).toBeInstanceOf(WeChatMpError);
+            expect((<WeChatMpError>error).message).not.toContain('console.log');
+            expect((<WeChatMpError>error).message).not.toContain('.style');
             expect((<WeChatMpError>error).message).toContain('/mp/rsshub_test/waf');
+            expect((<WeChatMpError>error).message).toContain('Title');
             expect((<WeChatMpError>error).message).toContain('环境异常');
         }
     });

--- a/lib/utils/wechat-mp.test.ts
+++ b/lib/utils/wechat-mp.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { load } from 'cheerio';
 import Parser from 'rss-parser';
 import InvalidParameterError from '@/errors/types/invalid-parameter';
-import { exportedForTestingOnly, fetchArticle, finishArticleItem, fixArticleContent, normalizeUrl } from '@/utils/wechat-mp';
+import { exportedForTestingOnly, WeChatMpError, fetchArticle, finishArticleItem, fixArticleContent, normalizeUrl } from '@/utils/wechat-mp';
 const { ExtractMetadata, showTypeMapReverse } = exportedForTestingOnly;
 
 vi.mock('@/utils/request-rewriter', () => ({ default: null }));
@@ -403,6 +403,17 @@ describe('wechat-mp', () => {
         await testFetchArticleFinishArticleItem('/fallback', { setMpNameAsAuthor: true, skipLink: false });
         await testFetchArticleFinishArticleItem('/fallback', { setMpNameAsAuthor: false, skipLink: true });
         await testFetchArticleFinishArticleItem('/fallback', { setMpNameAsAuthor: true, skipLink: true });
+    });
+
+    it('hit_waf', async () => {
+        try {
+            await fetchArticle('https://mp.weixin.qq.com/s/rsshub_test_hit_waf');
+            expect.unreachable('Should throw an error');
+        } catch (error) {
+            expect(error).toBeInstanceOf(WeChatMpError);
+            expect((<WeChatMpError>error).message).toContain('/mp/rsshub_test/waf');
+            expect((<WeChatMpError>error).message).toContain('环境异常');
+        }
     });
 
     it('route_test', async () => {

--- a/lib/utils/wechat-mp.test.ts
+++ b/lib/utils/wechat-mp.test.ts
@@ -454,6 +454,23 @@ describe('wechat-mp', () => {
         }
     });
 
+    it('deleted_page', async () => {
+        const deletedPageUrl = 'https://mp.weixin.qq.com/s/deleted_page';
+
+        try {
+            await fetchArticle(deletedPageUrl);
+            expect.unreachable('Should throw an error');
+        } catch (error) {
+            expect(error).toBeInstanceOf(WeChatMpError);
+            expect((<WeChatMpError>error).message).not.toContain('console.log');
+            expect((<WeChatMpError>error).message).not.toContain('.style');
+            expect((<WeChatMpError>error).message).not.toContain('Consider raise an issue');
+            expect((<WeChatMpError>error).message).toContain('deleted by author:');
+            expect((<WeChatMpError>error).message).toContain('Title 该内容已被发布者删除');
+            expect((<WeChatMpError>error).message).toContain(deletedPageUrl);
+        }
+    });
+
     it('redirect', () => {
         expect(fetchArticle('https://mp.weixin.qq.com/s/rsshub_test_redirect_no_location')).rejects.toThrow('redirect without location');
         expect(fetchArticle('https://mp.weixin.qq.com/s/rsshub_test_recursive_redirect')).rejects.toThrow('too many redirects');

--- a/lib/utils/wechat-mp.ts
+++ b/lib/utils/wechat-mp.ts
@@ -507,8 +507,9 @@ class PageParsers {
                 page = PageParsers.fallback($, commonMetadata);
                 break;
             case undefined:
-                pageText = $('body').text().replaceAll(/\s+/g, ' ');
-                if (pageText.length >= 25) {
+                $('script, style').remove();
+                pageText = $('title, body').text().replaceAll(/\s+/g, ' ').trim();
+                if (pageText.length >= 25 + '...'.length) {
                     pageText = pageText.slice(0, 25);
                     pageText += '...';
                 }

--- a/lib/utils/wechat-mp.ts
+++ b/lib/utils/wechat-mp.ts
@@ -45,10 +45,14 @@ const formatLog = (...params: string[]): string => `${formatLogNoMention(...para
 Consider raise an issue (mentioning ${MAINTAINERS.join(', ')}) with the article URL for further investigation`;
 let warn = (...params: string[]) => logger.warn(formatLog(...params));
 const error = (...params: string[]): never => {
-    throw new WeChatMpError(formatLog(...params));
+    const msg = formatLog(...params);
+    logger.error(msg);
+    throw new WeChatMpError(msg);
 };
 const errorNoMention = (...params: string[]): never => {
-    throw new WeChatMpError(formatLogNoMention(...params));
+    const msg = formatLogNoMention(...params);
+    logger.error(msg);
+    throw new WeChatMpError(msg);
 };
 const toggleWerror = (() => {
     const onFunc = (...params: string[]) => error('WarningAsError', ...params);

--- a/lib/utils/wechat-mp.ts
+++ b/lib/utils/wechat-mp.ts
@@ -394,6 +394,10 @@ const fixArticleContent = (html?: string | Cheerio<Element>, skipImg = false) =>
 // Known params (temporary link):
 // src, timestamp, ver, signature, new (unessential)
 const normalizeUrl = (url: string, bypassHostCheck = false) => {
+    const oriUrl = url;
+    // already seen some weird urls with `&` escaped as `&amp;`, so fix it
+    // calling fixUrl should always be safe since having `&amp;` or `\x26` in a URL is meaningless
+    url = fixUrl(url);
     const urlObj = new URL(url);
     if (!bypassHostCheck && urlObj.host !== 'mp.weixin.qq.com') {
         error('URL host must be "mp.weixin.qq.com"', url);
@@ -421,11 +425,11 @@ const normalizeUrl = (url: string, bypassHostCheck = false) => {
                 // a temporary link, remove all unessential params
                 urlObj.search = `?src=${src}&timestamp=${timestamp}&ver=${ver}&signature=${signature}`;
             } else {
-                warn('unknown URL search parameters', url);
+                warn('unknown URL search parameters', oriUrl);
             }
         }
     } else {
-        warn('unknown URL path', url);
+        warn('unknown URL path', oriUrl);
     }
     return urlObj.href;
 };

--- a/lib/utils/wechat-mp.ts
+++ b/lib/utils/wechat-mp.ts
@@ -529,10 +529,13 @@ class PageParsers {
                     pageTextShort = pageText.slice(0, 25);
                     pageTextShort += '...';
                 }
-                if (new URL(url).pathname.includes('captcha') || pageText.includes('环境异常')) {
+                if (pageText.includes('已被发布者删除')) {
+                    errorNoMention('deleted by author', pageTextShort, url);
+                } else if (new URL(url).pathname.includes('captcha') || pageText.includes('环境异常')) {
                     errorNoMention('request blocked by WAF', pageTextShort, url);
+                } else {
+                    error('unknown page, probably due to WAF', pageTextShort, url);
                 }
-                error('unknown page, probably due to WAF', pageTextShort, url);
                 return {}; // just to make TypeScript happy, actually UNREACHABLE
             default:
                 warn('new showType, trying fallback method', `showType=${commonMetadata.showType}`, url);

--- a/lib/utils/wechat-mp.ts
+++ b/lib/utils/wechat-mp.ts
@@ -42,10 +42,17 @@ const MAINTAINERS = ['@Rongronggg9'];
 
 const formatLog = (...params: string[]): string => `wechat-mp: ${params.join(': ')}
 Consider raise an issue (mentioning ${MAINTAINERS.join(', ')}) with the article URL for further investigation`;
-const warn = (...params: string[]) => logger.warn(formatLog(...params));
+let warn = (...params: string[]) => logger.warn(formatLog(...params));
 const error = (...params: string[]): never => {
     throw new WeChatMpError(formatLog(...params));
 };
+const toggleWerror = (() => {
+    const onFunc = (...params: string[]) => error('WarningAsError', ...params);
+    const offFunc = warn;
+    return (on: boolean) => {
+        warn = on ? onFunc : offFunc;
+    };
+})();
 
 const replaceReturnNewline = (() => {
     const returnRegExp = /\r|\\(r|x0d)/g;
@@ -612,5 +619,5 @@ const finishArticleItem = async (item, setMpNameAsAuthor = false, skipLink = fal
     return item;
 };
 
-const exportedForTestingOnly = { ExtractMetadata, showTypeMapReverse };
+const exportedForTestingOnly = { toggleWerror, ExtractMetadata, showTypeMapReverse };
 export { exportedForTestingOnly, WeChatMpError, fixArticleContent, fetchArticle, finishArticleItem, normalizeUrl };


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

OFF-TOPIC: `ofetch` cannot follow redirects while `got` can do it. I've already seen someone encountering a relevant regression: #15075

**I wrote a simple code snippet to follow redirects in `wechat-mp`. It'd be better implement it project-wide in the `ofetch` or `fakeGot` helper sometime.**

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/test/wechat-mp/__biz=Mzg4NTA1MTkwNA==&mid=2247533067&idx=1&sn=778653e5fee2c949581b552c38d4fd8f
/test/wechat-mp/FnjcMXZ1xdS-d6n-pUUyyw
/test/wechat-mp/__biz=Mzg4NTA1MTkwNA==&mid=2247532942&idx=1&sn=a84e4adbe49fdb39e4d4c1b5c12a4c3f
/test/wechat-mp/FY6yQC_e4NMAxK0FBr6jwQ
/test/wechat-mp/__biz=Mzg4NTA1MTkwNA==&mid=2247532936&idx=1&sn=7a98b4381483b61fd7832cea4eb67bec
```

```
APP_MSG_PAGE
APP_MSG_PAGE (w/ audio and video)
VIDEO_SHARE_PAGE
AUDIO_SHARE_PAGE
IMG_SHARE_PAGE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
```
fix(core/utils/wechat-mp): empty description when request blocked by WAF

Silently falling back to the fallback method would generate empty
description. Fixed by throwing an error when failed to extract
item_show_type from the page.

Some misc warnings are also added to make bug reporting easier.

Signed-off-by: Rongrong <i@rong.moe>
```