### PR TITLE
fix(route): adds release year filters to metacritic

### DIFF
--- a/lib/routes/metacritic/index.ts
+++ b/lib/routes/metacritic/index.ts
@@ -44,7 +44,7 @@ async function handler(ctx) {
     const releaseTypes = currentUrlParams.getAll('releaseType').join(',');
     const releaseYearMin = currentUrlParams.getAll('releaseYearMin')[0];
     const releaseYearMax = currentUrlParams.getAll('releaseYearMax')[0];
-    
+
     if (genres) {
         searchParams.genres = genres;
     }
@@ -52,7 +52,7 @@ async function handler(ctx) {
     if (releaseTypes) {
         searchParams.releaseType = releaseTypes;
     }
-    
+
     if (releaseYearMin) {
         searchParams.releaseYearMin = releaseYearMin;
     }
@@ -60,7 +60,7 @@ async function handler(ctx) {
     if (releaseYearMax) {
         searchParams.releaseYearMax = releaseYearMax;
     }
-    
+ 
     const platforms = currentUrlParams.getAll('platform');
     const networks = currentUrlParams.getAll('network');
 

--- a/lib/routes/metacritic/index.ts
+++ b/lib/routes/metacritic/index.ts
@@ -60,7 +60,7 @@ async function handler(ctx) {
     if (releaseYearMax) {
         searchParams.releaseYearMax = releaseYearMax;
     }
- 
+
     const platforms = currentUrlParams.getAll('platform');
     const networks = currentUrlParams.getAll('network');
 

--- a/lib/routes/metacritic/index.ts
+++ b/lib/routes/metacritic/index.ts
@@ -42,8 +42,8 @@ async function handler(ctx) {
 
     const genres = currentUrlParams.getAll('genre').join(',').toLowerCase();
     const releaseTypes = currentUrlParams.getAll('releaseType').join(',');
-    const releaseYearMin = currentUrlParams.getAll('releaseYearMin')[0];
-    const releaseYearMax = currentUrlParams.getAll('releaseYearMax')[0];
+    const releaseYearMin = currentUrlParams.get('releaseYearMin');
+    const releaseYearMax = currentUrlParams.get('releaseYearMax');
 
     if (genres) {
         searchParams.genres = genres;

--- a/lib/routes/metacritic/index.ts
+++ b/lib/routes/metacritic/index.ts
@@ -42,7 +42,9 @@ async function handler(ctx) {
 
     const genres = currentUrlParams.getAll('genre').join(',').toLowerCase();
     const releaseTypes = currentUrlParams.getAll('releaseType').join(',');
-
+    const releaseYearMin = currentUrlParams.getAll('releaseYearMin')[0];
+    const releaseYearMax = currentUrlParams.getAll('releaseYearMax')[0];
+    
     if (genres) {
         searchParams.genres = genres;
     }
@@ -50,7 +52,15 @@ async function handler(ctx) {
     if (releaseTypes) {
         searchParams.releaseType = releaseTypes;
     }
+    
+    if (releaseYearMin) {
+        searchParams.releaseYearMin = releaseYearMin;
+    }
 
+    if (releaseYearMax) {
+        searchParams.releaseYearMax = releaseYearMax;
+    }
+    
     const platforms = currentUrlParams.getAll('platform');
     const networks = currentUrlParams.getAll('network');
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #16057

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes

```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/metacritic/game/metascore/releaseYearMin=2024&releaseYearMax=2024
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
The release year filters were simply not being passed to the metacritic api.