### PR TITLE
fix(route): 「141jav」和「141ppv」路由失效

### DIFF
--- a/lib/routes/141jav/index.ts
+++ b/lib/routes/141jav/index.ts
@@ -18,37 +18,37 @@ export const route: Route = {
     handler,
     description: `**类型**
 
-  | 最新 | 热门     | 随机    | 指定演员 | 指定标签 | 日期        |
-  | ---- | ------- | ------ | -------- | -------- | -------- |
-  | new  | popular | random | actress  | tag      | date     |
+| 最新 | 热门    | 随机   | 指定演员 | 指定标签 | 日期 |
+| ---- | ------- | ------ | -------- | -------- | ---- |
+| new  | popular | random | actress  | tag      | date |
 
-  **关键词**
+**关键词**
 
-  | 空 | 日期范围    | 演员名       | 标签名         | 年月日         |
-  | -- | ----------- | ------------ | -------------- | ---------- |
-  |    | 7 / 30 / 60 | Yua%20Mikami | Adult%20Awards | 2020/07/30 |
+| 空 | 日期范围    | 演员名       | 标签名         | 年月日     |
+| -- | ----------- | ------------ | -------------- | ---------- |
+|    | 7 / 30 / 60 | Yua%20Mikami | Adult%20Awards | 2020/07/30 |
 
-  **示例说明**
+**示例说明**
 
-  -  \`/141jav/new\`
+-  \`/141jav/new\`
 
-        仅当类型为 \`new\` \`popular\` 或 \`random\` 时关键词为 **空**
+      仅当类型为 \`new\` \`popular\` 或 \`random\` 时关键词为 **空**
 
-  -  \`/141jav/popular/30\`
+-  \`/141jav/popular/30\`
 
-        \`popular\` \`random\` 类型的关键词可填写 \`7\` \`30\` 或 \`60\` 三个 **日期范围** 之一，分别对应 **7 天**、**30 天** 或 **60 天内**
+      \`popular\` \`random\` 类型的关键词可填写 \`7\` \`30\` 或 \`60\` 三个 **日期范围** 之一，分别对应 **7 天**、**30 天** 或 **60 天内**
 
-  -  \`/141jav/actress/Yua%20Mikami\`
+-  \`/141jav/actress/Yua%20Mikami\`
 
-        \`actress\` 类型的关键词必须填写 **演员名** ，可在 [此处](https://141jav.com/actress/) 演员单页链接中获取
+      \`actress\` 类型的关键词必须填写 **演员名** ，可在 [此处](https://141jav.com/actress/) 演员单页链接中获取
 
-  -  \`/141jav/tag/Adult%20Awards\`
+-  \`/141jav/tag/Adult%20Awards\`
 
-        \`tag\` 类型的关键词必须填写 **标签名** 且标签中的 \`/\` 必须替换为 \`%2F\` ，可在 [此处](https://141jav.com/tag/) 标签单页链接中获取
+      \`tag\` 类型的关键词必须填写 **标签名** 且标签中的 \`/\` 必须替换为 \`%2F\` ，可在 [此处](https://141jav.com/tag/) 标签单页链接中获取
 
-  -  \`/141jav/date/2020/07/30\`
+-  \`/141jav/date/2020/07/30\`
 
-        \`date\` 类型的关键词必须填写 **日期(年/月/日)**`,
+      \`date\` 类型的关键词必须填写 **日期(年/月/日)**`,
 };
 
 async function handler(ctx) {
@@ -56,7 +56,7 @@ async function handler(ctx) {
     const type = ctx.req.param('type');
     const keyword = ctx.req.param('keyword') ?? '';
 
-    const currentUrl = `${rootUrl}/${type}/${keyword}`;
+    const currentUrl = `${rootUrl}/${type}${keyword ? `/${keyword}` : ''}`;
 
     const response = await got({
         method: 'get',

--- a/lib/routes/141jav/index.ts
+++ b/lib/routes/141jav/index.ts
@@ -10,49 +10,53 @@ import { art } from '@/utils/render';
 import path from 'node:path';
 
 export const route: Route = {
-    path: '/{.*}?',
+    path: '/:type/:keyword{.*}?',
     categories: ['multimedia'],
     name: '通用',
     maintainers: ['cgkings', 'nczitzk'],
+    parameters: { type: '类型，可查看下表的类型说明', keyword: '关键词，可查看下表的关键词说明' },
+    handler,
     description: `**类型**
 
-    | 最新 | 热门    | 随机   | 指定演员 | 指定标签 |
-    | ---- | ------- | ------ | -------- | -------- |
-    | new  | popular | random | actress  | tag      |
+  | 最新 | 热门     | 随机    | 指定演员 | 指定标签 | 日期        |
+  | ---- | ------- | ------ | -------- | -------- | -------- |
+  | new  | popular | random | actress  | tag      | date     |
 
-    **关键词**
+  **关键词**
 
-    | 空 | 日期范围    | 演员名       | 标签名         |
-    | -- | ----------- | ------------ | -------------- |
-    |    | 7 / 30 / 60 | Yua%20Mikami | Adult%20Awards |
+  | 空 | 日期范围    | 演员名       | 标签名         | 年月日         |
+  | -- | ----------- | ------------ | -------------- | ---------- |
+  |    | 7 / 30 / 60 | Yua%20Mikami | Adult%20Awards | 2020/07/30 |
 
-    **示例说明**
+  **示例说明**
 
-    -   \`/141jav/new\`
+  -  \`/141jav/new\`
 
         仅当类型为 \`new\` \`popular\` 或 \`random\` 时关键词为 **空**
 
-    -   \`/141jav/popular/30\`
+  -  \`/141jav/popular/30\`
 
         \`popular\` \`random\` 类型的关键词可填写 \`7\` \`30\` 或 \`60\` 三个 **日期范围** 之一，分别对应 **7 天**、**30 天** 或 **60 天内**
 
-    -   \`/141jav/actress/Yua%20Mikami\`
+  -  \`/141jav/actress/Yua%20Mikami\`
 
-        \`actress\` 类型的关键词必须填写 **演员名** ，可在 [此处](https://141jav.com/actress) 演员单页链接中获取
+        \`actress\` 类型的关键词必须填写 **演员名** ，可在 [此处](https://141jav.com/actress/) 演员单页链接中获取
 
-    -   \`/141jav/tag/Adult%20Awards\`
+  -  \`/141jav/tag/Adult%20Awards\`
 
-        \`tag\` 类型的关键词必须填写 **标签名** 且标签中的 \`/\` 必须替换为 \`%2F\` ，可在 [此处](https://141jav.com/tag) 标签单页链接中获取
+        \`tag\` 类型的关键词必须填写 **标签名** 且标签中的 \`/\` 必须替换为 \`%2F\` ，可在 [此处](https://141jav.com/tag/) 标签单页链接中获取
 
-    -   \`/141jav/date/2020/07/30\`
+  -  \`/141jav/date/2020/07/30\`
 
-        \`date\` 类型的关键词必须填写 **日期**`,
-    handler,
+        \`date\` 类型的关键词必须填写 **日期(年/月/日)**`,
 };
 
 async function handler(ctx) {
     const rootUrl = 'https://www.141jav.com';
-    const currentUrl = `${rootUrl}${getSubPath(ctx)}`;
+    const type = ctx.req.param('type');
+    const keyword = ctx.req.param('keyword') ?? '';
+
+    const currentUrl = `${rootUrl}/${type}/${keyword}`;
 
     const response = await got({
         method: 'get',

--- a/lib/routes/141ppv/index.ts
+++ b/lib/routes/141ppv/index.ts
@@ -10,49 +10,53 @@ import { art } from '@/utils/render';
 import path from 'node:path';
 
 export const route: Route = {
-    path: '/{.*}?',
+    path: '/:type/:keyword{.*}?',
     categories: ['multimedia'],
     name: '通用',
     maintainers: ['cgkings', 'nczitzk'],
+    parameters: { type: '类型，可查看下表的类型说明', keyword: '关键词，可查看下表的关键词说明' },
     handler,
     description: `**类型**
 
-    | 最新 | 热门    | 随机   | 指定演员 | 指定标签 |
-    | ---- | ------- | ------ | -------- | -------- |
-    | new  | popular | random | actress  | tag      |
+  | 最新 | 热门     | 随机    | 指定演员 | 指定标签 | 日期        |
+  | ---- | ------- | ------ | -------- | -------- | -------- |
+  | new  | popular | random | actress  | tag      | date     |
 
-    **关键词**
+  **关键词**
 
-    | 空 | 日期范围    | 演员名       | 标签名         |
-    | -- | ----------- | ------------ | -------------- |
-    |    | 7 / 30 / 60 | Yua%20Mikami | Adult%20Awards |
+  | 空 | 日期范围    | 演员名       | 标签名         | 年月日         |
+  | -- | ----------- | ------------ | -------------- | ---------- |
+  |    | 7 / 30 / 60 | Yua%20Mikami | Adult%20Awards | 2020/07/30 |
 
-    **示例说明**
+  **示例说明**
 
-    -   \`/141ppv/new\`
+  -  \`/141ppv/new\`
 
         仅当类型为 \`new\` \`popular\` 或 \`random\` 时关键词为 **空**
 
-    -   \`/141ppv/popular/30\`
+  -  \`/141ppv/popular/30\`
 
         \`popular\` \`random\` 类型的关键词可填写 \`7\` \`30\` 或 \`60\` 三个 **日期范围** 之一，分别对应 **7 天**、**30 天** 或 **60 天内**
 
-    -   \`/141ppv/actress/Yua%20Mikami\`
+  -  \`/141ppv/actress/Yua%20Mikami\`
 
-        \`actress\` 类型的关键词必须填写 **演员名** ，可在 [此处](https://141ppv.com/actress) 演员单页链接中获取
+        \`actress\` 类型的关键词必须填写 **演员名** ，可在 [此处](https://141ppv.com/actress/) 演员单页链接中获取
 
-    -   \`/141ppv/tag/Adult%20Awards\`
+  -  \`/141ppv/tag/Adult%20Awards\`
 
-        \`tag\` 类型的关键词必须填写 **标签名** 且标签中的 \`/\` 必须替换为 \`%2F\` ，可在 [此处](https://141ppv.com/tag) 标签单页链接中获取
+        \`tag\` 类型的关键词必须填写 **标签名** 且标签中的 \`/\` 必须替换为 \`%2F\` ，可在 [此处](https://141ppv.com/tag/) 标签单页链接中获取
 
-    -   \`/141ppv/date/2020/07/30\`
+  -  \`/141ppv/date/2020/07/30\`
 
-        \`date\` 类型的关键词必须填写 **日期**`,
+        \`date\` 类型的关键词必须填写 **日期(年/月/日)**`,
 };
 
 async function handler(ctx) {
     const rootUrl = 'https://www.141ppv.com';
-    const currentUrl = `${rootUrl}${getSubPath(ctx)}`;
+    const type = ctx.req.param('type');
+    const keyword = ctx.req.param('keyword') ?? '';
+
+    const currentUrl = `${rootUrl}/${type}/${keyword}`;
 
     const response = await got({
         method: 'get',

--- a/lib/routes/141ppv/index.ts
+++ b/lib/routes/141ppv/index.ts
@@ -18,37 +18,37 @@ export const route: Route = {
     handler,
     description: `**类型**
 
-  | 最新 | 热门     | 随机    | 指定演员 | 指定标签 | 日期        |
-  | ---- | ------- | ------ | -------- | -------- | -------- |
-  | new  | popular | random | actress  | tag      | date     |
+| 最新 | 热门    | 随机   | 指定演员 | 指定标签 | 日期 |
+| ---- | ------- | ------ | -------- | -------- | ---- |
+| new  | popular | random | actress  | tag      | date |
 
-  **关键词**
+**关键词**
 
-  | 空 | 日期范围    | 演员名       | 标签名         | 年月日         |
-  | -- | ----------- | ------------ | -------------- | ---------- |
-  |    | 7 / 30 / 60 | Yua%20Mikami | Adult%20Awards | 2020/07/30 |
+| 空 | 日期范围    | 演员名       | 标签名         | 年月日     |
+| -- | ----------- | ------------ | -------------- | ---------- |
+|    | 7 / 30 / 60 | Yua%20Mikami | Adult%20Awards | 2020/07/30 |
 
-  **示例说明**
+**示例说明**
 
-  -  \`/141ppv/new\`
+-  \`/141ppv/new\`
 
-        仅当类型为 \`new\` \`popular\` 或 \`random\` 时关键词为 **空**
+      仅当类型为 \`new\` \`popular\` 或 \`random\` 时关键词为 **空**
 
-  -  \`/141ppv/popular/30\`
+-  \`/141ppv/popular/30\`
 
-        \`popular\` \`random\` 类型的关键词可填写 \`7\` \`30\` 或 \`60\` 三个 **日期范围** 之一，分别对应 **7 天**、**30 天** 或 **60 天内**
+      \`popular\` \`random\` 类型的关键词可填写 \`7\` \`30\` 或 \`60\` 三个 **日期范围** 之一，分别对应 **7 天**、**30 天** 或 **60 天内**
 
-  -  \`/141ppv/actress/Yua%20Mikami\`
+-  \`/141ppv/actress/Yua%20Mikami\`
 
-        \`actress\` 类型的关键词必须填写 **演员名** ，可在 [此处](https://141ppv.com/actress/) 演员单页链接中获取
+      \`actress\` 类型的关键词必须填写 **演员名** ，可在 [此处](https://141ppv.com/actress/) 演员单页链接中获取
 
-  -  \`/141ppv/tag/Adult%20Awards\`
+-  \`/141ppv/tag/Adult%20Awards\`
 
-        \`tag\` 类型的关键词必须填写 **标签名** 且标签中的 \`/\` 必须替换为 \`%2F\` ，可在 [此处](https://141ppv.com/tag/) 标签单页链接中获取
+      \`tag\` 类型的关键词必须填写 **标签名** 且标签中的 \`/\` 必须替换为 \`%2F\` ，可在 [此处](https://141ppv.com/tag/) 标签单页链接中获取
 
-  -  \`/141ppv/date/2020/07/30\`
+-  \`/141ppv/date/2020/07/30\`
 
-        \`date\` 类型的关键词必须填写 **日期(年/月/日)**`,
+      \`date\` 类型的关键词必须填写 **日期(年/月/日)**`,
 };
 
 async function handler(ctx) {
@@ -56,7 +56,7 @@ async function handler(ctx) {
     const type = ctx.req.param('type');
     const keyword = ctx.req.param('keyword') ?? '';
 
-    const currentUrl = `${rootUrl}/${type}/${keyword}`;
+    const currentUrl = `${rootUrl}/${type}${keyword ? `/${keyword}` : ''}`;
 
     const response = await got({
         method: 'get',


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #15473

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/141ppv/new
/141ppv/popular
/141ppv/popular/7
/141ppv/random
/141ppv/random/7
/141ppv/date/2024/08/03
/141jav/new
/141jav/popular
/141jav/popular/7
/141jav/random
/141jav/random/7
/141jav/date/2024/08/03
/141jav/tag/Married%20Woman
/141jav/actress/Futaba%20Reena
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
