### PR TITLE
fix(route/zhihu): Fix bug that zhihu answers would be truncated

### DIFF
--- a/lib/routes/zhihu/answers.ts
+++ b/lib/routes/zhihu/answers.ts
@@ -3,6 +3,7 @@ import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { header, processImage } from './utils';
 import { parseDate } from '@/utils/parse-date';
+import { config } from '@/config';
 
 export const route: Route = {
     path: '/people/answers/:id',
@@ -29,9 +30,17 @@ export const route: Route = {
 
 async function handler(ctx) {
     const id = ctx.req.param('id');
+
+    const zc0 = config.zhihu.cookies
+        ?.split(';')
+        .map((e) => e.trim())
+        .find((e) => e.includes('z_c0'))
+        ?.slice('z_c0='.length);
+
     const headers = {
         'User-Agent': 'ZhihuHybrid com.zhihu.android/Futureve/6.59.0 Mozilla/5.0 (Linux; Android 10; GM1900 Build/QKQ1.190716.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.127 Mobile Safari/537.36',
         Referer: `https://www.zhihu.com/people/${id}/answers`,
+        Cookie: `z_c0=${zc0}`,
     };
 
     const response = await got({


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #16260 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/zhihu/people/answers/L.M.Sherlock
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/zhihu/people/answers/L.M.Sherlock
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

路由 `/zhihu/people/activities/:id` 可以正常获得回答和文章的全文，但路由 `/zhihu/people/answers/:id` 却始终只能获得截断的回答。

检查源代码后，发现 `/zhihu/people/answers/:id` 代码中，并没有从本地读取并使用 `z_c0` ，这就导致即使配置了环境变量，在该路由下也无法获取回答的全文。

该pr中，添加了读取 `z_c0` 的代码，使路由 `/zhihu/people/answers/:id` 可以正常获得回答全文。

https://github.com/DIYgod/RSSHub/issues/16260#issuecomment-2295206323