### PR TITLE
feat(route): add feed for ESPN News

### DIFF
--- a/lib/routes/espn/namespace.ts
+++ b/lib/routes/espn/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'ESPN',
+    url: 'espn.com',
+};

--- a/lib/routes/espn/news.ts
+++ b/lib/routes/espn/news.ts
@@ -6,7 +6,7 @@ export const route: Route = {
     path: '/news/:sport',
     name: 'News',
     maintainers: ['GymRat102'],
-    example: '/news/nba',
+    example: '/espn/news/nba',
     categories: ['traditional-media'],
     parameters: { sport: 'sport category, can be nba, nfl, mlb, nhl etc.' },
     description: `Get the news feed of the sport you love on ESPN.
@@ -42,11 +42,9 @@ export const route: Route = {
                 const itemType = itemDetail.type;
 
                 return {
-                    // distinguish among normal news/stories, videos and shortstops
-                    title: itemType === 'Media' ? `[Video] ${itemDetail.headline}` : itemType === 'Shortstop' ? `[Shortstop] ${itemDetail.headline}` : itemDetail.headline,
+                    title: itemDetail.headline,
                     link: itemDetail.links.web.href,
-                    author: itemType === 'Media' ? '' : itemDetail.byline,
-                    guid: item.id,
+                    author: itemDetail.byline,
                     pubDate: item.date,
                     // for videos and shortstops, no need to extract full text below
                     description: itemType === 'Media' ? itemDetail.description : itemType === 'Shortstop' ? itemDetail.headline : '',
@@ -64,11 +62,9 @@ export const route: Route = {
                         });
 
                         item.description = article.content.story;
-
-                        return item;
-                    } else {
-                        return item;
                     }
+
+                    return item;
                 })
             )
         );

--- a/lib/routes/espn/news.ts
+++ b/lib/routes/espn/news.ts
@@ -1,0 +1,80 @@
+import { Route } from '@/types';
+import { load } from 'cheerio';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import Parser from 'rss-parser';
+
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+import 'dayjs/locale/en';
+dayjs.locale('en');
+dayjs.extend(timezone);
+dayjs.extend(utc);
+
+const parser = new Parser();
+
+export const route: Route = {
+    path: '/news/:sport',
+    name: 'ESPN News Archive',
+    maintainers: ['GymRat102'],
+    example: '/news/nba',
+    categories: ['traditional-media'],
+    parameters: { sport: 'sport category, can be nba, nfl, mlb, nhl etc.' },
+    description: `Get the news feed of the sport you love on ESPN.
+| Sport                |  sport  |  Sport         |  sport  |
+|----------------------|---------|----------------|---------|
+| 🏀NBA                | nba     | 🎾Tennis       | tennis  |
+| 🏀WNBA               | wnba    | ⛳️Golf         | golf    |
+| 🏈NFL                | nfl     | 🏏Cricket      | cricket |
+| ⚾️MLB                | mlb     | 🏍️Motorsports  | rpm     |
+| 🏒NHL                | nhl     | 🏎️F1           | f1      |
+| ⛹️College Basketball | nhl     | 🥊MMA          | mma     |
+| 🏟️️College Football   | nhl     | 🏈UFL          | uffl    |
+| 📆NCAA               | ncaa    | 🏉Rugby        | rugby   |
+| 📆NCAA Woman         | ncaaw   | 🃏Poker        | poker   |
+| ⚽️Soccer             | soccer  |                |         |`,
+    radar: [
+        {
+            source: ['espn.com/:sport*'],
+            target: '/news/:sport',
+        },
+    ],
+    handler: async (ctx) => {
+        const { sport = 'nba' } = ctx.req.param();
+        const response = await ofetch(`https://www.espn.com/espn/rss/${sport}/news`);
+        const feed = await parser.parseString(response);
+
+        const list = feed.items.map((item) => ({
+            title: item.title ?? '',
+            link: item.link ?? '',
+            author: item.creator,
+            guid: item.guid,
+        }));
+
+        const items = await Promise.all(
+            list.map((item) =>
+                cache.tryGet(item.link, async () => {
+                    const response = await ofetch(item.link);
+                    const $ = load(response);
+
+                    const rawPubDate = $('.article-meta span.timestamp').text().replace(' ET', '');
+                    item.pubDate = dayjs.tz(rawPubDate, 'MMM D, YYYY, HH:mm A', 'America/New_York');
+
+                    item.description = $('.article-body:first p:not(aside p), .article-body:first aside.inline-photo')
+                        .map((i, el) => $(el).html())
+                        .toArray()
+                        .join('<br/><br/>');
+
+                    return item;
+                })
+            )
+        );
+
+        return {
+            title: `ESPN ${sport.toUpperCase()} News`,
+            link: `https://www.espn.com/espn/rss/${sport}/news`,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/espn/news.ts
+++ b/lib/routes/espn/news.ts
@@ -34,21 +34,24 @@ export const route: Route = {
             },
         });
 
