### PR TITLE
feat(route): add nixpk.gs/pr-tracker.html

### DIFF
--- a/lib/routes/nixpkgs/namespace.ts
+++ b/lib/routes/nixpkgs/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'nixpkgs',
+    lang: 'en',
+};

--- a/lib/routes/nixpkgs/pr-tracker.ts
+++ b/lib/routes/nixpkgs/pr-tracker.ts
@@ -1,0 +1,75 @@
+import { Route, ViewType } from '@/types';
+import type { Context } from 'hono';
+import { load } from 'cheerio';
+import ofetch from '@/utils/ofetch';
+
+async function handler(ctx: Context) {
+    const { pr } = ctx.req.param();
+    const fullUrl = `https://nixpk.gs/pr-tracker.html?pr=${pr}`;
+    const response = await ofetch(fullUrl);
+    const $ = load(response);
+    const rejected = $('ol').find('span.state-rejected').parent();
+    if (rejected.length === 1) {
+        return {
+            title: rejected.text(),
+            url: fullUrl,
+            item: [
+                {
+                    title: rejected.text(),
+                    link: rejected.find('a').attr('href'),
+                },
+            ],
+        };
+    }
+    let landed = false;
+    const item = $('ol')
+        .find('span.state-accepted')
+        .toArray()
+        .map((x) => {
+            const link = $(x).parent().find('a').first();
+            if (link.text() === 'nixos-unstable') {
+                landed = true;
+            }
+            return {
+                title: link.text(),
+                link: link.attr('href'),
+            };
+        });
+    const title = $('ol').find('li').first();
+    title.find('span').remove();
+    return {
+        title: `${landed ? '✅ ' : ''}nixpkgs ${title.text()}`,
+        url: fullUrl,
+        item,
+    };
+}
+
+export const route: Route = {
+    url: 'nixpk.gs',
+    name: 'pr-tracker',
+    description: 'pr-tracker pull request tracker for nixpkgs',
+    path: '/pr-tracker/:pr',
+    categories: ['programming'],
+    example: '/nixpkgs/pr-tracker/332217',
+    view: ViewType.Notifications,
+    parameters: {
+        pr: 'pr number',
+    },
+    radar: [
+        {
+            source: ['nixpk.gs/pr-tracker.html?pr=:pr'],
+            target: '/pr-tracker/:pr',
+        },
+    ],
+    features: {
+        supportRadar: true,
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    maintainers: ['phanirithvij'],
+    handler,
+};


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/nixpkgs/pr-tracker/342287
/nixpkgs/pr-tracker/322127
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

I wasn't able to figure out how to get it to appear in `RSSHub for the current page` section.
I wasn't able to join telegram group due to captcha issues.