### PR TITLE
feat(route): 将 Bangumi番组计划 从 アニメ新番組 分离

### DIFF
--- a/lib/routes/bgm/calendar/_base.ts
+++ b/lib/routes/bgm/calendar/_base.ts
@@ -1,0 +1,38 @@
+import got from '@/utils/got';
+import { config } from '@/config';
+
+const getData = (tryGet) => {
+    const bgmCalendarUrl = 'https://api.bgm.tv/calendar';
+    const bgmDataUrl = 'https://cdn.jsdelivr.net/npm/bangumi-data/dist/data.json';
+
+    const urls = [bgmCalendarUrl, bgmDataUrl];
+
+    return Promise.all(
+        urls.map((item, i) =>
+            tryGet(
+                item,
+                async () => {
+                    const { data } = await got(item);
+
+                    if (i === 1) {
+                        // 只保留有 bangumi id 的番剧
+                        const items = [];
+                        for (const item of data.items) {
+                            const bgmSite = item.sites.find((s) => s.site === 'bangumi');
+                            if (bgmSite) {
+                                item.bgmId = bgmSite.id;
+                                items.push(item);
+                            }
+                        }
+                        data.items = items;
+                    }
+
+                    return data;
+                },
+                config.cache.contentExpire,
+                false
+            )
+        )
+    );
+};
+export default getData;

--- a/lib/routes/bgm/calendar/today.ts
+++ b/lib/routes/bgm/calendar/today.ts
@@ -1,0 +1,92 @@
+import { Route } from '@/types';
+import { getCurrentPath } from '@/utils/helpers';
+const __dirname = getCurrentPath(import.meta.url);
+
+import cache from '@/utils/cache';
+import getData from './_base';
+import { art } from '@/utils/render';
+import path from 'node:path';
+
+export const route: Route = {
+    path: '/calendar/today',
+    categories: ['anime'],
+    example: '/bgm/calendar/today',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['bgm.tv/calendar', 'bangumi.tv/calendar', 'chii.in/calendar'],
+        },
+    ],
+    name: '放送列表',
+    maintainers: ['magic-akari'],
+    handler,
+    url: 'bgm.tv/calendar',
+};
+
+async function handler() {
+    const [list, data] = await getData(cache.tryGet);
+    const siteMeta = data.siteMeta;
+
+    const today = new Date(Date.now());
+    // 将 UTC 时间向前移动9小时，即可在数值上表示东京时间
+    today.setUTCHours(today.getUTCHours() + 9);
+    const day = today.getUTCDay();
+
+    const todayList = list.find((l) => l.weekday.id % 7 === day);
+    const todayBgmId = new Set(todayList.items.map((t) => t.id.toString()));
+    const images = todayList.items.reduce((p, c) => {
+        p[c.id] = (c.images || {}).large;
+        return p;
+    }, {});
+    const todayBgm = data.items.filter((d) => todayBgmId.has(d.bgmId));
+    for (const bgm of todayBgm) {
+        bgm.image = images[bgm.bgmId];
+    }
+
+    return {
+        title: 'bangumi 每日放送',
+        link: 'https://bgm.tv/calendar',
+        item: todayBgm.map((bgm) => {
+            const updated = new Date(Date.now());
+            updated.setSeconds(0);
+            const begin = new Date(bgm.begin || updated);
+            updated.setHours(begin.getHours());
+            updated.setMinutes(begin.getMinutes());
+            updated.setSeconds(begin.getSeconds());
+
+            const link = `https://bgm.tv/subject/${bgm.bgmId}`;
+            const id = `${link}#${new Intl.DateTimeFormat('zh-CN').format(updated)}`;
+
+            const html = art(path.resolve(__dirname, '../templates/today.art'), {
+                bgm,
+                siteMeta,
+            });
+
+            return {
+                id,
+                guid: id,
+                title: [
+                    bgm.title,
+                    Object.values(bgm.titleTranslate)
+                        .map((t) => t.join('｜'))
+                        .join('｜'),
+                ]
+                    .filter(Boolean) // don't join if empty
+                    .join('｜'),
+                updated: updated.toISOString(),
+                pubDate: updated.toUTCString(),
+                link,
+                description: html,
+                content: { html },
+            };
+        }),
+    };
+}

