### PR TITLE
Restore podcast enclosures in kemono feeds.

### DIFF
--- a/lib/routes/kemono/index.ts
+++ b/lib/routes/kemono/index.ts
@@ -140,6 +140,26 @@ async function handler(ctx) {
                     desc += kemonoFile;
                 }
 
+                let enclosureInfo = {};
+                load(desc)('audio source, video source').each(function () {
+                    const src = $(this).attr('src') ?? '';
+                    const mimeType =
+                        {
+                            m4a: 'audio/mp4',
+                            mp3: 'audio/mpeg',
+                            mp4: 'video/mp4',
+                        }[src.replace(/.*\./, '').toLowerCase()] || null;
+
+                    if (mimeType === null) {
+                        return;
+                    }
+
+                    enclosureInfo = {
+                        enclosure_url: src,
+                        enclosure_type: mimeType,
+                    };
+                });
+
                 return {
                     title: i.title,
                     description: desc,
@@ -147,6 +167,7 @@ async function handler(ctx) {
                     pubDate: parseDate(i.published),
                     guid: `${apiUrl}/${i.service}/user/${i.user}/post/${i.id}`,
                     link: `${rootUrl}/${i.service}/user/${i.user}/post/${i.id}`,
+                    ...enclosureInfo,
                 };
             });
     }


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/kemono/patreon/5437626
/kemono/patreon/5461428
/kemono/patreon/44261000
```

## Note / 说明

this restores a feature originally introduced in #13821 that was removed in b2f3bcc5c36a8cde7748de09ddcac3251400699f, allowing these feeds to be used in a podcast client.