-        const list = response.feed.map((item) => {
-            const itemDetail = item.data.now[0];
-            const itemType = itemDetail.type;
+        const handledTypes = new Set(['HeadlineNews', 'Story', 'Media', 'Shortstop']);
+        const list = response.feed
+            .filter((item) => handledTypes.has(item.data.now[0].type))
+            .map((item) => {
+                const itemDetail = item.data.now[0];
+                const itemType = itemDetail.type;
 
-            return {
-                // distinguish among normal news/stories, videos and shortstops
-                title: itemType === 'Media' ? `[Video] ${itemDetail.headline}` : itemType === 'Shortstop' ? `[Shortstop] ${itemDetail.headline}` : itemDetail.headline,
-                link: itemDetail.links.web.href,
-                author: itemType === 'Media' ? '' : itemDetail.byline,
-                guid: item.id,
-                pubDate: item.date,
-                // for videos and shortstops, no need to extract full text below
-                description: itemType === 'Media' ? itemDetail.description : itemType === 'Shortstop' ? itemDetail.headline : '',
-            };
-        });
+                return {
+                    // distinguish among normal news/stories, videos and shortstops
+                    title: itemType === 'Media' ? `[Video] ${itemDetail.headline}` : itemType === 'Shortstop' ? `[Shortstop] ${itemDetail.headline}` : itemDetail.headline,
+                    link: itemDetail.links.web.href,
+                    author: itemType === 'Media' ? '' : itemDetail.byline,
+                    guid: item.id,
+                    pubDate: item.date,
+                    // for videos and shortstops, no need to extract full text below
+                    description: itemType === 'Media' ? itemDetail.description : itemType === 'Shortstop' ? itemDetail.headline : '',
+                };
+            });
 
         const items = await Promise.all(
             list.map((item) =>

--- a/lib/routes/espn/news.ts
+++ b/lib/routes/espn/news.ts
@@ -95,7 +95,11 @@ export const route: Route = {
                                 const mediaType = ele.name.match(mediaPattern)[1] === 'photo' ? 'images' : 'video';
                                 const mediaIndex = Number.parseInt(ele.name.match(mediaPattern)[2]) - 1;
                                 const media = article.content[mediaType][mediaIndex];
-                                $(ele).replaceWith(renderMedia(media));
+                                if (media) {
+                                    $(ele).replaceWith(renderMedia(media));
+                                } else {
+                                    $(ele).remove();
+                                }
                             }
                         });
 

--- a/lib/routes/espn/templates/media.art
+++ b/lib/routes/espn/templates/media.art
@@ -1,0 +1,19 @@
+{{ if video.src }}
+    <video controls preload="metadata" width="100%" height="auto" cover="{{ video.cover }}">
+        <source src="{{ video.src }}" type="video/mp4">
+    </video>
+    {{ if video.title || video.description }}
+        <div>
+            {{ if video.title }}<div><b>{{ video.title }}</b></div>{{ /if }}
+            {{ if video.description }}<p>{{ video.description }}</p>{{ /if }}
+        </div>
+    {{ /if }}
+{{ /if }}
+
+{{ if image.src }}
+<figure>
+    <img src="{{ image.src }}" alt="{{ image.alt }}">
+    {{ if image.caption }}<figcaption>{{ image.caption }}</figcaption>{{ /if }}
+    {{ if image.credit }}<cite>{{ image.credit }}</cite>{{ /if }}
+</figure>
+{{ /if }}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/espn/news/nba
/espn/news/tennis
/espn/news/wnba
/espn/news/golf
/espn/news/nfl
/espn/news/cricket
/espn/news/mlb
/espn/news/soccer
/espn/news/f1
/espn/news/nhl
/espn/news/ncb
/espn/news/mma
/espn/news/ncf
/espn/news/ufl
/espn/news/rugby
/espn/news/poker
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

