### PR TITLE
feat(route): 增加了国防科技大学研究生院中的硕士招生和通知公告的rss源

### DIFF
--- a/lib/routes/nudt/namespace.ts
+++ b/lib/routes/nudt/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '中国人民解放军国防科技大学',
+    url: 'www.nudt.edu.cn',
+};

--- a/lib/routes/nudt/yjszs.ts
+++ b/lib/routes/nudt/yjszs.ts
@@ -1,0 +1,68 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import timezone from '@/utils/timezone';
+
+/* 研究生院*/
+const host = 'http://yjszs.nudt.edu.cn';
+
+const yjszs = new Map([
+    // http://yjszs.nudt.edu.cn//pubweb/homePageList/searchContent.view
+    ['tzgg', { title: '国防科技大学研究生院 - 通知公告', view: 'searchContent' }],
+    // http://yjszs.nudt.edu.cn//pubweb/homePageList/recruitStudents.view?keyId=16
+    ['sszs', { title: '国防科技大学研究生院 - 硕士招生', view: 'recruitStudents', keyId: '16' }],
+]);
+
+export const route: Route = {
+    path: '/yjszs/:type?',
+    categories: ['university'],
+    example: '/nudt/yjszs/sszs',
+    parameters: { type: '分类，见下表，默认为硕士招生' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '国防科技大学研究生院',
+    maintainers: ['blankTourist'],
+    handler,
+    url: 'yjszs.nudt.edu.cn/',
+    description: `| 通知公告 | 硕士招生 |
+  | -------- | -------- |
+  | tzgg     | sszs     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type') ?? 'sszs';
+    const info = yjszs.get(type);
+    if (!info) {
+        throw new InvalidParameterError('invalid type');
+    }
+    const link = `${host}/pubweb/homePageList/${info.view}.view?keyId=${info.keyId ?? ''}`;
+    const response = await got({
+        method: 'get',
+        url: link,
+    });
+
+    const $ = load(response.data);
+    const content = $('.news-list li');
+    const items = content.toArray().map((elem) => {
+        elem = $(elem);
+        return {
+            link: new URL(elem.find('a').attr('href'), host).href,
+            title: elem.find('h3').text().trim(),
+            pubDate: timezone(parseDate(elem.find('.time').text(), 'YYYY-MM-DD'), -8),
+        };
+    });
+
+    return {
+        title: info.title,
+        link,
+        item: items,
+    };
+}

--- a/lib/routes/nudt/yjszs.ts
+++ b/lib/routes/nudt/yjszs.ts
@@ -28,8 +28,8 @@ export const route: Route = {
         supportPodcast: false,
         supportScihub: false,
     },
-    name: '国防科技大学研究生院',
-    maintainers: ['blankTourist'],
+    name: '研究生院',
+    maintainers: ['Blank0120'],
     handler,
     url: 'yjszs.nudt.edu.cn/',
     description: `| 通知公告 | 硕士招生 |


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/nudt/yjszs
/nudt/yjszs/sszs
/nudt/yjszs/tzgg
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
增加了国防科技大学研究生院中的硕士招生和通知公告的rss源