### PR TITLE
feat(route): add route for 任天堂新闻

### DIFF
--- a/lib/routes/nintendo/news-hk.ts
+++ b/lib/routes/nintendo/news-hk.ts
@@ -1,0 +1,49 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import util from './utils';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/news/hk',
+    categories: ['game'],
+    example: '/nintendo/news/hk',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['nintendo.com.hk/topics', 'nintendo.com.hk/'],
+        },
+    ],
+    name: 'News（Hong Kong）',
+    maintainers: ['benzking'],
+    handler,
+    url: 'nintendo.com.hk/topics',
+};
+
+async function handler(ctx) {
+    const response = await got('https://www.nintendo.com.hk/api/top/topics_pickup');
+    const data = response.data.slice(0, ctx.req.query('limit') ? Number(ctx.req.query('limit')) : 30);
+
+    // 获取新闻正文
+    const result = await util.ProcessNews(data, cache);
+
+    return {
+        title: 'Nintendo（香港）主页资讯',
+        link: 'https://www.nintendo.com.hk/topics/',
+        description: 'Nintendo 香港有限公司官网刊登的资讯',
+        item: result.map((item) => ({
+            title: item.title,
+            description: item.content,
+            link: `https://www.nintendo.com.hk${item.url}`,
+            pubDate: parseDate(item.release_date, 'YYYY.MM.DD'),
+        })),
+    };
+}

--- a/lib/routes/nintendo/news-jp.ts
+++ b/lib/routes/nintendo/news-jp.ts
@@ -1,0 +1,49 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import util from './utils';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/news/jp',
+    categories: ['game'],
+    example: '/nintendo/news/jp',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['nintendo.com/jp'],
+        },
+    ],
+    name: 'News（Hong Kong）',
+    maintainers: ['benzking'],
+    handler,
+    url: 'nintendo.com/jp',
+};
+
+async function handler(ctx) {
+    const response = await got('https://www.nintendo.com/jp/topics/c/api/json_list?key=newtopics');
+    const data = response.data.slice(0, ctx.req.query('limit') ? Number(ctx.req.query('limit')) : 30);
+
+    // 获取新闻正文
+    const result = await util.ProcessNews(data, cache);
+
+    return {
+        title: 'Nintendo（日本）主页资讯',
+        link: 'https://www.nintendo.com/jp/topics',
+        description: 'Nintendo JP',
+        item: result.map((item) => ({
+            title: item.title,
+            description: item.content,
+            link: item.topic_url,
+            pubDate: parseDate(item.release_date, 'YYYY/MM/DD HH:mm:ss'), // "release_date": "2024/10/18 17:00:00"
+        })),
+    };
+}


### PR DESCRIPTION
* newly add 任天堂-香港 route
* newly add 任天堂-日本 route

---------

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/nintendo/news/jp
/nintendo/news/hk
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
