### PR TITLE
feat: support  podwise.ai

### DIFF
--- a/lib/routes/podwise/collections.ts
+++ b/lib/routes/podwise/collections.ts
@@ -4,17 +4,8 @@ import ofetch from '@/utils/ofetch'; // 统一使用的请求库
 
 export const route: Route = {
     path: '/explore',
-    categories: ['multimedia', 'programming'],
+    categories: ['multimedia'],
     example: '/podwise/explore',
-    parameters: {},
-    features: {
-        requireConfig: false,
-        requirePuppeteer: false,
-        antiCrawler: false,
-        supportBT: false,
-        supportPodcast: false,
-        supportScihub: false,
-    },
     radar: [
         {
             source: ['podwise.ai', 'podwise.ai/explore'],
@@ -23,14 +14,14 @@ export const route: Route = {
     name: 'Collections',
     maintainers: ['lyling'],
     handler: async () => {
-        const link = `https://podwise.ai/explore`;
+        const link = 'https://podwise.ai/explore';
         const response = await ofetch(link);
         const $ = load(response);
         const content = $('#navigator').next();
         // header/[div => content]/footer, content p(2)
         const collectinDescription = content.find('p').eq(1).text();
 
-        const list = content
+        const items = content
             .find('.group')
             .toArray()
             .map((item) => {
@@ -40,21 +31,16 @@ export const route: Route = {
                 const description = item.find('p').first().text();
                 return {
                     title,
-                    link,
+                    link: `https://podwise.ai${link}`,
                     description,
                 };
             });
-
-        const items = list.map((item) => ({
-            title: item.title,
-            link: `https://podwise.ai${item.link}`,
-            description: item.description,
-        }));
 
         return {
             title: $('title').text(),
             description: collectinDescription,
             item: items,
+            link,
         };
     },
 };

--- a/lib/routes/podwise/collections.ts
+++ b/lib/routes/podwise/collections.ts
@@ -1,0 +1,60 @@
+import { Route } from '@/types';
+import { load } from 'cheerio';
+import ofetch from '@/utils/ofetch'; // 统一使用的请求库
+
+export const route: Route = {
+    path: '/explore',
+    categories: ['multimedia', 'programming'],
+    example: '/podwise/explore',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['podwise.ai', 'podwise.ai/explore'],
+        },
+    ],
+    name: 'Collections',
+    maintainers: ['lyling'],
+    handler: async () => {
+        const link = `https://podwise.ai/explore`;
+        const response = await ofetch(link);
+        const $ = load(response);
+        const content = $('#navigator').next();
+        // header/[div => content]/footer, content p(2)
+        const collectinDescription = content.find('p').eq(1).text();
+
+        const list = content
+            .find('.group')
+            .toArray()
+            .map((item) => {
+                item = $(item);
+                const title = item.find('a').first().text();
+                const link = item.find('a').first().attr('href');
+                const description = item.find('p').first().text();
+                return {
+                    title,
+                    link,
+                    description,
+                };
+            });
+
+        const items = list.map((item) => ({
+            title: item.title,
+            link: `https://podwise.ai${item.link}`,
+            description: item.description,
+        }));
+
+        return {
+            title: $('title').text(),
+            description: collectinDescription,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/podwise/episodes.ts
+++ b/lib/routes/podwise/episodes.ts
@@ -7,17 +7,9 @@ import timezone from '@/utils/timezone';
 
 export const route: Route = {
     path: '/explore/:type',
-    categories: ['multimedia', 'programming'],
+    categories: ['multimedia'],
     example: '/podwise/explore/latest',
     parameters: { type: 'latest or all episodes.' },
-    features: {
-        requireConfig: false,
-        requirePuppeteer: false,
-        antiCrawler: false,
-        supportBT: false,
-        supportPodcast: false,
-        supportScihub: false,
-    },
     radar: [
         {
             source: ['podwise.ai/explore/:type'],
@@ -70,6 +62,7 @@ export const route: Route = {
         return {
             title,
             description,
+            link,
             item: items,
         };
     },

--- a/lib/routes/podwise/episodes.ts
+++ b/lib/routes/podwise/episodes.ts
@@ -1,0 +1,76 @@
+import { Route } from '@/types';
+import { load } from 'cheerio';
+import ofetch from '@/utils/ofetch'; // 统一使用的请求库
+import cache from '@/utils/cache';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+export const route: Route = {
+    path: '/explore/:type',
+    categories: ['multimedia', 'programming'],
+    example: '/podwise/explore/latest',
+    parameters: { type: 'latest or all episodes.' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['podwise.ai/explore/:type'],
+        },
+    ],
+    name: 'Episodes',
+    maintainers: ['lyling'],
+    handler: async (ctx) => {
+        const type = ctx.req.param('type');
+        const link = `https://podwise.ai/explore/${type}`;
+        const response = await ofetch(link);
+        const $ = load(response);
+        const content = $('#navigator').next();
+        // header/[div => content]/footer, content>div(2)>h1
+        const title = content.find('h1').first().text();
+        const description = content.find('p').eq(1).text();
+
+        const list = content
+            .find('.group')
+            .toArray()
+            .map((item) => {
+                item = $(item);
+                const title = item.find('a').first().text();
+                const link = item.find('a').first().attr('href');
+                const description = item.find('p').first().text();
+                const author = item.children('div').last().children('div').first().text();
+                const pubDate = item.find('a').next().children('span').text();
+
+                return {
+                    title,
+                    link: `https://podwise.ai${link}`,
+                    description,
+                    author,
+                    pubDate: timezone(parseDate(pubDate, 'DD MMM YYYY', 'en'), 8),
+                };
+            });
+
+        const items = await Promise.all(
+            list.map((item) =>
+                cache.tryGet(item.link, async () => {
+                    const response = await ofetch(item.link);
+                    const $ = load(response);
+
+                    item.description = $('summary').first().html();
+                    return item;
+                })
+            )
+        );
+
+        return {
+            title,
+            description,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/podwise/episodes.ts
+++ b/lib/routes/podwise/episodes.ts
@@ -55,7 +55,6 @@ export const route: Route = {
                     item.description = $('summary').first().html();
 
                     // duration
-                    // item.itunes_duration = parseDate("");
                     const $cover = $('img[alt="Podcast cover"]').eq(1);
                     const $duration = $cover.next().find('span').eq(2);
 

--- a/lib/routes/podwise/episodes.ts
+++ b/lib/routes/podwise/episodes.ts
@@ -75,7 +75,7 @@ export const route: Route = {
                     item.itunes_duration = parseDuration($duration.text());
                     item.enclosure_url = podcastData.link;
                     // item.enclosure_length: nothing can convert to.
-                    item.enclosure_type = podcastData.linkType;
+                    item.enclosure_type = toEnclosureType(podcastData.linkType);
 
                     return item;
                 })
@@ -103,4 +103,17 @@ function parseDuration(durationStr) {
             minutes,
         })
         .asSeconds();
+}
+
+function toEnclosureType(linkType: string): string {
+    switch (linkType) {
+        case 'mp3':
+            return 'audio/mpeg';
+        case 'm4a':
+            return 'audio/x-m4a';
+        case 'mp4':
+            return 'video/mp4';
+        default:
+            return linkType;
+    }
 }

--- a/lib/routes/podwise/episodes.ts
+++ b/lib/routes/podwise/episodes.ts
@@ -4,8 +4,8 @@ import ofetch from '@/utils/ofetch'; // 统一使用的请求库
 import cache from '@/utils/cache';
 import { parseDate } from '@/utils/parse-date';
 import timezone from '@/utils/timezone';
-const dayjs = require('dayjs');
-const duration = require('dayjs/plugin/duration');
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
 dayjs.extend(duration);
 
 export const route: Route = {

--- a/lib/routes/podwise/namespace.ts
+++ b/lib/routes/podwise/namespace.ts
@@ -3,16 +3,6 @@ import type { Namespace } from '@/types';
 export const namespace: Namespace = {
     name: 'Podwise',
     url: 'podwise.ai',
-    description: `
-:::tip
-Podwise provides  none of official RSS feeds.
-This route support below:
-
--   Collections: \`https://podwise.ai/explore\`
--   Episodes: \`https://podwise.ai/explore/:category\`
--   Episode: \`https://podwise.ai/dashboard/episodes/:episode\`
-:::`,
-
     zh: {
         name: 'Podwise',
     },

--- a/lib/routes/podwise/namespace.ts
+++ b/lib/routes/podwise/namespace.ts
@@ -1,0 +1,19 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Podwise',
+    url: 'podwise.ai',
+    description: `
+:::tip
+Podwise provides  none of official RSS feeds.
+This route support below:
+
+-   Collections: \`https://podwise.ai/explore\`
+-   Episodes: \`https://podwise.ai/explore/:category\`
+-   Episode: \`https://podwise.ai/dashboard/episodes/:episode\`
+:::`,
+
+    zh: {
+        name: 'Podwise',
+    },
+};


### PR DESCRIPTION


## Example for the Proposed Route(s) / 路由地址示例

```routes
/podwise/explore
/podwise/explore/latest
/podwise/explore/all
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

当网站时间为的月份缩写(MMM)与浏览器地区不一致时， 需要指定parseDate的语言参数，如'en', 如果发现parseDate为Invalid Date时, 调用

```js
import localeData from 'dayjs/plugin/localeDate';
dayjs.extent(localeData); 
dayjs.monthShort();
```
来查看缩写是否与时间的月份一致
