### PR TITLE
feat(route): 新增 华南理工大学校团委通知公告 路由

### DIFF
--- a/lib/routes/scut/young/notice.ts
+++ b/lib/routes/scut/young/notice.ts
@@ -1,0 +1,63 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+
+export const route: Route = {
+    path: '/young/notice',
+    categories: ['university'],
+    example: '/scut/young/notice',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '校团委 - 通知公告',
+    maintainers: ['gdzhht'],
+    handler,
+    description: `:::warning
+由于学校网站对非大陆 IP 的访问存在限制，可能需自行部署。
+:::`,
+};
+
+async function handler() {
+    const baseUrl = 'https://www2.scut.edu.cn';
+    const url = 'https://www2.scut.edu.cn/youth/tzgg/list.htm';
+
+    const { data: response } = await got(url);
+    const $ = load(response);
+
+    const list = $('#wp_news_w3 ul li')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const a = item.find('li  a');
+            return {
+                title: item.find('li a .title span').text(),
+                link: a.attr('href')?.startsWith('http') ? a.attr('href') : `${baseUrl}${a.attr('href')}`,
+                pubDate: parseDate(item.find('li a .date').text(), 'YYYY-MM-DD'),
+            };
+        });
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const response = await ofetch(item.link);
+                const $ = load(response);
+                item.description = $('div.wp_articlecontent').html();
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: '共青团华南理工大学委员会 - 通知公告',
+        link: url,
+        item: items,
+    };
+}


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/scut/young/notice
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
