### PR TITLE
fix: hko earthquake route pubDate issue fixing

### DIFF
--- a/lib/routes/hko/earthquake.ts
+++ b/lib/routes/hko/earthquake.ts
@@ -43,7 +43,7 @@ async function handler() {
             return {
                 title: `[震級:${degree}] [地點:${city}]`,
                 description: `${citystring}, ${latAndLon}`,
-                pubDate: timezone(parseDate(hktDate + hktTime, 'YYYYMMDDHHMM'), +8),
+                pubDate: timezone(parseDate(hktDate + hktTime, 'YYYYMMDDHHmm'), +8),
             };
         });
 


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

#17297 

## Example for the Proposed Route(s) / 路由地址示例

```routes
/hko/earthquake
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

修复issue #17297 问题，之前的parseDate方法中的格式参数使用错误了。