--- a/lib/routes/bgm/group/reply.ts
+++ b/lib/routes/bgm/group/reply.ts
@@ -1,0 +1,83 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+export const route: Route = {
+    path: '/topic/:id',
+    categories: ['anime'],
+    example: '/bgm/topic/367032',
+    parameters: { id: '话题 id, 在话题页面地址栏查看' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['bgm.tv/group/topic/:id', 'bangumi.tv/group/topic/:id', 'chii.in/group/topic/:id'],
+        },
+    ],
+    name: '小组话题的新回复',
+    maintainers: ['ylc395'],
+    handler,
+};
+
+async function handler(ctx) {
+    // bangumi.tv未提供获取小组话题的API，因此仍需要通过抓取网页来获取
+    const topicID = ctx.req.param('id');
+    const link = `https://bgm.tv/group/topic/${topicID}`;
+    const { data: html } = await got(link);
+    const $ = load(html);
+    const title = $('#pageHeader h1').text();
+    const latestReplies = $('.row_reply')
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+            return {
+                id: $el.attr('id'),
+                author: $el.find('.userInfo .l').text(),
+                content: $el.find('.reply_content .message').html(),
+                date: $el.children().first().find('small').children().remove().end().text().slice(3),
+            };
+        });
+    const latestSubReplies = $('.sub_reply_bg')
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+            return {
+                id: $el.attr('id'),
+                author: $el.find('.userName .l').text(),
+                content: $el.find('.cmt_sub_content').html(),
+                date: $el.children().first().find('small').children().remove().end().text().slice(3),
+            };
+        });
+    const finalLatestReplies = [...latestReplies, ...latestSubReplies].sort((a, b) => (a.id < b.id ? 1 : -1));
+
+    const postTopic = {
+        title,
+        description: $('.postTopic .topic_content').html(),
+        author: $('.postTopic .inner strong a').first().text(),
+        pubDate: timezone(parseDate($('.postTopic .re_info small').text().trim().slice(5)), +8),
+        link,
+    };
+
+    return {
+        title: `${title}的最新回复`,
+        link,
+        item: [
+            ...finalLatestReplies.map((c) => ({
+                title: `${c.author} 回复了小组话题《${title}》`,
+                description: c.content,
+                pubDate: timezone(parseDate(c.date), +8),
+                author: c.author,
+                link: `${link}#${c.id}`,
+            })),
+            postTopic,
+        ],
+    };
+}

--- a/lib/routes/bgm/group/topic.ts
+++ b/lib/routes/bgm/group/topic.ts
@@ -1,0 +1,64 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+const base_url = 'https://bgm.tv';
+
+export const route: Route = {
+    path: '/group/:id',
+    categories: ['anime'],
+    example: '/bgm/group/boring',
+    parameters: { id: '小组 id, 在小组页面地址栏查看' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['bgm.tv/group/:id', 'bangumi.tv/group/:id', 'chii.in/group/:id'],
+        },
+    ],
+    name: '小组话题',
+    maintainers: ['SettingDust'],
+    handler,
+};
+
+async function handler(ctx) {
+    const groupID = ctx.req.param('id');
+    const link = `${base_url}/group/${groupID}/forum`;
+    const { data: html } = await got(link);
+    const $ = load(html);
+    const title = 'Bangumi - ' + $('.SecondaryNavTitle').text();
+
+    const items = await Promise.all(
+        $('.topic_list .topic')
+            .toArray()
+            .map(async (elem) => {
+                const link = new URL($('.subject a', elem).attr('href'), base_url).href;
+                const fullText = await cache.tryGet(link, async () => {
+                    const { data: html } = await got(link);
+                    const $ = load(html);
+                    return $('.postTopic .topic_content').html();
+                });
+                const summary = 'Reply: ' + $('.posts', elem).text();
+                return {
+                    link,
+                    title: $('.subject a', elem).attr('title'),
+                    pubDate: parseDate($('.lastpost .time', elem).text()),
+                    description: fullText ? summary + '<br><br>' + fullText : summary,
+                    author: $('.author a', elem).text(),
+                };
+            })
+    );
+
+    return {
+        title,
+        link,
+        item: items,
+    };
+}

