### PR TITLE
feat(route): add Bugzilla

### DIFF
--- a/lib/routes/bugzilla/bug.ts
+++ b/lib/routes/bugzilla/bug.ts
@@ -1,0 +1,58 @@
+import { load } from 'cheerio';
+import { Context } from 'hono';
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import { Data, DataItem, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const INSTANCES = new Map([
+    ['apache', 'bz.apache.org/bugzilla'],
+    ['apache.ooo', 'bz.apache.org/ooo'], // Apache OpenOffice
+    ['apache.SpamAssassin', 'bz.apache.org/SpamAssassin'],
+    ['mozilla', 'bugzilla.mozilla.org'],
+    ['webkit', 'bugs.webkit.org'],
+]);
+
+async function handler(ctx: Context): Promise<Data> {
+    const { site, bugId } = ctx.req.param();
+    if (!INSTANCES.has(site)) {
+        throw new InvalidParameterError(`unknown site: ${site}`);
+    }
+    const link = `https://${INSTANCES.get(site)}/show_bug.cgi?id=${bugId}`;
+    const $ = load(await ofetch(`${link}&ctype=xml`));
+    const items = $('long_desc').map((index, rawItem) => {
+        const $ = load(rawItem, null, false);
+        return {
+            title: `comment #${$('commentid').text()}`,
+            link: `${link}#c${index}`,
+            description: $('thetext').text(),
+            pubDate: parseDate($('bug_when').text()),
+            author: $('who').attr('name'),
+        } as DataItem;
+    });
+    return { title: $('short_desc').text(), link, item: items.toArray() };
+}
+
+function markdownFrom(instances: Map<string, string>, separator: string = ', '): string {
+    return [...instances.entries()].map(([k, v]) => `[\`${k}\`](https://${v})`).join(separator);
+}
+
+export const route: Route = {
+    path: '/bug/:site/:bugId',
+    name: 'bugs',
+    maintainers: ['FranklinYu'],
+    handler,
+    example: '/bug/webkit/251528',
+    parameters: {
+        site: 'site identifier',
+        bugId: 'numeric identifier of the bug in the site',
+    },
+    description: `Supported site identifiers: ${markdownFrom(INSTANCES)}.`,
+    categories: ['programming'],
+
+    // Radar is infeasible, because it needs access to URL parameters.
+    zh: {
+        name: 'bugs',
+        description: `支持的站点标识符：${markdownFrom(INSTANCES, '、')}。`,
+    },
+};

--- a/lib/routes/bugzilla/namespace.ts
+++ b/lib/routes/bugzilla/namespace.ts
@@ -1,0 +1,11 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Bugzilla',
+    url: 'bugzilla.org',
+    description: 'Bugzilla instances hosted by organizations.',
+    zh: {
+        name: 'Bugzilla',
+        description: '各组织自建的Bugzilla实例。',
+    },
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

(N/A)

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bugzilla/bug/apache/55899
/bugzilla/bug/apache.ooo/74164
/bugzilla/bug/apache.SpamAssassin/8091
/bugzilla/bug/mozilla/840640
/bugzilla/bug/webkit/251528
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Need to maintain a mapping from identifiers to site prefixes. A future PR may add a free-form site prefix parameter.
- `@/utils/parse-date` changed the timezone from UTC to GMT. They are assumed to be synonyms, but IMO we should label it as UTC, as it is the modern name for that timezone.