### PR TITLE
feat(twitter): support LoginEnterAlternateIdentifierSubtask task and better login flow controll

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -298,6 +298,7 @@ export type Config = {
         username?: string[];
         password?: string[];
         authenticationSecret?: string[];
+        phoneOrEmail?: string[];
         authToken?: string[];
     };
     uestc: {
@@ -701,6 +702,7 @@ const calculateValue = () => {
             username: envs.TWITTER_USERNAME?.split(','),
             password: envs.TWITTER_PASSWORD?.split(','),
             authenticationSecret: envs.TWITTER_AUTHENTICATION_SECRET?.split(','),
+            phoneOrEmail: envs.TWITTER_PHONE_OR_EMAIL?.split(','),
             authToken: envs.TWITTER_AUTH_TOKEN?.split(','),
         },
         uestc: {

--- a/lib/routes/twitter/api/mobile-api/login.ts
+++ b/lib/routes/twitter/api/mobile-api/login.ts
@@ -10,6 +10,8 @@ import logger from '@/utils/logger';
 import cache from '@/utils/cache';
 import { RateLimiterMemory, RateLimiterRedis, RateLimiterQueue } from 'rate-limiter-flexible';
 
+const ENDPOINT = 'https://api.x.com/1.1/onboarding/task.json';
+
 const NAMESPACE = 'd41d092b-b007-48f7-9129-e9538d2d8fe9';
 
 let authentication = null;
@@ -41,12 +43,70 @@ const loginLimiter = cache.clients.redisClient
 
 const loginLimiterQueue = new RateLimiterQueue(loginLimiter);
 
-async function login({ username, password, authenticationSecret }) {
+const postTask = async (flowToken: string, subtaskId: string, subtaskInput: any) => {
+    const task = await got.post(ENDPOINT, {
+        headers,
+        json: {
+            flow_token: flowToken,
+            subtask_inputs: [Object.assign({ subtask_id: subtaskId }, subtaskInput)],
+        },
+    });
+    logger.debug(`Twitter login flow task finished: ${subtaskId}.`);
+    return task;
+};
+
+async function login({ username, password, authenticationSecret, phoneOrEmail }) {
     return (await cache.tryGet(
         `twitter:authentication:${username}`,
         async () => {
             try {
                 await loginLimiterQueue.removeTokens(1);
+
+                const flowTasks = {
+                    async LoginEnterUserIdentifier(flowToken: string) {
+                        return await postTask(flowToken, 'LoginEnterUserIdentifier', {
+                            enter_text: {
+                                suggestion_id: null,
+                                text: username,
+                                link: 'next_link',
+                            },
+                        });
+                    },
+                    async LoginEnterPassword(flowToken: string) {
+                        return await postTask(flowToken, 'LoginEnterPassword', {
+                            enter_password: {
+                                password,
+                                link: 'next_link',
+                            },
+                        });
+                    },
+                    async LoginEnterAlternateIdentifierSubtask(flowToken: string) {
+                        return await postTask(flowToken, 'LoginEnterAlternateIdentifierSubtask', {
+                            enter_text: {
+                                suggestion_id: null,
+                                text: phoneOrEmail,
+                                link: 'next_link',
+                            },
+                        });
+                    },
+                    async AccountDuplicationCheck(flowToken: string) {
+                        return await postTask(flowToken, 'AccountDuplicationCheck', {
+                            check_logged_in_account: {
+                                link: 'AccountDuplicationCheck_false',
+                            },
+                        });
+                    },
+                    async LoginTwoFactorAuthChallenge(flowToken: string) {
+                        const token = authenticator.generate(authenticationSecret);
+                        return await postTask(flowToken, 'LoginTwoFactorAuthChallenge', {
+                            enter_text: {
+                                suggestion_id: null,
+                                text: token,
+                                link: 'next_link',
+                            },
+                        });
+                    },
+                };
 
                 logger.debug('Twitter login start.');
                 const android_id = uuidv5(username, NAMESPACE);
@@ -61,12 +121,13 @@ async function login({ username, password, authenticationSecret }) {
                     },
                     method: 'POST',
                 });
-                logger.debug('Twitter login 1 finished: guest token.');
+                logger.debug('Twitter login guest token.');
 
                 headers['x-guest-token'] = guestToken.data.guest_token;
 
-                const task1 = await ofetch.raw(
-                    'https://api.x.com/1.1/onboarding/task.json?' +
+                let task: any = await ofetch.raw(
+                    ENDPOINT +
+                        '?' +
                         new URLSearchParams({
                             flow_name: 'login',
                             api_version: '1',
@@ -95,112 +156,41 @@ async function login({ username, password, authenticationSecret }) {
                         },
                     }
                 );
-                logger.debug('Twitter login 2 finished: login flow.');
+                logger.debug('Twitter login flow start.');
 
-                headers.att = task1.headers.get('att');
+                // @ts-ignore
+                headers.att = task.headers.get('att');
 
-                const task2 = await got.post('https://api.x.com/1.1/onboarding/task.json', {
-                    headers,
-                    json: {
-                        flow_token: task1._data.flow_token,
-                        subtask_inputs: [
-                            {
-                                enter_text: {
-                                    suggestion_id: null,
-                                    text: username,
-                                    link: 'next_link',
-                                },
-                                subtask_id: 'LoginEnterUserIdentifier',
-                            },
-                        ],
-                    },
-                });
-                logger.debug('Twitter login 3 finished: LoginEnterUserIdentifier.');
-
-                const task3 = await got.post('https://api.x.com/1.1/onboarding/task.json', {
-                    headers,
-                    json: {
-                        flow_token: task2.data.flow_token,
-                        subtask_inputs: [
-                            {
-                                enter_password: {
-                                    password,
-                                    link: 'next_link',
-                                },
-                                subtask_id: 'LoginEnterPassword',
-                            },
-                        ],
-                    },
-                });
-                logger.debug('Twitter login 4 finished: LoginEnterPassword.');
-                for (const subtask of task3.data?.subtasks || []) {
+                const runTask = async (subtaskId: string, flowToken: string) => {
+                    if (!(subtaskId in flowTasks)) {
+                        logger.error(`Twitter login flow failed: unknown subtask: ${subtaskId}`);
+                        return null;
+                    }
+                    task = await flowTasks[subtaskId](flowToken);
+                    const subtask = task.data.subtasks.shift();
                     if (subtask.open_account) {
+                        logger.debug('Twitter login success.');
                         return subtask.open_account;
                     }
-                }
+                    subtaskId = subtask.subtask_id;
+                    flowToken = task.data.flow_token;
+                    return await runTask(subtaskId, flowToken);
+                };
 
-                const task4 = await got.post('https://api.x.com/1.1/onboarding/task.json', {
-                    headers,
-                    json: {
-                        flow_token: task3.data.flow_token,
-                        subtask_inputs: [
-                            {
-                                check_logged_in_account: {
-                                    link: 'AccountDuplicationCheck_false',
-                                },
-                                subtask_id: 'AccountDuplicationCheck',
-                            },
-                        ],
-                    },
-                });
-                logger.debug('Twitter login 5 finished: AccountDuplicationCheck.');
+                const subtaskId = task._data.subtasks.shift().subtask_id;
+                const flowToken = task._data.flow_token;
+                authentication = await runTask(subtaskId, flowToken);
 
-                for await (const subtask of task4.data?.subtasks || []) {
-                    if (subtask.open_account) {
-                        authentication = subtask.open_account;
-                        break;
-                    } else if (authenticationSecret && subtask.subtask_id === 'LoginTwoFactorAuthChallenge') {
-                        const token = authenticator.generate(authenticationSecret);
-
-                        const task5 = await got.post('https://api.x.com/1.1/onboarding/task.json', {
-                            headers,
-                            json: {
-                                flow_token: task4.data.flow_token,
-                                subtask_inputs: [
-                                    {
-                                        enter_text: {
-                                            suggestion_id: null,
-                                            text: token,
-                                            link: 'next_link',
-                                        },
-                                        subtask_id: 'LoginTwoFactorAuthChallenge',
-                                    },
-                                ],
-                            },
-                        });
-                        logger.debug('Twitter login 6 finished: LoginTwoFactorAuthChallenge.');
-
-                        for (const subtask of task5.data?.subtasks || []) {
-                            if (subtask.open_account) {
-                                authentication = subtask.open_account;
-                                break;
-                            }
-                        }
-                        break;
-                    } else {
-                        logger.error(`Twitter login 6 failed: unknown subtask: ${subtask.subtask_id}`);
-                    }
-                }
                 if (authentication) {
-                    logger.debug('Twitter login success.');
+                    logger.debug('Twitter login success.', authentication);
                 } else {
-                    logger.error(`Twitter login failed. ${JSON.stringify(task4.data?.subtasks, null, 2)}`);
+                    logger.error(`Twitter login failed. ${JSON.stringify(task.data?.subtasks, null, 2)}`);
                 }
-
-                return authentication;
             } catch (error) {
                 logger.error(`Twitter username ${username} login failed:`, error);
             }
+
+            return authentication as unknown as string | Record<string, any>;
         },
         60 * 60 * 24 * 30, // 30 days
         false

--- a/lib/routes/twitter/api/mobile-api/login.ts
+++ b/lib/routes/twitter/api/mobile-api/login.ts
@@ -8,7 +8,7 @@ import { v5 as uuidv5 } from 'uuid';
 import { authenticator } from 'otplib';
 import logger from '@/utils/logger';
 import cache from '@/utils/cache';
-import { RateLimiterMemory, RateLimiterRedis, RateLimiterQueue } from 'rate-limiter-flexible';
+import { RateLimiterMemory, RateLimiterQueue, RateLimiterRedis } from 'rate-limiter-flexible';
 
 const ENDPOINT = 'https://api.x.com/1.1/onboarding/task.json';
 
@@ -41,16 +41,62 @@ const loginLimiter = cache.clients.redisClient
 
 const loginLimiterQueue = new RateLimiterQueue(loginLimiter);
 
-const postTask = async (flowToken: string, subtaskId: string, subtaskInput: Record<string, unknown>) => {
-    const task = await got.post(ENDPOINT, {
+const postTask = async (flowToken: string, subtaskId: string, subtaskInput: Record<string, unknown>) =>
+    await got.post(ENDPOINT, {
         headers,
         json: {
             flow_token: flowToken,
             subtask_inputs: [Object.assign({ subtask_id: subtaskId }, subtaskInput)],
         },
     });
-    logger.debug(`Twitter login flow task finished: ${subtaskId}.`);
-    return task;
+
+// In the Twitter login flow, each task successfully requested will respond with a 'subtask_id' to determine what the next task is, and the execution sequence of the tasks is non-fixed.
+// So abstract these tasks out into a map so that they can be dynamically executed during the login flow.
+// If there are missing tasks in the future, simply add the implementation of that task to it.
+const flowTasks = {
+    async LoginEnterUserIdentifier({ flowToken, username }) {
+        return await postTask(flowToken, 'LoginEnterUserIdentifier', {
+            enter_text: {
+                suggestion_id: null,
+                text: username,
+                link: 'next_link',
+            },
+        });
+    },
+    async LoginEnterPassword({ flowToken, password }) {
+        return await postTask(flowToken, 'LoginEnterPassword', {
+            enter_password: {
+                password,
+                link: 'next_link',
+            },
+        });
+    },
+    async LoginEnterAlternateIdentifierSubtask({ flowToken, phoneOrEmail }) {
+        return await postTask(flowToken, 'LoginEnterAlternateIdentifierSubtask', {
+            enter_text: {
+                suggestion_id: null,
+                text: phoneOrEmail,
+                link: 'next_link',
+            },
+        });
+    },
+    async AccountDuplicationCheck({ flowToken }) {
+        return await postTask(flowToken, 'AccountDuplicationCheck', {
+            check_logged_in_account: {
+                link: 'AccountDuplicationCheck_false',
+            },
+        });
+    },
+    async LoginTwoFactorAuthChallenge({ flowToken, authenticationSecret }) {
+        const token = authenticator.generate(authenticationSecret);
+        return await postTask(flowToken, 'LoginTwoFactorAuthChallenge', {
+            enter_text: {
+                suggestion_id: null,
+                text: token,
+                link: 'next_link',
+            },
+        });
+    },
 };
 
 async function login({ username, password, authenticationSecret, phoneOrEmail }) {
@@ -60,55 +106,9 @@ async function login({ username, password, authenticationSecret, phoneOrEmail })
             try {
                 await loginLimiterQueue.removeTokens(1);
 
-                const flowTasks = {
-                    async LoginEnterUserIdentifier(flowToken: string) {
-                        return await postTask(flowToken, 'LoginEnterUserIdentifier', {
-                            enter_text: {
-                                suggestion_id: null,
-                                text: username,
-                                link: 'next_link',
-                            },
-                        });
-                    },
-                    async LoginEnterPassword(flowToken: string) {
-                        return await postTask(flowToken, 'LoginEnterPassword', {
-                            enter_password: {
-                                password,
-                                link: 'next_link',
-                            },
-                        });
-                    },
-                    async LoginEnterAlternateIdentifierSubtask(flowToken: string) {
-                        return await postTask(flowToken, 'LoginEnterAlternateIdentifierSubtask', {
-                            enter_text: {
-                                suggestion_id: null,
-                                text: phoneOrEmail,
-                                link: 'next_link',
-                            },
-                        });
-                    },
-                    async AccountDuplicationCheck(flowToken: string) {
-                        return await postTask(flowToken, 'AccountDuplicationCheck', {
-                            check_logged_in_account: {
-                                link: 'AccountDuplicationCheck_false',
-                            },
-                        });
-                    },
-                    async LoginTwoFactorAuthChallenge(flowToken: string) {
-                        const token = authenticator.generate(authenticationSecret);
-                        return await postTask(flowToken, 'LoginTwoFactorAuthChallenge', {
-                            enter_text: {
-                                suggestion_id: null,
-                                text: token,
-                                link: 'next_link',
-                            },
-                        });
-                    },
-                };
-
                 logger.debug('Twitter login start.');
-                const android_id = uuidv5(username, NAMESPACE);
-                headers['X-Twitter-Client-DeviceID'] = android_id;
+
+                headers['X-Twitter-Client-DeviceID'] = uuidv5(username, NAMESPACE);
 
                 const ct0 = crypto.randomUUID().replaceAll('-', '');
                 const guestToken = await got(guestActivateUrl, {
@@ -119,7 +119,7 @@ async function login({ username, password, authenticationSecret, phoneOrEmail })
                     },
                     method: 'POST',
                 });
-                logger.debug('Twitter login guest token.');
+                logger.debug('Twitter login: guest token');
 
                 headers['x-guest-token'] = guestToken.data.guest_token;
 
@@ -155,34 +155,39 @@ async function login({ username, password, authenticationSecret, phoneOrEmail })
                             },
                         }
                     )
-                    .then(({ headers, _data }) => ({
-                        headers,
-                        data: _data,
-                    }));
+                    .then(({ headers, _data }) => {
+                        headers.att = headers.get('att');
+                        return { data: _data };
+                    });
+
                 logger.debug('Twitter login flow start.');
+                const runTask = async ({ data }) => {
+                    const { subtask_id, open_account } = data.subtasks.shift();
 
-                headers.att = task.headers.get('att');
+                    // If `open_account` exists (and 'subtask_id' is `LoginSuccessSubtask`), it means the login was successful.
+                    if (open_account) {
+                        return open_account;
+                    }
 
-                const runTask = async (subtaskId: string, flowToken: string) => {
-                    if (!(subtaskId in flowTasks)) {
-                        logger.error(`Twitter login flow failed: unknown subtask: ${subtaskId}`);
+                    // If task does not exist in `flowTasks`, we need to implement it.
+                    if (!(subtask_id in flowTasks)) {
+                        logger.error(`Twitter login flow task failed: unknown subtask: ${subtask_id}`);
                         return;
                     }
-                    task = await flowTasks[subtaskId](flowToken);
-                    const subtask = task.data.subtasks.shift();
-                    if (subtask.open_account) {
-                        logger.debug('Twitter login success.');
-                        return subtask.open_account;
-                    }
-                    subtaskId = subtask.subtask_id;
-                    flowToken = task.data.flow_token;
-                    return await runTask(subtaskId, flowToken);
+
+                    task = await flowTasks[subtask_id]({
+                        flowToken: data.flow_token,
+                        username,
+                        password,
+                        authenticationSecret,
+                        phoneOrEmail,
+                    });
+                    logger.debug(`Twitter login flow task finished: subtask: ${subtask_id}.`);
+
+                    return await runTask(task);
                 };
-
-                const subtaskId = task.data.subtasks.shift().subtask_id;
-                const flowToken = task.data.flow_token;
-
-                const authentication = await runTask(subtaskId, flowToken);
+                const authentication = await runTask(task);
+                logger.debug('Twitter login flow finished.');
 
                 if (authentication) {
                     logger.debug('Twitter login success.', authentication);

--- a/lib/routes/twitter/api/mobile-api/login.ts
+++ b/lib/routes/twitter/api/mobile-api/login.ts
@@ -155,8 +155,8 @@ async function login({ username, password, authenticationSecret, phoneOrEmail })
                             },
                         }
                     )
-                    .then(({ headers, _data }) => {
-                        headers.att = headers.get('att');
+                    .then(({ headers: _headers, _data }) => {
+                        headers.att = _headers.get('att');
                         return { data: _data };
                     });
 

--- a/lib/routes/twitter/api/mobile-api/token.ts
+++ b/lib/routes/twitter/api/mobile-api/token.ts
@@ -11,11 +11,13 @@ async function getToken() {
         const username = config.twitter.username[index];
         const password = config.twitter.password[index];
         const authenticationSecret = config.twitter.authenticationSecret?.[index];
+        const phoneOrEmail = config.twitter.phoneOrEmail?.[index];
         if (username && password) {
             const authentication = await login({
                 username,
                 password,
                 authenticationSecret,
+                phoneOrEmail,
             });
             if (!authentication) {
                 throw new ConfigNotFoundError(`Invalid twitter configs: ${username}`);


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/twitter/user/DIYgod
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Implement the `LoginEnterAlternateIdentifierSubtask` task and added an environment variable `TWITTER_PHONE_OR_EMAIL` for this purpose.
  增加对登录风控触发 `LoginEnterAlternateIdentifierSubtask` 时的处理，并为此增加了一个环境变量 `TWITTER_PHONE_OR_EMAIL`。
- Refactored the flow control of the login flow for easier maintenance.
  重写了登录的工作流。
