### PR TITLE
fix(route/dockerhub): hash images

### DIFF
--- a/lib/routes/dockerhub/utils.ts
+++ b/lib/routes/dockerhub/utils.ts
@@ -2,9 +2,10 @@ import md5 from '@/utils/md5';
 
 function hash(images) {
     const entries = Object.entries(images)
-        .map((x) => [`${x[1].os}/${x[1].architecture}`, x[1].digest])
-        .sort((a, b) => a[0] - b[0]);
-    return md5(entries.map((x) => x.join(',')).join('|'));
+        .map((x) => `${x[1].os}/${x[1].architecture},${x[1].digest}`)
+        .sort((a, b) => a.localeCompare(b));
+    const text = entries.join('|');
+    return md5(text);
 }
 
 export { hash };


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/dockerhub/build/library/node
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

```json5
// images input
[
  {
    "architecture": "amd64",
    "features": "",
    "variant": null,
    "digest": "sha256:f729d1a1b8afd4df4a78f27c27ca7d32361ea333ff0affd09daef0bf6ded2650",
    "os": "linux",
    "os_features": "",
    "os_version": null,
    "size": 404143176,
    "status": "active",
    "last_pulled": "2024-09-20T14:42:20.24159Z",
    "last_pushed": "2024-09-18T03:39:41.751866Z"
  },
  {
    "architecture": "unknown",
    "features": "",
    "variant": null,
    "digest": "sha256:7df929747dd34b70808f781be322ebe6cff1716b3fae2ce4da4f1e8770e874cc",
    "os": "unknown",
    "os_features": "",
    "os_version": null,
    "size": 15734086,
    "status": "active",
    "last_pulled": "2024-09-20T14:42:54.112116Z",
    "last_pushed": "2024-09-18T03:39:41.8979Z"
  },
  {
    "architecture": "arm",
    "features": "",
    "variant": "v7",
    "digest": "sha256:7fd717569834bf28cd9b4a455b6ad7d0f7aa001be76c4568b412da1f6794b175",
    "os": "linux",
    "os_features": "",
    "os_version": null,
    "size": 352210289,
    "status": "active",
    "last_pulled": "2024-09-20T15:24:20.471495Z",
    "last_pushed": "2024-09-18T06:39:34.09621Z"
  },
  {
    "architecture": "unknown",
    "features": "",
    "variant": null,
    "digest": "sha256:4491b771713544c9dd7585c3e1613908db886c373084762faa10f5530c1dca58",
    "os": "unknown",
    "os_features": "",
    "os_version": null,
    "size": 15539114,
    "status": "active",
    "last_pulled": "2024-09-20T14:42:54.286826Z",
    "last_pushed": "2024-09-18T06:39:34.227593Z"
  },
  {
    "architecture": "arm64",
    "features": "",
    "variant": null,
    "digest": "sha256:15abbb0583becf156895ed3e969af0dbf0e462264b2320a26b3154a122b13798",
    "os": "linux",
    "os_features": "",
    "os_version": null,
    "size": 394788698,
    "status": "active",
    "last_pulled": "2024-09-20T15:31:04.289846Z",
    "last_pushed": "2024-09-18T03:39:42.076956Z"
  },
  {
    "architecture": "unknown",
    "features": "",
    "variant": null,
    "digest": "sha256:91c713470524a3e8c99180828237824efac8ded48a062cae1bdbd9ede94a0569",
    "os": "unknown",
    "os_features": "",
    "os_version": null,
    "size": 15763099,
    "status": "active",
    "last_pulled": "2024-09-20T14:42:54.501814Z",
    "last_pushed": "2024-09-18T03:39:42.222462Z"
  },
  {
    "architecture": "ppc64le",
    "features": "",
    "variant": null,
    "digest": "sha256:b2de42dbd738540742d453bb4c0bc2ac9c3151f5063416a45f4a736f50fd2bd3",
    "os": "linux",
    "os_features": "",
    "os_version": null,
    "size": 421196638,
    "status": "active",
    "last_pulled": "2024-09-20T14:42:54.588434Z",
    "last_pushed": "2024-09-18T03:39:42.413539Z"
  },
  {
    "architecture": "unknown",
    "features": "",
    "variant": null,
    "digest": "sha256:aa0919be243e6e5ca0109ec3aa04c49c42e0bd81409c5c94be47396a95a79c9b",
    "os": "unknown",
    "os_features": "",
    "os_version": null,
    "size": 15710722,
    "status": "active",
    "last_pulled": "2024-09-20T14:42:54.67989Z",
    "last_pushed": "2024-09-18T03:39:42.581652Z"
  },
  {
    "architecture": "s390x",
    "features": "",
    "variant": null,
    "digest": "sha256:e58fef0a373b819a6a5bbdf4c9cf13d2ec1afae6c3dedbb9174b072b8a9bd481",
    "os": "linux",
    "os_features": "",
    "os_version": null,
    "size": 373456073,
    "status": "active",
    "last_pulled": "2024-09-20T14:42:54.782144Z",
    "last_pushed": "2024-09-18T03:39:42.778455Z"
  },
  {
    "architecture": "unknown",
    "features": "",
    "variant": null,
    "digest": "sha256:c94ab81c17f7c3d28560fe4d8d3faa440e63752fcfc9fe92da63d9efe302f7c5",
    "os": "unknown",
    "os_features": "",
    "os_version": null,
    "size": 15547480,
    "status": "active",
    "last_pulled": "2024-09-20T14:29:21.220723Z",
    "last_pushed": "2024-09-18T03:39:42.91815Z"
  }
]
```

