### PR TITLE
fix(route/whu): Fix the failedness of whu route

### DIFF
--- a/lib/routes/whu/cs.ts
+++ b/lib/routes/whu/cs.ts
@@ -71,10 +71,16 @@ async function handler(ctx) {
             };
         });
 
-    const items = await Promise.all(
+    let items = await Promise.all(
         list.map((item) =>
             cache.tryGet(item.link, async () => {
-                const response = await got(item.link);
+                let response;
+                try {
+                    // 实测发现有些链接无法访问
+                    response = await got(item.link);
+                } catch {
+                    return null;
+                }
                 const $ = load(response.data);
 
                 if ($('.prompt').length) {
@@ -101,6 +107,7 @@ async function handler(ctx) {
             })
         )
     );
+    items = items.filter((item) => item !== null);
 
     return {
         title: $('title').first().text(),

--- a/lib/routes/whu/cs.ts
+++ b/lib/routes/whu/cs.ts
@@ -87,7 +87,8 @@ async function handler(ctx) {
                 content.find('img').each((_, e) => {
                     e = $(e);
                     if (e.attr('orisrc')) {
-                        e.attr('src', new URL(e.attr('orisrc'), response.url).href);
+                        const newUrl = new URL(e.attr('orisrc'), 'https://cs.whu.edu.cn');
+                        e.attr('src', newUrl.href);
                         e.removeAttr('orisrc');
                         e.removeAttr('vurl');
                     }

--- a/lib/routes/whu/gs/index.ts
+++ b/lib/routes/whu/gs/index.ts
@@ -46,7 +46,8 @@ export const route: Route = {
 
 async function handler(ctx) {
     const host = 'https://gs.whu.edu.cn/';
-    const type = (ctx.params && Number.parseInt(ctx.req.param('type'))) || 0;
+    const paremType = ctx.req.param('type');
+    const type = paremType ? Number.parseInt(paremType) : 0;
     const response = await got(host + gsIndexMap.get(type));
 
     const $ = load(response.data);

--- a/lib/routes/whu/news.ts
+++ b/lib/routes/whu/news.ts
@@ -1,11 +1,3 @@
-/*
- * Copyright (c) 2024 by frostime. All Rights Reserved.
- * @Author       : frostime
- * @Date         : 2024-09-19 21:26:26
- * @FilePath     : /lib/routes/whu/news.ts
- * @LastEditTime : 2024-09-20 01:28:07
- * @Description  :
- */
 import { Route } from '@/types';
 import { getCurrentPath } from '@/utils/helpers';
 const __dirname = getCurrentPath(import.meta.url);

--- a/lib/routes/whu/news.ts
+++ b/lib/routes/whu/news.ts
@@ -16,18 +16,18 @@ export const route: Route = {
     categories: ['university'],
     example: '/whu/news',
     parameters: { category: '新闻栏目，可选' },
-    name: '武汉大学新闻',
+    name: '新闻网',
     maintainers: [],
     handler,
     description: `
-    category 参数可选，范围如下:
+category 参数可选，范围如下:
 
-    | 新闻栏目 | 武大资讯 | 学术动态 | 珞珈影像 | 武大视频 |
-    | -------- | -------- | -------- | -------- | -------- |
-    | 参数     |  0 或 \`wdzx/wdyw\`  | 1 或 \`kydt\` | 2 或 \`stkj/ljyx\` | 3 或 \`stkj/wdsp\` |
+| 新闻栏目 | 武大资讯 | 学术动态 | 珞珈影像 | 武大视频 |
+| -------- | -------- | -------- | -------- | -------- |
+| 参数     |  0 或 \`wdzx/wdyw\`  | 1 或 \`kydt\` | 2 或 \`stkj/ljyx\` | 3 或 \`stkj/wdsp\` |
 
-    另外 route 后可以加上 \`?limit=n\` 的查询参数，表示只获取前 n 条新闻；如果不指定默认为 10。
-    `,
+此外 route 后可以加上 \`?limit=n\` 的查询参数，表示只获取前 n 条新闻；如果不指定默认为 10。
+`,
 };
 
 const parseCategory = (category: string | number) => {

--- a/lib/routes/whu/news.ts
+++ b/lib/routes/whu/news.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2024 by frostime. All Rights Reserved.
+ * @Author       : frostime
+ * @Date         : 2024-09-19 21:26:26
+ * @FilePath     : /lib/routes/whu/news.ts
+ * @LastEditTime : 2024-09-20 01:28:07
+ * @Description  :
+ */
 import { Route } from '@/types';
 import { getCurrentPath } from '@/utils/helpers';
 const __dirname = getCurrentPath(import.meta.url);
@@ -13,14 +21,39 @@ import { domain, processMeta, getMeta, processItems } from './util';
 
 export const route: Route = {
     path: '/news/:category{.+}?',
-    name: 'Unknown',
+    categories: ['university'],
+    example: '/whu/news',
+    parameters: { category: '新闻栏目，可选' },
+    name: '武汉大学新闻',
     maintainers: [],
     handler,
+    description: `
+    category 参数可选，范围如下:
+
+    | 新闻栏目 | 武大资讯 | 学术动态 | 珞珈影像 | 武大视频 |
+    | -------- | -------- | -------- | -------- | -------- |
+    | 参数     |  0 或 \`wdzx/wdyw\`  | 1 或 \`kydt\` | 2 或 \`stkj/ljyx\` | 3 或 \`stkj/wdsp\` |
+
+    另外 route 后可以加上 \`?limit=n\` 的查询参数，表示只获取前 n 条新闻；如果不指定默认为 10。
+    `,
+};
+
+const parseCategory = (category: string | number) => {
+    const outputs = ['wdzx/wdyw', 'kydt', 'stkj/ljyx', 'stkj/wdsp'];
+    if (['0', '1', '2', '3'].includes(category)) {
+        return outputs[category];
+    }
+    if (outputs.includes(category)) {
+        return category;
+    }
+    return 'wdzx/wdyw';
 };
 
 async function handler(ctx) {
-    const { category = 'wdzx/wdyw' } = ctx.req.param();
+    let { category } = ctx.req.param();
     const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 10;
+
+    category = parseCategory(category);
 
     const rootUrl = `https://news.${domain}`;
     const currentUrl = new URL(`${category}.htm`, rootUrl).href;


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

No related issue.

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/whu/news/0
/whu/news/1
/whu/news/2
/whu/news/3
/whu/cs/0
/whu/cs/1
/whu/cs/2
/whu/cs/3
/whu/gs/0
/whu/gs/1
/whu/gs/2
/whu/gs/3
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

本 PR 修复了/whu 路由下几个 RSS 的问题：

### 1. 修复了无法获取 `/whu/cs` 内容的问题

此前内部的爬虫解析程序编写有问题，在运行的时候会抛出异常，导致无法获取数据。

本 PR 修复了此 bug，并能正确获取数据。

效果对比如下：

![image](https://github.com/user-attachments/assets/33c80b66-f225-45e1-9afc-cc98e9e0adcc)


### 2. 修复了 `/whu/gs/` 的类型路由参数没有被正确解析的问题

此前 `/whu/gs/` 下的 category 参数无法被正常解析，会全部定向到类别 0。

![image](https://github.com/user-attachments/assets/e6807455-2cbb-44c9-b275-08e6bb7e4c47)

修复之后，能够正确定位到指定的类别下。

![image](https://github.com/user-attachments/assets/5d79265a-0071-43c5-b425-e406bfdb17ee)
 

### 3. 优化了 `/whu/news`

- 为路由添加了说明文档等
- 并增加了基于数字符号的用法（原始用法需要输入复杂的字符串），新方案兼容旧方案，但是更加易用

![image](https://github.com/user-attachments/assets/6f5214c2-b815-4e03-8bb2-3ba9389b2d02)


