### PR TITLE
fix: tweet detail route not work

### DIFF
--- a/lib/routes/twitter/api/web-api/constants.ts
+++ b/lib/routes/twitter/api/web-api/constants.ts
@@ -10,6 +10,7 @@ const graphQLEndpointsPlain = [
     '/graphql/tD8zKvQzwY3kdx5yz6YmOw/UserByRestId',
     '/graphql/flaR-PUMshxFWZWPNpq4zA/SearchTimeline',
     '/graphql/TOTgqavWmxywKv5IbMMK1w/ListLatestTweetsTimeline',
+    '/graphql/zJvfJs3gSbrVhC0MKjt_OQ/TweetDetail',
 ];
 
 const gqlMap = Object.fromEntries(graphQLEndpointsPlain.map((endpoint) => [endpoint.split('/')[3].replace(/V2$|Query$|QueryV2$/, ''), endpoint]));
@@ -49,6 +50,34 @@ const gqlFeatureFeed = {
     longform_notetweets_inline_media_enabled: true,
     responsive_web_enhance_cards_enabled: false,
 };
+
+const TweetDetailFeatures = {
+    rweb_tipjar_consumption_enabled: true,
+    responsive_web_graphql_exclude_directive_enabled: true,
+    verified_phone_label_enabled: false,
+    creator_subscriptions_tweet_preview_api_enabled: true,
+    responsive_web_graphql_timeline_navigation_enabled: true,
+    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+    communities_web_enable_tweet_community_results_fetch: true,
+    c9s_tweet_anatomy_moderator_badge_enabled: true,
+    articles_preview_enabled: false,
+    tweetypie_unmention_optimization_enabled: true,
+    responsive_web_edit_tweet_api_enabled: true,
+    graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+    view_counts_everywhere_api_enabled: true,
+    longform_notetweets_consumption_enabled: true,
+    responsive_web_twitter_article_tweet_consumption_enabled: true,
+    tweet_awards_web_tipping_enabled: false,
+    creator_subscriptions_quote_tweet_preview_enabled: false,
+    freedom_of_speech_not_reach_fetch_enabled: true,
+    standardized_nudges_misinfo: true,
+    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+    tweet_with_visibility_results_prefer_gql_media_interstitial_enabled: true,
+    rweb_video_timestamps_enabled: true,
+    longform_notetweets_rich_text_read_enabled: true,
+    longform_notetweets_inline_media_enabled: true,
+    responsive_web_enhance_cards_enabled: false,
+};
 const gqlFeatures = {
     UserByScreenName: gqlFeatureUser,
     UserByRestId: gqlFeatureUser,
@@ -58,6 +87,7 @@ const gqlFeatures = {
     SearchTimeline: gqlFeatureFeed,
     ListLatestTweetsTimeline: gqlFeatureFeed,
     HomeTimeline: gqlFeatureFeed,
+    TweetDetail: TweetDetailFeatures,
 };
 
 const timelineParams = {

--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -55,7 +55,6 @@ export const paginationTweets = async (endpoint: string, userId: number | undefi
         }),
         features: JSON.stringify(gqlFeatures[endpoint]),
     });
-
     let instructions;
     if (path) {
         instructions = data;
@@ -121,5 +120,6 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
             }
         }
     }
+
     return tweets;
 }

--- a/lib/routes/twitter/tweet.ts
+++ b/lib/routes/twitter/tweet.ts
@@ -39,7 +39,16 @@ async function handler(ctx) {
     const status = ctx.req.param('status');
     const routeParams = new URLSearchParams(ctx.req.param('original'));
     const original = fallback(undefined, queryToBoolean(routeParams.get('original')), false);
-    const params = { focalTweetId: status };
+    const params = {
+        focalTweetId: status,
+        with_rux_injections: false,
+        includePromotedContent: true,
+        withCommunity: true,
+        withQuickPromoteEligibilityTweetFields: true,
+        withBirdwatchNotes: true,
+        withVoice: true,
+        withV2Timeline: true,
+    };
     await api.init();
     const userInfo = await api.getUser(id);
     const data = await api.getUserTweet(id, params);


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/twitter/tweet/questflow/status/1771391133010333778/0
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

There was a problem with the original TweetDetail routing, which has now been fixed.

Docs: https://docs.rsshub.app/routes/social-media#tweet-details
Route: /twitter/tweet/:id/status/:status/:original?


