### PR TITLE
feat(route): 新增 华南理工大学广州国际校区通知公告、新闻聚焦、媒体报道 路由

### DIFF
--- a/lib/routes/scut/gzic/media.ts
+++ b/lib/routes/scut/gzic/media.ts
@@ -21,12 +21,12 @@ export const route: Route = {
     maintainers: ['gdzhht'],
     handler,
     description: `:::warning
-    由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
-    :::`,
+由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
+:::`,
 };
 
 async function handler() {
-    const url = `https://www2.scut.edu.cn/gzic/30281/list.htm`;
+    const url = 'https://www2.scut.edu.cn/gzic/30281/list.htm';
 
     const { data: response } = await got(url);
     const $ = load(response);
@@ -39,7 +39,7 @@ async function handler() {
             const pubDate = item.find('.thr-box a span');
             return {
                 title: item.find('.thr-box a p').text(),
-                link: a.attr('href')?.includes('http') ? a.attr('href') : `https://www2.scut.edu.cn${a.attr('href')}`,
+                link: a.attr('href')?.startsWith('http') ? a.attr('href') : `https://www2.scut.edu.cn${a.attr('href')}`,
                 pubDate: parseDate(pubDate.text()),
             };
         });
@@ -64,7 +64,7 @@ async function handler() {
     );
 
     return {
-        title: `华南理工大学广州国际校区 - 媒体报道`,
+        title: '华南理工大学广州国际校区 - 媒体报道',
         link: url,
         item: items,
     };

--- a/lib/routes/scut/gzic/media.ts
+++ b/lib/routes/scut/gzic/media.ts
@@ -1,0 +1,71 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+
+export const route: Route = {
+    path: '/gzic/media',
+    categories: ['university'],
+    example: '/scut/gzic/media',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '广州国际校区 - 媒体报道',
+    maintainers: ['gdzhht'],
+    handler,
+    description: `:::warning
+    由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
+    :::`,
+};
+
+async function handler() {
+    const url = `https://www2.scut.edu.cn/gzic/30281/list.htm`;
+
+    const { data: response } = await got(url);
+    const $ = load(response);
+
+    const list = $('.right-nr .row .col-lg-4')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const a = item.find('.thr-box a');
+            const pubDate = item.find('.thr-box a span');
+            return {
+                title: item.find('.thr-box a p').text(),
+                link: a.attr('href')?.includes('http') ? a.attr('href') : `https://www2.scut.edu.cn${a.attr('href')}`,
+                pubDate: parseDate(pubDate.text()),
+            };
+        });
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                try {
+                    const response = await ofetch(item.link);
+                    const $ = load(response);
+                    item.description = $('div.wp_articlecontent').html();
+                } catch (error) {
+                    if (error.response && error.response.status === 404) {
+                        item.description = '';
+                    } else {
+                        throw error;
+                    }
+                }
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: `华南理工大学广州国际校区 - 媒体报道`,
+        link: url,
+        item: items,
+    };
+}

--- a/lib/routes/scut/gzic/news.ts
+++ b/lib/routes/scut/gzic/news.ts
@@ -51,7 +51,7 @@ async function handler() {
             cache.tryGet(item.link, async () => {
                 const response = await ofetch(item.link);
                 const $ = load(response);
-                item.description = item.link.startsWith('https://mp.weixin.qq.com') ? $('div.rich_media_content section').html() : $('div.wp_articlecontent').html();
+                item.description = item.link.startsWith('https://mp.weixin.qq.com/') ? $('div.rich_media_content section').html() : $('div.wp_articlecontent').html();
                 return item;
             })
         )

--- a/lib/routes/scut/gzic/news.ts
+++ b/lib/routes/scut/gzic/news.ts
@@ -21,13 +21,13 @@ export const route: Route = {
     maintainers: ['gdzhht'],
     handler,
     description: `:::warning
-    由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
-    :::`,
+由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
+:::`,
 };
 
 async function handler() {
     const baseUrl = 'https://www2.scut.edu.cn';
-    const url = `https://www2.scut.edu.cn/gzic/30279/list.htm`;
+    const url = 'https://www2.scut.edu.cn/gzic/30279/list.htm';
 
     const { data: response } = await got(url);
     const $ = load(response);
@@ -40,7 +40,7 @@ async function handler() {
             const pubDate = item.find('.li-img a span');
             return {
                 title: item.find('.li-img a p').text(),
-                link: a.attr('href')?.includes('http') ? a.attr('href') : `${baseUrl}${a.attr('href')}`,
+                link: a.attr('href')?.startsWith('http') ? a.attr('href') : `${baseUrl}${a.attr('href')}`,
                 pubDate: parseDate(pubDate.text().replaceAll(/年|月/g, '-').replaceAll('日', '')),
                 itunes_item_image: `${baseUrl}${item.find('.li-img img').attr('src')}`,
             };
@@ -51,14 +51,14 @@ async function handler() {
             cache.tryGet(item.link, async () => {
                 const response = await ofetch(item.link);
                 const $ = load(response);
-                item.description = item.link.includes('mp.weixin.qq.com') ? $('div.rich_media_content section').html() : $('div.wp_articlecontent').html();
+                item.description = item.link.startsWith('https://mp.weixin.qq.com') ? $('div.rich_media_content section').html() : $('div.wp_articlecontent').html();
                 return item;
             })
         )
     );
 
     return {
-        title: `华南理工大学广州国际校区 - 新闻聚焦`,
+        title: '华南理工大学广州国际校区 - 新闻聚焦',
         link: url,
         item: items,
     };

--- a/lib/routes/scut/gzic/news.ts
+++ b/lib/routes/scut/gzic/news.ts
@@ -1,0 +1,65 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+
+export const route: Route = {
+    path: '/gzic/news',
+    categories: ['university'],
+    example: '/scut/gzic/news',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '广州国际校区 - 新闻聚焦',
+    maintainers: ['gdzhht'],
+    handler,
+    description: `:::warning
+    由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
+    :::`,
+};
+
+async function handler() {
+    const baseUrl = 'https://www2.scut.edu.cn';
+    const url = `https://www2.scut.edu.cn/gzic/30279/list.htm`;
+
+    const { data: response } = await got(url);
+    const $ = load(response);
+
+    const list = $('.right-nr .row .col-lg-4')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const a = item.find('.li-img a');
+            const pubDate = item.find('.li-img a span');
+            return {
+                title: item.find('.li-img a p').text(),
+                link: a.attr('href')?.includes('http') ? a.attr('href') : `${baseUrl}${a.attr('href')}`,
+                pubDate: parseDate(pubDate.text().replaceAll(/年|月/g, '-').replaceAll('日', '')),
+                itunes_item_image: `${baseUrl}${item.find('.li-img img').attr('src')}`,
+            };
+        });
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const response = await ofetch(item.link);
+                const $ = load(response);
+                item.description = item.link.includes('mp.weixin.qq.com') ? $('div.rich_media_content section').html() : $('div.wp_articlecontent').html();
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: `华南理工大学广州国际校区 - 新闻聚焦`,
+        link: url,
+        item: items,
+    };
+}

