### PR TITLE
fix: /2048 route down

### DIFF
--- a/lib/routes/2048/index.ts
+++ b/lib/routes/2048/index.ts
@@ -9,6 +9,7 @@ import timezone from '@/utils/timezone';
 import { parseDate } from '@/utils/parse-date';
 import { art } from '@/utils/render';
 import path from 'node:path';
+import { ofetch } from 'ofetch';
 
 export const route: Route = {
     path: '/:id?',
@@ -81,12 +82,9 @@ async function handler(ctx) {
 
     const currentUrl = `${entranceDomain}/2048/thread.php?fid-${id}.html`;
 
-    const response = await got({
-        method: 'get',
-        url: currentUrl,
-    });
+    const response = await ofetch.raw(currentUrl);
 
-    const $ = load(response.data);
+    const $ = load(response._data);
     const currentHost = `https://${new URL(response.url).host}`; // redirected host
 
     $('#shortcut').remove();
@@ -127,8 +125,8 @@ async function handler(ctx) {
                 item.pubDate = timezone(parseDate(content('span.fl.gray').first().attr('title')), +8);
 
                 const downloadLink = content('#read_tpc').first().find('a').last();
-
-                if (downloadLink?.text()?.startsWith('http') && /datapps\.org$/.test(new URL(downloadLink.text()).hostname)) {
+                const copyLink = content('#copytext')?.first()?.text();
+                if (downloadLink?.text()?.startsWith('http') && /down2048\.com$/.test(new URL(downloadLink.text()).hostname)) {
                     const torrentResponse = await got({
                         method: 'get',
                         url: downloadLink.text(),
@@ -137,7 +135,8 @@ async function handler(ctx) {
                     const torrent = load(torrentResponse.data);
 
                     item.enclosure_type = 'application/x-bittorrent';
-                    item.enclosure_url = `https://data.datapps.org/${torrent('.uk-button').last().attr('href')}`;
+                    const ahref = torrent('.uk-button').last().attr('href');
+                    item.enclosure_url = ahref?.startsWith('http') ? ahref : `https://data.datapps.org/${ahref}`;
 
                     const magnet = torrent('.uk-button').first().attr('href');
 
@@ -147,6 +146,9 @@ async function handler(ctx) {
                             torrent: item.enclosure_url,
                         })
                     );
+                } else if (copyLink?.startsWith('magnet')) {
+                    // copy link
+                    item.enclosure_url = copyLink;
                 }
 
                 const desp = content('#read_tpc').first();

--- a/lib/routes/2048/index.ts
+++ b/lib/routes/2048/index.ts
@@ -1,10 +1,14 @@
 import { Route } from '@/types';
+import { getCurrentPath } from '@/utils/helpers';
+const __dirname = getCurrentPath(import.meta.url);
 
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { load } from 'cheerio';
 import timezone from '@/utils/timezone';
 import { parseDate } from '@/utils/parse-date';
+import { art } from '@/utils/render';
+import path from 'node:path';
 
 export const route: Route = {
     path: '/:id?',
@@ -83,14 +87,7 @@ async function handler(ctx) {
     });
 
     const $ = load(response.data);
-
-    const headbase = $('#headbase')?.attr('href');
-
-    if (!headbase) {
-        throw new Error('headbase not found');
-    }
-
-    const currentHost = new URL(headbase).origin; // redirected host
+    const currentHost = `https://${new URL(response.url).host}`; // redirected host
 
     $('#shortcut').remove();
     $('tr[onmouseover="this.className=\'tr3 t_two\'"]').remove();
@@ -106,10 +103,6 @@ async function handler(ctx) {
                 title: item.text(),
                 link: `${currentHost}/2048/${item.attr('href')}`,
                 guid: `${rootUrl}/2048/${item.attr('href')}`,
-                enclosure_url: '',
-                pubDate: new Date(),
-                author: '',
-                description: '',
             };
         })
         .filter((item) => !item.link.includes('undefined'));
@@ -133,63 +126,37 @@ async function handler(ctx) {
                 item.author = content('.fl.black').first().text();
                 item.pubDate = timezone(parseDate(content('span.fl.gray').first().attr('title')), +8);
 
-                const desp = content('#read_tpc').first();
-
-                content('.showhide img').each(function () {
-                    desp.append(`<br><img style="max-width: 100%;" src="${content(this).attr('src')}">`);
-                });
-
-                item.description = desp.html() ?? '';
-
                 const downloadLink = content('#read_tpc').first().find('a').last();
-                const copyLink = content('#copytext')?.first()?.text();
-                const attachments = content('.r_one')
-                    .find('a')
-                    .map((i, t) => {
-                        const a = content(t);
-                        const res = {
-                            name: a.text(),
-                            link: a.attr('href'),
-                        };
-                        return res;
-                    })
-                    .filter((i, e) => e.link && e.link.includes('action=download'));
 
-                if (downloadLink?.text()?.startsWith('https') && /down2048\.com\/list\.php/.test(downloadLink?.text())) {
-                    // second level page magnet url
+                if (downloadLink?.text()?.startsWith('http') && /datapps\.org$/.test(new URL(downloadLink.text()).hostname)) {
                     const torrentResponse = await got({
                         method: 'get',
                         url: downloadLink.text(),
                     });
 
                     const torrent = load(torrentResponse.data);
-                    const magUrl = torrent('.uk-button').first().attr('href');
-                    if (magUrl) {
-                        item.enclosure_url = magUrl;
-                    }
-                } else if (copyLink?.startsWith('magnet')) {
-                    // copy link
-                    item.enclosure_url = copyLink;
-                } else if (attachments && attachments.length > 0) {
-                    // use attachment make item replicas
-                    const copyItem = item;
-                    item = [];
-                    for (const attachment of attachments) {
-                        if (attachment.link && !attachment.link.startsWith('http')) {
-                            attachment.link = `${currentHost}/${attachment.link}`;
-                        }
-                        const attachmentItem = {
-                            title: `${copyItem.title} [${attachment.name}]`,
-                            link: copyItem.link,
-                            guid: copyItem.guid,
-                            enclosure_url: attachment.link,
-                            pubDate: copyItem.pubDate,
-                            author: copyItem.author,
-                            description: copyItem.description,
-                        };
-                        item.push(attachmentItem);
-                    }
+
+                    item.enclosure_type = 'application/x-bittorrent';
+                    item.enclosure_url = `https://data.datapps.org/${torrent('.uk-button').last().attr('href')}`;
+
+                    const magnet = torrent('.uk-button').first().attr('href');
+
+                    downloadLink.replaceWith(
+                        art(path.join(__dirname, 'templates/download.art'), {
+                            magnet,
+                            torrent: item.enclosure_url,
+                        })
+                    );
                 }
+
+                const desp = content('#read_tpc').first();
+
+                content('.showhide img').each(function () {
+                    desp.append(`<br><img style="max-width: 100%;" src="${content(this).attr('src')}">`);
+                });
+
+                item.description = desp.html();
+
                 return item;
             })
         )
@@ -198,6 +165,6 @@ async function handler(ctx) {
     return {
         title: `${$('#main #breadCrumb a').last().text()} - 2048核基地`,
         link: currentUrl,
-        item: items.flat().filter((i) => i !== null && i.enclosure_url && i.enclosure_url !== ''),
+        item: items,
     };
 }

--- a/lib/routes/2048/index.ts
+++ b/lib/routes/2048/index.ts
@@ -9,7 +9,7 @@ import timezone from '@/utils/timezone';
 import { parseDate } from '@/utils/parse-date';
 import { art } from '@/utils/render';
 import path from 'node:path';
-import { ofetch } from 'ofetch';
+import ofetch from '@/utils/ofetch';
 
 export const route: Route = {
     path: '/:id?',
@@ -149,6 +149,7 @@ async function handler(ctx) {
                 } else if (copyLink?.startsWith('magnet')) {
                     // copy link
                     item.enclosure_url = copyLink;
+                    item.enclosure_type = 'x-scheme-handler/magnet';
                 }
 
                 const desp = content('#read_tpc').first();


### PR DESCRIPTION

```routes
/2048
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
