### PR TITLE
fix(route/iwara): fix user login failure

### DIFF
--- a/lib/routes/iwara/subscriptions.ts
+++ b/lib/routes/iwara/subscriptions.ts
@@ -69,7 +69,7 @@ async function handler() {
                 headers: {
                     'content-type': 'application/json',
                 },
-                data: JSON.stringify({
+                body: JSON.stringify({
                     email: username,
                     password,
                 }),


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #16462

## Example for the Proposed Route(s) / 路由地址示例

```routes
/iwara/subscriptions
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
The parameter in got() was named `data` instead of `body`, causing the JSON body not to be sent to the server.