### PR TITLE
feat(route/bilibili): add getRenderData to bypass the risk control mechanism

### DIFF
--- a/lib/routes/bilibili/utils.ts
+++ b/lib/routes/bilibili/utils.ts
@@ -66,6 +66,10 @@ function hexsign(e) {
     return o;
 }
 
+function addRenderData(params, renderData) {
+    return `${params}&w_webid=${encodeURIComponent(renderData)}`;
+}
+
 function addWbiVerifyInfo(params, wbiVerifyString) {
     const searchParams = new URLSearchParams(params);
     searchParams.sort();
@@ -122,4 +126,5 @@ export default {
     getDmImgList,
     addDmVerifyInfo,
     bvidTime,
+    addRenderData,
 };

--- a/lib/routes/bilibili/video.ts
+++ b/lib/routes/bilibili/video.ts
@@ -35,6 +35,7 @@ async function handler(ctx) {
     const cookie = await cache.getCookie();
     const wbiVerifyString = await cache.getWbiVerifyString();
     const dmImgList = utils.getDmImgList();
+    const renderData = await cache.getRenderData(uid);
     const [name, face] = await cache.getUsernameAndFaceFromUID(uid);
 
     // await got(`https://space.bilibili.com/${uid}/video?tid=0&page=1&keyword=&order=pubdate`, {
@@ -43,7 +44,7 @@ async function handler(ctx) {
     //         Cookie: cookie,
     //     },
     // });
-    const params = utils.addWbiVerifyInfo(utils.addDmVerifyInfo(`mid=${uid}&ps=30&tid=0&pn=1&keyword=&order=pubdate&platform=web&web_location=1550101&order_avoided=true`, dmImgList), wbiVerifyString);
+    const params = utils.addWbiVerifyInfo(utils.addRenderData(utils.addDmVerifyInfo(`mid=${uid}&ps=30&tid=0&pn=1&keyword=&order=pubdate&platform=web&web_location=1550101&order_avoided=true`, dmImgList), renderData), wbiVerifyString);
     const response = await got(`https://api.bilibili.com/x/space/wbi/arc/search?${params}`, {
         headers: {
             Referer: `https://space.bilibili.com/${uid}/video?tid=0&page=1&keyword=&order=pubdate`,


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #16717

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bilibili/user/video/14583962
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
