### PR TITLE
build(Dockerfile): set CHROMIUM_EXECUTABLE_PATH to absolute path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,13 +64,13 @@ jobs:
         chromium:
           - name: bundled Chromium
             dependency: ''
-            environment: '{}'
+            environment: '{ "PUPPETEER_SKIP_DOWNLOAD": "0" }'
           - name: Chromium from Ubuntu
             dependency: chromium-browser
-            environment: '{ "CHROMIUM_EXECUTABLE_PATH": "chromium-browser" }'
+            environment: '{ "PUPPETEER_SKIP_DOWNLOAD": "1" }'
           - name: Chrome from Google
             dependency: google-chrome-stable
-            environment: '{ "CHROMIUM_EXECUTABLE_PATH": "google-chrome-stable" }'
+            environment: '{ "PUPPETEER_SKIP_DOWNLOAD": "1" }'
     name: Vitest puppeteer on Node ${{ matrix.node-version }} with ${{ matrix.chromium.name }}
     steps:
       - uses: actions/checkout@v4
@@ -83,10 +83,13 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies (pnpm)
         run: pnpm i
+        env: ${{ fromJSON(matrix.chromium.environment) }}
       - name: Run postinstall script for dependencies
         run: pnpm rb
+        env: ${{ fromJSON(matrix.chromium.environment) }}
       - name: Build routes
         run: pnpm build
+        env: ${{ fromJSON(matrix.chromium.environment) }}
       - name: Install Chromium
         if: ${{ matrix.chromium.dependency != '' }}
         # 'chromium-browser' from Ubuntu APT repo is a dummy package. Its version (85.0.4183.83) means
@@ -94,7 +97,7 @@ jobs:
         # That's not really a problem since the Chromium-bundled Docker image is based on Debian bookworm,
         # which provides up-to-date native packages.
         run: |
-          set -ex
+          set -eux
           curl -s "https://dl.google.com/linux/linux_signing_key.pub" | gpg --dearmor |
             sudo tee /etc/apt/trusted.gpg.d/google-chrome.gpg > /dev/null
           echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" |
@@ -102,7 +105,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -yq --no-install-recommends ${{ matrix.chromium.dependency }}
       - name: Test puppeteer
-        run: pnpm run vitest puppeteer
+        run: |
+          set -eux
+          export CHROMIUM_EXECUTABLE_PATH="$(which ${{ matrix.chromium.dependency }})"
+          pnpm run vitest puppeteer
         env: ${{ fromJSON(matrix.chromium.environment) }}
 
   all:

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,20 +146,18 @@ RUN \
             apt-get install -yq --no-install-recommends \
                 chromium \
             && \
-            echo 'CHROMIUM_EXECUTABLE_PATH=chromium' | tee /app/.env ; \
+            echo "CHROMIUM_EXECUTABLE_PATH=$(which chromium)" | tee /app/.env ; \
         fi; \
     fi; \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=chromium-downloader /app/node_modules/.cache/puppeteer /app/node_modules/.cache/puppeteer
 
-# if grep matches nothing then it will exit with 1, thus, we cannot `set -e` here
 RUN \
-    set -x && \
+    set -ex && \
     if [ "$PUPPETEER_SKIP_DOWNLOAD" = 0 ] && [ "$TARGETPLATFORM" = 'linux/amd64' ]; then \
         echo 'Verifying Chromium installation...' && \
-        ldd $(find /app/node_modules/.cache/puppeteer/ -name chrome -type f) | grep "not found" ; \
-        if [ "$?" = 0 ]; then \
+        if ldd $(find /app/node_modules/.cache/puppeteer/ -name chrome -type f) | grep "not found"; then \
             echo "!!! Chromium has unmet shared libs !!!" && \
             exit 1 ; \
         else \


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

This should help resolve https://github.com/DIYgod/RSSHub/pull/15244#issuecomment-2057906761. However, there are still some other dependency issues before #15244. This is not taken into consideration in this PR.

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

CI `test.yml` is also updated to use an absolute path.

This PR can be safely merged now because no user-visible change is made.