### PR TITLE
fix(route/weibo): Solve the problem that Weibo Radar rules cannot be generated correctly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             REDIS_URL: "redis://redis:6379/"
             PUPPETEER_WS_ENDPOINT: "ws://browserless:3000" # marked
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:1200/healthz"]
+            test: ["CMD-SHELL", "curl -f http://localhost:1200/healthz?key=$$ACCESS_KEY"]
             interval: 30s
             timeout: 10s
             retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             REDIS_URL: "redis://redis:6379/"
             PUPPETEER_WS_ENDPOINT: "ws://browserless:3000" # marked
         healthcheck:
-            test: ["CMD-SHELL", "curl -f http://localhost:1200/healthz?key=$$ACCESS_KEY"]
+            test: ["CMD", "curl", "-f", "http://localhost:1200/healthz"]
             interval: 30s
             timeout: 10s
             retries: 3

--- a/lib/routes/weibo/user.ts
+++ b/lib/routes/weibo/user.ts
@@ -30,7 +30,15 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['m.weibo.cn/u/:uid', 'm.weibo.cn/profile/:uid', 'weibo.com/u/:uid', 'www.weibo.com/u/:uid'],
+            source: ['m.weibo.cn/u/:uid', 'm.weibo.cn/profile/:uid'],
+            target: '/user/:uid',
+        },
+        {
+            source: ['weibo.com/u/:uid'],
+            target: '/user/:uid',
+        },
+        {
+            source: ['www.weibo.com/u/:uid'],
             target: '/user/:uid',
         },
     ],


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #17090

## Example for the Proposed Route(s) / 路由地址示例

```routes
/weibo/user/1195230310
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

微博Radar规则优化，由于[Radar规则生成的逻辑](https://github.com/DIYgod/RSSHub/blob/2de569b4d2f0c83ffdd4334b04f51950481242e4/lib/api/radar/rules/all.ts#L15-L18)，source列表中的所有元素必须为相同的hostname才有效