### PR TITLE
feat: HOTLINK_TEMPLATE environment variable applied to audio and video link

### DIFF
--- a/lib/middleware/anti-hotlink.ts
+++ b/lib/middleware/anti-hotlink.ts
@@ -117,6 +117,7 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
     // Force config hotlink template on conflict
     if (config.hotlink.template) {
         imageHotlinkTemplate = filterPath(ctx.req.path) ? config.hotlink.template : undefined;
+        multimediaHotlinkTemplate = filterPath(ctx.req.path) ? config.hotlink.template : undefined;
     }
 
     if (!imageHotlinkTemplate && !multimediaHotlinkTemplate) {


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #12841

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

将HOTLINK_TEMPLATE环境变量应用于音频和视频链接