### PR TITLE
feat(misskey): add withRenotes and mediaOnly options for user timeline

### DIFF
--- a/lib/routes/misskey/templates/note.art
+++ b/lib/routes/misskey/templates/note.art
@@ -1,3 +1,9 @@
+{{ if reply }}
+    <blockquote>
+        <p>{{ reply.text }}</p>
+    </blockquote>
+{{ /if }}
+
 {{ if text }}
     <p>{{ text.replace(/\n/g, '<br>') }}</p>
 {{ /if }}

--- a/lib/routes/misskey/types.ts
+++ b/lib/routes/misskey/types.ts
@@ -50,7 +50,7 @@ export interface MisskeyNote {
     renote?: MisskeyNote;
 }
 
-// https://github.com/misskey-dev/misskey/blob/d2e8dc4fe3c6e90e68001ed1f092d4e3d2454283/packages/backend/src/models/json-schema/user.ts#L728
+// https://github.com/misskey-dev/misskey/blob/d2e8dc4fe3c6e90e68001ed1f092d4e3d2454283/packages/backend/src/models/json-schema/user.ts
 interface MisskeyUser {
     id: string;
     name: string | null;

--- a/lib/routes/misskey/types.ts
+++ b/lib/routes/misskey/types.ts
@@ -1,0 +1,111 @@
+// https://github.com/misskey-dev/misskey/blob/d2e8dc4fe3c6e90e68001ed1f092d4e3d2454283/packages/backend/src/misc/json-schema.ts
+
+// https://github.com/misskey-dev/misskey/blob/d2e8dc4fe3c6e90e68001ed1f092d4e3d2454283/packages/backend/src/models/json-schema/note.ts
+export interface MisskeyNote {
+    id: string;
+    createdAt: string;
+    userId: string;
+    user: MisskeyUser;
+    text: string | null;
+    cw: string | null;
+    visibility: 'public' | 'home' | 'followers' | 'specified';
+    localOnly: boolean;
+    reactionAcceptance: string | null;
+    renoteCount: number;
+    repliesCount: number;
+    reactions: Record<string, number>;
+    reactionEmojis: Record<string, string>;
+    fileIds: string[];
+    files: MisskeyFile[];
+    replyId: string | null;
+    renoteId: string | null;
+    channelId: string | undefined;
+    channel?: {
+        id: string;
+        name: string;
+        color: string;
+        isSensitive: boolean;
+        allowRenoteToExternal: boolean;
+        userId: string | null;
+    };
+    mentions?: string[];
+    uri?: string;
+    url?: string;
+    reactionAndUserPairCache?: string[];
+    poll?: {
+        expiresAt: string | null;
+        multiple: boolean;
+        choices: {
+            text: string;
+            votes: number;
+            isVoted: boolean;
+        }[];
+    };
+    emojis?: Record<string, string>;
+    tags?: string[];
+    clippedCount?: number;
+    myReaction?: string | null;
+
+    reply?: MisskeyNote;
+    renote?: MisskeyNote;
+}
+
+// https://github.com/misskey-dev/misskey/blob/d2e8dc4fe3c6e90e68001ed1f092d4e3d2454283/packages/backend/src/models/json-schema/user.ts#L728
+interface MisskeyUser {
+    id: string;
+    name: string | null;
+    username: string;
+    host: string | null;
+    avatarUrl: string | null;
+    avatarBlurhash: string | null;
+    avatarDecorations: Array<{
+        id: string;
+        url: string;
+        angle?: number;
+        flipH?: boolean;
+        offsetX?: number;
+        offsetY?: number;
+    }>;
+    isBot?: boolean;
+    isCat?: boolean;
+    instance?: {
+        name: string | null;
+        softwareName: string | null;
+        softwareVersion: string | null;
+        iconUrl: string | null;
+        faviconUrl: string | null;
+        themeColor: string | null;
+    };
+    emojis: Record<string, string>;
+    onlineStatus: 'unknown' | 'online' | 'active' | 'offline';
+    badgeRoles?: Array<{
+        name: string;
+        iconUrl: string | null;
+        displayOrder: number;
+    }>;
+}
+
+// https://github.com/misskey-dev/misskey/blob/d2e8dc4fe3c6e90e68001ed1f092d4e3d2454283/packages/backend/src/models/json-schema/drive-file.ts
+interface MisskeyFile {
+    id: string;
+    createdAt: string;
+    name: string;
+    type: string;
+    md5: string;
+    size: number;
+    isSensitive: boolean;
+    blurhash: string | null;
+    properties: {
+        width?: number;
+        height?: number;
+        orientation?: number;
+        avgColor?: string;
+    };
+    url: string;
+    thumbnailUrl: string | null;
+    comment: string | null;
+    folderId: string | null;
+    folder?: unknown | null;
+    userId: string | null;
+    user?: MisskeyUser | null;
+}

--- a/lib/routes/misskey/user-timeline.ts
+++ b/lib/routes/misskey/user-timeline.ts
@@ -12,7 +12,7 @@ export const route: Route = {
     view: ViewType.SocialMedia,
     example: '/misskey/users/notes/support@misskey.io',
     parameters: {
-        username: 'Misskey username in the format of user@instance.domain',
+        username: 'Misskey username in the format of username@instance.domain',
         routeParams: `
     | Key         | Description                        | Accepted Values | Default |
     | ----------- | ---------------------------------- | --------------- | ------- |

--- a/lib/routes/misskey/user-timeline.ts
+++ b/lib/routes/misskey/user-timeline.ts
@@ -14,16 +14,16 @@ export const route: Route = {
     parameters: {
         username: 'Misskey username in the format of username@instance.domain',
         routeParams: `
-    | Key         | Description                        | Accepted Values | Default |
-    | ----------- | ---------------------------------- | --------------- | ------- |
-    | withRenotes | Include renotes in the timeline    | 0/1/true/false  | false   |
-    | mediaOnly   | Only return posts containing media | 0/1/true/false  | false   |
+| Key         | Description                        | Accepted Values | Default |
+| ----------- | ---------------------------------- | --------------- | ------- |
+| withRenotes | Include renotes in the timeline    | 0/1/true/false  | false   |
+| mediaOnly   | Only return posts containing media | 0/1/true/false  | false   |
 
-    Note: \`withRenotes\` and \`mediaOnly\` are mutually exclusive and cannot both be set to true.
+Note: \`withRenotes\` and \`mediaOnly\` are mutually exclusive and cannot both be set to true.
 
-    Examples:
-    • /misskey/users/notes/mttb2ccp@misskey.io/withRenotes=true
-    • /misskey/users/notes/mttb2ccp@misskey.io/mediaOnly=true`,
+Examples:
+- /misskey/users/notes/mttb2ccp@misskey.io/withRenotes=true
+- /misskey/users/notes/mttb2ccp@misskey.io/mediaOnly=true`,
     },
     features: {
         requireConfig: false,

--- a/lib/routes/misskey/user-timeline.ts
+++ b/lib/routes/misskey/user-timeline.ts
@@ -3,13 +3,28 @@ import utils from './utils';
 import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
 import InvalidParameterError from '@/errors/types/invalid-parameter';
+import { fallback, queryToBoolean } from '@/utils/readable-social';
+import querystring from 'querystring';
 
 export const route: Route = {
-    path: '/users/notes/:username',
+    path: '/users/notes/:username/:routeParams?',
     categories: ['social-media', 'popular'],
     view: ViewType.SocialMedia,
     example: '/misskey/users/notes/support@misskey.io',
-    parameters: { username: 'misskey username format, like support@misskey.io' },
+    parameters: {
+        username: 'Misskey username in the format of user@instance.domain',
+        routeParams: `
+    | Key         | Description                        | Accepted Values | Default |
+    | ----------- | ---------------------------------- | --------------- | ------- |
+    | withRenotes | Include renotes in the timeline    | 0/1/true/false  | false   |
+    | mediaOnly   | Only return posts containing media | 0/1/true/false  | false   |
+
+    Note: \`withRenotes\` and \`mediaOnly\` are mutually exclusive and cannot both be set to true.
+
+    Examples:
+    • /misskey/users/notes/mttb2ccp@misskey.io/withRenotes=true
+    • /misskey/users/notes/mttb2ccp@misskey.io/mediaOnly=true`,
+    },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -19,7 +34,7 @@ export const route: Route = {
         supportScihub: false,
     },
     name: 'User timeline',
-    maintainers: ['siygle'],
+    maintainers: ['siygle', 'SnowAgar25'],
     handler,
 };
 
@@ -33,7 +48,19 @@ async function handler(ctx) {
         throw new ConfigNotFoundError(`This RSS is disabled unless 'ALLOW_USER_SUPPLY_UNSAFE_DOMAIN' is set to 'true'.`);
     }
 
-    const { accountData } = await utils.getUserTimelineByUsername(pureUsername, site);
+    const routeParams = querystring.parse(ctx.req.param('routeParams'));
+    const withRenotes = fallback(undefined, queryToBoolean(routeParams.withRenotes), false);
+    const mediaOnly = fallback(undefined, queryToBoolean(routeParams.mediaOnly), false);
+
+    // Check for conflicting parameters
+    if (withRenotes && mediaOnly) {
+        throw new InvalidParameterError('withRenotes and mediaOnly cannot both be true.');
+    }
+
+    const { accountData } = await utils.getUserTimelineByUsername(pureUsername, site, {
+        withRenotes,
+        mediaOnly,
+    });
 
     return {
         title: `User timeline for ${username} on ${site}`,


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/misskey/users/notes/mttb2ccp@misskey.io
/misskey/users/notes/mttb2ccp@misskey.io/withRenotes=true
/misskey/users/notes/mttb2ccp@misskey.io/mediaOnly=true
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
- Add optional route parameters `withRenotes` and `mediaOnly`
- Update route documentation with new parameter descriptions and examples
- Modify `parseNotes` function to handle renotes