### PR TITLE
fix(route/zsxq): 优化问答型消息可读性

### DIFF
--- a/lib/routes/zsxq/types.ts
+++ b/lib/routes/zsxq/types.ts
@@ -147,6 +147,8 @@ export interface TopicImage {
 
 export type Topic = TalkTopic | QATopic | TaskTopic | SolutionTopic;
 
+export type ResponseData = UserInfo | GroupInfo | Topic[];
+
 export type UserInfoResponse = BasicResponse<UserInfo>;
 
 export type GroupInfoResponse = BasicResponse<GroupInfo>;

--- a/lib/routes/zsxq/types.ts
+++ b/lib/routes/zsxq/types.ts
@@ -63,6 +63,13 @@ export interface QATopic extends BasicTopic {
     question: {
         images?: TopicImage[];
         text?: string;
+        owner?: {
+            avatar_url: string;
+            description: string;
+            location: string;
+            name: string;
+            user_id: number;
+        };
     };
 }
 

--- a/lib/routes/zsxq/utils.ts
+++ b/lib/routes/zsxq/utils.ts
@@ -46,7 +46,7 @@ export function generateTopicDataItem(topics: Topic[]): DataItem[] {
             case 'q&a':
                 title = topic.question?.text?.split('\n')[0] ?? '问答';
                 description = parseTopicContent(topic.question?.text, topic.question?.images);
-                description = `<blockquote>${String(topic.question?.owner?.name)} 提问：${description}</blockquote>`;
+                description = `<blockquote>${String(topic.question?.owner?.name ?? '匿名用户')} 提问：${description}</blockquote>`;
                 if (topic.answered) {
                     description += '<br>' + topic.answer?.owner.name + ' 回答：<br><br>';
                     description += parseTopicContent(topic.answer?.text, topic.answer?.images);

--- a/lib/routes/zsxq/utils.ts
+++ b/lib/routes/zsxq/utils.ts
@@ -46,8 +46,9 @@ export function generateTopicDataItem(topics: Topic[]): DataItem[] {
             case 'q&a':
                 title = topic.question?.text?.split('\n')[0] ?? '问答';
                 description = parseTopicContent(topic.question?.text, topic.question?.images);
+                description = `<blockquote>${String(topic.question?.owner?.name)} 提问：${description}</blockquote>`;
                 if (topic.answered) {
-                    description += '<br><br>';
+                    description += '<br>' + topic.answer?.owner.name + ' 回答：<br><br>';
                     description += parseTopicContent(topic.answer?.text, topic.answer?.images);
                 }
                 break;

--- a/lib/routes/zsxq/utils.ts
+++ b/lib/routes/zsxq/utils.ts
@@ -1,10 +1,10 @@
 import got from '@/utils/got';
-import type { TopicImage, Topic, BasicResponse } from './types';
+import type { TopicImage, Topic, BasicResponse, ResponseData } from './types';
 import { parseDate } from '@/utils/parse-date';
 import { config } from '@/config';
 import type { DataItem } from '@/types';
 
-export async function customFetch<T extends BasicResponse<any>>(path: string, retryCount = 0): Promise<T['resp_data']> {
+export async function customFetch<T extends BasicResponse<ResponseData>>(path: string, retryCount = 0): Promise<T['resp_data']> {
     const apiUrl = 'https://api.zsxq.com/v2';
 
     const response = await got(apiUrl + path, {


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->



```routes
/zsxq/group/88855458825252
/zsxq/user/2414218251
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

使用 blockquote 元素引用问答型消息的提问部分，使浏览效果更接近原版样式，提升可读性
补充提问人与回答人用户名，进一步提升可读性

原网站样式：

![image](https://github.com/user-attachments/assets/63a69f89-6675-459d-8752-ce902c9c4895)

修改前样式（使用 Fluent Reader）：

![image](https://github.com/user-attachments/assets/b6284d86-f86f-4d03-820a-91ff64b924a6)

修改后样式（使用 Fluent Reader）：

![image](https://github.com/user-attachments/assets/26e52846-44c9-4fdf-9c03-824f43cf42b3)


