### PR TITLE
feat(route): introduce `/bluearchive/news`

### DIFF
--- a/lib/routes/bluearchive/namespace.ts
+++ b/lib/routes/bluearchive/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Blue Archive',
+    url: 'bluearchive.jp',
+    categories: ['game'],
+};

--- a/lib/routes/bluearchive/news.ts
+++ b/lib/routes/bluearchive/news.ts
@@ -1,0 +1,88 @@
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+// type id => display name
+type Mapping = Record<string, string>;
+
+const JP: Mapping = {
+    '0': '全て',
+    '1': 'メンテナンス',
+    '2': 'お知らせ',
+    '3': 'イベント',
+};
+
+// render into MD table
+const mkTable = (mapping: Mapping): string => {
+    const heading: string[] = [],
+        separator: string[] = [],
+        body: string[] = [];
+
+    for (const key in mapping) {
+        heading.push(mapping[key]);
+        separator.push(':--:');
+        body.push(key);
+    }
+
+    return [heading.join(' | '), separator.join(' | '), body.join(' | ')].map((s) => `| ${s} |`).join('\n');
+};
+
+const handler: Route['handler'] = async (ctx) => {
+    const { server } = ctx.req.param();
+
+    switch (server.toUpperCase()) {
+        case 'JP':
+            return await ja(ctx);
+        default:
+            throw [];
+    }
+};
+
+const ja: Route['handler'] = async (ctx) => {
+    const { type = '0' } = ctx.req.param();
+
+    const data = await ofetch<{ data: { rows: { id: string; content: string; summary: string; publishTime: number }[] } }, 'json'>('https://api-web.bluearchive.jp/api/news/list', {
+        params: {
+            typeId: type,
+            pageNum: 16,
+            pageIndex: 1,
+        },
+    });
+
+    return {
+        title: `ブルアカ - ${JP[type]}`,
+        link: 'https://bluearchive.jp/news/newsJump',
+        language: 'ja-JP',
+        image: 'https://webcnstatic.yostar.net/ba_cn_web/prod/web/favicon.png', // The CN website has a larger one
+        icon: 'https://webcnstatic.yostar.net/ba_cn_web/prod/web/favicon.png',
+        logo: 'https://webcnstatic.yostar.net/ba_cn_web/prod/web/favicon.png',
+        item: data.data.rows.map((row) => ({
+            title: row.summary,
+            description: row.content,
+            link: `https://bluearchive.jp/news/newsJump/${row.id}`,
+            pubDate: parseDate(row.publishTime),
+        })),
+    };
+};
+
+export const route: Route = {
+    path: '/news/:server/:type?',
+    name: 'News',
+    categories: ['game'],
+    maintainers: ['equt'],
+    example: '/bluearchive/news/jp',
+    parameters: {
+        server: 'game server (ISO 3166 two-letter country code, case-insensitive), only `JP` is supported for now',
+        type: 'news type, checkout the table below for details',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    handler,
+    description: [JP].map((el) => mkTable(el)).join('\n\n'),
+};

--- a/lib/routes/bluearchive/news.ts
+++ b/lib/routes/bluearchive/news.ts
@@ -41,7 +41,7 @@ const handler: Route['handler'] = async (ctx) => {
 const ja: Route['handler'] = async (ctx) => {
     const { type = '0' } = ctx.req.param();
 
-    const data = await ofetch<{ data: { rows: { id: string; content: string; summary: string; publishTime: number }[] } }, 'json'>('https://api-web.bluearchive.jp/api/news/list', {
+    const data = await ofetch<{ data: { rows: { id: number; content: string; summary: string; publishTime: number }[] } }, 'json'>('https://api-web.bluearchive.jp/api/news/list', {
         params: {
             typeId: type,
             pageNum: 16,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N / A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bluearchive/news/jp/0
/bluearchive/news/jp/1
/bluearchive/news/jp/2
/bluearchive/news/jp/3
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Only JP server is added in this commit, I may add support for the rest in the future.