### PR TITLE
feat(route): 增加机器之心首页

### DIFF
--- a/lib/routes/jiqizhixin/index.ts
+++ b/lib/routes/jiqizhixin/index.ts
@@ -1,0 +1,46 @@
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import { Route, DataItem } from '@/types';
+
+export const route: Route = {
+    path: '/index',
+    name: '机器之心首页',
+    url: 'jiqizhixin.com',
+    maintainers: ['ovo-tim'],
+    example: '/jiqizhixin/index',
+    description: '通过请求 HTML 获取机器之心首页，可获取10条',
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handler: async (_) => {
+        const baseUrl = 'https://www.jiqizhixin.com';
+        const response = await ofetch(baseUrl, {
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+            },
+        });
+
+        const $ = load(response);
+
+        const items: DataItem[] = $('article')
+            .map((_index, article) => {
+                const titleTag = $(article).find('a.article-item__title');
+                const summaryTag = $(article).find('p.article-item__summary');
+                const dateTag = $(article).find('time');
+
+                return {
+                    title: titleTag.text().trim(),
+                    link: titleTag.attr('href') ? baseUrl + titleTag.attr('href') : undefined,
+                    description: summaryTag.text().trim(),
+                    pubDate: parseDate(dateTag.attr('datetime')!),
+                };
+            })
+            .toArray();
+
+        return {
+            title: '机器之心',
+            link: baseUrl,
+            description: '机器之心首页',
+            item: items,
+        };
+    },
+};

--- a/lib/routes/jiqizhixin/index.ts
+++ b/lib/routes/jiqizhixin/index.ts
@@ -2,6 +2,7 @@ import ofetch from '@/utils/ofetch';
 import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
 import { Route, DataItem } from '@/types';
+import { config } from '@/config';
 
 export const route: Route = {
     path: '/index',
@@ -15,7 +16,7 @@ export const route: Route = {
         const baseUrl = 'https://www.jiqizhixin.com';
         const response = await ofetch(baseUrl, {
             headers: {
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+                'User-Agent': config.ua,
             },
         });
 

--- a/lib/routes/jiqizhixin/namespace.ts
+++ b/lib/routes/jiqizhixin/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '机器之心',
+    url: 'jiqizhixin.com',
+};

--- a/lib/routes/jiqizhixin/query.ts
+++ b/lib/routes/jiqizhixin/query.ts
@@ -1,0 +1,118 @@
+export const query = `query timelineInHome($category: String!, $type: String!, $count: Int, $cursor: String) {
+  timelines(category: $category, type: $type, first: $count, after: $cursor) {
+    ...Timeline
+    __typename
+  }
+}
+
+fragment Timeline on TimelineConnection {
+  edges {
+    node {
+      id
+      content_type
+      content {
+        ... on Article {
+          ...ArticleInfo
+          __typename
+        }
+        ... on Report {
+          ...ReportItem
+          __typename
+        }
+        ... on Topic {
+          ...TopicItem
+          __typename
+        }
+        ... on Periodical {
+          title
+          cover_image_url
+          path
+          __typename
+        }
+        ... on Event {
+          ...EventItem
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+  pageInfo {
+    ...PageInfo
+    __typename
+  }
+  __typename
+}
+
+fragment PageInfo on PageInfo {
+  endCursor
+  hasNextPage
+  __typename
+}
+
+fragment TopicItem on Topic {
+  id
+  title
+  path
+  category
+  likes_count
+  comments_count
+  cover_image_url
+  author {
+    id
+    name
+    path
+    __typename
+  }
+  __typename
+}
+
+fragment ArticleInfo on Article {
+  ...ArticleSimple
+  category_name
+  category_path
+  author {
+    name
+    id
+    avatar_url
+    path
+    __typename
+  }
+  __typename
+}
+
+fragment ArticleSimple on Article {
+  id
+  path
+  title
+  cover_image_url
+  published_at
+  likes_count
+  comments_count
+  description
+  __typename
+}
+
+fragment ReportItem on Report {
+  id
+  title
+  description
+  likes_count
+  comments_count
+  path
+  created_at
+  __typename
+}
+
+fragment EventItem on Event {
+  id
+  name
+  description
+  likes_count
+  comments_count
+  cover_image_url
+  path
+  __typename
+}`;

--- a/lib/routes/jiqizhixin/utils.ts
+++ b/lib/routes/jiqizhixin/utils.ts
@@ -1,6 +1,7 @@
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 import { config } from '@/config';
+import { query } from './query';
 
 const url = 'https://www.jiqizhixin.com/graphql';
 const headers = {
@@ -9,32 +10,15 @@ const headers = {
     'X-CSRF-Token': '',
 };
 
-const query = `
-query timelineInHome($category: String!, $type: String!, $count: Int, $cursor: String) {
-  timelines(category: $category, type: $type, first: $count, after: $cursor) {
-    edges {
-      node {
-        content {
-          ... on Article {
-            title
-            description
-            published_at
-          }
-        }
-      }
-    }
-  }
-}
-`;
-
 const variables = {
     category: 'all',
     type: 'everyone',
     count: 10,
-    cursor: '',
+    cursor: 'MTI=',
 };
 
 const data = {
+    operationName: 'timelineInHome',
     query,
     variables,
 };

--- a/lib/routes/jiqizhixin/utils.ts
+++ b/lib/routes/jiqizhixin/utils.ts
@@ -1,0 +1,79 @@
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import { config } from '@/config';
+
+const url = 'https://www.jiqizhixin.com/graphql';
+const headers = {
+    'Content-Type': 'application/json',
+    'User-Agent': config.ua,
+    'X-CSRF-Token': '',
+};
+
+const query = `
+query timelineInHome($category: String!, $type: String!, $count: Int, $cursor: String) {
+  timelines(category: $category, type: $type, first: $count, after: $cursor) {
+    edges {
+      node {
+        content {
+          ... on Article {
+            title
+            description
+            published_at
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const variables = {
+    category: 'all',
+    type: 'everyone',
+    count: 10,
+    cursor: '',
+};
+
+const data = {
+    query,
+    variables,
+};
+
+interface Article {
+    title: string;
+    description: string;
+    pubDate: Date | string;
+}
+
+export async function fetchArticles(csfr_token): Promise<Article[] | null> {
+    headers['X-CSRF-Token'] = csfr_token;
+
+    const response = await ofetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(data),
+    });
+
+    if (response.status === 200) {
+        const responseData = await response.json();
+
+        const articles: Article[] = [];
+        for (const edge of responseData.data.timelines.edges) {
+            const article = edge.node.content;
+            if (article.title) {
+                const title = article.title;
+                const summary = article.description;
+                const published_at = parseDate(article.published_at);
+                articles.push({
+                    title,
+                    description: summary,
+                    pubDate: published_at,
+                });
+            }
+        }
+
+        return articles;
+    } else {
+        return null;
+    }
+}


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例


```routes
/jiqizhixin/index
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
这个一次性只能抓10篇文章，后面看看基于 `Puppeteer` 的方案，应该能抓更多。
![image](https://github.com/user-attachments/assets/260751c0-16e2-4cc7-85c0-682f9f2853b0)

“解析全文”功能可用：
![image](https://github.com/user-attachments/assets/4b184aab-e913-464b-a093-17affbe956ad)
