### PR TITLE
fix(route): fix Spotify TypeError

### DIFF
--- a/lib/routes/spotify/artist.ts
+++ b/lib/routes/spotify/artist.ts
@@ -1,7 +1,7 @@
 import { Route } from '@/types';
 import utils from './utils';
-import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import { ofetch } from 'ofetch';
 
 export const route: Route = {
     path: '/artist/:id',
@@ -38,21 +38,18 @@ export const route: Route = {
 async function handler(ctx) {
     const token = await utils.getPublicToken();
     const id = ctx.req.param('id');
-    const meta = await got
-        .get(`https://api.spotify.com/v1/artists/${id}`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        })
-        .json();
-
-    const itemsResponse = await got
-        .get(`https://api.spotify.com/v1/artists/${id}/albums`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        })
-        .json();
+    const meta = await ofetch(`https://api.spotify.com/v1/artists/${id}`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+    const itemsResponse = await ofetch(`https://api.spotify.com/v1/artists/${id}/albums`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
     const albums = itemsResponse.items;
 
     return {

--- a/lib/routes/spotify/artist.ts
+++ b/lib/routes/spotify/artist.ts
@@ -1,7 +1,7 @@
 import { Route } from '@/types';
 import utils from './utils';
 import { parseDate } from '@/utils/parse-date';
-import { ofetch } from 'ofetch';
+import ofetch from '@/utils/ofetch';
 
 export const route: Route = {
     path: '/artist/:id',

--- a/lib/routes/spotify/artists-top.ts
+++ b/lib/routes/spotify/artists-top.ts
@@ -1,6 +1,6 @@
 import { Route } from '@/types';
 import utils from './utils';
-import got from '@/utils/got';
+import { ofetch } from 'ofetch';
 
 export const route: Route = {
     path: '/top/artists',
@@ -41,13 +41,12 @@ export const route: Route = {
 
 async function handler() {
     const token = await utils.getPrivateToken();
-    const itemsResponse = await got
-        .get(`https://api.spotify.com/v1/me/top/artists`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        })
-        .json();
+    const itemsResponse = await ofetch(`https://api.spotify.com/v1/me/top/artists`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
     const items = itemsResponse.items;
 
     return {

--- a/lib/routes/spotify/artists-top.ts
+++ b/lib/routes/spotify/artists-top.ts
@@ -1,6 +1,6 @@
 import { Route } from '@/types';
 import utils from './utils';
-import { ofetch } from 'ofetch';
+import ofetch from '@/utils/ofetch';
 
 export const route: Route = {
     path: '/top/artists',

--- a/lib/routes/spotify/playlist.ts
+++ b/lib/routes/spotify/playlist.ts
@@ -1,7 +1,7 @@
 import { Route } from '@/types';
 import utils from './utils';
 import { parseDate } from '@/utils/parse-date';
-import { ofetch } from 'ofetch';
+import ofetch from '@/utils/ofetch';
 
 export const route: Route = {
     path: '/playlist/:id',

--- a/lib/routes/spotify/playlist.ts
+++ b/lib/routes/spotify/playlist.ts
@@ -1,7 +1,7 @@
 import { Route } from '@/types';
 import utils from './utils';
-import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import { ofetch } from 'ofetch';
 
 export const route: Route = {
     path: '/playlist/:id',
@@ -38,13 +38,12 @@ export const route: Route = {
 async function handler(ctx) {
     const token = await utils.getPublicToken();
     const id = ctx.req.param('id');
-    const meta = await got
-        .get(`https://api.spotify.com/v1/playlists/${id}`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        })
-        .json();
+    const meta = await ofetch(`https://api.spotify.com/v1/playlists/${id}`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
     const tracks = meta.tracks.items;
 
     return {

--- a/lib/routes/spotify/saved.ts
+++ b/lib/routes/spotify/saved.ts
@@ -1,7 +1,7 @@
 import { Route } from '@/types';
 import utils from './utils';
-import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import { ofetch } from 'ofetch';
 
 export const route: Route = {
     path: '/saved/:limit?',
@@ -47,13 +47,12 @@ async function handler(ctx) {
     const limit = ctx.req.param('limit');
     const pageSize = isNaN(Number.parseInt(limit)) ? 50 : Number.parseInt(limit);
 
-    const itemsResponse = await got
-        .get(`https://api.spotify.com/v1/me/tracks?limit=${pageSize}`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        })
-        .json();
+    const itemsResponse = await ofetch(`https://api.spotify.com/v1/me/tracks?limit=${pageSize}`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
     const tracks = itemsResponse.items;
 
     return {

--- a/lib/routes/spotify/saved.ts
+++ b/lib/routes/spotify/saved.ts
@@ -1,7 +1,7 @@
 import { Route } from '@/types';
 import utils from './utils';
 import { parseDate } from '@/utils/parse-date';
-import { ofetch } from 'ofetch';
+import ofetch from '@/utils/ofetch';
 
 export const route: Route = {
     path: '/saved/:limit?',

--- a/lib/routes/spotify/show.ts
+++ b/lib/routes/spotify/show.ts
@@ -1,6 +1,6 @@
 import { Route } from '@/types';
 import utils from './utils';
-import got from '@/utils/got';
+import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
@@ -39,13 +39,12 @@ async function handler(ctx) {
     const token = await utils.getPublicToken();
     const id = ctx.req.param('id');
 
-    const meta = await got
-        .get(`https://api.spotify.com/v1/shows/${id}?market=US`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        })
-        .json();
+    const meta = await ofetch(`https://api.spotify.com/v1/shows/${id}?market=US`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
 
     const episodes = meta.episodes.items;
 

--- a/lib/routes/spotify/tracks-top.ts
+++ b/lib/routes/spotify/tracks-top.ts
@@ -1,6 +1,6 @@
 import { Route } from '@/types';
 import utils from './utils';
-import { ofetch } from 'ofetch';
+import ofetch from '@/utils/ofetch';
 
 export const route: Route = {
     path: '/top/tracks',

--- a/lib/routes/spotify/tracks-top.ts
+++ b/lib/routes/spotify/tracks-top.ts
@@ -1,6 +1,6 @@
 import { Route } from '@/types';
 import utils from './utils';
-import got from '@/utils/got';
+import { ofetch } from 'ofetch';
 
 export const route: Route = {
     path: '/top/tracks',
@@ -41,13 +41,12 @@ export const route: Route = {
 
 async function handler() {
     const token = await utils.getPrivateToken();
-    const itemsResponse = await got
-        .get(`https://api.spotify.com/v1/me/top/tracks`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        })
-        .json();
+    const itemsResponse = await ofetch(`https://api.spotify.com/v1/me/top/tracks`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
     const items = itemsResponse.items;
 
     return {

--- a/lib/routes/spotify/utils.ts
+++ b/lib/routes/spotify/utils.ts
@@ -1,6 +1,6 @@
 import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
-import got from '@/utils/got';
+import ofetch from '@/utils/ofetch';
 
 // Token used to retrieve public information.
 async function getPublicToken() {
@@ -10,16 +10,16 @@ async function getPublicToken() {
 
     const { clientId, clientSecret } = config.spotify;
 
-    const tokenResponse = await got
-        .post('https://accounts.spotify.com/api/token', {
-            headers: {
-                Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
-            },
-            form: {
-                grant_type: 'client_credentials',
-            },
-        })
-        .json();
+    const tokenResponse = await ofetch('https://accounts.spotify.com/api/token', {
+        method: 'POST',
+        headers: {
+            Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+            grant_type: 'client_credentials',
+        }).toString(),
+    });
     return tokenResponse.access_token;
 }
 
@@ -32,17 +32,17 @@ async function getPrivateToken() {
 
     const { clientId, clientSecret, refreshToken } = config.spotify;
 
-    const tokenResponse = await got
-        .post('https://accounts.spotify.com/api/token', {
-            headers: {
-                Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
-            },
-            form: {
-                grant_type: 'refresh_token',
-                refresh_token: refreshToken,
-            },
-        })
-        .json();
+    const tokenResponse = await ofetch('https://accounts.spotify.com/api/token', {
+        method: 'POST',
+        headers: {
+            Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+        }).toString(),
+    });
     return tokenResponse.access_token;
 }
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #15648

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/spotify/artist/6k9TBCxyr4bXwZ8Y21Kwn1
/spotify/top/artists
/spotify/playlist/4UBVy1LttvodwivPUuwJk2
/spotify/saved/50
/spotify/top/tracks
/spotify/show/5CfCWKI5pZ28U0uOzXkDHe
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/spotify/artist/6k9TBCxyr4bXwZ8Y21Kwn1
/spotify/top/artists
/spotify/playlist/4UBVy1LttvodwivPUuwJk2
/spotify/saved/50
/spotify/top/tracks
/spotify/show/5CfCWKI5pZ28U0uOzXkDHe
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
fix Spotify TypeError by replacing `got` with `ofetch`.
