### PR TITLE
fix(route): change url in `/tvb/news`

### DIFF
--- a/lib/routes/tvb/news.ts
+++ b/lib/routes/tvb/news.ts
@@ -85,6 +85,7 @@ async function handler(ctx) {
     const language = ctx.req.param('language') ?? 'tc';
 
     const rootUrl = 'https://inews-api.tvb.com';
+    const linkRootUrl = 'https://news.tvb.com';
     const apiUrl = `${rootUrl}/news/entry/category`;
     const currentUrl = `${rootUrl}/${language}/${category}`;
 
@@ -102,7 +103,7 @@ async function handler(ctx) {
 
     const items = response.data.content.map((item) => ({
         title: item.title,
-        link: `${rootUrl}/${language}/${category}/${item.id}`,
+        link: `${linkRootUrl}/${language}/${category}/${item.id}`,
         pubDate: parseDate(item.publish_datetime),
         category: [...item.category.map((c) => c.title), ...item.tags],
         description: art(path.join(__dirname, 'templates/description.art'), {


### PR DESCRIPTION

## Involved Issue / 该 PR 相关 Issue

Open #17097 

## Example for the Proposed Route(s) / 路由地址示例

```routes
/tvb/news
```

## New RSS Route Checklist / 新 RSS 路由检查表
  

## Note / 说明
将原来的link里面的二级域名inews-api更换为news即可修正问题
