### PR TITLE
fix(route/sjtu/jwc): handle error when fetching sjtu/jwc article

### DIFF
--- a/lib/routes/sjtu/jwc.ts
+++ b/lib/routes/sjtu/jwc.ts
@@ -7,7 +7,10 @@ import { parseDate } from '@/utils/parse-date';
 const urlRoot = 'https://jwc.sjtu.edu.cn/xwtg';
 
 async function getFullArticle(link) {
-    const response = await got(link);
+    const response = await got(link).catch(() => null);
+    if (!response) {
+        return null;
+    }
     const $ = load(response.body);
     const content = $('.content-con');
     if (content.length === 0) {


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例


```routes
/sjtu/jwc
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

部分已删除的通知没有从索引列表中移除，导致抓取页面的时候产生FetchError错误。

![image](https://github.com/user-attachments/assets/0986f702-2149-404e-94ee-495825a1bddc)