--- a/lib/routes/scut/gzic/notice.ts
+++ b/lib/routes/scut/gzic/notice.ts
@@ -31,10 +31,11 @@ export const route: Route = {
     description: `| 学术预告 | 教研通知 | 海外学习 | 事务通知 |
   | -------- | -------- | -------- | -------- |
   | xsyg     | jytz     | hwxx     | swtz     |
-    :::warning
-    由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
-    部分通知详情页可能会被删除（返回 404），或在校园网外无法访问。
-    :::`,
+
+:::warning
+由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
+部分通知详情页可能会被删除（返回 404），或在校园网外无法访问。
+:::`,
 };
 
 async function handler(ctx) {
@@ -55,7 +56,7 @@ async function handler(ctx) {
             const pubDate = item.find('.thr-box a span');
             return {
                 title: item.find('.thr-box a p').text(),
-                link: a.attr('href')?.includes('http') ? a.attr('href') : `${baseUrl}${a.attr('href')}`,
+                link: a.attr('href')?.startsWith('http') ? a.attr('href') : `${baseUrl}${a.attr('href')}`,
                 pubDate: parseDate(pubDate.text()),
             };
         });

--- a/lib/routes/scut/gzic/notice.ts
+++ b/lib/routes/scut/gzic/notice.ts
@@ -1,0 +1,87 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+
+const categoryMap = {
+    xsyg: { title: '学术预告', tag: '30284' },
+    jytz: { title: '教研通知', tag: '30307' },
+    hwxx: { title: '海外学习', tag: 'hwxx' },
+    swtz: { title: '事务通知', tag: '30283' },
+};
+
+export const route: Route = {
+    path: '/gzic/notice/:category?',
+    categories: ['university'],
+    example: '/scut/gzic/notice/swtz',
+    parameters: { category: '通知分类，默认为 `swtz`' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '广州国际校区 - 通知公告',
+    maintainers: ['gdzhht'],
+    handler,
+    description: `| 学术预告 | 教研通知 | 海外学习 | 事务通知 |
+  | -------- | -------- | -------- | -------- |
+  | xsyg     | jytz     | hwxx     | swtz     |
+    :::warning
+    由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
+    部分通知详情页可能会被删除（返回 404），或在校园网外无法访问。
+    :::`,
+};
+
+async function handler(ctx) {
+    const baseUrl = 'https://www2.scut.edu.cn';
+
+    const categoryName = ctx.req.param('category') || 'swtz';
+    const categoryMeta = categoryMap[categoryName];
+    const url = `${baseUrl}/gzic/${categoryMeta.tag}/list.htm`;
+
+    const { data: response } = await got(url);
+    const $ = load(response);
+
+    const list = $('.right-nr .row .col-lg-4')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const a = item.find('.thr-box a');
+            const pubDate = item.find('.thr-box a span');
+            return {
+                title: item.find('.thr-box a p').text(),
+                link: a.attr('href')?.includes('http') ? a.attr('href') : `${baseUrl}${a.attr('href')}`,
+                pubDate: parseDate(pubDate.text()),
+            };
+        });
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                try {
+                    const response = await ofetch(item.link);
+                    const $ = load(response);
+                    item.description = $('div.wp_articlecontent').html();
+                } catch (error) {
+                    if (error.response && error.response.status === 404) {
+                        item.description = '';
+                    } else {
+                        throw error;
+                    }
+                }
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: `华南理工大学广州国际校区 - ${categoryMeta.title}`,
+        link: url,
+        item: items,
+    };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/scut/gzic/media
/scut/gzic/news
/scut/gzic/notice
/scut/gzic/notice/xsyg
/scut/gzic/notice/jytz
/scut/gzic/notice/hwxx
/scut/gzic/notice/swtz
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
