### PR TITLE
ci(test): enable the GitHub Actions reporter for Vitest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,14 @@ jobs:
       - name: Build routes
         run: pnpm build
       - name: Test all and generate coverage
-        run: pnpm run vitest:coverage
+        run: pnpm run vitest:coverage --outputFile=tmp/vitest-coverage.xml
         env:
           REDIS_URL: redis://localhost:${{ job.services.redis.ports[6379] }}/
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v4
+        if: ${{ matrix.node-version == '20' }}
+        with:
+          report_paths: 'tmp/vitest-coverage.xml'
       - name: Upload coverage to Codecov
         if: ${{ matrix.node-version == '20' }}
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   fix-pnpm-lock:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,14 +69,9 @@ jobs:
       - name: Build routes
         run: pnpm build
       - name: Test all and generate coverage
-        run: pnpm run vitest:coverage --outputFile=tmp/vitest-coverage.xml
+        run: pnpm run vitest:coverage --reporter=github-actions
         env:
           REDIS_URL: redis://localhost:${{ job.services.redis.ports[6379] }}/
-      - name: Publish test report
-        uses: mikepenz/action-junit-report@v4
-        if: ${{ matrix.node-version == '20' }}
-        with:
-          report_paths: 'tmp/vitest-coverage.xml'
       - name: Upload coverage to Codecov
         if: ${{ matrix.node-version == '20' }}
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This should publish the JUnit report for human consumption. The raw XML is too long, so not as readable for PR reviewers.

Reference:
- https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28