### PR TITLE
feat(route): add route for HFUT合肥工业大学通知公告

### DIFF
--- a/lib/routes/hfut/hf/notice.ts
+++ b/lib/routes/hfut/hf/notice.ts
@@ -1,0 +1,42 @@
+import { Route } from '@/types';
+import parseList from './utils';
+
+export const route: Route = {
+    path: '/hf/notice/:type?',
+    categories: ['university'],
+    example: '/hfut/hf/notice/tzgg',
+    parameters: { type: '分类，见下表（默认为 `tzgg`)' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['news.hfut.edu.cn'],
+        },
+    ],
+    name: '合肥工业大学',
+    maintainers: ['Flamma'],
+    handler,
+    description: `| 通知公告(https://news.hfut.edu.cn/tzgg2.htm) | 教学科研(https://news.hfut.edu.cn/tzgg2/jxky.htm) | 其他通知(https://news.hfut.edu.cn/tzgg2/qttz.htm) |
+  | ------------ | -------------- | ------------------ |
+  | tzgg         | jxky            | qttz              |`,
+};
+
+async function handler(ctx) {
+    // set default router type
+    const type = ctx.req.param('type') ?? 'tzgg';
+
+    const { link, title, resultList } = await parseList(ctx, type);
+
+    return {
+        title,
+        link,
+        description: '合肥工业大学 - 通知公告',
+        item: resultList,
+    };
+}

--- a/lib/routes/hfut/hf/utils.ts
+++ b/lib/routes/hfut/hf/utils.ts
@@ -1,0 +1,87 @@
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+const typeMap = {
+    tzgg: { name: 'tzgg', url: 'https://news.hfut.edu.cn/tzgg2.htm', root: 'https://news.hfut.edu.cn', title: '合肥工业大学 - 通知公告' },
+    jxky: { name: 'jxky', url: 'https://news.hfut.edu.cn/tzgg2.htm', root: 'https://news.hfut.edu.cn', title: '合肥工业大学 - 通知公告 - 教学科研' },
+    qttz: { name: 'qttz', url: 'https://news.hfut.edu.cn/tzgg2.htm', root: 'https://news.hfut.edu.cn', title: '合肥工业大学 - 通知公告 - 其它通知' },
+};
+
+const commLink = 'https://news.hfut.edu.cn/';
+
+const parseList = async (ctx, type) => {
+    const link = typeMap[type].url;
+    const title = typeMap[type].title;
+
+    const response = await got(link);
+    const $ = load(response.data);
+
+    const resultList = await parseArticle(typeMap[type].name, $);
+
+    return {
+        title,
+        link,
+        resultList,
+    };
+};
+
+async function parseArticle(type, $) {
+    let data = $('#tzz').find('li').toArray();
+
+    if (type === 'jxky') {
+        data = $('#c01').find('li').toArray();
+    } else if (type === 'qttz') {
+        data = $('#c02').find('li').toArray();
+    }
+
+    const items = data.map((item) => {
+        item = $(item);
+        const oriLink = item.find('a').attr('href');
+        let linkRes = oriLink;
+        if (!oriLink.includes('http')) {
+            linkRes = commLink + item.find('a').attr('href');
+        }
+        const pubDate = parseDate(item.find('i').text(), 'YYYY-MM-DD');
+
+        return {
+            title: item.find('p').text(),
+            pubDate,
+            link: linkRes,
+        };
+    });
+
+    const resultItems = await Promise.all(
+        items.map((item) =>
+            cache.tryGet(item.link, async () => {
+                let description;
+                try {
+                    const response = await got(item.link);
+                    const $ = load(response.data);
+                    description = $('.wp_articlecontent').html();
+
+                    if (description === null) {
+                        description = $('.v_news_content').html();
+                    }
+                    if (description === null) {
+                        description = item.link;
+                    }
+                } catch {
+                    description = item.link;
+                }
+
+                return {
+                    title: item.title,
+                    link: item.link,
+                    description,
+                    pubDate: item.pubDate,
+                };
+            })
+        )
+    );
+
+    return resultItems;
+}
+
+export default parseList;

