### PR TITLE
fix(core): restore LISTEN_INADDR_ANY functionality

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,17 +5,21 @@ import { config } from '@/config';
 import app from '@/app';
 
 const port = config.connect.port;
+const listenInaddrAny = Number.parseInt(config.listenInaddrAny);
 const hostIPList = getLocalhostAddress();
 
 logger.info(`🎉 RSSHub is running on port ${port}! Cheers!`);
 logger.info('💖 Can you help keep this open source project alive? Please sponsor 👉 https://docs.rsshub.app/sponsor');
 logger.info(`🔗 Local: 👉 http://localhost:${port}`);
-for (const ip of hostIPList) {
-    logger.info(`🔗 Network: 👉 http://${ip}:${port}`);
+if (listenInaddrAny) {
+    for (const ip of hostIPList) {
+        logger.info(`🔗 Network: 👉 http://${ip}:${port}`);
+    }
 }
 
 const server = serve({
     fetch: app.fetch,
+    hostname: listenInaddrAny ? null : '127.0.0.1',
     port,
 });
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Somehow the functionality is lost during Hono migration [1]. Let's add it back.

[1] https://github.com/DIYgod/RSSHub/commit/8e0154552ce3a5c2f9b88fa45447eb809d5ec252