### PR TITLE
feat: implement #16160 provide user timeline endpoint for misskey

### DIFF
--- a/lib/routes/misskey/user-timeline.ts
+++ b/lib/routes/misskey/user-timeline.ts
@@ -1,0 +1,41 @@
+import { Route } from '@/types';
+import utils from './utils';
+import { config } from '@/config';
+import ConfigNotFoundError from '@/errors/types/config-not-found';
+
+export const route: Route = {
+    path: '/users/notes/:username',
+    categories: ['social-media'],
+    example: '/misskey/users/notes/@support@misskey.io',
+    parameters: { username: 'misskey username format, like @support@misskey.io' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'User timeline',
+    maintainers: ['siygle'],
+    handler,
+};
+
+async function handler(ctx) {
+    const username = ctx.req.param('username');
+    const [, pureusername, site] = username.match(/@(\w+)@(\w+\.\w+)/) || [];
+    if (!pureusername || !site) {
+        throw new ConfigNotFoundError('Provide a valid Misskey username');
+    }
+    if (!config.feature.allow_user_supply_unsafe_domain && !utils.allowSiteList.includes(site)) {
+        throw new ConfigNotFoundError(`This RSS is disabled unless 'ALLOW_USER_SUPPLY_UNSAFE_DOMAIN' is set to 'true'.`);
+    }
+
+    const { account_data } = await utils.getUserTimelineByUsername(pureusername, site);
+
+    return {
+        title: `User timeline for ${username} on ${site}`,
+        link: `https://${site}/@${pureusername}`,
+        item: utils.parseNotes(account_data, site),
+    };
+}

--- a/lib/routes/misskey/utils.ts
+++ b/lib/routes/misskey/utils.ts
@@ -4,6 +4,8 @@ const __dirname = getCurrentPath(import.meta.url);
 import { art } from '@/utils/render';
 import { parseDate } from '@/utils/parse-date';
 import path from 'node:path';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
 
 const allowSiteList = ['misskey.io', 'madost.one', 'mk.nixnet.social'];
 
@@ -28,4 +30,42 @@ const parseNotes = (data, site) =>
         };
     });
 
-export default { parseNotes, allowSiteList };
+async function getUserTimelineByUsername(username, site) {
+    const search_url = `https://${site}/api/users/search-by-username-and-host`;
+    const cacheUid = `misskey_username/${site}/${username}`;
+
+    const account_id = await cache.tryGet(cacheUid, async () => {
+        const search_response = await got({
+            method: 'post',
+            url: search_url,
+            json: {
+                username,
+                host: site,
+                detail: true,
+                limit: 1,
+            },
+        });
+        const userData = search_response.data.filter((item) => item.username === username);
+
+        if (userData.length === 0) {
+            throw new Error(`username ${username} not found`);
+        }
+        return userData[0].id;
+    });
+
+    const usernotes_url = `https://${site}/api/users/notes`;
+    const usernotes_response = await got({
+        method: 'post',
+        url: usernotes_url,
+        json: {
+            userId: account_id,
+            withChannelNotes: true,
+            limit: 10,
+            offset: 0,
+        },
+    });
+    const account_data = usernotes_response.data;
+    return { site, account_id, account_data };
+}
+
+export default { parseNotes, getUserTimelineByUsername, allowSiteList };


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #16160 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/misskey/users/notes/:username
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

參考 mastodon user timeline 的類似行為，實作 misskey 的版本，呼叫了

1.  利用 [/users/search-by-username-and-host](https://misskey.io/api-doc#tag/users/operation/users___search-by-username-and-host) 反查 User ID。
2. 再利用上述取得的 User ID 呼叫 [/users/notes](https://misskey.io/api-doc#tag/users/operation/users___notes) 取得該用戶的 timeline 資料。