--- a/lib/routes/bgm/namespace.ts
+++ b/lib/routes/bgm/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Bangumi 番组计划',
+    url: 'bgm.tv',
+};

--- a/lib/routes/bgm/other/followrank.ts
+++ b/lib/routes/bgm/other/followrank.ts
@@ -1,0 +1,80 @@
+import { Route } from '@/types';
+import { load } from 'cheerio';
+import { config } from '@/config';
+import ofetch from '@/utils/ofetch';
+
+export const route: Route = {
+    path: '/:type/followrank',
+    categories: ['anime'],
+    example: '/bgm/anime/followrank',
+    parameters: { type: '类型：anime - 动画, book - 图书, music - 音乐, game - 游戏, real - 三次元' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['bgm.tv/:type', 'bangumi.tv/:type', 'chii.in/:type'],
+            target: '/:type/followrank',
+        },
+    ],
+    name: '成员关注榜',
+    maintainers: ['honue', 'zhoukuncheng'],
+    handler,
+};
+
+async function handler(ctx) {
+    let type = ctx.req.param('type');
+    if (!type || type === 'tv') {
+        type = 'anime';
+    }
+    const url = `https://bgm.tv/${type}`;
+
+    const response = await ofetch(url, {
+        headers: {
+            'User-Agent': config.trueUA,
+        },
+    });
+
+    const $ = load(response);
+
+    const items = [
+        ...$('#columnB > div:nth-child(4) > table > tbody')
+            .find('tr')
+            .toArray()
+            .map((item) => {
+                const aTag = $(item).children('td').next().find('a');
+                return {
+                    title: aTag.html(),
+                    link: 'https://bgm.tv' + aTag.attr('href'),
+                };
+            }),
+        ...$('#chl_subitem > ul')
+            .find('li')
+            .toArray()
+            .map((item) => ({
+                title: $(item).children('a').attr('title'),
+                link: 'https://bgm.tv' + $(item).children('a').attr('href'),
+            })),
+    ];
+
+    const RANK_TYPES = {
+        tv: '动画',
+        anime: '动画',
+        book: '图书',
+        music: '音乐',
+        game: '游戏',
+        real: '三次元',
+    };
+
+    return {
+        title: `BangumiTV 成员关注${RANK_TYPES[type]}榜`,
+        link: url,
+        item: items,
+        description: `BangumiTV 首页-成员关注${RANK_TYPES[type]}榜`,
+    };
+}

--- a/lib/routes/bgm/person/index.ts
+++ b/lib/routes/bgm/person/index.ts
@@ -1,0 +1,62 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/person/:id',
+    categories: ['anime'],
+    example: '/bgm/person/32943',
+    parameters: { id: '人物 id, 在人物页面的地址栏查看' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['bgm.tv/person/:id', 'bangumi.tv/person/:id', 'chii.in/person/:id'],
+        },
+    ],
+    name: '现实人物的新作品',
+    maintainers: ['ylc395'],
+    handler,
+};
+
+async function handler(ctx) {
+    // bangumi.tv未提供获取“人物信息”的API，因此仍需要通过抓取网页来获取
+    const personID = ctx.req.param('id');
+    const link = `https://bgm.tv/person/${personID}/works?sort=date`;
+    const { data: html } = await got(link);
+    const $ = load(html);
+    const personName = $('.nameSingle a').text();
+    const works = $('.item')
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+            const $workEl = $el.find('.l');
+            return {
+                work: $workEl.text(),
+                workURL: `https://bgm.tv${$workEl.attr('href')}`,
+                workInfo: $el.find('p.info').text(),
+                job: $el.find('.badge_job').text(),
+            };
+        });
+
+    return {
+        title: `${personName}参与的作品`,
+        link,
+        item: works.map((c) => {
+            const match = c.workInfo.match(/(\d{4}[年-]\d{1,2}[月-]\d{1,2})/);
+            return {
+                title: `${personName}以${c.job}的身份参与了作品《${c.work}》`,
+                description: c.workInfo,
+                link: c.workURL,
+                pubDate: match ? parseDate(match[1], ['YYYY-MM-DD', 'YYYY-M-D']) : null,
+            };
+        }),
+    };
+}

