### PR TITLE
feat(route): add route for social science journals

### DIFF
--- a/lib/routes/ajcass/namespace.ts
+++ b/lib/routes/ajcass/namespace.ts
@@ -1,0 +1,10 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '社科期刊网',
+    url: 'ajcass.com',
+    description: '中国社会科学院学术期刊方阵',
+    zh: {
+        name: '社科期刊网',
+    },
+};

--- a/lib/routes/ajcass/shxyj.ts
+++ b/lib/routes/ajcass/shxyj.ts
@@ -1,0 +1,87 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/shxyj/:year?/:issue?',
+    categories: ['academic'],
+    example: '/ajcass/shxyj/2024/1',
+    parameters: {
+        year: {
+            type: 'string',
+            description: 'Year of the issue',
+            optional: true,
+        },
+        issue: {
+            type: 'string',
+            description: 'Issue number',
+            optional: true,
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '社会学研究',
+    maintainers: ['CNYoki'],
+    handler,
+};
+
+async function handler(ctx) {
+    let { year, issue } = ctx.req.param();
+
+    if (!year) {
+        // 获取最新一期的 year 和 issue
+        const response = await got('https://shxyj.ajcass.com/');
+        const $ = load(response.body);
+        const latestIssueText = $('p.hod.pop').first().text();
+
+        const match = latestIssueText.match(/(\d{4}) Vol\.(\d+):/);
+        if (match) {
+            year = match[1];
+            issue = match[2];
+        } else {
+            throw new Error('无法获取最新的 year 和 issue');
+        }
+    }
+
+    const url = `https://shxyj.ajcass.com/Magazine/?Year=${year}&Issue=${issue}`;
+    const response = await got(url);
+    const $ = load(response.body);
+
+    const items = $('#tab tr')
+        .map((_, item) => {
+            const $item = $(item);
+            const articleTitle = $item.find('a').first().text().trim();
+            const articleLink = $item.find('a').first().attr('href');
+            const summary = $item.find('li').eq(1).text().replace('[摘要]', '').trim();
+            const authors = $item.find('li').eq(2).text().replace('作者：', '').trim();
+            const pubDate = parseDate(`${year}-${Number.parseInt(issue) * 2}`);
+
+            if (articleTitle && articleLink) {
+                return {
+                    title: articleTitle,
+                    link: `https://shxyj.ajcass.com${articleLink}`,
+                    description: summary,
+                    author: authors,
+                    pubDate,
+                };
+            }
+            return null; // 确保在所有情况下都有返回值
+        })
+        .toArray();
+
+    // eslint-disable-next-line no-console
+    console.log('items:', JSON.stringify(items, null, 2));
+
+    return {
+        title: `社会学研究 ${year}年第${issue}期`,
+        link: url,
+        item: items,
+    };
+}

--- a/lib/routes/ajcass/shxyj.ts
+++ b/lib/routes/ajcass/shxyj.ts
@@ -36,7 +36,6 @@ async function handler(ctx) {
     let { year, issue } = ctx.req.param();
 
     if (!year) {
-        // 获取最新一期的 year 和 issue
         const response = await got('https://shxyj.ajcass.com/');
         const $ = load(response.body);
         const latestIssueText = $('p.hod.pop').first().text();
@@ -55,7 +54,8 @@ async function handler(ctx) {
     const $ = load(response.body);
 
     const items = $('#tab tr')
-        .map((_, item) => {
+        .toArray()
+        .map((item) => {
             const $item = $(item);
             const articleTitle = $item.find('a').first().text().trim();
             const articleLink = $item.find('a').first().attr('href');
@@ -72,12 +72,9 @@ async function handler(ctx) {
                     pubDate,
                 };
             }
-            return null; // 确保在所有情况下都有返回值
+            return null;
         })
-        .toArray();
-
-    // eslint-disable-next-line no-console
-    console.log('items:', JSON.stringify(items, null, 2));
+        .filter((item) => item !== null);
 
     return {
         title: `社会学研究 ${year}年第${issue}期`,


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes

```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/ajcass/shxyj
/ajcass/shxyj/2024/6
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Support for Social Science Journal and its Sociology Studies Journal