### PR TITLE
feat: 添加podwise.ai的支持

### DIFF
--- a/lib/routes/podwise/collections.ts
+++ b/lib/routes/podwise/collections.ts
@@ -1,0 +1,60 @@
+import { Route } from '@/types';
+import { load } from 'cheerio';
+import ofetch from '@/utils/ofetch'; // 统一使用的请求库
+
+export const route: Route = {
+    path: '/explore',
+    categories: ['multimedia', 'programming'],
+    example: '/podwise/explore',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['podwise.ai', 'podwise.ai/explore'],
+        },
+    ],
+    name: 'Collections',
+    maintainers: ['lyling'],
+    handler: async () => {
+        const link = `https://podwise.ai/explore`;
+        const response = await ofetch(link);
+        const $ = load(response);
+        const content = $('#navigator').next();
+        // header/[div => content]/footer, content p(2)
+        const collectinDescription = content.find('p').eq(1).text();
+
+        const list = content
+            .find('.group')
+            .toArray()
+            .map((item) => {
+                item = $(item);
+                const title = item.find('a').first().text();
+                const link = item.find('a').first().attr('href');
+                const description = item.find('p').first().text();
+                return {
+                    title,
+                    link,
+                    description,
+                };
+            });
+
+        const items = list.map((item) => ({
+            title: item.title,
+            link: `https://podwise.ai${item.link}`,
+            description: item.description,
+        }));
+
+        return {
+            title: $('title').text(),
+            description: collectinDescription,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/podwise/episodes.ts
+++ b/lib/routes/podwise/episodes.ts
@@ -1,0 +1,76 @@
+import { Route } from '@/types';
+import { load } from 'cheerio';
+import ofetch from '@/utils/ofetch'; // 统一使用的请求库
+import cache from '@/utils/cache';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+export const route: Route = {
+    path: '/explore/:type',
+    categories: ['multimedia', 'programming'],
+    example: '/podwise/explore/latest',
+    parameters: { type: 'latest or all episodes.' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['podwise.ai/explore/:type'],
+        },
+    ],
+    name: 'Episodes',
+    maintainers: ['lyling'],
+    handler: async (ctx) => {
+        const type = ctx.req.param('type');
+        const link = `https://podwise.ai/explore/${type}`;
+        const response = await ofetch(link);
+        const $ = load(response);
+        const content = $('#navigator').next();
+        // header/[div => content]/footer, content>div(2)>h1
+        const title = content.find('h1').first().text();
+        const description = content.find('p').eq(1).text();
+
+        const list = content
+            .find('.group')
+            .toArray()
+            .map((item) => {
+                item = $(item);
+                const title = item.find('a').first().text();
+                const link = item.find('a').first().attr('href');
+                const description = item.find('p').first().text();
+                const author = item.children('div').last().children('div').first().text();
+                const pubDate = item.find('a').next().children('span').text();
+
+                return {
+                    title,
+                    link: `https://podwise.ai${link}`,
+                    description,
+                    author,
+                    pubDate: timezone(parseDate(pubDate, 'DD MMM YYYY', 'en'), 8),
+                };
+            });
+
+        const items = await Promise.all(
+            list.map((item) =>
+                cache.tryGet(item.link, async () => {
+                    const response = await ofetch(item.link);
+                    const $ = load(response);
+
+                    item.description = $('summary').first().html();
+                    return item;
+                })
+            )
+        );
+
+        return {
+            title,
+            description,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/podwise/namespace.ts
+++ b/lib/routes/podwise/namespace.ts
@@ -1,0 +1,19 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Podwise',
+    url: 'podwise.ai',
+    description: `
+:::tip
+Podwise provides  none of official RSS feeds.
+This route support below:
+
+-   Collections: \`https://podwise.ai/explore\`
+-   Episodes: \`https://podwise.ai/explore/:category\`
+-   Episode: \`https://podwise.ai/dashboard/episodes/:episode\`
+:::`,
+
+    zh: {
+        name: 'Podwise',
+    },
+};


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/podwise
/podwise/explore
/podwise/explore/latest
/podwise/explore/all
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

当网站时间为的月份缩写(MMM)与浏览器地区不一致时， 需要指定parseDate的语言参数，如'en', 如果发现parseDate为Invalid Date时, 调用

```js
import localeData from 'dayjs/plugin/localeDate';
dayjs.extent(localeData); 
dayjs.monthShort();
```
来查看缩写是否与时间的月份一致
