### PR TITLE
chore: Skip pull request labeler for forked repositories

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
 
   labeler:
     name: Pull Request Labeler
-    if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name == 'pull_request_target' && github.actor != 'dependabot[bot]' && github.repository == 'DIYgod/RSSHub' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

No issue currently

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Similar to https://github.com/DIYgod/RSSHub/commit/206b6d2c9978bf77746c529a7d386772efb51712, this skips running the "Pull Request Labeler" job when running on a forked repository. This avoids unnecessary traffic to the GitHub API when forks synchronize with this repository.