### PR TITLE
feat(route): add IEEE journal publication dates to RSS entry items

### DIFF
--- a/lib/routes/ieee/earlyaccess.ts
+++ b/lib/routes/ieee/earlyaccess.ts
@@ -7,6 +7,7 @@ import got from '@/utils/got';
 import { load } from 'cheerio';
 import path from 'node:path';
 import { art } from '@/utils/render';
+import { parseDate } from '@/utils/parse-date'; // Tool function for parsing dates
 
 import { CookieJar } from 'tough-cookie';
 const cookieJar = new CookieJar();
@@ -82,10 +83,12 @@ async function handler(ctx) {
             cache.tryGet(item.link, async () => {
                 if (item.abstract !== '') {
                     const response3 = await got(`${host}${item.link}`);
-                    const { abstract } = JSON.parse(response3.body.match(/metadata=(.*);/)[1]);
+                    const { abstract, displayPublicationDate} = JSON.parse(response3.body.match(/metadata=(.*);/)[1]);
                     const $3 = load(abstract);
+                    const $4 = load(displayPublicationDate)
                     item.abstract = $3.text();
                     item.description = renderDesc(item);
+                    item.pubDate = parseDate($4.text()); // Ignore pubDate unless with abstract.
                 }
                 return item;
             })

--- a/lib/routes/ieee/journal.ts
+++ b/lib/routes/ieee/journal.ts
@@ -7,6 +7,7 @@ import got from '@/utils/got';
 import { load } from 'cheerio';
 import path from 'node:path';
 import { art } from '@/utils/render';
+import { parseDate } from '@/utils/parse-date'; // Tool function for parsing dates
 
 import { CookieJar } from 'tough-cookie';
 const cookieJar = new CookieJar();
@@ -72,10 +73,12 @@ async function handler(ctx) {
             cache.tryGet(item.link, async () => {
                 if (item.abstract !== '') {
                     const response3 = await got(`${host}${item.link}`);
-                    const { abstract } = JSON.parse(response3.body.match(/metadata=(.*);/)[1]);
+                    const { abstract, displayPublicationDate} = JSON.parse(response3.body.match(/metadata=(.*);/)[1]);
                     const $3 = load(abstract);
+                    const $4 = load(displayPublicationDate)
                     item.abstract = $3.text();
                     item.description = renderDesc(item);
+                    item.pubDate = parseDate($4.text()); // Ignore pubDate unless with abstract.
                 }
                 return item;
             })

--- a/lib/routes/ieee/recent.ts
+++ b/lib/routes/ieee/recent.ts
@@ -7,6 +7,7 @@ import got from '@/utils/got';
 import { load } from 'cheerio';
 import path from 'node:path';
 import { art } from '@/utils/render';
+import { parseDate } from '@/utils/parse-date'; // Tool function for parsing dates
 
 import { CookieJar } from 'tough-cookie';
 const cookieJar = new CookieJar();
@@ -89,10 +90,12 @@ async function handler(ctx) {
             cache.tryGet(item.link, async () => {
                 if (item.abstract !== '') {
                     const response3 = await got(`${host}${item.link}`);
-                    const { abstract } = JSON.parse(response3.body.match(/metadata=(.*);/)[1]);
+                    const { abstract, displayPublicationDate} = JSON.parse(response3.body.match(/metadata=(.*);/)[1]);
                     const $3 = load(abstract);
+                    const $4 = load(displayPublicationDate)
                     item.abstract = $3.text();
                     item.description = renderDesc(item);
+                    item.pubDate = parseDate($4.text()); // Ignore pubDate unless with abstract.
                 }
                 return item;
             })

--- a/lib/routes/ieee/templates/description.art
+++ b/lib/routes/ieee/templates/description.art
@@ -1,6 +1,6 @@
-<p>
+<!-- <p>
     <span><big>{{ item.title }}</big></span><br>
-</p>
+</p> -->
 <p>
     <span><small><i>{{ item.authors }}</i></small></span><br>
     <span><small><i>https://doi.org/{{ item.doi }}</i></small></span><br>


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes

```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/ieee/journal/4359257/earlyaccess
/ieee/journal/8860/recent
/ieee/journal/8860
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
This PR uses the Date of Publication property from IEEE journal paper document pages ([like this](https://ieeexplore.ieee.org/document/10288547)) as the `pubDate` value of RSS entries which is unset before, so that RSS readers can identify duplicate papers and properly display them every time when fetching. 