### PR TITLE
feat(route): introduce `/notion/release`

### DIFF
--- a/lib/routes/notion/release.ts
+++ b/lib/routes/notion/release.ts
@@ -4,6 +4,7 @@ import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 import cache from '@/utils/cache';
 import day from 'dayjs';
+import wait from '@/utils/wait';
 
 const handler: Route['handler'] = async () => {
     const data = await ofetch('https://notion.so/releases', {
@@ -24,16 +25,19 @@ const handler: Route['handler'] = async () => {
     const item = (await Promise.all(
         $('a[href^="/releases/"]')
             .toArray()
-            .map(async (item) => {
+            .slice(0, 2)
+            .map(async (item, i) => {
                 const link = `https://notion.so${item.attribs.href}`;
 
-                const data = (await cache.tryGet(`notion:release:${link}`, () =>
-                    ofetch(link, {
+                const data = (await cache.tryGet(`notion:release:${link}`, async () => {
+                    await wait(500 * i);
+                    return await ofetch(link, {
                         headers: {
                             'Accept-Language': 'en-US', // TODO accept param
+                            Referer: 'https://notion.so/releases',
                         },
-                    })
-                )) as string;
+                    });
+                })) as string;
 
                 const $ = load(data);
 

--- a/lib/routes/notion/release.ts
+++ b/lib/routes/notion/release.ts
@@ -25,26 +25,25 @@ const handler: Route['handler'] = async () => {
         $('div[class^="releasePreviewsSection"] h3 a[href^="/releases/"]')
             .toArray()
             .slice(0, 5)
-            .map(async (item) => {
+            .map((item) => {
                 const link = `https://notion.so${item.attribs.href}`;
 
-                const data = (await cache.tryGet(`notion:release:${link}`, () =>
-                    ofetch(link, {
+                return cache.tryGet(`notion:release:${link}`, async () => {
+                    const data = await ofetch(link, {
                         headers: {
-                            'Accept-Language': 'en-US', // TODO accept param
-                            Referer: 'https://notion.so/releases',
+                            'Accept-Language': 'en-US', // Notion will adjust returned content based on this header
                         },
-                    })
-                )) as string;
+                    });
 
-                const $ = load(data);
+                    const $ = load(data);
 
-                return {
-                    title: $('h2').first().text() ?? '',
-                    pubDate: parseDate($('time').first().text()),
-                    description: $('article.release article').first().html() ?? '',
-                    link,
-                };
+                    return {
+                        title: $('h2').first().text() ?? '',
+                        pubDate: parseDate($('time').first().text()),
+                        description: $('article.release article').first().html() ?? '',
+                        link,
+                    };
+                });
             })
     )) as DataItem[];
 

--- a/lib/routes/notion/release.ts
+++ b/lib/routes/notion/release.ts
@@ -1,0 +1,79 @@
+import type { DataItem, Route } from '@/types';
+import { load } from 'cheerio';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import cache from '@/utils/cache';
+import day from 'dayjs';
+
+const handler: Route['handler'] = async () => {
+    const data = await ofetch('https://notion.so/releases', {
+        headers: {
+            'Accept-Language': 'en-US', // TODO accept param
+        },
+    });
+
+    const $ = load(data);
+
+    // the first post, do not cache
+    const title = $('h2').first().text() ?? '';
+    const pubDate = parseDate($('time').first().text());
+    const description = $('article.release article').first().html() ?? '';
+    const link = `https://notion.so/releases/${day(pubDate).format('YYYY-MM-DD')}`;
+
+    // archive
+    const item = (await Promise.all(
+        $('a[href^="/releases/"]')
+            .toArray()
+            .map(async (item) => {
+                const link = `https://notion.so${item.attribs.href}`;
+
+                const data = (await cache.tryGet(`notion:release:${link}`, () =>
+                    ofetch(link, {
+                        headers: {
+                            'Accept-Language': 'en-US', // TODO accept param
+                        },
+                    })
+                )) as string;
+
+                const $ = load(data);
+
+                return {
+                    title: $('h2').first().text() ?? '',
+                    pubDate: parseDate($('time').first().text()),
+                    description: $('article.release article').first().html() ?? '',
+                };
+            })
+    )) as DataItem[];
+
+    return {
+        title: 'Notion Releases',
+        link: 'https://notion.so/releases',
+        item: [
+            {
+                title,
+                description,
+                pubDate,
+                link,
+            },
+            ...item,
+        ],
+    };
+};
+
+export const route: Route = {
+    name: 'Release',
+    path: '/release',
+    url: 'notion.so/releases',
+    example: '/notion/release',
+    categories: ['program-update'],
+    maintainers: ['equt'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    handler,
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N / A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/notion/release
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明