### PR TITLE
fix(route): PornHub pornstar pages

### DIFF
--- a/lib/routes/pornhub/pornstar.ts
+++ b/lib/routes/pornhub/pornstar.ts
@@ -44,10 +44,21 @@ async function handler(ctx) {
 
     const { data: response } = await got(link, { headers });
     const $ = load(response);
-    const items = $('#pornstarsVideoSection .videoBox')
-        .toArray()
-        .map((e) => parseItems($(e)));
+    
 
+    if ($('.withBio').length == 0) {
+        const withoutbio_link = `https://${language}.pornhub.com/pornstar/${username}/videos?o=${sort}`;
+        const { data: response } = await got(withoutbio_link, { headers });
+        $withoutbio = load(response);
+        const items = $withoutbio('#mostRecentVideosSection .videoBox')
+            .toArray()
+            .map((e) => parseItems($(e)));
+    } else {
+        const items = $('#pornstarsVideoSection .videoBox')
+            .toArray()
+            .map((e) => parseItems($(e)));
+    }
+    
     return {
         title: $('h1').first().text(),
         description: $('section.aboutMeSection').text().trim(),

--- a/lib/routes/pornhub/pornstar.ts
+++ b/lib/routes/pornhub/pornstar.ts
@@ -46,7 +46,7 @@ async function handler(ctx) {
     let $ = load(response);
     let items;
 
-    if ($('.withBio').length == 0) {
+    if ($('.withBio').length === 0) {
         link = `https://${language}.pornhub.com/pornstar/${username}/videos?o=${sort}`;
         const { data: response } = await got(link, { headers });
         $ = load(response);

--- a/lib/routes/pornhub/pornstar.ts
+++ b/lib/routes/pornhub/pornstar.ts
@@ -37,28 +37,28 @@ export const route: Route = {
 
 async function handler(ctx) {
     const { language = 'www', username, sort = 'mr' } = ctx.req.param();
-    const link = `https://${language}.pornhub.com/pornstar/${username}?o=${sort}`;
+    let link = `https://${language}.pornhub.com/pornstar/${username}?o=${sort}`;
     if (!isValidHost(language)) {
         throw new InvalidParameterError('Invalid language');
     }
 
     const { data: response } = await got(link, { headers });
-    const $ = load(response);
-    
+    let $ = load(response);
+    let items;
 
     if ($('.withBio').length == 0) {
-        const withoutbio_link = `https://${language}.pornhub.com/pornstar/${username}/videos?o=${sort}`;
-        const { data: response } = await got(withoutbio_link, { headers });
-        $withoutbio = load(response);
-        const items = $withoutbio('#mostRecentVideosSection .videoBox')
+        link = `https://${language}.pornhub.com/pornstar/${username}/videos?o=${sort}`;
+        const { data: response } = await got(link, { headers });
+        $ = load(response);
+        items = $('#mostRecentVideosSection .videoBox')
             .toArray()
             .map((e) => parseItems($(e)));
     } else {
-        const items = $('#pornstarsVideoSection .videoBox')
+        items = $('#pornstarsVideoSection .videoBox')
             .toArray()
             .map((e) => parseItems($(e)));
     }
-    
+
     return {
         title: $('h1').first().text(),
         description: $('section.aboutMeSection').text().trim(),


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/pornhub/pornstar/natalie-lust
/pornhub/pornstar/hazel-moore
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fix issue introduced in https://github.com/DIYgod/RSSHub/pull/15616 to accommodate different types of pornstar pages

Page: https://www.pornhub.com/pornstar/natalie-lust
RSS: https://rsshub.app/pornhub/pornstar/natalie-lust

Page: https://www.pornhub.com/pornstar/hazel-moore
RSS: https://rsshub.app/pornhub/pornstar/hazel-moore