### PR TITLE
fix(route/{telegram/channel,wechat/tgchannel}): broken links

### DIFF
--- a/lib/routes/telegram/channel.ts
+++ b/lib/routes/telegram/channel.ts
@@ -159,6 +159,18 @@ async function handler(ctx) {
     );
 
     const $ = load(data);
+
+    /*
+     * Since 2024/4/20, t.me/s/ mistakenly have every '&' in **hyperlinks** replaced by '&amp;'.
+     * The characteristic of a hyperlink is [onclick] (pop-up confirmation), which is not present in ordinary links.
+     * This is a workaround to fix the issue until Telegram fixes it.
+     */
+    $('a[onclick][href]').each((_, elem) => {
+        const $elem = $(elem);
+        const href = $elem.attr('href');
+        href && $elem.attr('href', href.replaceAll('&amp;', '&'));
+    });
+
     const list = includeServiceMsg
         ? $('.tgme_widget_message_wrap:not(.tgme_widget_message_wrap:has(.tme_no_messages_found))') // exclude 'no posts found' messages
         : $('.tgme_widget_message_wrap:not(.tgme_widget_message_wrap:has(.service_message,.tme_no_messages_found))'); // also exclude service messages

--- a/lib/routes/wechat/tgchannel.ts
+++ b/lib/routes/wechat/tgchannel.ts
@@ -149,11 +149,18 @@ async function handler(ctx) {
 
                 const pubDate = new Date(item.find('.tgme_widget_message_date time').attr('datetime')).toUTCString();
 
+                /*
+                 * Since 2024/4/20, t.me/s/ mistakenly have every '&' in **hyperlinks** replaced by '&amp;'.
+                 * wechat-mp will take care of this, so no need to fix it here.
+                 * However, once the bug is eventually fixed, all guid will be changed again.
+                 * Considering that this is almost certain to happen, let's break guid consistency now by using
+                 * normalized URL from wechat-mp as guid to avoid similar issues in the future.
+                 */
                 const single = {
                     title,
                     pubDate,
                     link,
-                    guid: link,
+                    // guid: link,
                 };
 
                 if (link !== undefined) {


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/telegram/channel/RailTransit
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
```
fix(route/{telegram/channel,wechat/tgchannel}): broken links

route/telegram/channel:
Since 2024/4/20, t.me/s/ mistakenly have every '&' in **hyperlinks**
replaced by '&amp;'. The characteristic of a hyperlink is [onclick]
(pop-up confirmation), which is not present in ordinary links. This is a
workaround to fix the issue until Telegram fixes it.

route/wechat/tgchannel:
Since 2024/4/20, t.me/s/ mistakenly have every '&' in **hyperlinks**
replaced by '&amp;'. wechat-mp will take care of this, so no need to fix
it here. However, once the bug is eventually fixed, all guid will be
changed again. Considering that this is almost certain to happen, let's
break guid consistency now by using normalized URL from wechat-mp as
guid to avoid similar issues in the future.

Signed-off-by: Rongrong <i@rong.moe>
```