### PR TITLE
fix(wallstreetcn): crash when article delete

### DIFF
--- a/lib/routes/wallstreetcn/news.ts
+++ b/lib/routes/wallstreetcn/news.ts
@@ -74,7 +74,14 @@ async function handler(ctx) {
                     url: `${apiRootUrl}/apiv1/content/${item.type === 'live' ? `lives/${item.guid}` : `articles/${item.guid}?extract=0`}`,
                 });
 
-                const data = detailResponse.data.data;
+                const response_data = detailResponse.data;
+
+                // 处理 { code: 60301, message: '内容不存在或已被删除', data: {} }
+                if (response_data.code !== 20000) {
+                    return null;
+                }
+
+                const data = response_data.data;
 
                 item.title = data.title || data.content_text;
                 item.author = data.source_name ?? data.author.display_name;
@@ -94,6 +101,8 @@ async function handler(ctx) {
             })
         )
     );
+
+    items = items.filter((item) => item !== null);
 
     return {
         title: `华尔街见闻 - 资讯 - ${titles[category]}`,

--- a/lib/routes/wallstreetcn/news.ts
+++ b/lib/routes/wallstreetcn/news.ts
@@ -74,14 +74,14 @@ async function handler(ctx) {
                     url: `${apiRootUrl}/apiv1/content/${item.type === 'live' ? `lives/${item.guid}` : `articles/${item.guid}?extract=0`}`,
                 });
 
-                const response_data = detailResponse.data;
+                const responseData = detailResponse.data;
 
                 // 处理 { code: 60301, message: '内容不存在或已被删除', data: {} }
-                if (response_data.code !== 20000) {
+                if (responseData.code !== 20000) {
                     return null;
                 }
 
-                const data = response_data.data;
+                const data = responseData.data;
 
                 item.title = data.title || data.content_text;
                 item.author = data.source_name ?? data.author.display_name;


### PR DESCRIPTION
修复 wallstreetcn 
```
TypeError: Cannot read properties of undefined (reading 'display_name')
```

## Example for the Proposed Route(s) / 路由地址示例

```routes
/wallstreetcn/news/tmt
/wallstreetcn/news/global
```