### PR TITLE
doc(route): fix incorrect MD syntax

### DIFF
--- a/lib/routes/telegram/channel.ts
+++ b/lib/routes/telegram/channel.ts
@@ -63,7 +63,7 @@ export const route: Route = {
         username: 'channel username',
         routeParams: `extra parameters, see the table below
 | Key                    | Description                                                           | Accepts                                            | Defaults to  |
-| ---------------------- | --------------------------------------------------------------------- | -------------------------------------------------- | ------------ |
+| :--------------------: | :-------------------------------------------------------------------: | :------------------------------------------------: | :----------: |
 | showLinkPreview        | Show the link preview from Telegram                                   | 0/1/true/false                                     | true         |
 | showViaBot             | For messages sent via bot, show the bot                               | 0/1/true/false                                     | true         |
 | showReplyTo            | For reply messages, show the target of the reply                      | 0/1/true/false                                     | true         |


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N / A

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

It would be better to have a script like `dev:docs` for rendering & serving the doc locally.