### PR TITLE
feat(dockerhub): 添加 DockerHub 仓库路由

### DIFF
--- a/lib/routes/dockerhub/repositories.ts
+++ b/lib/routes/dockerhub/repositories.ts
@@ -5,6 +5,7 @@ import { Context } from 'hono';
 
 export const route: Route = {
     name: 'DockerHub Repositories',
+    description: `List of repositories for an image owner`,
     maintainers: ['CaoMeiYouRen'],
     path: '/repositories/:owner',
     categories: ['program-update'],

--- a/lib/routes/dockerhub/repositories.ts
+++ b/lib/routes/dockerhub/repositories.ts
@@ -1,0 +1,40 @@
+import { Route, ViewType } from '@/types';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import { Context } from 'hono';
+
+export const route: Route = {
+    name: 'DockerHub Repositories',
+    maintainers: ['CaoMeiYouRen'],
+    path: '/repositories/:owner',
+    categories: ['program-update'],
+    view: ViewType.Notifications,
+    example: '/dockerhub/repositories/library',
+    parameters: { owner: 'Image owner' },
+    handler,
+};
+
+async function handler(ctx: Context) {
+    const { owner, limits } = ctx.req.param();
+    const link = `https://hub.docker.com/r/${owner}`;
+    const url = `https://hub.docker.com/v2/repositories/${owner}`;
+    const response = await got(url, {
+        searchParams: {
+            page_size: Number.parseInt(limits) || 10,
+        },
+    });
+    const item = response.data.results.map((repo) => ({
+        title: repo.name,
+        description: `${repo.description}<br>status: ${repo.status_description}<br>stars: ${repo.star_count}<br>pulls: ${repo.pull_count}`,
+        link: `https://hub.docker.com/r/${owner}/${repo.name}`,
+        author: owner,
+        pubDate: parseDate(repo.last_updated),
+        guid: `${owner}/${repo.name}`,
+    }));
+    return {
+        title: `${owner} repositories`,
+        description: `List of repositories for ${owner}`,
+        link,
+        item,
+    };
+}

--- a/lib/routes/dockerhub/repositories.ts
+++ b/lib/routes/dockerhub/repositories.ts
@@ -4,24 +4,25 @@ import { parseDate } from '@/utils/parse-date';
 import { Context } from 'hono';
 
 export const route: Route = {
-    name: 'DockerHub Repositories',
-    description: `List of repositories for an image owner`,
+    name: 'Owner Repositories',
+    description: 'List of repositories for an image owner',
     maintainers: ['CaoMeiYouRen'],
     path: '/repositories/:owner',
     categories: ['program-update'],
     view: ViewType.Notifications,
-    example: '/dockerhub/repositories/library',
+    example: '/dockerhub/repositories/diygod',
     parameters: { owner: 'Image owner' },
     handler,
 };
 
 async function handler(ctx: Context) {
-    const { owner, limits } = ctx.req.param();
+    const owner = ctx.req.param('owner').toLowerCase();
+    const limit = Number.parseInt(ctx.req.query('limit') || '10');
     const link = `https://hub.docker.com/r/${owner}`;
     const url = `https://hub.docker.com/v2/repositories/${owner}`;
     const response = await got(url, {
         searchParams: {
-            page_size: Number.parseInt(limits) || 10,
+            page_size: limit,
         },
     });
     const item = response.data.results.map((repo) => ({


### PR DESCRIPTION
- 新增 DockerHub 仓库路由，支持获取指定用户的仓库列表
- 支持分页获取仓库信息，默认每页10条记录

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/dockerhub/repositories/library
/dockerhub/repositories/DIYgod
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
