### PR TITLE
fix(route/neea): fix routing priority and improve descriptions

### DIFF
--- a/lib/routes/neea/index.ts
+++ b/lib/routes/neea/index.ts
@@ -25,7 +25,7 @@ function loadContent(link) {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const host = `http://${type}.neea.edu.cn${typeDic[type].url}`;
+    const host = `https://${type}.neea.edu.cn${typeDic[type].url}`;
     const response = await got({
         method: 'get',
         url: host,
@@ -39,7 +39,7 @@ async function handler(ctx) {
         list.map(async (item) => {
             const ReportIDname = $(item).find('#ReportIDname > a');
             const ReportIDIssueTime = $(item).find('#ReportIDIssueTime');
-            const itemUrl = `http://${type}.neea.edu.cn` + $(ReportIDname).attr('href');
+            const itemUrl = `https://${type}.neea.edu.cn` + $(ReportIDname).attr('href');
             const time = ReportIDIssueTime.text();
             const single = {
                 title: $(ReportIDname).text(),

--- a/lib/routes/neea/index.ts
+++ b/lib/routes/neea/index.ts
@@ -114,11 +114,11 @@ const typeDic = {
 };
 
 export const route: Route = {
-    path: '/:type',
-    name: '考试动态',
+    path: '/local/:type',
+    name: '国内考试动态',
     url: 'www.neea.edu.cn',
     maintainers: ['SunShinenny'],
-    example: '/neea/cet',
+    example: '/neea/local/cet',
     parameters: { type: '考试项目，见下表' },
     categories: ['study'],
     features: {
@@ -127,7 +127,7 @@ export const route: Route = {
     radar: Object.entries(typeDic).map(([type, value]) => ({
         title: `${value.title}动态`,
         source: [`${type}.neea.edu.cn`, `${type}.neea.cn`],
-        target: `/${type}`,
+        target: `/local/${type}`,
     })),
     handler,
     description: `|              | 考试项目                      | type     |

--- a/lib/routes/neea/index.ts
+++ b/lib/routes/neea/index.ts
@@ -2,6 +2,9 @@ import { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
 function loadContent(link) {
     return cache.tryGet(link, async () => {
         // 开始加载页面
@@ -20,13 +23,6 @@ function loadContent(link) {
     });
 }
 
-export const route: Route = {
-    path: '/:type?',
-    name: 'Unknown',
-    maintainers: ['SunShinenny'],
-    handler,
-};
-
 async function handler(ctx) {
     const type = ctx.req.param('type');
     const host = `http://${type}.neea.edu.cn${typeDic[type].url}`;
@@ -44,13 +40,12 @@ async function handler(ctx) {
             const ReportIDname = $(item).find('#ReportIDname > a');
             const ReportIDIssueTime = $(item).find('#ReportIDIssueTime');
             const itemUrl = `http://${type}.neea.edu.cn` + $(ReportIDname).attr('href');
-            let time = new Date(ReportIDIssueTime.text()).getTime();
-            time += new Date().getTimezoneOffset() * 60 * 1000 + 8 * 60 * 60 * 1000; // beijing timezone
+            const time = ReportIDIssueTime.text();
             const single = {
                 title: $(ReportIDname).text(),
                 link: itemUrl,
                 guid: itemUrl,
-                pubDate: new Date(time).toUTCString(),
+                pubDate: timezone(parseDate(time), +8),
             };
             const other = await loadContent(String(itemUrl));
             return Object.assign({}, single, other);
@@ -86,10 +81,14 @@ const typeDic = {
         url: '/html1/category/1507/1148-1.htm',
         title: '中小学教师资格考试',
     },
+    tdxl: {
+        url: '/html1/category/2210/313-1.htm',
+        title: '同等学力申请硕士学位考试',
+    },
     // 社会证书考试
     cet: {
         url: '/html1/category/16093/1124-1.htm',
-        title: '全国四六级（CET）',
+        title: '全国四六级考试（CET）',
     },
     ncre: {
         url: '/html1/category/1507/872-1.htm',
@@ -112,8 +111,37 @@ const typeDic = {
         url: '/html1/category/1507/2035-1.htm',
         title: '书画等级考试 (CCPT)',
     },
-    mets: {
-        url: '/html1/category/1507/2065-1.htm',
-        title: '医护英语水平考试 (METS)',
+};
+
+export const route: Route = {
+    path: '/:type',
+    name: '考试动态',
+    url: 'www.neea.edu.cn',
+    maintainers: ['SunShinenny'],
+    example: '/neea/cet',
+    parameters: { type: '考试项目，见下表' },
+    categories: ['study'],
+    features: {
+        supportRadar: true,
     },
+    radar: Object.entries(typeDic).map(([type, value]) => ({
+        title: `${value.title}动态`,
+        source: [`${type}.neea.edu.cn`, `${type}.neea.cn`],
+        target: `/${type}`,
+    })),
+    handler,
+    description: `|              | 考试项目                      | type     |
+| ------------ | ----------------------------- | -------- |
+| 国家教育考试 | 普通高考                      | gaokao   |
+|              | 成人高考                      | chengkao |
+|              | 研究生考试                    | yankao   |
+|              | 自学考试                      | zikao    |
+|              | 中小学教师资格考试            | ntce     |
+|              | 同等学力申请硕士学位考试      | tdxl     |
+| 社会证书考试 | 全国四六级考试（CET）         | cet      |
+|              | 全国计算机等级考试（NCRE）    | ncre     |
+|              | 全国计算机应用水平考试（NIT） | nit      |
+|              | 全国英语等级考试 (PETS)       | pets     |
+|              | 全国外语水平考试 (WSK)        | wsk      |
+|              | 书画等级考试 (CCPT)           | ccpt     |`,
 };

--- a/lib/routes/neea/index.ts
+++ b/lib/routes/neea/index.ts
@@ -25,7 +25,7 @@ function loadContent(link) {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const host = `http://${type}.neea.edu.cn${typeDic[type].url}`;
+    const host = `https://${type}.neea.edu.cn${typeDic[type].url}`;
     const response = await got({
         method: 'get',
         url: host,
@@ -39,7 +39,7 @@ async function handler(ctx) {
         list.map(async (item) => {
             const ReportIDname = $(item).find('#ReportIDname > a');
             const ReportIDIssueTime = $(item).find('#ReportIDIssueTime');
-            const itemUrl = `http://${type}.neea.edu.cn` + $(ReportIDname).attr('href');
+            const itemUrl = `https://${type}.neea.edu.cn` + $(ReportIDname).attr('href');
             const time = ReportIDIssueTime.text();
             const single = {
                 title: $(ReportIDname).text(),
@@ -101,24 +101,24 @@ const typeDic = {
 
     pets: {
         url: '/html1/category/1507/1570-1.htm',
-        title: '全国英语等级考试 (PETS)',
+        title: '全国英语等级考试（PETS）',
     },
     wsk: {
         url: '/html1/category/1507/1646-1.htm',
-        title: '全国外语水平考试 (WSK)',
+        title: '全国外语水平考试（WSK）',
     },
     ccpt: {
         url: '/html1/category/1507/2035-1.htm',
-        title: '书画等级考试 (CCPT)',
+        title: '书画等级考试（CCPT）',
     },
 };
 
 export const route: Route = {
-    path: '/:type',
-    name: '考试动态',
+    path: '/local/:type',
+    name: '国内考试动态',
     url: 'www.neea.edu.cn',
     maintainers: ['SunShinenny'],
-    example: '/neea/cet',
+    example: '/neea/local/cet',
     parameters: { type: '考试项目，见下表' },
     categories: ['study'],
     features: {
@@ -127,7 +127,7 @@ export const route: Route = {
     radar: Object.entries(typeDic).map(([type, value]) => ({
         title: `${value.title}动态`,
         source: [`${type}.neea.edu.cn`, `${type}.neea.cn`],
-        target: `/${type}`,
+        target: `/local/${type}`,
     })),
     handler,
     description: `|              | 考试项目                      | type     |
@@ -141,7 +141,7 @@ export const route: Route = {
 | 社会证书考试 | 全国四六级考试（CET）         | cet      |
 |              | 全国计算机等级考试（NCRE）    | ncre     |
 |              | 全国计算机应用水平考试（NIT） | nit      |
-|              | 全国英语等级考试 (PETS)       | pets     |
-|              | 全国外语水平考试 (WSK)        | wsk      |
-|              | 书画等级考试 (CCPT)           | ccpt     |`,
+|              | 全国英语等级考试（PETS）      | pets     |
+|              | 全国外语水平考试（WSK）       | wsk      |
+|              | 书画等级考试（CCPT）          | ccpt     |`,
 };

--- a/lib/routes/neea/jlpt.ts
+++ b/lib/routes/neea/jlpt.ts
@@ -3,29 +3,26 @@ import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
 
 export const route: Route = {
-    path: '/jlpt',
-    categories: ['study'],
-    example: '/neea/jlpt',
+    path: '/global/jlpt',
+    name: '日本语能力测试(JLPT)通知',
+    url: 'jlpt.neea.edu.cn',
+    maintainers: ['nczitzk'],
+    example: '/neea/global/jlpt',
     parameters: {},
+    categories: ['study'],
     features: {
-        requireConfig: false,
-        requirePuppeteer: false,
-        antiCrawler: false,
-        supportBT: false,
-        supportPodcast: false,
-        supportScihub: false,
+        supportRadar: true,
     },
     radar: [
         {
-            source: ['jlpt.neea.cn/'],
+            source: ['jlpt.neea.edu.cn', 'jlpt.neea.cn'],
+            target: '/global/jlpt',
         },
     ],
-    name: '教育部考试中心日本语能力测试重要通知',
-    maintainers: ['nczitzk'],
     handler,
-    url: 'jlpt.neea.cn/',
 };
 
 async function handler() {
@@ -49,7 +46,7 @@ async function handler() {
             return {
                 title: item.text(),
                 link: `${rootUrl}/JLPT/1/${item.attr('href')}`,
-                pubDate: matches ? parseDate(matches[1]) : '',
+                pubDate: matches ? timezone(parseDate(matches[1]), +8) : '',
             };
         });
 
@@ -71,7 +68,7 @@ async function handler() {
     );
 
     return {
-        title: '重要通知 - 教育部考试中心日本语能力测试',
+        title: '日本语能力测试(JLPT)通知',
         link: currentUrl,
         item: items,
     };

--- a/lib/routes/neea/jlpt.ts
+++ b/lib/routes/neea/jlpt.ts
@@ -3,62 +3,76 @@ import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
-import timezone from '@/utils/timezone';
 
 export const route: Route = {
-    path: '/global/jlpt',
-    name: '日本语能力测试(JLPT)通知',
-    url: 'jlpt.neea.edu.cn',
-    maintainers: ['nczitzk'],
-    example: '/neea/global/jlpt',
-    parameters: {},
+    path: '/jlpt',
     categories: ['study'],
+    example: '/neea/jlpt',
+    parameters: {},
     features: {
-        supportRadar: true,
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
     },
     radar: [
         {
-            source: ['jlpt.neea.edu.cn', 'jlpt.neea.cn'],
-            target: '/global/jlpt',
+            source: ['jlpt.neea.cn/'],
         },
     ],
+    name: '教育部考试中心日本语能力测试重要通知',
+    maintainers: ['nczitzk'],
     handler,
+    url: 'jlpt.neea.cn/',
 };
 
 async function handler() {
-    const baseUrl = 'https://news.neea.edu.cn/JLPT/1';
-    const newsUrl = `${baseUrl}/newslist.htm`;
-    const response = await got.get(newsUrl);
+    const rootUrl = 'https://news.neea.cn';
+    const currentUrl = `${rootUrl}/JLPT/1/newslist.htm`;
+
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+    });
+
     const $ = load(response.data);
-    const list = $('a').get();
-    const items = await Promise.all(
-        list.map(async (item) => {
-            const title = $(item).text();
-            const link = `${baseUrl}/${$(item).attr('href')}`;
-            const date = $(item)
-                .text()
-                .match(/(\d{4}-\d{2}-\d{2})/);
-            const data = await cache.get(link);
-            if (data) {
-                return JSON.parse(data);
-            }
-            const response = await got.get(link);
-            const $$ = load(response.data);
-            const description = $$('.dvContent').html();
-            const ret = {
-                title,
-                link,
-                pubDate: date ? timezone(parseDate(date[1]), +8) : '',
-                description,
+
+    let items = $('a')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+
+            const matches = item.text().match(/(\d{4}-\d{2}-\d{2})/);
+
+            return {
+                title: item.text(),
+                link: `${rootUrl}/JLPT/1/${item.attr('href')}`,
+                pubDate: matches ? parseDate(matches[1]) : '',
             };
-            cache.set(link, ret);
-            return ret;
-        })
+        });
+
+    items = await Promise.all(
+        items.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const detailResponse = await got({
+                    method: 'get',
+                    url: item.link,
+                });
+
+                const content = load(detailResponse.data);
+
+                item.description = content('.dvContent').html();
+
+                return item;
+            })
+        )
     );
 
     return {
-        title: '日本语能力测试(JLPT)通知',
-        link: newsUrl,
+        title: '重要通知 - 教育部考试中心日本语能力测试',
+        link: currentUrl,
         item: items,
     };
 }

--- a/lib/routes/neea/jlpt.ts
+++ b/lib/routes/neea/jlpt.ts
@@ -3,76 +3,70 @@ import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
 
 export const route: Route = {
-    path: '/jlpt',
-    categories: ['study'],
-    example: '/neea/jlpt',
+    path: '/global/jlpt',
+    name: '日本语能力测试(JLPT)通知',
+    url: 'jlpt.neea.edu.cn',
+    maintainers: ['nczitzk'],
+    example: '/neea/global/jlpt',
     parameters: {},
+    categories: ['study'],
     features: {
-        requireConfig: false,
-        requirePuppeteer: false,
-        antiCrawler: false,
-        supportBT: false,
-        supportPodcast: false,
-        supportScihub: false,
+        supportRadar: true,
     },
     radar: [
         {
-            source: ['jlpt.neea.cn/'],
+            source: ['jlpt.neea.edu.cn', 'jlpt.neea.cn'],
+            target: '/global/jlpt',
         },
     ],
-    name: '教育部考试中心日本语能力测试重要通知',
-    maintainers: ['nczitzk'],
     handler,
-    url: 'jlpt.neea.cn/',
 };
 
-async function handler() {
-    const rootUrl = 'https://news.neea.cn';
-    const currentUrl = `${rootUrl}/JLPT/1/newslist.htm`;
-
-    const response = await got({
-        method: 'get',
-        url: currentUrl,
+function loadContent(link: string) {
+    return cache.tryGet(link, async () => {
+        const response = await got.get(link);
+        const $ = load(response.data);
+        const description = $('.dvContent').html();
+        return {
+            description,
+            link,
+        };
     });
+}
+
+async function handler() {
+    const baseUrl = 'https://news.neea.edu.cn/JLPT/1';
+    const newsUrl = `${baseUrl}/newslist.htm`;
+
+    const response = await got.get(newsUrl);
 
     const $ = load(response.data);
 
-    let items = $('a')
-        .toArray()
-        .map((item) => {
-            item = $(item);
+    const list = $('a').get();
 
-            const matches = item.text().match(/(\d{4}-\d{2}-\d{2})/);
-
-            return {
-                title: item.text(),
-                link: `${rootUrl}/JLPT/1/${item.attr('href')}`,
-                pubDate: matches ? parseDate(matches[1]) : '',
+    const items = await Promise.all(
+        list.map(async (item) => {
+            const title = $(item).text();
+            const link = `${baseUrl}/${$(item).attr('href')}`;
+            const time = $(item)
+                .text()
+                .match(/(\d{4}-\d{2}-\d{2})/);
+            const chunk = {
+                title,
+                link,
+                pubDate: time ? timezone(parseDate(time[1]), +8) : '',
             };
-        });
-
-    items = await Promise.all(
-        items.map((item) =>
-            cache.tryGet(item.link, async () => {
-                const detailResponse = await got({
-                    method: 'get',
-                    url: item.link,
-                });
-
-                const content = load(detailResponse.data);
-
-                item.description = content('.dvContent').html();
-
-                return item;
-            })
-        )
+            const other = await loadContent(link);
+            return Object.assign({}, chunk, other);
+        })
     );
 
     return {
-        title: '重要通知 - 教育部考试中心日本语能力测试',
-        link: currentUrl,
+        title: '日本语能力测试(JLPT)通知',
+        link: newsUrl,
         item: items,
     };
 }

--- a/lib/routes/neea/namespace.ts
+++ b/lib/routes/neea/namespace.ts
@@ -1,6 +1,6 @@
 import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
-    name: 'NEEA 中国教育考试网',
-    url: 'jlpt.neea.cn',
+    name: '中国教育考试网',
+    url: 'www.neea.edu.cn',
 };


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/neea/local/cet
/neea/local/ncre
/neea/global/jlpt
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
完善了路由描述并添加了 radar 规则
为了解决 jlpt 路由的优先级问题修改了原有的路由规则：
```routes
/neea/:type? -> /neea/local/:type
/neea/jlpt(not working) -> /neea/global/jlpt
```
但我不太确定这是否是一个合适的改动 :disappointed_relieved: