### PR TITLE
feat: better error message display

### DIFF
--- a/lib/middleware/access-control.ts
+++ b/lib/middleware/access-control.ts
@@ -3,8 +3,8 @@ import { config } from '@/config';
 import md5 from '@/utils/md5';
 import RejectError from '@/errors/types/reject';
 
-const reject = () => {
-    throw new RejectError('Authentication failed. Access denied.');
+const reject = (requestPath) => {
+    throw new RejectError(`Authentication failed. Access denied.\n${requestPath}`);
 };
 
 const middleware: MiddlewareHandler = async (ctx, next) => {
@@ -16,7 +16,7 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
         await next();
     } else {
         if (config.accessKey && !(config.accessKey === accessKey || accessCode === md5(requestPath + config.accessKey))) {
-            return reject();
+            return reject(requestPath);
         }
         await next();
     }

--- a/lib/views/error.tsx
+++ b/lib/views/error.tsx
@@ -26,7 +26,7 @@ const Index: FC<{
                     <p className="message">
                         Error Message:
                         <br />
-                        <code className="mt-2 block max-h-28 overflow-auto bg-zinc-100 align-bottom w-fit details">{message}</code>
+                        <code className="mt-2 block max-h-28 overflow-auto bg-zinc-100 align-bottom w-fit details whitespace-pre-line">{message}</code>
                     </p>
                     <p className="message">
                         Route: <code className="ml-2 bg-zinc-100">{errorRoute}</code>


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
- Fix line breaks in error messages to display properly
- Show the actual request path that generated the code (access-control)

|  ENV | Before | After |
|-------------|--------|-------|
| Dev | ![Dev Before](https://github.com/user-attachments/assets/5b724aed-56c7-45f4-84a8-8d7670a72c5f) | ![Dev After](https://github.com/user-attachments/assets/ad89f74a-bc63-4aae-a294-d6f4f40b2db5) |
| Prod | ![Prod Before](https://github.com/user-attachments/assets/7a4ac75f-4aa4-4430-ae62-a2871282240a) | ![Prod After](https://github.com/user-attachments/assets/1cbf5369-aa1e-491e-a398-5bf76c1b45f4) |