### PR TITLE
fix(bilibili): fix `-352` error by mocking new required parameters

### DIFF
--- a/lib/routes/bilibili/dynamic.ts
+++ b/lib/routes/bilibili/dynamic.ts
@@ -232,14 +232,8 @@ async function handler(ctx) {
 
     const cookie = await cacheIn.getCookie();
 
-    const response = await got({
-        method: 'get',
-        url: `https://api.bilibili.com/x/polymer/web-dynamic/v1/feed/space`,
-        searchParams: {
-            host_mid: uid,
-            platform: 'web',
-            features: 'itemOpusStyle,listOnlyfans,opusBigCover,onlyfansVote',
-        },
+    const params = utils.addDmVerifyInfo(`host_mid=${uid}&platform=web&features=itemOpusStyle,listOnlyfans,opusBigCover,onlyfansVote`, utils.getDmImgList());
+    const response = await got(`https://api.bilibili.com/x/polymer/web-dynamic/v1/feed/space?${params}`, {
         headers: {
             Referer: `https://space.bilibili.com/${uid}/`,
             Cookie: cookie,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

None

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bilibili/user/dynamic/672328094/disableEmbed=1
/bilibili/user/dynamic/1437582453/disableEmbed=1
/bilibili/user/dynamic/8047632
```

## Note / 说明

Since 2024-09-04 20:09 (UTC+8), the bilibili dynamic API `https://api.bilibili.com/x/polymer/web-dynamic/v1/feed/space` suddenly keeps returning `{ "code": -352, "message": "-352", "ttl": 1 }` in my personal project.

After investigation, the browser sends requests with more parameters attached, where `dm_img_list`, `dm_img_str`, `dm_cover_img_str` become required, and they all seem to be fingerprints for tracking purposes.

Reference from the blog: [浅度剖析B站的新 -352 风控策略](https://im.salty.fish/index.php/archives/revengr-bilibili-352.html)

- `dm_img_list`: JSON object, probably mouse activities.
- `dm_img_str`: Base64 encoded string, WebGL version, most users have the same value `"V2ViR0wgMS"`, decoded to "WebGL 1".
- `dm_cover_img_str`: Base64 encoded string, WebGL renderer, contains information about user's graphic card, values vary.

None of them validate the values, as long as those parameters are present that's enough. The fix is copied from https://github.com/SpriteOvO/closely/commit/ddbc9eea8ed7f099911c578358c29624978e7867.