### PR TITLE
fix(middleware): use URL pathname to maintain exact user access path …

### DIFF
--- a/lib/middleware/access-control.ts
+++ b/lib/middleware/access-control.ts
@@ -8,7 +8,7 @@ const reject = () => {
 };
 
 const middleware: MiddlewareHandler = async (ctx, next) => {
-    const requestPath = ctx.req.path;
+    const requestPath = new URL(ctx.req.url).pathname;
     const accessKey = ctx.req.query('key');
     const accessCode = ctx.req.query('code');
 


### PR DESCRIPTION
…for access control

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
The current implementation using `ctx.req.path` automatically decodes URL encoded content, which causes mismatch between the actual URL path and the path string used for generating access code.

For example:

User access path and expected path string for generating code:
`/dlsite/books/fsr/=/language/jp/sex_category%5B0%5D/male/work_category%5B0%5D/books/order%5B0%5D/release_d/genre%5B0%5D/118/genre_name%5B0%5D/%E3%83%AC%E3%82%BA%2F%E5%A5%B3%E5%90%8C%E5%A3%AB/options_and_or/and/options%5B0%5D/JPN/options%5B1%5D/NM/options_name%5B0%5D/%E6%97%A5%E6%9C%AC%E8%AA%9E%E4%BD%9C%E5%93%81/options_name%5B1%5D/%E8%A8%80%E8%AA%9E%E4%B8%8D%E5%95%8F%E4%BD%9C%E5%93%81/per_page/30/page/1/show_type/3/lang_options%5B0%5D/%E6%97%A5%E6%9C%AC%E8%AA%9E/lang_options%5B1%5D/%E8%A8%80%E8%AA%9E%E4%B8%8D%E8%A6%81`

Current generated path string for generating code:
`/dlsite/books/fsr/=/language/jp/sex_category[0]/male/work_category[0]/books/order[0]/release_d/genre[0]/118/genre_name[0]/レズ%2F女同士/options_and_or/and/options[0]/JPN/options[1]/NM/options_name[0]/日本語作品/options_name[1]/言語不問作品/per_page/30/page/1/show_type/3/lang_options[0]/日本語/lang_options[1]/言語不要`