--- a/lib/routes/bgm/subject/comments.ts
+++ b/lib/routes/bgm/subject/comments.ts
@@ -1,0 +1,48 @@
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate, parseRelativeDate } from '@/utils/parse-date';
+
+const getComments = async (subjectID, minLength) => {
+    // bangumi.tv未提供获取“吐槽（comments）”的API，因此仍需要通过抓取网页来获取
+    const link = `https://bgm.tv/subject/${subjectID}/comments`;
+    const { data: html } = await got(link);
+    const $ = load(html);
+    const title = $('.nameSingle').find('a').text();
+    const comments = $('.item')
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+            const $rateEl = $el.find('.starlight');
+            let rate = null;
+            if ($rateEl.length > 0) {
+                rate = $rateEl.attr('class').match(/stars(\d)/)[1];
+            }
+
+            const dateString = $el.find('small.grey').text().slice(2);
+
+            const date = dateString.includes('ago')
+                ? parseRelativeDate(dateString) // 处理表示相对日期的字符串
+                : parseDate(dateString); // 表示绝对日期的字符串
+
+            return {
+                user: $el.find('.l').text(),
+                rate: rate || '无',
+                content: $el.find('p').text(),
+                date,
+            };
+        })
+        .filter((obj) => obj.content.length >= minLength);
+
+    return {
+        title: `${title}的 Bangumi 吐槽箱`,
+        link,
+        item: comments.map((c) => ({
+            title: `${c.user}的吐槽`,
+            description: `【评分：${c.rate}】  ${c.content}`,
+            guid: `${link}#${c.user}`,
+            pubDate: c.date,
+            link,
+        })),
+    };
+};
+export default getComments;

--- a/lib/routes/bgm/subject/ep.ts
+++ b/lib/routes/bgm/subject/ep.ts
@@ -1,0 +1,36 @@
+import { getCurrentPath } from '@/utils/helpers';
+const __dirname = getCurrentPath(import.meta.url);
+
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import { art } from '@/utils/render';
+import path from 'node:path';
+import { getLocalName } from './utils';
+
+const getEps = async (subjectID, showOriginalName) => {
+    const url = `https://api.bgm.tv/subject/${subjectID}?responseGroup=large`;
+    const { data: epsInfo } = await got(url);
+    const activeEps = [];
+
+    for (const e of epsInfo.eps) {
+        if (e.status === 'Air') {
+            activeEps.push(e);
+        }
+    }
+
+    return {
+        title: getLocalName(epsInfo, showOriginalName),
+        link: `https://bgm.tv/subject/${subjectID}`,
+        description: epsInfo.summary,
+        item: activeEps.map((e) => ({
+            title: `ep.${e.sort} ${getLocalName(e, showOriginalName)}`,
+            description: art(path.resolve(__dirname, '../templates/ep.art'), {
+                e,
+                epsInfo,
+            }),
+            pubDate: parseDate(e.airdate),
+            link: e.url.replace('http:', 'https:'),
+        })),
+    };
+};
+export default getEps;

