### PR TITLE
fix(core): posting form as `x-www-form-urlencoded` in got wrapper

### DIFF
--- a/lib/setup.test.ts
+++ b/lib/setup.test.ts
@@ -228,6 +228,7 @@ Unknown paragraph
         const formData = await request.formData();
         return HttpResponse.json({
             test: formData.get('test'),
+            req: { headers: Object.fromEntries(request.headers.entries()) },
         });
     }),
     http.post(`http://rsshub.test/json-post`, async ({ request }) => {

--- a/lib/utils/got.test.ts
+++ b/lib/utils/got.test.ts
@@ -36,8 +36,9 @@ describe('got', () => {
                 test: 'rsshub',
             },
         });
-        expect(response.body).toBe('{"test":"rsshub"}');
+        expect(response.body).toContain('"test":"rsshub"');
         expect(response.data.test).toBe('rsshub');
+        expect(response.data.req.headers['content-type']).toBe('application/x-www-form-urlencoded');
     });
 
     it('json-post', async () => {

--- a/lib/utils/got.ts
+++ b/lib/utils/got.ts
@@ -27,14 +27,11 @@ const getFakeGot = (defaultOptions?: any) => {
             delete options.json;
         }
         if (options?.form && !options.body) {
-            const body = new FormData();
-            for (const key in options.form) {
-                body.append(key, options.form[key]);
-            }
-            options.body = body;
+            options.body = new URLSearchParams(options.form as Record<string, string>).toString();
             if (!options.headers) {
                 options.headers = {};
             }
+            options.headers['content-type'] = 'application/x-www-form-urlencoded';
             delete options.form;
         }
         if (options?.searchParams) {


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Related #15238

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This restores the behaviour when posting with `option.form` like `got`.

https://github.com/sindresorhus/got/blob/88e623a0d8140e02eef44d784f8d0327118548bc/source/core/index.ts#L596-L604
https://github.com/sindresorhus/got/blob/88e623a0d8140e02eef44d784f8d0327118548bc/documentation/2-options.md?plain=1#L364-L370