### PR TITLE
feat(route/weibo): add option to filter retweeted posts

### DIFF
--- a/lib/routes/weibo/namespace.ts
+++ b/lib/routes/weibo/namespace.ts
@@ -30,6 +30,7 @@ export const namespace: Namespace = {
 | showEmojiInDescription     | 是否展示正文中的微博表情，关闭则替换为 \`[表情名]\`                  | 0/1/true/false | true                                |
 | showLinkIconInDescription  | 是否展示正文中的链接图标                                           | 0/1/true/false | true                                |
 | preferMobileLink           | 是否使用移动版链接（默认使用 PC 版）                               | 0/1/true/false | false                               |
+| showRetweeted              | 是否显示转发的微博                                                 | 0/1/true/false | true                               |
 
 指定更多与默认值不同的参数选项可以改善 RSS 的可读性，如
 

--- a/lib/routes/weibo/user.ts
+++ b/lib/routes/weibo/user.ts
@@ -47,6 +47,7 @@ async function handler(ctx) {
     let displayVideo = '1';
     let displayArticle = '0';
     let displayComments = '0';
+    let showRetweeted = '1';
     if (ctx.req.param('routeParams')) {
         if (ctx.req.param('routeParams') === '1' || ctx.req.param('routeParams') === '0') {
             displayVideo = ctx.req.param('routeParams');
@@ -55,6 +56,7 @@ async function handler(ctx) {
             displayVideo = fallback(undefined, queryToBoolean(routeParams.displayVideo), true) ? '1' : '0';
             displayArticle = fallback(undefined, queryToBoolean(routeParams.displayArticle), false) ? '1' : '0';
             displayComments = fallback(undefined, queryToBoolean(routeParams.displayComments), false) ? '1' : '0';
+            showRetweeted = fallback(undefined, queryToBoolean(routeParams.showRetweeted), false) ? '1' : '0';
         }
     }
     const containerData = await cache.tryGet(
@@ -102,7 +104,15 @@ async function handler(ctx) {
 
     let resultItems = await Promise.all(
         cards
-            .filter((item) => item.mblog)
+            .filter((item) => {
+                if (item.mblog === undefined) {
+                    return false;
+                }
+                if (showRetweeted === '0' && item.mblog.retweeted_status) {
+                    return false;
+                }
+                return true;
+            })
             .map(async (item) => {
                 // TODO: unify cache key and let weiboUtils.getShowData() handle the cache? It seems safe to do so.
                 //       Need more investigation, pending for now since the current version works fine.


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/weibo/user/1195230310
/weibo/user/1195230310/showRetweeted=0
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Introduce a new feature to filter retweeted posts in Weibo RSS feeds. 
Users can now choose whether to display retweeted Weibo posts by setting the `showRetweeted` parameter.
This parameter defaults to `true`, ensuring retweeted posts are shown unless explicitly disabled.

- Updated `namespace.ts` to include `showRetweeted` in the parameter options.
- Modified `user.ts` handler to respect the `showRetweeted` setting, filtering 
  out retweeted posts when set to `false`. 