--- a/lib/routes/hfut/namespace.ts
+++ b/lib/routes/hfut/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '合肥工业大学',
+    url: 'hfut.edu.cn',
+};

--- a/lib/routes/hfut/xc/notice.ts
+++ b/lib/routes/hfut/xc/notice.ts
@@ -1,0 +1,43 @@
+import { Route } from '@/types';
+import parseList from './utils';
+
+export const route: Route = {
+    path: '/xc/notice/:type?',
+    categories: ['university'],
+    example: '/hfut/xc/notice/tzgg',
+    parameters: { type: '分类，见下表（默认为 `tzgg`)' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportRadar: true,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['xc.hfut.edu.cn'],
+        },
+    ],
+    name: '合肥工业大学宣城校区',
+    maintainers: ['Flamma'],
+    handler,
+    description: `| 通知公告(https://xc.hfut.edu.cn/1955/list.htm) | 院系动态-工作通知(https://xc.hfut.edu.cn/gztz/list.htm) |
+  | ------------ | -------------- |
+  | tzgg         | gztz           |`,
+};
+
+async function handler(ctx) {
+    // set default router type
+    const type = ctx.req.param('type') ?? 'tzgg';
+
+    const { link, title, resultList } = await parseList(ctx, type);
+
+    return {
+        title,
+        link,
+        description: '合肥工业大学宣城校区 - 通知公告',
+        item: resultList,
+    };
+}

--- a/lib/routes/hfut/xc/utils.ts
+++ b/lib/routes/hfut/xc/utils.ts
@@ -1,0 +1,81 @@
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+const typeMap = {
+    tzgg: { name: 'tzgg', url: 'https://xc.hfut.edu.cn/1955/list.htm', root: 'https://xc.hfut.edu.cn', title: '合肥工业大学宣城校区 - 通知公告' },
+    gztz: { name: 'gztz', url: 'https://xc.hfut.edu.cn/gztz/list.htm', root: 'https://xc.hfut.edu.cn', title: '合肥工业大学宣城校区 - 院系动态 - 工作通知' },
+};
+
+const commLink = 'https://xc.hfut.edu.cn/';
+
+const parseList = async (ctx, type) => {
+    const link = typeMap[type].url;
+    const title = typeMap[type].title;
+
+    const response = await got(link);
+    const $ = load(response.data);
+
+    const resultList = await parseArticle(typeMap[type].name, $);
+
+    return {
+        title,
+        link,
+        resultList,
+    };
+};
+
+async function parseArticle(type, $) {
+    const data = $('#wp_news_w6').find('li').toArray();
+
+    const items = data.map((item) => {
+        item = $(item);
+        const oriLink = item.find('a').attr('href');
+        let linkRes = oriLink;
+        if (!oriLink.includes('http')) {
+            linkRes = commLink + item.find('a').attr('href');
+        }
+        const pubDate = parseDate(item.find('.news_meta').text(), 'YYYY-MM-DD');
+
+        return {
+            title: item.find('a').attr('title'),
+            pubDate,
+            link: linkRes,
+        };
+    });
+
+    const resultItems = await Promise.all(
+        items.map((item) =>
+            cache.tryGet(item.link, async () => {
+                let description;
+                try {
+                    const response = await got(item.link);
+                    const $ = load(response.data);
+                    description = $('.wp_articlecontent').html();
+
+                    if (description === null) {
+                        description = $('.v_news_content').html();
+                    }
+
+                    if (description === null) {
+                        description = item.link;
+                    }
+                } catch {
+                    description = item.link;
+                }
+
+                return {
+                    title: item.title,
+                    link: item.link,
+                    description,
+                    pubDate: item.pubDate,
+                };
+            })
+        )
+    );
+
+    return resultItems;
+}
+
+export default parseList;


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/hfut/hf/notice
/hfut/hf/notice/tzgg
/hfut/hf/notice/jxky
/hfut/hf/notice/qttz
/hfut/xc/notice
/hfut/xc/notice/tzgg
/hfut/xc/notice/gztz
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
新增HFUT合肥工业大学通知公告路由