### PR TITLE
fix(route): bilibili vsearch

### DIFF
--- a/lib/routes/bilibili/vsearch.ts
+++ b/lib/routes/bilibili/vsearch.ts
@@ -83,7 +83,7 @@ async function handler(ctx) {
                     `Danmaku: ${item.video_review}    Comment: ${item.review}<br/>` +
                     `<br/>${des}<br/>` +
                     `<img src="${img}"><br/>` +
-                    `Match By: ${item.hit_columns.join(',')}` +
+                    `Match By: ${item.hit_columns?.join(',') || ''}` +
                     (disableEmbed ? '' : `<br><br>${utils.iframe(item.aid)}`),
                 pubDate: parseDate(item.pubdate, 'X'),
                 guid: item.arcurl,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bilibili/vsearch/摄影/totalrank/false/0
```

## Note / 说明

hit_columns 可能返回 null，这里需要新增一个判空