### PR TITLE
feat(route): 添加Lofter的合集获取功能

### DIFF
--- a/lib/routes/lofter/collection.ts
+++ b/lib/routes/lofter/collection.ts
@@ -65,8 +65,8 @@ async function handler(ctx) {
 
     return {
         title: `${response.data.response.collection.name} | LOFTER`,
-        link: `${items[0].link}`,
+        link: String(items[0].link),
         item: items,
-        description:  `${response.data.response.collection.description}`,
+        description: String(response.data.response.collection.description),
     };
 }

--- a/lib/routes/lofter/collection.ts
+++ b/lib/routes/lofter/collection.ts
@@ -20,7 +20,6 @@ export const route: Route = {
     name: 'Collection',
     maintainers: ['SrakhiuMeow'],
     handler,
-    description: ``,
 };
 
 async function fetchCollection(collectionID, limit, offset = 0, items = []) {
@@ -36,7 +35,7 @@ async function fetchCollection(collectionID, limit, offset = 0, items = []) {
         }),
     });
 
-    if (!response.data.response || response.data.response.items.length === 0) {
+    if (!response.data.response) {
         throw new Error('Collection Not Found');
     }
 
@@ -77,11 +76,11 @@ async function handler(ctx) {
                     if (photo.raw?.match(/\/\/nos\.netease\.com\//)) {
                         photo.raw = `https://${photo.raw.match(/(imglf\d)/)[0]}.lf127.net${photo.raw.match(/\/\/nos\.netease\.com\/imglf\d(.*)/)[1]}`;
                     }
-                    return `<img src="${photo.raw || photo.orign}">`;
+                    return `<img src='${photo.raw || photo.orign}'>`;
                 })
                 .join('') +
             JSON.parse(item.post.embed ? `[${item.post.embed}]` : `[]`)
-                .map((video) => `<video src="${video.originUrl}" poster="${video.video_img_url}" controls="controls"></video>`)
+                .map((video) => `<video src='${video.originUrl}' poster='${video.video_img_url}' controls='controls'></video>`)
                 .join('') +
             item.post.content,
         pubDate: parseDate(item.post.publishTime),

--- a/lib/routes/lofter/collection.ts
+++ b/lib/routes/lofter/collection.ts
@@ -1,0 +1,73 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+
+
+export const route: Route = {
+    path: '/collection/:collectionID',
+    categories: ['social-media'],
+    example: '/lofter/collection/collectionID',
+    parameters: { collectionID: 'Lofter collection ID, can be found in the share URL'},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Collection',
+    maintainers: ['SrakhiuMeow'],
+    handler,
+    description: ``,
+};
+
+// 在lofter/user.ts 的基础上修改而成
+async function handler(ctx) {
+    const collectionID = ctx.req.param('collectionID');
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : '50';
+
+
+    const response = await got({
+        method: 'post',
+        url: `https://api.lofter.com/v1.1/postCollection.api?product=lofter-android-7.6.12`,
+        body: new URLSearchParams({
+            collectionid: collectionID,
+            limit: limit.toString(),
+            method: 'getCollectionDetail',
+            offset: '0',
+        }),
+    });
+
+    if (!response.data.response || response.data.response.items.length === 0) {
+        throw new Error('Collection Not Found');
+    }
+
+    const items = response.data.response.items.map((item) => ({
+        title: item.post.title,
+        link: item.post.blogPageUr,
+        description:
+            JSON.parse(item.post.photoLinks || `[]`)
+                .map((photo) => {
+                    if (photo.raw?.match(/\/\/nos\.netease\.com\//)) {
+                        photo.raw = `https://${photo.raw.match(/(imglf\d)/)[0]}.lf127.net${photo.raw.match(/\/\/nos\.netease\.com\/imglf\d(.*)/)[1]}`;
+                    }
+                    return `<img src="${photo.raw || photo.orign}">`;
+                })
+                .join('') +
+            JSON.parse(item.post.embed ? `[${item.post.embed}]` : `[]`)
+                .map((video) => `<video src="${video.originUrl}" poster="${video.video_img_url}" controls="controls"></video>`)
+                .join('') +
+            item.post.content,
+        pubDate: parseDate(item.post.publishTime),
+        author: item.post.blogInfo.blogNickName,
+        category: item.post.tag.split(','),
+    }));
+
+    return {
+        title: `${response.data.response.collection.name} | LOFTER`,
+        link: `${items[0].link}`,
+        item: items,
+        description:  `${response.data.response.collection.description}`,
+    };
+}

--- a/lib/routes/lofter/collection.ts
+++ b/lib/routes/lofter/collection.ts
@@ -22,7 +22,7 @@ export const route: Route = {
     handler,
 };
 
-async function fetchCollection(collectionID, limit, offset = 0, items = []) {
+async function fetchCollection(collectionID, limit, offset = 0) {
     const response = await got({
         method: 'post',
         url: 'https://api.lofter.com/v1.1/postCollection.api?product=lofter-android-7.6.12',
@@ -39,13 +39,13 @@ async function fetchCollection(collectionID, limit, offset = 0, items = []) {
         throw new Error('Collection Not Found');
     }
 
-    const newItems = [...items, ...response.data.response.items];
+    const data = response.data.response;
 
     return {
-        title: response.data.response.collection.name || 'Lofter Collection',
-        link: response.data.response.blogInfo.homePageUrl || 'https://www.lofter.com/',
-        description: response.data.response.collection.description || 'No description provided.',
-        items: newItems,
+        title: data.collection.name || 'Lofter Collection',
+        link: data.blogInfo.homePageUrl || 'https://www.lofter.com/',
+        description: data.collection.description || 'No description provided.',
+        items: data.items,
     } as object;
 }
 
@@ -58,8 +58,8 @@ async function handler(ctx) {
     const { title, link, description, items } = response;
 
     const itemsArray = items.map((item) => ({
-        title: item.post.title,
-        link: item.post.blogPageUr,
+        title: item.post.title || item.post.noticeLinkTitle,
+        link: item.post.blogPageUrl,
         description:
             JSON.parse(item.post.photoLinks || `[]`)
                 .map((photo) => {

--- a/lib/routes/lofter/collection.ts
+++ b/lib/routes/lofter/collection.ts
@@ -7,7 +7,6 @@ import { parseDate } from '@/utils/parse-date';
 export const route: Route = {
     path: '/collection/:collectionID',
     categories: ['social-media'],
-    example: '/lofter/collection/collectionID',
     parameters: { collectionID: 'Lofter collection ID, can be found in the share URL' },
     features: {
         requireConfig: false,
@@ -25,7 +24,7 @@ export const route: Route = {
 async function fetchCollection(collectionID, limit, offset = 0, items = []) {
     const response = await got({
         method: 'post',
-        url: `https://api.lofter.com/v1.1/postCollection.api?product=lofter-android-7.6.12`,
+        url: 'https://api.lofter.com/v1.1/postCollection.api?product=lofter-android-7.6.12',
         body: new URLSearchParams({
             collectionid: collectionID,
             limit: limit.toString(),
@@ -85,8 +84,8 @@ async function handler(ctx) {
 
     return {
         title: `${title} | LOFTER`,
-        link: String(link),
+        link: link,
         item: itemsArray,
-        description: String(description),
+        description: description,
     };
 }

--- a/lib/routes/lofter/collection.ts
+++ b/lib/routes/lofter/collection.ts
@@ -22,7 +22,7 @@ export const route: Route = {
     handler,
 };
 
-async function fetchCollection(collectionID, limit, offset = 0, items = []) {
+async function fetchCollection(collectionID, limit, offset = 0, items: any[] = []) {
     const response = await got({
         method: 'post',
         url: `https://api.lofter.com/v1.1/postCollection.api?product=lofter-android-7.6.12`,
@@ -40,7 +40,7 @@ async function fetchCollection(collectionID, limit, offset = 0, items = []) {
     }
 
     const total = response.data.response.collection.postCount;
-    const newItems = items.concat(response.data.response.items);
+    const newItems = [...items, ...response.data.response.items];
 
     if (offset + limit < total) {
         return fetchCollection(collectionID, limit, offset + limit, newItems);

--- a/lib/routes/lofter/collection.ts
+++ b/lib/routes/lofter/collection.ts
@@ -22,7 +22,6 @@ export const route: Route = {
     description: ``,
 };
 
-// 在lofter/user.ts 的基础上修改而成
 async function handler(ctx) {
     const collectionID = ctx.req.param('collectionID');
     const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : '50';

--- a/lib/routes/lofter/collection.ts
+++ b/lib/routes/lofter/collection.ts
@@ -22,7 +22,7 @@ export const route: Route = {
     handler,
 };
 
-async function fetchCollection(collectionID, limit, offset = 0, items: any[] = []) {
+async function fetchCollection(collectionID, limit, offset = 0, items = []) {
     const response = await got({
         method: 'post',
         url: `https://api.lofter.com/v1.1/postCollection.api?product=lofter-android-7.6.12`,
@@ -50,7 +50,7 @@ async function fetchCollection(collectionID, limit, offset = 0, items: any[] = [
         title: response.data.response.collection.name || 'Lofter Collection',
         link: response.data.response.blogInfo.homePageUrl || 'https://www.lofter.com/',
         description: response.data.response.collection.description || 'No description provided.',
-        items: newItems || [],
+        items: newItems,
     } as object;
 }
 
@@ -60,12 +60,7 @@ async function handler(ctx) {
 
     const response = await cache.tryGet(collectionID, () => fetchCollection(collectionID, Number(limit)), config.cache.routeExpire, false);
 
-    const { title, link, description, items } = response as {
-        title: string;
-        link: string;
-        description: string;
-        items: any[];
-    };
+    const { title, link, description, items } = response;
 
     const itemsArray = items.map((item) => ({
         title: item.post.title,

--- a/lib/routes/lofter/collection.ts
+++ b/lib/routes/lofter/collection.ts
@@ -7,6 +7,7 @@ import { parseDate } from '@/utils/parse-date';
 export const route: Route = {
     path: '/collection/:collectionID',
     categories: ['social-media'],
+    example: '/lofter/collection/552041',
     parameters: { collectionID: 'Lofter collection ID, can be found in the share URL' },
     features: {
         requireConfig: false,
@@ -38,12 +39,7 @@ async function fetchCollection(collectionID, limit, offset = 0, items = []) {
         throw new Error('Collection Not Found');
     }
 
-    const total = response.data.response.collection.postCount;
     const newItems = [...items, ...response.data.response.items];
-
-    if (offset + limit < total) {
-        return fetchCollection(collectionID, limit, offset + limit, newItems);
-    }
 
     return {
         title: response.data.response.collection.name || 'Lofter Collection',
@@ -83,9 +79,9 @@ async function handler(ctx) {
     }));
 
     return {
-        title: `${title} | LOFTER`,
-        link: link,
+        title,
+        link,
         item: itemsArray,
-        description: description,
+        description,
     };
 }


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例


```routes
/lofter/collection/20460170
/lofter/collection/20763900
```


## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
通过合集ID(collectionID)，获取Lofter的合集内容；
首次提交PR，有问题请见谅；
根据/lofter/user修改得到。