### PR TITLE
fix(route/bugzilla): add missing prefix to example

### DIFF
--- a/lib/routes/bugzilla/bug.ts
+++ b/lib/routes/bugzilla/bug.ts
@@ -9,6 +9,7 @@ const INSTANCES = new Map([
     ['apache', 'bz.apache.org/bugzilla'],
     ['apache.ooo', 'bz.apache.org/ooo'], // Apache OpenOffice
     ['apache.SpamAssassin', 'bz.apache.org/SpamAssassin'],
+    ['kernel', 'bugzilla.kernel.org'],
     ['mozilla', 'bugzilla.mozilla.org'],
     ['webkit', 'bugs.webkit.org'],
 ]);
@@ -42,7 +43,7 @@ export const route: Route = {
     name: 'bugs',
     maintainers: ['FranklinYu'],
     handler,
-    example: '/bug/webkit/251528',
+    example: '/bugzilla/bug/webkit/251528',
     parameters: {
         site: 'site identifier',
         bugId: 'numeric identifier of the bug in the site',


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bugzilla/bug/apache/55899
/bugzilla/bug/apache.ooo/74164
/bugzilla/bug/apache.SpamAssassin/8091
/bugzilla/bug/kernel/218790
/bugzilla/bug/mozilla/840640
/bugzilla/bug/webkit/251528
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

1. Fix the example.
2. Add Kernel Bugzilla (added to the example above).