### PR TITLE
fix(route): 修复 bilibili 动态路由在部分情况下出现空图片的问题

### DIFF
--- a/lib/routes/bilibili/dynamic.ts
+++ b/lib/routes/bilibili/dynamic.ts
@@ -117,6 +117,7 @@ const getIframe = (data?: Modules, embed: boolean = true) => {
     if (aid === undefined && bvid === undefined) {
         return '';
     }
+    // 不通过 utils.renderUGCDescription 渲染 img/description 以兼容其他格式的动态
     return utils.renderUGCDescription(embed, '', '', aid, undefined, bvid);
 };
 
@@ -146,7 +147,10 @@ const getImgs = (data?: Modules) => {
     if (major[type]?.cover) {
         imgUrls.push(major[type].cover);
     }
-    return imgUrls.map((url) => `<img src="${url}">`).join('');
+    return imgUrls
+        .filter(Boolean)
+        .map((url) => `<img src="${url}">`)
+        .join('');
 };
 
 const getUrl = (item?: Item2, useAvid = false) => {
@@ -354,10 +358,9 @@ async function handler(ctx) {
                 // 换行处理
                 description = description.replaceAll('\r\n', '<br>').replaceAll('\n', '<br>');
                 originDescription = originDescription.replaceAll('\r\n', '<br>').replaceAll('\n', '<br>');
-
-                const descriptions = [description, originDescription, urlText, originUrlText, getIframe(data, embed), getIframe(origin, embed), getImgs(data), getImgs(origin)]
-                    .filter(Boolean)
+                const descriptions = [description, getIframe(data, embed), getImgs(data), urlText, originDescription, getIframe(origin, embed), getImgs(origin), originUrlText]
                     .map((e) => e?.trim())
+                    .filter(Boolean)
                     .join('<br>');
 
                 return {

--- a/lib/routes/bilibili/templates/description.art
+++ b/lib/routes/bilibili/templates/description.art
@@ -7,6 +7,8 @@
 {{ /if }}
 <br>
 {{ /if }}
+{{ if img}}
 <img src="{{ img }}">
 <br>
+{{ /if }}
 {{@ description }}


### PR DESCRIPTION
fix #17414

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #17414

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/bilibili/user/dynamic/25876945
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
