### PR TITLE
feat(route/nudt): Add more RSS source about yjszs

### DIFF
--- a/lib/routes/nudt/yjszs.ts
+++ b/lib/routes/nudt/yjszs.ts
@@ -5,21 +5,35 @@ import { parseDate } from '@/utils/parse-date';
 import InvalidParameterError from '@/errors/types/invalid-parameter';
 import timezone from '@/utils/timezone';
 
-/* 研究生院*/
+/* 研究生院 */
 const host = 'http://yjszs.nudt.edu.cn';
 
+// 目前研究生院最近仍在更新的链接
 const yjszs = new Map([
+    // http://yjszs.nudt.edu.cn/pubweb/homePageList/recruitStudents.view?keyId=2
     // http://yjszs.nudt.edu.cn//pubweb/homePageList/searchContent.view
-    ['tzgg', { title: '国防科技大学研究生院 - 通知公告', view: 'searchContent' }],
+    ['2', { title: '国防科技大学研究生院 - 通知公告' }],
+    // http://yjszs.nudt.edu.cn/pubweb/homePageList/recruitStudents.view?keyId=1
+    ['1', { title: '国防科技大学研究生院 - 首页' }],
+    // http://yjszs.nudt.edu.cn/pubweb/homePageList/recruitStudents.view?keyId=8
+    ['8', { title: '国防科技大学研究生院 - 招生简章' }],
+    // http://yjszs.nudt.edu.cn/pubweb/homePageList/recruitStudents.view?keyId=12
+    ['12', { title: '国防科技大学研究生院 - 学校政策' }],
     // http://yjszs.nudt.edu.cn//pubweb/homePageList/recruitStudents.view?keyId=16
-    ['sszs', { title: '国防科技大学研究生院 - 硕士招生', view: 'recruitStudents', keyId: '16' }],
+    ['16', { title: '国防科技大学研究生院 - 硕士招生' }],
+    // http://yjszs.nudt.edu.cn/pubweb/homePageList/recruitStudents.view?keyId=17
+    ['17', { title: '国防科技大学研究生院 - 博士招生' }],
+    // http://yjszs.nudt.edu.cn/pubweb/homePageList/recruitStudents.view?keyId=23
+    ['23', { title: '国防科技大学研究生院 - 院所发文' }],
+    // http://yjszs.nudt.edu.cn/pubweb/homePageList/recruitStudents.view?keyId=25
+    ['25', { title: '国防科技大学研究生院 - 数据统计' }],
 ]);
 
 export const route: Route = {
-    path: '/yjszs/:type?',
+    path: '/yjszs/:keyId?',
     categories: ['university'],
-    example: '/nudt/yjszs/sszs',
-    parameters: { type: '分类，见下表，默认为硕士招生' },
+    example: '/nudt/yjszs/2',
+    parameters: { keyId: '分类，见下表，默认为通知公告' },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -28,22 +42,28 @@ export const route: Route = {
         supportPodcast: false,
         supportScihub: false,
     },
+    radar: [
+        {
+            source: ['yjszs.nudt.edu.cn'],
+        },
+    ],
     name: '研究生院',
     maintainers: ['Blank0120'],
     handler,
     url: 'yjszs.nudt.edu.cn/',
-    description: `| 通知公告 | 硕士招生 |
-  | -------- | -------- |
-  | tzgg     | sszs     |`,
+    description: `| 通知公告 | 首页 | 招生简章 | 学校政策 | 硕士招生 | 博士招生 | 院所发文 | 数据统计 |
+  | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- |
+  | 2     | 1     | 8     | 12     | 16     | 17     | 23     | 25     |`,
 };
 
 async function handler(ctx) {
-    const type = ctx.req.param('type') ?? 'sszs';
-    const info = yjszs.get(type);
+    const keyId = ctx.req.param('keyId') ?? '2';
+    const info = yjszs.get(keyId);
     if (!info) {
-        throw new InvalidParameterError('invalid type');
+        throw new InvalidParameterError('invalid keyId');
     }
-    const link = `${host}/pubweb/homePageList/${info.view}.view?keyId=${info.keyId ?? ''}`;
+    let link = `${host}/pubweb/homePageList`;
+    link += keyId === '2' ? `/searchContent.view` : `/recruitStudents.view?keyId=${keyId}`;
     const response = await got({
         method: 'get',
         url: link,


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/nudt/yjszs
/nudt/yjszs/2
/nudt/yjszs/1
/nudt/yjszs/8
/nudt/yjszs/12
/nudt/yjszs/16
/nudt/yjszs/17
/nudt/yjszs/23
/nudt/yjszs/25
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
- 稍微修改了以前的路由参数
- 增加了国防科技大学研究生院更多的RSS源
- 增加了radar