### PR TITLE
feat(route): add LastOrigin日本官网公告

### DIFF
--- a/lib/routes/last-origin/namespace.ts
+++ b/lib/routes/last-origin/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'LastOrigin官网公告',
+    url: 'www.last-origin.com',
+    lang: 'ja',
+};

--- a/lib/routes/last-origin/namespace.ts
+++ b/lib/routes/last-origin/namespace.ts
@@ -1,7 +1,7 @@
 import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
-    name: 'LastOrigin官网公告',
+    name: 'LastOrigin',
     url: 'www.last-origin.com',
     lang: 'ja',
 };

--- a/lib/routes/last-origin/news.ts
+++ b/lib/routes/last-origin/news.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['www.last-origin.com'],
+            source: ['www.last-origin.com/news.html', 'www.last-origin.com'],
             target: '/news',
         },
     ],

--- a/lib/routes/last-origin/news.ts
+++ b/lib/routes/last-origin/news.ts
@@ -7,7 +7,7 @@ import timezone from '@/utils/timezone';
 
 export const route: Route = {
     path: '/news.html',
-    name: '公告',
+    name: 'News',
     url: 'www.last-origin.com',
     maintainers: ['gudezhi'],
     example: '/news.html',

--- a/lib/routes/last-origin/news.ts
+++ b/lib/routes/last-origin/news.ts
@@ -19,7 +19,7 @@ export const route: Route = {
     radar: [
         {
             source: ['www.last-origin.com'],
-            target: '/news.html',
+            target: '/news',
         },
     ],
     handler,

--- a/lib/routes/last-origin/news.ts
+++ b/lib/routes/last-origin/news.ts
@@ -10,7 +10,7 @@ export const route: Route = {
     name: 'News',
     url: 'www.last-origin.com',
     maintainers: ['gudezhi'],
-    example: '/news.html',
+    example: '/last-origin/news',
     parameters: {},
     categories: ['game'],
     features: {

--- a/lib/routes/last-origin/news.ts
+++ b/lib/routes/last-origin/news.ts
@@ -6,7 +6,7 @@ import { parseDate } from '@/utils/parse-date';
 import timezone from '@/utils/timezone';
 
 export const route: Route = {
-    path: '/news.html',
+    path: '/news',
     name: 'News',
     url: 'www.last-origin.com',
     maintainers: ['gudezhi'],

--- a/lib/routes/last-origin/news.ts
+++ b/lib/routes/last-origin/news.ts
@@ -1,0 +1,65 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+export const route: Route = {
+    path: '/news.html',
+    name: '公告',
+    url: 'www.last-origin.com',
+    maintainers: ['gudezhi'],
+    example: '/news.html',
+    parameters: {},
+    categories: ['game'],
+    features: {
+        supportRadar: true,
+    },
+    radar: [
+        {
+            source: ['www.last-origin.com'],
+            target: '/news.html',
+        },
+    ],
+    handler,
+    description: '',
+};
+
+async function handler() {
+    const baseUrl = 'https://www.last-origin.com/news.html';
+    const response = await ofetch(baseUrl);
+    const $ = load(response);
+
+    const list = $('.contents .news_wrap')
+        .toArray()
+        .map((item) => {
+            const title = $(item).find('.news_title').text().trim();
+            const link = new URL($(item).find('a').attr('href')!, baseUrl).href;
+            const date = $(item).find('time').text().trim();
+            const pubDate = timezone(parseDate(date), +9);
+            return {
+                title,
+                link,
+                pubDate,
+                description: '',
+            };
+        });
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const response = await ofetch(item.link);
+                const $ = load(response);
+                item.description = $('.news_contents_editor').html() ?? '';
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: 'LastOrigin官网公告',
+        link: baseUrl,
+        item: items,
+    };
+}


### PR DESCRIPTION
```routes
/last-origin/news
```

- [x] New Route / 新的路由
- [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [x] Full text / 全文获取
- [x] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [x] Parsed / 可以解析
- [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`