### PR TITLE
fix: /6v123/latestMovies filter tv series

### DIFF
--- a/lib/routes/6v123/latest-movies.ts
+++ b/lib/routes/6v123/latest-movies.ts
@@ -28,7 +28,7 @@ export const route: Route = {
 };
 
 async function handler(ctx) {
-    const item = await processItems(ctx, baseURL, [/第*集/, /第*季/, /(EP|ep)\d+/, /([Ss])\d+/, /更新/]);
+    const item = await processItems(ctx, baseURL, [/第*集/, /第*季/, /(ep)\d+/i, /(s)\d+/i, /更新/]);
 
     return {
         title: '6v电影-最新电影',

--- a/lib/routes/6v123/latest-movies.ts
+++ b/lib/routes/6v123/latest-movies.ts
@@ -28,7 +28,7 @@ export const route: Route = {
 };
 
 async function handler(ctx) {
-    const item = await processItems(ctx, baseURL);
+    const item = await processItems(ctx, baseURL, [/第*集/, /第*季/, /(EP|ep)\d+/, /([Ss])\d+/, /更新/]);
 
     return {
         title: '6v电影-最新电影',

--- a/lib/routes/6v123/latest-tvseries.ts
+++ b/lib/routes/6v123/latest-tvseries.ts
@@ -28,7 +28,7 @@ export const route: Route = {
 };
 
 async function handler(ctx) {
-    const item = await processItems(ctx, baseURL);
+    const item = await processItems(ctx, baseURL, []);
 
     return {
         title: '6v电影-最新电影',

--- a/lib/routes/6v123/utils.ts
+++ b/lib/routes/6v123/utils.ts
@@ -28,7 +28,7 @@ export async function loadDetailPage(link) {
     };
 }
 
-export async function processItems(ctx, baseURL) {
+export async function processItems(ctx, baseURL, exclude) {
     const response = await got.get(baseURL, {
         responseType: 'buffer',
     });
@@ -42,8 +42,14 @@ export async function processItems(ctx, baseURL) {
             const link = $(item).find('a');
             const href = link.attr('href');
             const pubDate = timezone(parseDate($(item).find('span').text().replaceAll(/[[\]]/g, ''), 'MM-DD'), +8);
+            const text = link.text();
 
             if (href === undefined) {
+                return;
+            }
+
+            if (exclude && exclude.some((e) => e.test(text))) {
+                // 过滤掉满足正则的标题条目
                 return;
             }
 


### PR DESCRIPTION
latestMovies has some tv series data in list, use filter with reg skip it. 

```routes
/6v123/latestMovies
/6v123/latestTVSeries
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
