### PR TITLE
fix(route): Vice component role fix

### DIFF
--- a/lib/routes/vice/topic.ts
+++ b/lib/routes/vice/topic.ts
@@ -16,7 +16,6 @@ export const route: Route = {
     example: '/vice/topic/politics/en',
     parameters: {
         topic: 'Can be found in the URL',
-        content: 'Set to true to retrieve the full article (images are blurry), anything else will pull the short text',
         language: 'defaults to `en`, use the website to discover other codes',
     },
     radar: [

--- a/lib/routes/vice/topic.ts
+++ b/lib/routes/vice/topic.ts
@@ -69,9 +69,6 @@ async function handler(ctx) {
                                     return render({ body: { html: component.html } });
                                 case 'heading2':
                                     return render({ heading2: { html: component.html } });
-                                case 'article':
-                                case 'divider':
-                                    return '';
                                 case 'image':
                                     return render({
                                         image: {
@@ -85,7 +82,7 @@ async function handler(ctx) {
                                 case 'youtube':
                                     return render({ oembed: { html: component.oembed.html } });
                                 default:
-                                    throw new Error(`Unhandled component: ${component.role} from ${item.link}`);
+                                    return '';
                             }
                         })
                         .join('');


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #15736

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/vice/topic/hacking
/vice/topic/cleveland
/vice/topic/assault
/vice/topic/millenial
/vice/topic/sex
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [X] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Fixes a few issues with VICE route. NEXT_DATA has some roles that are currently unsupported. Problem is that these roles vary from article to article. Fortunately, however all these roles, so far have been internal ads pointing at other articles.

I have added extra routes for testing purposes in the PR