### PR TITLE
fix: 部分Telegram频道的文章在inoreader中显示一个巨大的logo

### DIFF
--- a/lib/views/rss.tsx
+++ b/lib/views/rss.tsx
@@ -4,6 +4,7 @@ import { Data } from '@/types';
 const RSS: FC<{ data: Data }> = ({ data }) => {
     const hasItunes = data.itunes_author || data.itunes_category || (data.item && data.item.some((i) => i.itunes_item_image || i.itunes_duration));
     const hasMedia = data.item?.some((i) => i.media);
+    const isTelegramLink = data.link?.startsWith("https://t.me/s/");
 
     return (
         <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes={hasItunes ? 'http://www.itunes.com/dtds/podcast-1.0.dtd' : undefined} xmlns:media={hasMedia ? 'http://search.yahoo.com/mrss/' : undefined} version="2.0">
@@ -23,6 +24,12 @@ const RSS: FC<{ data: Data }> = ({ data }) => {
                         <url>{data.image}</url>
                         <title>{data.title || 'RSSHub'}</title>
                         <link>{data.link}</link>
+                        {isTelegramLink && (
+                            <>
+                                <height>31</height>
+                                <width>88</width>
+                            </>
+                        )}
                     </image>
                 )}
                 <lastBuildDate>{data.lastBuildDate}</lastBuildDate>


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #16747 

## Example for the Proposed Route(s) / 路由地址示例

```routes
/telegram/channel/tnews365
/telegram/channel/DNSPODT
/telegram/channel/xhqcankao
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

这个很难说是inoreader或者哪个客户端的问题，不同客户端对同一份rss有着不同的表现。
最简单的办法当然是直接把telegram频道的rss中的image去掉：
https://github.com/DIYgod/RSSHub/blob/de188c3aa8038086f28b5ce73a62a752651b4eeb/lib/routes/telegram/channel.ts#L206
但频道的logo有时候还是有点用的，于是搜了下网上的资料，这方面不太懂，欢迎指正。

https://github.com/DIYgod/RSSHub/blob/de188c3aa8038086f28b5ce73a62a752651b4eeb/lib/views/rss.tsx#L9
[Atom规约](https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.8)中的atom:logo起到一个banner的作用，同时Atom中还有一个atom:icon的元素起到favicon的作用。但[RSS 2.0 规范](https://cyber.harvard.edu/rss/rss.html#ltimagegtSubelementOfLtchannelgt)中，只有笼统的一个image元素，起到一个banner的作用。
image元素的可选子元素包含width和height，有默认值88、31，本项目中没加入这两个可选元素：
https://github.com/DIYgod/RSSHub/blob/de188c3aa8038086f28b5ce73a62a752651b4eeb/lib/views/rss.tsx#L21-L27

测试发现，当加上这两个可选子元素后，inoreader中的表现就正常了。

由于客户端各异，无法全面测试，为了不影响其他路由，只在telegram频道的rss中加入这两个可选元素。