### PR TITLE
chore: compress using zstd in docker test

### DIFF
--- a/.github/workflows/docker-test-cont.yml
+++ b/.github/workflows/docker-test-cont.yml
@@ -58,7 +58,7 @@ jobs:
         if: (env.TEST_CONTINUE)
         run: |
           set -ex
-          gzip -cvd docker-image/rsshub.tar.gz | docker load
+          zstd -d --stdout rssshub.tar.zst | docker load
           docker run -d \
             --name rsshub \
             -e NODE_ENV=dev \

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -66,11 +66,11 @@ jobs:
         run: bash scripts/docker/test-docker.sh
 
       - name: Export Docker image
-        run: docker save rsshub:latest | gzip -1cf > rsshub.tar.gz
+        run: docker save rsshub:latest | zstdmt -o rsshub.tar.zst
 
       - name: Upload Docker image
         uses: actions/upload-artifact@v4
         with:
           name: docker-image
-          path: rsshub.tar.gz
+          path: rsshub.tar.zst
           retention-days: 1


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/test/1
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Compress time: [30s](https://github.com/DIYgod/RSSHub/actions/runs/8910280008/job/24469234135) -> [13s](https://github.com/DIYgod/RSSHub/actions/runs/8910501376/job/24469899374#step:8:1)
Size: [450MB](https://github.com/DIYgod/RSSHub/actions/runs/8910280008/job/24469234135#step:8:1) -> [373MB](https://github.com/DIYgod/RSSHub/actions/runs/8910501376/job/24469899374#step:8:30)
Decompress time: [30s](https://github.com/DIYgod/RSSHub/actions/runs/8910317628/job/24469348716) -> 2s