### PR TITLE
fix(route/fediverse): Fixes for ActivityPub

### DIFF
--- a/lib/routes/fediverse/timeline.ts
+++ b/lib/routes/fediverse/timeline.ts
@@ -65,9 +65,12 @@ async function handler(ctx) {
     const itemResolvers = [] as Promise<any>[];
 
     for (const item of items) {
+        if (!['Announce', 'Create', 'Update'].includes(item.type)) {
+            continue;
+        }
         if (typeof item.object === 'string') {
             itemResolvers.push(
-                (async (item: any) => {
+                (async (item) => {
                     item.object = await ofetch(item.object, requestOptions);
                     return item;
                 })(item)
@@ -85,11 +88,11 @@ async function handler(ctx) {
         image: self.icon?.url || self.image?.url,
         link,
         item: resolvedItems.map((item) => ({
-                title: item.object.content,
-                description: `${item.object.content}\n${item.object.attachment?.map((attachment) => `<img src="${attachment.url}" width="${attachment.width}" height="${attachment.height}" />`).join('\n') || ''}`,
-                link: item.url,
-                pubDate: parseDate(item.published),
-                guid: item.id,
-            })),
+            title: item.object.content,
+            description: `${item.object.content}\n${item.object.attachment?.map((attachment) => `<img src="${attachment.url}" width="${attachment.width}" height="${attachment.height}" />`).join('\n') || ''}`,
+            link: item.url,
+            pubDate: parseDate(item.published),
+            guid: item.id,
+        })),
     };
 }

--- a/lib/routes/fediverse/timeline.ts
+++ b/lib/routes/fediverse/timeline.ts
@@ -26,6 +26,7 @@ export const route: Route = {
 };
 
 const allowedDomain = new Set(['mastodon.social', 'pawoo.net', config.mastodon.apiHost].filter(Boolean));
+const activityPubTypes = new Set(['application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"']);
 
 async function handler(ctx) {
     const account = ctx.req.param('account');
@@ -47,7 +48,7 @@ async function handler(ctx) {
 
     const acc = await ofetch(`https://${domain}/.well-known/webfinger?resource=acct:${account}`, requestOptions);
 
-    const jsonLink = acc.links.find((link) => link.rel === 'self')?.href;
+    const jsonLink = acc.links.find((link) => link.rel === 'self' && activityPubTypes.has(link.type))?.href;
     const link = acc.links.find((link) => link.rel === 'http://webfinger.net/rel/profile-page')?.href;
 
     const self = await ofetch(jsonLink, requestOptions);

--- a/lib/routes/fediverse/timeline.ts
+++ b/lib/routes/fediverse/timeline.ts
@@ -46,7 +46,11 @@ async function handler(ctx) {
         },
     };
 
-    const acc = await ofetch(`https://${domain}/.well-known/webfinger?resource=acct:${account}`, requestOptions);
+    const acc = await ofetch(`https://${domain}/.well-known/webfinger?resource=acct:${account}`, {
+        headers: {
+            Accept: 'application/jrd+json',
+        },
+    });
 
     const jsonLink = acc.links.find((link) => link.rel === 'self' && activityPubTypes.has(link.type))?.href;
     const link = acc.links.find((link) => link.rel === 'http://webfinger.net/rel/profile-page')?.href;

--- a/lib/routes/fediverse/timeline.ts
+++ b/lib/routes/fediverse/timeline.ts
@@ -42,7 +42,7 @@ async function handler(ctx) {
 
     const requestOptions = {
         headers: {
-            Accept: 'application/activity+json',
+            Accept: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
         },
     };
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

None

## Example for the Proposed Route(s) / 路由地址示例

```routes
/fediverse/timeline/Mastodon@mastodon.social
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- According to RFC 7033, sending WebFinger queries with `Accept` other than `application/jrd+json` may result in a non-JRD response.
  > The client MAY include the "Accept"
   header to indicate a desired representation; representations other
   than JRD might be defined in future specifications.
- Check for ActivityPub media types when looking for AP `Actor` document. The first RD with `type=self` may points to things other than AP `Actor` document.
- Use `application/ld+json; profile="https://www.w3.org/ns/activitystreams"` as accept type when retrieving AP documents, according to the current ActivityPub specification:
  > The client MUST specify an Accept header with the application/ld+json; profile="https://www.w3.org/ns/activitystreams" media type in order to retrieve the activity. 
- When getting strings in outbox collection, this means that we need to resolve these `Object` as a JSON-LD reference, but not responding with a RSS full of links to AP `Object` documents.
- Ignore activities other than `Create` (post), `Announce` (repost), `Update` (edit).