```text
// original

linux/amd64,sha256:f729d1a1b8afd4df4a78f27c27ca7d32361ea333ff0affd09daef0bf6ded2650|
unknown/unknown,sha256:7df929747dd34b70808f781be322ebe6cff1716b3fae2ce4da4f1e8770e874cc|
linux/arm,sha256:7fd717569834bf28cd9b4a455b6ad7d0f7aa001be76c4568b412da1f6794b175|
unknown/unknown,sha256:4491b771713544c9dd7585c3e1613908db886c373084762faa10f5530c1dca58|
linux/arm64,sha256:15abbb0583becf156895ed3e969af0dbf0e462264b2320a26b3154a122b13798|
unknown/unknown,sha256:91c713470524a3e8c99180828237824efac8ded48a062cae1bdbd9ede94a0569|
linux/ppc64le,sha256:b2de42dbd738540742d453bb4c0bc2ac9c3151f5063416a45f4a736f50fd2bd3|
unknown/unknown,sha256:aa0919be243e6e5ca0109ec3aa04c49c42e0bd81409c5c94be47396a95a79c9b|
linux/s390x,sha256:e58fef0a373b819a6a5bbdf4c9cf13d2ec1afae6c3dedbb9174b072b8a9bd481|
unknown/unknown,sha256:c94ab81c17f7c3d28560fe4d8d3faa440e63752fcfc9fe92da63d9efe302f7c5
```

```text
// fixed

linux/amd64,sha256:f729d1a1b8afd4df4a78f27c27ca7d32361ea333ff0affd09daef0bf6ded2650|
linux/arm,sha256:7fd717569834bf28cd9b4a455b6ad7d0f7aa001be76c4568b412da1f6794b175|
linux/arm64,sha256:15abbb0583becf156895ed3e969af0dbf0e462264b2320a26b3154a122b13798|
linux/ppc64le,sha256:b2de42dbd738540742d453bb4c0bc2ac9c3151f5063416a45f4a736f50fd2bd3|
linux/s390x,sha256:e58fef0a373b819a6a5bbdf4c9cf13d2ec1afae6c3dedbb9174b072b8a9bd481|
unknown/unknown,sha256:4491b771713544c9dd7585c3e1613908db886c373084762faa10f5530c1dca58|
unknown/unknown,sha256:7df929747dd34b70808f781be322ebe6cff1716b3fae2ce4da4f1e8770e874cc|
unknown/unknown,sha256:91c713470524a3e8c99180828237824efac8ded48a062cae1bdbd9ede94a0569|
unknown/unknown,sha256:aa0919be243e6e5ca0109ec3aa04c49c42e0bd81409c5c94be47396a95a79c9b|
unknown/unknown,sha256:c94ab81c17f7c3d28560fe4d8d3faa440e63752fcfc9fe92da63d9efe302f7c5
```