--- a/lib/routes/bgm/subject/index.ts
+++ b/lib/routes/bgm/subject/index.ts
@@ -1,0 +1,57 @@
+import { Route } from '@/types';
+import getComments from './comments';
+import getFromAPI from './offcial-subject-api';
+import getEps from './ep';
+import { queryToBoolean } from '@/utils/readable-social';
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+
+export const route: Route = {
+    path: '/subject/:id/:type?/:showOriginalName?',
+    categories: ['anime'],
+    example: '/bgm/subject/328609/ep/true',
+    parameters: { id: '条目 id, 在条目页面的地址栏查看', type: '条目类型，可选值为 `ep`, `comments`, `blogs`, `topics`，默认为 `ep`', showOriginalName: '显示番剧标题原名，可选值 0/1/false/true，默认为 false' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['bgm.tv/subject/:id', 'bangumi.tv/subject/:id', 'chii.in/subject/:id'],
+            target: '/subject/:id',
+        },
+    ],
+    name: '条目的通用路由格式',
+    maintainers: ['JimenezLi'],
+    handler,
+    description: `:::warning
+  此通用路由仅用于对路由参数的描述，具体信息请查看下方与条目相关的路由
+  :::`,
+};
+
+async function handler(ctx) {
+    const id = ctx.req.param('id');
+    const type = ctx.req.param('type') || 'ep';
+    const showOriginalName = queryToBoolean(ctx.req.param('showOriginalName'));
+    let response;
+    switch (type) {
+        case 'ep':
+            response = await getEps(id, showOriginalName);
+            break;
+        case 'comments':
+            response = await getComments(id, Number(ctx.req.query('minLength')) || 0);
+            break;
+        case 'blogs':
+            response = await getFromAPI('blog')(id, showOriginalName);
+            break;
+        case 'topics':
+            response = await getFromAPI('topic')(id, showOriginalName);
+            break;
+        default:
+            throw new InvalidParameterError(`暂不支持对${type}的订阅`);
+    }
+    return response;
+}

--- a/lib/routes/bgm/subject/offcial-subject-api.ts
+++ b/lib/routes/bgm/subject/offcial-subject-api.ts
@@ -1,0 +1,34 @@
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import { getLocalName } from './utils';
+
+const getFromAPI = (type) => {
+    const mapping = {
+        blog: {
+            en: 'reviews',
+            cn: '评论',
+        },
+        topic: {
+            en: 'board',
+            cn: '讨论',
+        },
+    };
+
+    return async (subjectID, showOriginalName) => {
+        // 官方提供的条目API文档见 https://github.com/bangumi/api/blob/3f3fa6390c468816f9883d24be488e41f8946159/docs-raw/Subject-API.md
+        const url = `https://api.bgm.tv/subject/${subjectID}?responseGroup=large`;
+        const { data: subjectInfo } = await got(url);
+        return {
+            title: `${getLocalName(subjectInfo, showOriginalName)}的 Bangumi ${mapping[type].cn}`,
+            link: `https://bgm.tv/subject/${subjectInfo.id}/${mapping[type].en}`,
+            item: subjectInfo[type].map((article) => ({
+                title: `${article.user.nickname}：${article.title}`,
+                description: article.summary || '',
+                link: article.url.replace('http:', 'https:'),
+                pubDate: parseDate(article.timestamp, 'X'),
+                author: article.user.nickname,
+            })),
+        };
+    };
+};
+export default getFromAPI;

--- a/lib/routes/bgm/subject/utils.ts
+++ b/lib/routes/bgm/subject/utils.ts
@@ -1,0 +1,3 @@
+const getLocalName = (obj, showOriginalName) => (showOriginalName ? obj.name || obj.name_cn : obj.name_cn || obj.name);
+
+export { getLocalName };

--- a/lib/routes/bgm/templates/ep.art
+++ b/lib/routes/bgm/templates/ep.art
@@ -1,0 +1,2 @@
+<img src="{{ epsInfo.images.large || epsInfo.images.common }}" alt="ep.{{ e.sort }} {{ e.name_cn || e.name }}">
+<p>{{@ e.desc.replace(/\r\n/g, '<br>') }}</p>

--- a/lib/routes/bgm/templates/today.art
+++ b/lib/routes/bgm/templates/today.art
@@ -1,0 +1,12 @@
+<img src={{ bgm.image }}>
+<ul>
+{{ each bgm.sites site }}
+{{ set url }}
+{{ if site.url }}
+    {{ url = site.url }}
+{{ else }}
+    <% url = siteMeta[site.site].urlTemplate.replace('{{id}}', site.id) %>
+{{ /if }}
+<li><a href="{{ url }}">{{ siteMeta[site.site].title }}</a></li>
+{{ /each }}
+</ul>

