### PR TITLE
feat: route for 'The Sydney Morning Herald'

### DIFF
--- a/lib/routes/smh/author.ts
+++ b/lib/routes/smh/author.ts
@@ -1,0 +1,66 @@
+import { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+
+export const route: Route = {
+    path: '/by/:authorSlug',
+    categories: ['programming'],
+    example: '/smh/by/natassia-chrysanthos-h17jwj',
+    parameters: { authorSlug: 'Slug of the author profile URL' },
+    name: 'Articles by an author',
+    maintainers: ['yue-dongchen'],
+    handler: async (ctx) => {
+        const baseUrl = 'https://smh.com.au';
+        const { authorSlug = 'natassia-chrysanthos-h17jwj' } = ctx.req.param();
+        const link = `https://smh.com.au/by/${authorSlug}`;
+
+        const response = await ofetch(link);
+        const $ = load(response);
+        const items = $('div.X3yYQ')
+            .toArray()
+            .map((item) => {
+                const summaryBlock = $(item).find('div._2g9tm');
+                const image = $(item).find('img._1MQMh');
+
+                // Content extraction not possible due to paywall.
+                return {
+                    title: summaryBlock.find('[data-testid=article-link]').text(),
+                    description: summaryBlock.find('p._3b7W-').text(),
+                    pubDate: summaryBlock.find('time').attr('datetime'),
+                    image: image.attr('src'),
+                    link: baseUrl + summaryBlock.find('[data-testid=article-link]').attr('href'),
+                };
+            });
+
+        // Extract the headline, which is not within the scope of above selections.
+        const headline = $('div._15r1L');
+        const headlineSummaryBlock = headline.find('div._1YzQk');
+        const headlineTitle = headlineSummaryBlock.find('[data-testid=article-link]').text();
+        const headlineDescription = headlineSummaryBlock.find('p._3XEsE').text();
+        const headlineDate = (() => {
+            const value = headlineSummaryBlock.find('time').attr('datetime');
+            if (value === undefined) {
+                return;
+            }
+            return new Date(value);
+        })();
+        const headlineImage = headline.find('img._1MQMh').attr('src');
+
+        // Prepend the headline item to the array of items.
+        items.unshift({
+            title: headlineTitle,
+            description: headlineDescription,
+            pubDate: headlineDate,
+            image: headlineImage,
+            link: baseUrl + headlineSummaryBlock.find('[data-testid=article-link]').attr('href'),
+        });
+
+        const authorName = $('h2.s9igt').text();
+
+        return {
+            title: `Articles by ${authorName} (SMH)`,
+            link,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/smh/namespace.ts
+++ b/lib/routes/smh/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'The Sydney Morning Herald',
+    url: 'smh.com.au',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
smh/by/natassia-chrysanthos-h17jwj
smh/by/david-crowe-h0waa9
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
This is a route for articles by a specific author in _The Sydney Morning Herald_. No full-text extraction due to paywall.
