### PR TITLE
feat(route): 添加北京邮电大学教务处通知公告的路由

### DIFF
--- a/lib/routes/bupt/jwctzgg.ts
+++ b/lib/routes/bupt/jwctzgg.ts
@@ -1,0 +1,97 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import timezone from '@/utils/timezone';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/jwctzgg',
+    categories: ['university'],
+    example: '/bupt/jwctzgg',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['jwc.bupt.edu.cn/'],
+        },
+    ],
+    name: '教务处通知公告',
+    maintainers: ['Yoruet'],
+    handler,
+    url: 'https://jwc.bupt.edu.cn/',
+};
+
+async function handler() {
+    const rootUrl = 'https://jwc.bupt.edu.cn';
+    const currentUrl = `${rootUrl}/tzgg1.htm`; // 更改为教务处通知公告页面
+
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+    });
+
+    const $ = load(response.data);
+
+    const list = $('.txt-elise')
+        .map((_, item) => {
+            item = $(item);
+            return {
+                title: item.children().first().text(),
+                link: `${rootUrl}/${item.children().first().attr('href')}`,
+            };
+        })
+        .get();
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const detailResponse = await got({
+                    method: 'get',
+                    url: item.link,
+                });
+
+                const content = load(detailResponse.data);
+
+                // 选择包含新闻内容的元素
+                const newsContent = content('.v_news_content');
+
+                // 移除不必要的标签，比如 <p> 和 <span> 中无用的内容
+                newsContent.find('p, span, strong').each(function () {
+                    const element = content(this);
+                    const text = element.text().trim();
+
+                    // 删除没有有用文本的元素，防止空元素被保留
+                    if (text === '') {
+                        element.remove();
+                    } else {
+                        // 去除多余的嵌套标签，但保留其内容
+                        element.replaceWith(text);
+                    }
+                });
+
+                // 清理后的内容转换为文本
+                const cleanedDescription = newsContent.text().trim();
+
+                // 提取并格式化发布时间
+                item.description = cleanedDescription;
+                item.pubDate = timezone(parseDate(content('.info').text().replace('发布时间：', '').trim()), +8);
+
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: $('title').text(),
+        link: currentUrl,
+        item: items,
+    };
+}


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```route
/bupt/jwctzgg
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
- [ ] Follows [[Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [[路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [ ] Full text / 全文获取
- [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [[Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)](https://docs.rsshub.app/joinus/advanced/pub-date) / [[日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [ ] Parsed / 可以解析
- [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明