--- a/lib/routes/bgm/user/blog.ts
+++ b/lib/routes/bgm/user/blog.ts
@@ -1,0 +1,68 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+export const route: Route = {
+    path: '/user/blog/:id',
+    categories: ['anime'],
+    example: '/bgm/user/blog/sai',
+    parameters: { id: '用户 id, 在用户页面地址栏查看' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['bgm.tv/user/:id', 'bangumi.tv/user/:id', 'chii.in/user/:id'],
+        },
+    ],
+    name: '用户日志',
+    maintainers: ['nczitzk'],
+    handler,
+};
+
+async function handler(ctx) {
+    const currentUrl = `https://bgm.tv/user/${ctx.req.param('id')}/blog`;
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+    });
+    const $ = load(response.data);
+    const list = $('#entry_list div.item')
+        .find('h2.title')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const a = item.find('a');
+            return {
+                title: a.text(),
+                link: new URL(a.attr('href'), 'https://bgm.tv').href,
+                pubDate: timezone(parseDate(item.parent().find('small.time').text()), 0),
+            };
+        });
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const res = await got({ method: 'get', url: item.link });
+                const content = load(res.data);
+
+                item.description = content('#entry_content').html();
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: $('title').text(),
+        link: currentUrl,
+        item: items,
+    };
+}

--- a/lib/routes/bgm/user/wish.ts
+++ b/lib/routes/bgm/user/wish.ts
@@ -1,0 +1,62 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import timezone from '@/utils/timezone';
+import { parseDate } from '@/utils/parse-date';
+import { config } from '@/config';
+export const route: Route = {
+    path: '/user/wish/:id',
+    categories: ['anime'],
+    example: '/bgm/user/wish/sai',
+    parameters: { id: '用户 id, 在用户页面地址栏查看' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['bgm.tv/anime/list/:id/wish', 'bangumi.tv/anime/list/:id/wish', 'chii.in/anime/list/:id/wish'],
+        },
+    ],
+    name: '用户想看',
+    maintainers: ['honue'],
+    handler,
+};
+
+async function handler(ctx) {
+    const userid = ctx.req.param('id');
+    const url = `https://bgm.tv/anime/list/${userid}/wish`;
+    const response = await got({
+        url,
+        method: 'get',
+        headers: {
+            'User-Agent': config.trueUA,
+        },
+    });
+    const $ = load(response.body);
+
+    const username = $('.name').find('a').html();
+    const items = $('#browserItemList')
+        .find('li')
+        .toArray()
+        .map((item) => {
+            const aTag = $(item).find('h3').children('a');
+            const jdate = $(item).find('.collectInfo').find('span').html();
+            return {
+                title: aTag.html(),
+                link: 'https://bgm.tv' + aTag.attr('href'),
+                pubDate: timezone(parseDate(jdate), 0),
+            };
+        });
+
+    return {
+        title: `${username}想看的动画`,
+        link: url,
+        item: items,
+        description: `${username}想看的动画列表`,
+    };
+}


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/bgm/calendar/today
/bgm/group/boring
/bgm/topic/367032
/bgm/anime/followrank
/bgm/person/32943
/bgm/subject/328609/ep/true
/bgm/user/blog/sai
/bgm/user/wish/sai
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

bangumi.tv（Bangumi番组计划 ） 和 bangumi.moe（アニメ新番組） 为两不同网站，因域名相似而共用同一 namespace，导致在文档中反而无法有效搜索到 bangumi 番组计划。
因此我取前者的简短域名 bgm.tv 作为新的命名空间将二者分离。但为防止之前使用 /bangumi/tv 路由的用户被迫更改，暂时保留旧的路由不变。

顺便，我给 bgm.tv 的 Radar 规则增加了其他两个指向该网站的域名