### PR TITLE
fix: duplicated items in ershcimi

### DIFF
--- a/lib/routes/wechat/ershcimi.ts
+++ b/lib/routes/wechat/ershcimi.ts
@@ -41,12 +41,14 @@ async function handler(ctx) {
                 pubDate: timezone(parseDate($item('.weui_media_extra_info').attr('title')), +8),
             };
         })
-        .get();
+        .toArray();
 
     return {
         title: `微信公众号 - ${$('span.name').text()}`,
         link: url,
         description: $('div.Profile-sideColumnItemValue').text(),
-        item: await Promise.all(items.map((item) => finishArticleItem(item).catch(() => item))),
+        item: await Promise.all(items.map((item) => finishArticleItem(item))).catch((error) => {
+            throw error;
+        }),
     };
 }


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #15753

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/wechat/ershicimi/KQP8gqQ7
```

## Note / 说明
ershicimi sometimes produces invalid url or url with extra params, like:
- https://mp.weixin.qq.com/mp/wappoc_appmsgcaptcha?poc_token=HCr69majRai...
- https://mp.weixin.qq.com/s?__biz=...&idx=1&sn=...&chksm=f2...&scene=0&xtrack=1#rd

In `lib/utils/wechat-mp.ts`'s `fetchArticle` method, the url will be normalized first, then being parsed. If the parse fails, simply let the client retry so that only normalized and valid urls will be returned.


