### PR TITLE
feat(route): douyu room api update with fallback

### DIFF
--- a/lib/routes/douyu/room.ts
+++ b/lib/routes/douyu/room.ts
@@ -20,37 +20,74 @@ export const route: Route = {
         },
     ],
     name: '直播间开播',
-    maintainers: ['DIYgod'],
+    maintainers: ['DIYgod', 'ChaosTong'],
     handler,
 };
 
 async function handler(ctx) {
     const id = ctx.req.param('id');
 
-    const response = await got({
-        method: 'get',
-        url: `http://open.douyucdn.cn/api/RoomApi/room/${id}`,
-        headers: {
-            Referer: `https://www.douyu.com/${id}`,
-        },
-    });
-
-    const data = response.data.data;
-
+    let data;
     let item;
-    if (data.online !== 0) {
-        item = [
-            {
-                title: `开播: ${data.room_name}`,
-                pubDate: new Date(data.start_time).toUTCString(),
-                guid: data.start_time,
-                link: `https://www.douyu.com/${id}`,
+    let room_thumb;
+    try {
+        const response = await got({
+            method: 'get',
+            url: `https://www.douyu.com/betard/${id}`,
+        });
+
+        if (!response.data.room) {
+            throw new Error('Invalid response');
+        }
+
+        data = response.data.room;
+        room_thumb = data.room_pic;
+
+        if (data.show_status === 1) {
+            item = data.videoLoop === 1 ? [
+                    {
+                        title: `视频轮播: ${data.room_name}`,
+                        pubDate: new Date(data.show_time * 1000).toUTCString(),
+                        guid: data.show_time,
+                        link: `https://www.douyu.com/${id}`,
+                    },
+                ] : [
+                    {
+                        title: `开播: ${data.room_name}`,
+                        pubDate: new Date(data.show_time * 1000).toUTCString(),
+                        guid: data.show_time,
+                        link: `https://www.douyu.com/${id}`,
+                    },
+                ];
+        }
+        // make a fallback to the old api
+    } catch {
+        const response = await got({
+            method: 'get',
+            url: `http://open.douyucdn.cn/api/RoomApi/room/${id}`,
+            headers: {
+                Referer: `https://www.douyu.com/${id}`,
             },
-        ];
+        });
+
+        data = response.data.data;
+        room_thumb = data.room_thumb;
+
+        if (data.online !== 0) {
+            item = [
+                {
+                    title: `开播: ${data.room_name}`,
+                    pubDate: new Date(data.start_time).toUTCString(),
+                    guid: data.start_time,
+                    link: `https://www.douyu.com/${id}`,
+                },
+            ];
+        }
     }
 
     return {
         title: `${data.owner_name}的斗鱼直播间`,
+        image: room_thumb,
         link: `https://www.douyu.com/${id}`,
         item,
         allowEmpty: true,

--- a/lib/routes/douyu/room.ts
+++ b/lib/routes/douyu/room.ts
@@ -44,21 +44,24 @@ async function handler(ctx) {
         room_thumb = data.room_pic;
 
         if (data.show_status === 1) {
-            item = data.videoLoop === 1 ? [
-                    {
-                        title: `视频轮播: ${data.room_name}`,
-                        pubDate: new Date(data.show_time * 1000).toUTCString(),
-                        guid: data.show_time,
-                        link: `https://www.douyu.com/${id}`,
-                    },
-                ] : [
-                    {
-                        title: `开播: ${data.room_name}`,
-                        pubDate: new Date(data.show_time * 1000).toUTCString(),
-                        guid: data.show_time,
-                        link: `https://www.douyu.com/${id}`,
-                    },
-                ];
+            item =
+                data.videoLoop === 1
+                    ? [
+                          {
+                              title: `视频轮播: ${data.room_name}`,
+                              pubDate: new Date(data.show_time * 1000).toUTCString(),
+                              guid: data.show_time,
+                              link: `https://www.douyu.com/${id}`,
+                          },
+                      ]
+                    : [
+                          {
+                              title: `开播: ${data.room_name}`,
+                              pubDate: new Date(data.show_time * 1000).toUTCString(),
+                              guid: data.show_time,
+                              link: `https://www.douyu.com/${id}`,
+                          },
+                      ];
         }
         // make a fallback to the old api
     } catch {


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/douyu/room/2421040
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
use new api get room info when error with fallback to old api, can detect is video loop or real live.