### PR TITLE
fix: Tencent news can't fetch non-digital users

### DIFF
--- a/lib/routes/tencent/news/author.ts
+++ b/lib/routes/tencent/news/author.ts
@@ -35,7 +35,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const mid = ctx.req.param('mid');
-    const homePageInfoUrl = `https://i.news.qq.com/i/getUserHomepageInfo?chlid=${mid}`;
+    const homePageInfoUrl = `https://i.news.qq.com/i/getUserHomepageInfo?apptype=web&from_scene=103&isInGuest=1&guestSuid=${mid}`;
     const userInfo = await cache.tryGet(homePageInfoUrl, async () => (await got(homePageInfoUrl)).data.userinfo);
     const title = userInfo.nick;
     const description = userInfo.user_desc;


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/tencent/news/author/5933889
/tencent/news/author/8QMf2XpZ7oIVvzjR
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

原链接无法获取非纯数字用户信息

![image](https://github.com/user-attachments/assets/a8e770bb-2c81-44ef-8139-b5a8ed720105)

![image](https://github.com/user-attachments/assets/f5fb7e29-26b4-4d13-91ae-d6f27280f79e)

