### PR TITLE
fix: broken url when not using optional :page parameter

### DIFF
--- a/lib/routes/github/wiki.ts
+++ b/lib/routes/github/wiki.ts
@@ -32,7 +32,15 @@ export const route: Route = {
 async function handler(ctx) {
     const { user, repo, page } = ctx.req.param();
 
-    const url = `${baseUrl}/${user}/${repo}/wiki${page ? `/${page}` : ''}/_history`;
+    let url = `${baseUrl}/${user}/${repo}/wiki${page ? `/${page}` : ''}/_history`;
+
+    // Fetch page slug. History fetched with no page specified has no <a> tag for commit.
+    if (!page) {
+        const { data } = await got(`${baseUrl}/${user}/${repo}/wiki`);
+        const $ = load(data);
+        
+        url = `${baseUrl}{$('a[href$=_history]')}`;
+    }
 
     const { data } = await got(url);
     const $ = load(data);

--- a/lib/routes/github/wiki.ts
+++ b/lib/routes/github/wiki.ts
@@ -38,8 +38,8 @@ async function handler(ctx) {
     if (!page) {
         const { data } = await got(`${baseUrl}/${user}/${repo}/wiki`);
         const $ = load(data);
-        
-        url = `${baseUrl}{$('a[href$=_history]')}`;
+
+        url = `${baseUrl}${$('a[href$=_history]')}`;
     }
 
     const { data } = await got(url);

--- a/lib/routes/github/wiki.ts
+++ b/lib/routes/github/wiki.ts
@@ -39,7 +39,7 @@ async function handler(ctx) {
         const { data } = await got(`${baseUrl}/${user}/${repo}/wiki`);
         const $ = load(data);
 
-        url = `${baseUrl}${$('a[href$=_history]')}`;
+        url = `${baseUrl}${$('a[href$=_history]').attr('href')}`;
     }
 
     const { data } = await got(url);


### PR DESCRIPTION

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #14387

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/github/wiki/flutter/flutter
```
