### PR TITLE
feat(route): Add 51CTO  text parsing

### DIFF
--- a/lib/routes/51cto/recommend.ts
+++ b/lib/routes/51cto/recommend.ts
@@ -32,7 +32,7 @@ async function getFullcontent(item, cookie = '') {
         },
     });
     const $ = load(articleResponse);
-    fullContent = item.url.includes('ost.51cto.com') ? $('.posts-content').html() : $('article').html();
+    fullContent = item.url.startsWith('https://ost.51cto.com') ? $('.posts-content').html() : $('article').html();
 
     if (!fullContent && cookie === '') {
         // If fullContent is null and haven't tried to request with cookie, try to get fullContent with cookie

--- a/lib/routes/51cto/recommend.ts
+++ b/lib/routes/51cto/recommend.ts
@@ -2,6 +2,10 @@ import { Route } from '@/types';
 import { parseDate } from '@/utils/parse-date';
 import got from '@/utils/got';
 import { getToken, sign } from './utils';
+import { load } from 'cheerio';
+import cache from '@/utils/cache';
+import puppeteer from '@/utils/puppeteer';
+import logger from '@/utils/logger';
 
 export const route: Route = {
     path: '/index/recommend',
@@ -18,6 +22,39 @@ export const route: Route = {
     url: '51cto.com/',
 };
 
+async function get_fullcontent(item, browser) {
+    let fullContent: null | string = null;
+    const articleResponse = await puppeteer_get(item.url, browser);
+    const $ = load(articleResponse);
+    fullContent = item.url.includes('ost.51cto.com') ? $('.posts-content').html() : $('article').html();
+
+    return {
+        title: item.title,
+        link: item.url,
+        pubDate: parseDate(item.pubdate, +8),
+        description: fullContent || item.abstract + '(RSSHub: Failed to get fullContent)', // Return item.abstract if fullContent is null
+    };
+}
+
+async function puppeteer_get(link, browser) {
+    const page = await browser.newPage();
+    await page.setRequestInterception(true);
+    page.on('request', (request) => {
+        request.resourceType() === 'document' ? request.continue() : request.abort();
+    });
+    logger.http(`Requesting ${link}`);
+    // You have to request the page twice. I guess it's setting cookies when you request for the first time.
+    await page.goto(link, {
+        waitUntil: 'domcontentloaded',
+    });
+    await page.goto(link, {
+        waitUntil: 'domcontentloaded',
+    });
+    const response = await page.content();
+    page.close();
+    return response;
+}
+
 async function handler(ctx) {
     const url = 'https://api-media.51cto.com';
     const requestPath = 'index/index/recommend';
@@ -29,6 +66,10 @@ async function handler(ctx) {
         limit_time: 0,
         name_en: '',
     };
+
+    // 导入 puppeteer 工具类并初始化浏览器实例
+    const browser = await puppeteer();
+
     const response = await got(`${url}/${requestPath}`, {
         searchParams: {
             ...params,
@@ -38,15 +79,14 @@ async function handler(ctx) {
         },
     });
     const list = response.data.data.data.list;
+
+    const items = await Promise.all(list.map((item) => cache.tryGet(item.url, () => get_fullcontent(item, browser))));
+
+    browser.close();
     return {
         title: '51CTO',
         link: 'https://www.51cto.com/',
         description: '51cto - 推荐',
-        item: list.map((item) => ({
-            title: item.title,
-            link: item.url,
-            pubDate: parseDate(item.pubdate, +8),
-            description: item.abstract,
-        })),
+        item: items,
     };
 }

--- a/lib/routes/51cto/recommend.ts
+++ b/lib/routes/51cto/recommend.ts
@@ -18,7 +18,7 @@ export const route: Route = {
         },
     ],
     name: '推荐',
-    maintainers: ['cnkmmk'],
+    maintainers: ['cnkmmk', 'ovo-tim'],
     handler,
     url: '51cto.com/',
 };
@@ -37,16 +37,9 @@ async function get_fullcontent(item, cookie = '') {
     fullContent = item.url.includes('ost.51cto.com') ? $('.posts-content').html() : $('article').html();
 
     if (!fullContent && cookie === '') {
-        // try {
-        //     const matches = fullContent!.match(pattern)!.slice(0, 3);
-        //     const [v1, v2, v3] = matches as unknown as number[];
-        //     const cookie = '__tst_status=' + (v1 + v2 + v3) + ';';
-        //     console.log(cookie);
-        //     return await get_fullcontent(item, cookie);
-        // } catch (error) {
-        //     logger.error(error);
-        // }
+        // If fullContent is null and cookie is empty, try to get fullContent with cookie
         try {
+            // More details: https://github.com/DIYgod/RSSHub/pull/16583#discussion_r1738643033
             const _matches = articleResponse!.match(pattern)!.slice(0, 3);
             const matches = _matches.map((str) => Number(str.split(':')[1]));
             const [v1, v2, v3] = matches;

--- a/lib/routes/51cto/recommend.ts
+++ b/lib/routes/51cto/recommend.ts
@@ -37,7 +37,7 @@ async function get_fullcontent(item, cookie = '') {
     fullContent = item.url.includes('ost.51cto.com') ? $('.posts-content').html() : $('article').html();
 
     if (!fullContent && cookie === '') {
-        // If fullContent is null and cookie is empty, try to get fullContent with cookie
+        // If fullContent is null and haven't tried to request with cookie, try to get fullContent with cookie
         try {
             // More details: https://github.com/DIYgod/RSSHub/pull/16583#discussion_r1738643033
             const _matches = articleResponse!.match(pattern)!.slice(0, 3);

--- a/lib/routes/51cto/recommend.ts
+++ b/lib/routes/51cto/recommend.ts
@@ -32,7 +32,8 @@ async function getFullcontent(item, cookie = '') {
         },
     });
     const $ = load(articleResponse);
-    fullContent = item.url.startsWith('https://ost.51cto.com') ? $('.posts-content').html() : $('article').html();
+
+    fullContent = new URL(item.url).host === 'ost.51cto.com' ? $('.posts-content').html() : $('article').html();
 
     if (!fullContent && cookie === '') {
         // If fullContent is null and haven't tried to request with cookie, try to get fullContent with cookie


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/51cto/index/recommend
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
原本只能提供摘要，在原来的基础上增加了正文解析
Originally, only summaries could be provided.  And now, the text parsing has been added.

Before:
![image](https://github.com/user-attachments/assets/2c7ddb6a-e6e1-4070-a6a6-600899ebaade)
After:
![image](https://github.com/user-attachments/assets/ccc5ac12-65ce-4485-ab2a-ba20ea40dc21)
