### PR TITLE
fix(route): fix bilibili followings-dynamic parse error

### DIFF
--- a/lib/routes/bilibili/followings-dynamic.ts
+++ b/lib/routes/bilibili/followings-dynamic.ts
@@ -110,7 +110,9 @@ async function handler(ctx) {
         data.map(async (item) => {
             const parsed = JSONbig.parse(item.card);
             const data = parsed.apiSeasonInfo || (getTitle(parsed.item) ? parsed.item : parsed);
-            const origin = parsed.origin ? JSONbig.parse(parsed.origin) : null;
+            // parsed.origin is already parsed, and it may be json or string.
+            // Don't parse it again, or it will cause an error.
+            const origin = parsed.origin || null;
 
             // img
             let imgHTML = '';


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #16912 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/bilibili/followings/dynamic/123456789
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Issue 中由于 parsed.origin 为 string 类型而解析失败，且之前在解析 parsed 时已经一并解析了 origin，于是删除二次解析的步骤，以下是解析成功的结果
```xml
<item>
<title>切片吃点好的 （约稿私企鹅</title>
<description>切片吃点好的 （约稿私企鹅</description>
<link>https://t.bilibili.com/980922770377408520</link>
<guid isPermaLink="false">https://t.bilibili.com/980922770377408520</guid>
<pubDate>Wed, 25 Sep 2024 01:21:20 GMT</pubDate>
<author>蒜蓉小龙虾Lesiry</author>
</item>
```