### PR TITLE
fix(route): douban status item link

### DIFF
--- a/lib/routes/douban/people/status.ts
+++ b/lib/routes/douban/people/status.ts
@@ -95,11 +95,6 @@ function tryFixStatus(status) {
         }
     }
 
-    // 接口提供的URL最后有分享追踪器，要删去，否则路由无法工作
-    if (status.sharing_url) {
-        status.sharing_url = status.sharing_url.split('?')[0];
-    }
-
     if (!result.isFixSuccess) {
         status.sharing_url = 'https://www.douban.com?rsshub_failed=' + now.getTime().toString();
         if (!status.create_time) {


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/douban/people/29449961/status
```

## Note / 说明

同步 #17224 的修改