### PR TITLE
fix(route): people,handle diff site encoding.

### DIFF
--- a/lib/routes/people/index.ts
+++ b/lib/routes/people/index.ts
@@ -32,7 +32,9 @@ async function handler(ctx) {
         responseType: 'buffer',
     });
 
-    const $ = load(iconv.decode(response, 'gbk'));
+    const encoding = site === 'www' ? 'gbk' : 'utf-8';
+    const decodedResponse = iconv.decode(response, encoding);
+    const $ = load(decodedResponse);
 
     $('em').remove();
     $('.bshare-more, .page_n, .page').remove();
@@ -64,7 +66,7 @@ async function handler(ctx) {
                         responseType: 'buffer',
                     });
 
-                    const data = iconv.decode(detailResponse, 'gbk');
+                    const data = iconv.decode(detailResponse, encoding);
                     const content = load(data);
 
                     content('.paper_num, #rwb_tjyd').remove();


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #16388 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/people
/people/sc
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
现首页和各省市页RSS能够使用正确编码显示。

现首页`/people`
```rss
<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
<channel>
<title>首页头条--人民网</title>
<link>http://www.people.com.cn/GB/59476</link>
<atom:link href="http://localhost:1200/people" rel="self" type="application/rss+xml"/>
<description>首页头条--人民网 - Powered by RSSHub</description>
<generator>RSSHub</generator>
<webMaster>contact@rsshub.app (RSSHub)</webMaster>
<language>en</language>
<lastBuildDate>Wed, 07 Aug 2024 08:35:45 GMT</lastBuildDate>
<ttl>5</ttl>
<item>
<title>暑运以来全国铁路发送旅客超5亿人次</title>
<description><div class="bza"><span></span><p></p></div> <div class="box_pic"></div> <p>　　新华社北京8月7日电（记者樊曦）记者7日从中国国家铁路集团有限公司获悉，自暑运启动以来，7月1日至8月6日，全国铁路累计发送旅客5.13亿人次，同比增长5.4%，突破5亿人次大关，日均发送旅客1386万人次。</p> <p>　　国铁集团运输部相关负责人介绍，今年暑期学生流、旅游流、探亲流等出行需求旺盛，铁路客流保持高位运行。铁路部门认真统筹客货运输和防洪安全，精心制定暑期旅客运输工作方案，加大运输能力投放，落实便民利民惠民举措，努力为旅客平安有序出行和经济平稳运行提供可靠保障。</p> <p>　　为保障旅客安全有序出行，各地铁路部门加强站车服务，强化路地联动机制，全力做好旅客出行服务保障工作。国铁兰州局集团公司银川站发挥“向阳花”服务品牌优势，为旅客提供交通、美食、住宿等咨询服务，帮助旅客更好地了解当地风土人情；国铁成都局集团公司与南方电网贵阳供电局加强协同联动，对贵阳北站、贵阳东站等高铁枢纽站及管内沪昆、贵广等高速铁路沿线供电设施开展安全巡查；国铁郑州局集团公司积极协调郑州公交集团等地方市政交通部门，统筹安排公共交通运力，方便旅客出行“最后一公里”。</p><div class="zdfy clearfix"></div><center><table border="0" align="center" width="40%"><tbody><tr></tr></tbody></table></center> <div class="box_pic"></div> <div class="edit cf">(责编：岳弘彬、牛镛)</div> <style type="text/css"> .tjewm{width:100%;text-align:center;margin:30px auto;display:none;} .tjewm span{display:inline-block;width:248px;font-size:18px;margin:auto 20px;} @media (min-device-width:320px) and (max-width:689px),(max-device-width:480px){ .tjewm span{display:inline-block;width:60vw;margin:auto 4vw;font-size:16px;} .tjewm span img{width:100%;height:auto;} } </style> <div class="tjewm cf"><span><img src="http://finance.people.com.cn/NMediaFile/2022/0801/MAIN202208010936066173860781061.jpg" width="248" height="248" border="0" alt="关注公众号：人民网财经" referrerpolicy="no-referrer">关注公众号：人民网财经</span> </div> </description>
<link>http://finance.people.com.cn/n1/2024/0807/c1004-40294453.html</link>
<guid isPermaLink="false">http://finance.people.com.cn/n1/2024/0807/c1004-40294453.html</guid>
<pubDate>Wed, 07 Aug 2024 08:20:00 GMT</pubDate>
</item>
```
现省页`/people/sn`
```rss
<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
<channel>
<title>陕西频道--人民网_网上的人民日报</title>
<link>http://sn.people.com.cn/GB/</link>
<atom:link href="http://localhost:1200/people/sn" rel="self" type="application/rss+xml"/>
<description>陕西频道--人民网_网上的人民日报 - Powered by RSSHub</description>
<generator>RSSHub</generator>
<webMaster>contact@rsshub.app (RSSHub)</webMaster>
<language>en</language>
<lastBuildDate>Wed, 07 Aug 2024 08:39:03 GMT</lastBuildDate>
<ttl>5</ttl>
<item>
<title>全国青少年航空航天模型教育竞赛落幕</title>
<description><div class="bza"><span></span><p></p></div> <div class="box_pic"></div> <p style="text-align: center;"><img src="http://sn.people.com.cn/NMediaFile/2024/0806/LOCAL1722928683876PNT9R9JH4H.jpg" width="800" height="534" alt="" referrerpolicy="no-referrer"></p> <p style="text-indent: 2em;">8月6日，第二十五届“飞向北京·飞向太空”全国青少年航空航天模型教育竞赛活动总决赛闭幕式暨颁奖典礼在西安体育学院鄠邑校区举行。经过5天的激烈角逐，共产生了金牌、银牌、铜牌各95枚，优秀基层组织单位21个 。国家体育总局航空无线电模型运动管理中心运动三部飞北赛事项目主管王梓骅、西安体育学院鄠邑校区管理委员会副主任、党支部书记党康等参加活动并为获奖运动员和组织颁奖。</p> <p style="text-align: center;"><img src="http://sn.people.com.cn/NMediaFile/2024/0806/LOCAL1722928692947RS20R965O9.jpg" width="800" height="534" alt="" referrerpolicy="no-referrer"></p> <p style="text-align: center;"><img src="http://sn.people.com.cn/NMediaFile/2024/0806/LOCAL17229286994590DU8SOKKD3.jpg" width="800" height="534" alt="" referrerpolicy="no-referrer"></p> <p style="text-indent: 2em;">本次比赛，来自全国的69支队伍、4000余名参赛选手在为期5天的赛程里，在鄠邑区展开了“载荷火箭”“遥控电动直升机”“遥控火箭助推滑翔机”等29个竞时、竞速、竞距项目的比拼，涉及航模运动的各个门类，对青少年体育科技素质的培养、自主创新能力的提升有重大意义。（当地供稿 西安市体育局）</p><div class="zdfy clearfix"></div><center><table border="0" align="center" width="40%"><tbody><tr></tr></tbody></table></center> <div class="box_pic"></div> <div class="edit cf">(责编：白鸽、魏鑫)</div> </description>
<link>http://sn.people.com.cn/n2/2024/0806/c347857-40935840.html</link>
<guid isPermaLink="false">http://sn.people.com.cn/n2/2024/0806/c347857-40935840.html</guid>
<pubDate>Tue, 06 Aug 2024 07:18:00 GMT</pubDate>
</item>
```
