### PR TITLE
feat(twitter): only display tweets that contains a media

### DIFF
--- a/lib/routes/twitter/home-latest.ts
+++ b/lib/routes/twitter/home-latest.ts
@@ -40,7 +40,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     // For compatibility
-    const { count, include_rts, only_medias } = utils.parseRouteParams(ctx.req.param('routeParams'));
+    const { count, include_rts, only_media } = utils.parseRouteParams(ctx.req.param('routeParams'));
     const params = count ? { count } : {};
 
     await api.init();
@@ -48,7 +48,7 @@ async function handler(ctx) {
     if (!include_rts) {
         data = utils.excludeRetweet(data);
     }
-    if (only_medias) {
+    if (only_media) {
         data = utils.keepOnlyMedia(data);
     }
 

--- a/lib/routes/twitter/home-latest.ts
+++ b/lib/routes/twitter/home-latest.ts
@@ -40,13 +40,16 @@ export const route: Route = {
 
 async function handler(ctx) {
     // For compatibility
-    const { count, include_rts } = utils.parseRouteParams(ctx.req.param('routeParams'));
+    const { count, include_rts, only_medias } = utils.parseRouteParams(ctx.req.param('routeParams'));
     const params = count ? { count } : {};
 
     await api.init();
     let data = await api.getHomeLatestTimeline('', params);
     if (!include_rts) {
         data = utils.excludeRetweet(data);
+    }
+    if (only_medias) {
+        data = utils.keepOnlyMedia(data);
     }
 
     return {

--- a/lib/routes/twitter/home.ts
+++ b/lib/routes/twitter/home.ts
@@ -40,13 +40,16 @@ export const route: Route = {
 
 async function handler(ctx) {
     // For compatibility
-    const { count, include_rts } = utils.parseRouteParams(ctx.req.param('routeParams'));
+    const { count, include_rts, only_medias } = utils.parseRouteParams(ctx.req.param('routeParams'));
     const params = count ? { count } : {};
 
     await api.init();
     let data = await api.getHomeTimeline('', params);
     if (!include_rts) {
         data = utils.excludeRetweet(data);
+    }
+    if (only_medias) {
+        data = utils.keepOnlyMedia(data);
     }
 
     return {

--- a/lib/routes/twitter/home.ts
+++ b/lib/routes/twitter/home.ts
@@ -40,7 +40,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     // For compatibility
-    const { count, include_rts, only_medias } = utils.parseRouteParams(ctx.req.param('routeParams'));
+    const { count, include_rts, only_media } = utils.parseRouteParams(ctx.req.param('routeParams'));
     const params = count ? { count } : {};
 
     await api.init();
@@ -48,7 +48,7 @@ async function handler(ctx) {
     if (!include_rts) {
         data = utils.excludeRetweet(data);
     }
-    if (only_medias) {
+    if (only_media) {
         data = utils.keepOnlyMedia(data);
     }
 

--- a/lib/routes/twitter/likes.ts
+++ b/lib/routes/twitter/likes.ts
@@ -27,7 +27,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const id = ctx.req.param('id');
-    const { count, include_rts, only_medias } = utils.parseRouteParams(ctx.req.param('routeParams'));
+    const { count, include_rts, only_media } = utils.parseRouteParams(ctx.req.param('routeParams'));
     const params = count ? { count } : {};
 
     await api.init();
@@ -35,7 +35,7 @@ async function handler(ctx) {
     if (!include_rts) {
         data = utils.excludeRetweet(data);
     }
-    if (only_medias) {
+    if (only_media) {
         data = utils.keepOnlyMedia(data);
     }
 

--- a/lib/routes/twitter/likes.ts
+++ b/lib/routes/twitter/likes.ts
@@ -27,13 +27,16 @@ export const route: Route = {
 
 async function handler(ctx) {
     const id = ctx.req.param('id');
-    const { count, include_rts } = utils.parseRouteParams(ctx.req.param('routeParams'));
+    const { count, include_rts, only_medias } = utils.parseRouteParams(ctx.req.param('routeParams'));
     const params = count ? { count } : {};
 
     await api.init();
     let data = await api.getUserLikes(id, params);
     if (!include_rts) {
         data = utils.excludeRetweet(data);
+    }
+    if (only_medias) {
+        data = utils.keepOnlyMedia(data);
     }
 
     return {

--- a/lib/routes/twitter/list.ts
+++ b/lib/routes/twitter/list.ts
@@ -33,7 +33,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const id = ctx.req.param('id');
-    const { count, include_rts, only_medias } = utils.parseRouteParams(ctx.req.param('routeParams'));
+    const { count, include_rts, only_media } = utils.parseRouteParams(ctx.req.param('routeParams'));
     const params = count ? { count } : {};
 
     await api.init();
@@ -41,7 +41,7 @@ async function handler(ctx) {
     if (!include_rts) {
         data = utils.excludeRetweet(data);
     }
-    if (only_medias) {
+    if (only_media) {
         data = utils.keepOnlyMedia(data);
     }
 

--- a/lib/routes/twitter/list.ts
+++ b/lib/routes/twitter/list.ts
@@ -33,13 +33,16 @@ export const route: Route = {
 
 async function handler(ctx) {
     const id = ctx.req.param('id');
-    const { count, include_rts } = utils.parseRouteParams(ctx.req.param('routeParams'));
+    const { count, include_rts, only_medias } = utils.parseRouteParams(ctx.req.param('routeParams'));
     const params = count ? { count } : {};
 
     await api.init();
     let data = await api.getList(id, params);
     if (!include_rts) {
         data = utils.excludeRetweet(data);
+    }
+    if (only_medias) {
+        data = utils.keepOnlyMedia(data);
     }
 
     return {

--- a/lib/routes/twitter/namespace.ts
+++ b/lib/routes/twitter/namespace.ts
@@ -27,6 +27,7 @@ export const namespace: Namespace = {
 | \`includeRts\`                   | Include retweets, only available in \`/twitter/user\`                                                                                  | \`0\`/\`1\`/\`true\`/\`false\` | \`true\`                                    |
 | \`forceWebApi\`                  | Force using Web API even if Developer API is configured, only available in \`/twitter/user\` and \`/twitter/keyword\`                    | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                                   |
 | \`count\`                        | \`count\` parameter passed to Twitter API, only available in \`/twitter/user\`                                                           | Unspecified/Integer    | Unspecified                               |
+| \`onlyMedias\`                   | Only get tweets with a media                                                                                                             | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                 |
 
 Specify different option values than default values to improve readability. The URL
 

--- a/lib/routes/twitter/namespace.ts
+++ b/lib/routes/twitter/namespace.ts
@@ -27,7 +27,7 @@ export const namespace: Namespace = {
 | \`includeRts\`                   | Include retweets, only available in \`/twitter/user\`                                                                                  | \`0\`/\`1\`/\`true\`/\`false\` | \`true\`                                    |
 | \`forceWebApi\`                  | Force using Web API even if Developer API is configured, only available in \`/twitter/user\` and \`/twitter/keyword\`                    | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                                   |
 | \`count\`                        | \`count\` parameter passed to Twitter API, only available in \`/twitter/user\`                                                           | Unspecified/Integer    | Unspecified                               |
-| \`onlyMedias\`                   | Only get tweets with a media                                                                                                             | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                 |
+| \`onlyMedia\`                    | Only get tweets with a media                                                                                                             | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                 |
 
 Specify different option values than default values to improve readability. The URL
 

--- a/lib/routes/twitter/utils.ts
+++ b/lib/routes/twitter/utils.ts
@@ -451,7 +451,7 @@ if (config.twitter.consumer_key && config.twitter.consumer_secret) {
 }
 
 const parseRouteParams = (routeParams) => {
-    let count, exclude_replies, include_rts, only_medias;
+    let count, exclude_replies, include_rts, only_media;
     let force_web_api = false;
     switch (routeParams) {
         case 'exclude_rts_replies':
@@ -479,10 +479,10 @@ const parseRouteParams = (routeParams) => {
             exclude_replies = fallback(undefined, queryToBoolean(parsed.get('excludeReplies')), false);
             include_rts = fallback(undefined, queryToBoolean(parsed.get('includeRts')), true);
             force_web_api = fallback(undefined, queryToBoolean(parsed.get('forceWebApi')), false);
-            only_medias = fallback(undefined, queryToBoolean(parsed.get('onlyMedias')), false);
+            only_media = fallback(undefined, queryToBoolean(parsed.get('onlyMedia')), false);
         }
     }
-    return { count, exclude_replies, include_rts, force_web_api, only_medias };
+    return { count, exclude_replies, include_rts, force_web_api, only_media };
 };
 
 export const excludeRetweet = function (tweets) {

--- a/lib/routes/twitter/utils.ts
+++ b/lib/routes/twitter/utils.ts
@@ -451,7 +451,7 @@ if (config.twitter.consumer_key && config.twitter.consumer_secret) {
 }
 
 const parseRouteParams = (routeParams) => {
-    let count, exclude_replies, include_rts;
+    let count, exclude_replies, include_rts, only_medias;
     let force_web_api = false;
     switch (routeParams) {
         case 'exclude_rts_replies':
@@ -479,9 +479,10 @@ const parseRouteParams = (routeParams) => {
             exclude_replies = fallback(undefined, queryToBoolean(parsed.get('excludeReplies')), false);
             include_rts = fallback(undefined, queryToBoolean(parsed.get('includeRts')), true);
             force_web_api = fallback(undefined, queryToBoolean(parsed.get('forceWebApi')), false);
+            only_medias = fallback(undefined, queryToBoolean(parsed.get('onlyMedias')), false);
         }
     }
-    return { count, exclude_replies, include_rts, force_web_api };
+    return { count, exclude_replies, include_rts, force_web_api, only_medias };
 };
 
 export const excludeRetweet = function (tweets) {
@@ -495,4 +496,15 @@ export const excludeRetweet = function (tweets) {
     return excluded;
 };
 
-export default { ProcessFeed, getAppClient, parseRouteParams, excludeRetweet };
+export const keepOnlyMedia = function (tweets) {
+    const excluded = [];
+    for (const t of tweets) {
+        if (!t.extended_entities || !t.extended_entities.media) {
+            continue;
+        }
+        excluded.push(t);
+    }
+    return excluded;
+};
+
+export default { ProcessFeed, getAppClient, parseRouteParams, excludeRetweet, keepOnlyMedia };

--- a/lib/routes/twitter/utils.ts
+++ b/lib/routes/twitter/utils.ts
@@ -497,13 +497,7 @@ export const excludeRetweet = function (tweets) {
 };
 
 export const keepOnlyMedia = function (tweets) {
-    const excluded = [];
-    for (const t of tweets) {
-        if (!t.extended_entities || !t.extended_entities.media) {
-            continue;
-        }
-        excluded.push(t);
-    }
+    const excluded = tweets.filter((t) => t.extended_entities && t.extended_entities.media);
     return excluded;
 };
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/twitter/home
/twitter/likes/DIYgod
/twitter/list/221172095
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Add an option to only display tweets that contains a media. Effectively this excludes "text only" tweets, but as the filtering itself is mroe "keep only medias" I prefered to name it that way. I don't know your preferences about it.

Didn't add this option to the `user` route as there is the `media` route that basically does the same.
Added info in the params table, though as it isn't added to every route I'm not too sure (though same params in that list are not on all routes anyways).
