### PR TITLE
fix(route): bluearchive jp incorrect news type

### DIFF
--- a/lib/routes/bluearchive/news.ts
+++ b/lib/routes/bluearchive/news.ts
@@ -7,9 +7,9 @@ type Mapping = Record<string, string>;
 
 const JP: Mapping = {
     '0': '全て',
-    '1': 'メンテナンス',
+    '1': 'イベント',
     '2': 'お知らせ',
-    '3': 'イベント',
+    '3': 'メンテナンス',
 };
 
 // render into MD table


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N / A

## Example for the Proposed Route(s) / 路由地址示例


```routes
/bluearchive/news/jp/1
/bluearchive/news/jp/3
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Just realized the type id is not correct 😅.
