### PR TITLE
fix(route/nodejs): Aready has official rss, and tweak selector of nod…

### DIFF
--- a/lib/routes/nodejs/blog.ts
+++ b/lib/routes/nodejs/blog.ts
@@ -25,7 +25,8 @@ export const route: Route = {
     name: 'News',
     maintainers: ['nczitzk'],
     handler,
-    description: `| العربية | Catalan | Deutsch | Español | زبان فارسی |
+    description: `Official RSS Source: https://nodejs.org/en/feed/blog.xml
+    | العربية | Catalan | Deutsch | Español | زبان فارسی |
   | ------- | ------- | ------- | ------- | ---------- |
   | ar      | ca      | de      | es      | fa         |
 
@@ -55,16 +56,22 @@ async function handler(ctx) {
 
     const $ = load(response.data);
 
-    $('.summary').remove();
-
-    let items = $('ul.blog-index li a')
+    let items = $('article')
         .toArray()
-        .map((item) => {
-            item = $(item);
+        .map((article) => {
+            const $article = load(article);
+
+            const author = $article('footer p').text();
+            const pubDate = parseDate($article('footer time').attr('datetime'));
+
+            const title = $article('a[aria-label]').prop('aria-label');
+            const href = $article('a[aria-label]').attr('href');
 
             return {
-                title: item.text(),
-                link: `${rootUrl}${item.attr('href')}`,
+                title,
+                link: `${rootUrl}${href}`,
+                author,
+                pubDate,
             };
         });
 
@@ -76,17 +83,9 @@ async function handler(ctx) {
                     url: item.link,
                 });
 
-                const content = load(detailResponse.data);
+                const $content = load(detailResponse.data);
 
-                item.pubDate = parseDate(content('time').attr('datetime'));
-                item.author = content('.blogpost-meta')
-                    .text()
-                    .match(/by (.*), /)?.[1];
-
-                content('.blogpost-header').remove();
-
-                item.description = content('article').html();
-
+                item.description = $content('main').html();
                 return item;
             })
         )


### PR DESCRIPTION
…ejs, but still has language error.

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/nodejs/blog/ar
/nodejs/blog/ca
/nodejs/blog/de
/nodejs/blog/es
/nodejs/blog/fa
/nodejs/blog/fr
/nodejs/blog/gl
/nodejs/blog/gl
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Nodejs的博客有官方的RSS源了，目前的RSS拉取不到blog，调整了选择器，拉取NodeJsBlog源。