### PR TITLE
feat(route/nytimes): Add support for EN version

### DIFF
--- a/lib/routes/nytimes/rss.ts
+++ b/lib/routes/nytimes/rss.ts
@@ -11,7 +11,7 @@ export const route: Route = {
     example: '/nytimes/rss/HomePage',
     parameters: {
         cat: {
-            description: '',
+            description: "Category name, corresponding to the last segment of [official feed's](https://www.nytimes.com/rss) url.",
         },
     },
     features: {
@@ -32,7 +32,7 @@ export const route: Route = {
     maintainers: ['HenryQW', 'pseudoyu'],
     handler,
     url: 'nytimes.com/',
-    description: `By extracting the full text of articles, we provide a better reading experience (full text articles) over the official one.`,
+    description: `Enhance the official EN RSS feed`,
 };
 
 async function handler(ctx) {

--- a/lib/routes/nytimes/rss.ts
+++ b/lib/routes/nytimes/rss.ts
@@ -1,0 +1,57 @@
+import { Route, ViewType } from '@/types';
+import cache from '@/utils/cache';
+import parser from '@/utils/rss-parser';
+import { load } from 'cheerio';
+import ofetch from '@/utils/ofetch';
+
+export const route: Route = {
+    path: '/rss/:cat?',
+    categories: ['traditional-media', 'popular'],
+    view: ViewType.Articles,
+    example: '/nytimes/rss/HomePage',
+    parameters: {
+        cat: {
+            description: '',
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['nytimes.com/'],
+            target: '',
+        },
+    ],
+    name: 'News',
+    maintainers: ['HenryQW', 'pseudoyu'],
+    handler,
+    url: 'nytimes.com/',
+    description: `By extracting the full text of articles, we provide a better reading experience (full text articles) over the official one.`,
+};
+
+async function handler(ctx) {
+    const url = `https://rss.nytimes.com/services/xml/rss/nyt/${ctx.req.param('cat')}.xml`;
+
+    const rss = await parser.parseURL(url);
+
+    return {
+        ...rss,
+        item: await Promise.all(
+            rss.items.map((e) =>
+                cache.tryGet(e.link, async () => {
+                    const res = await ofetch(e.link, { headers: { 'User-Agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' }, referrer: 'https://www.google.com/' });
+
+                    const $ = load(res);
+
+                    return { ...e, description: $("[name='articleBody']").html() };
+                })
+            )
+        ),
+    };
+}

--- a/lib/routes/nytimes/rss.ts
+++ b/lib/routes/nytimes/rss.ts
@@ -29,7 +29,7 @@ export const route: Route = {
         },
     ],
     name: 'News',
-    maintainers: ['HenryQW', 'pseudoyu'],
+    maintainers: ['HenryQW', 'pseudoyu', 'dzx-dzx'],
     handler,
     url: 'nytimes.com/',
     description: `Enhance the official EN RSS feed`,


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/nytimes/HomePage
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
