### PR TITLE
fix: qweather route example inaccuracy.

### DIFF
--- a/lib/routes/qweather/3days.ts
+++ b/lib/routes/qweather/3days.ts
@@ -35,19 +35,20 @@ export const route: Route = {
     name: '近三天天气',
     maintainers: ['Rein-Ou', 'la3rence'],
     handler,
-    description: `需自行注册获取 api 的 key，并在环境变量 HEFENG\_KEY 中进行配置，获取订阅近三天天气预报`,
+    description: '获取订阅近三天天气预报',
 };
 
 async function handler(ctx) {
     if (!config.hefeng.key) {
         throw new ConfigNotFoundError('QWeather RSS is disabled due to the lack of <a href="https://docs.rsshub.app/zh/install/config#%E5%92%8C%E9%A3%8E%E5%A4%A9%E6%B0%94">relevant config</a>');
     }
-    const id = await cache.tryGet(ctx.req.param('location') + '_id', async () => {
+
+    const id = await cache.tryGet('qweather:' + ctx.req.param('location') + ':id', async () => {
         const response = await got(`${CIRY_LOOKUP_API}?location=${ctx.req.param('location')}&key=${config.hefeng.key}`);
         return response.data.location[0].id;
     });
     const weatherData = await cache.tryGet(
-        ctx.req.param('location'),
+        'qweather:' + ctx.req.param('location'),
         async () => {
             const response = await got(`${WEATHER_API}?key=${config.hefeng.key}&location=${id}`);
             return response.data;

--- a/lib/routes/qweather/now.ts
+++ b/lib/routes/qweather/now.ts
@@ -8,7 +8,10 @@ import { art } from '@/utils/render';
 import path from 'node:path';
 import { parseDate } from '@/utils/parse-date';
 import { config } from '@/config';
+import ConfigNotFoundError from '@/errors/types/config-not-found';
+
 const rootUrl = 'https://devapi.qweather.com/v7/weather/now?';
+
 export const route: Route = {
     path: '/now/:location',
     categories: ['forecast'],
@@ -18,7 +21,7 @@ export const route: Route = {
         requireConfig: [
             {
                 name: 'HEFENG_KEY',
-                description: '访问 `https://www.qweather.com/` 注册开发API Key。',
+                description: '访问 `https://www.qweather.com/` 注册开发 API Key。',
             },
         ],
         requirePuppeteer: false,
@@ -30,21 +33,21 @@ export const route: Route = {
     name: '实时天气',
     maintainers: ['Rein-Ou'],
     handler,
-    description: `需自行注册获取 api 的 key，每小时更新一次数据`,
 };
 
 async function handler(ctx) {
-    const id = await cache.tryGet(ctx.req.param('location') + '_id', async () => {
+    if (!config.hefeng.key) {
+        throw new ConfigNotFoundError('QWeather RSS is disabled due to the lack of <a href="https://docs.rsshub.app/zh/install/config#%E5%92%8C%E9%A3%8E%E5%A4%A9%E6%B0%94">relevant config</a>');
+    }
+
+    const id = await cache.tryGet('qweather:' + ctx.req.param('location') + ':id', async () => {
         const response = await got(`https://geoapi.qweather.com/v2/city/lookup?location=${ctx.req.param('location')}&key=${config.hefeng.key}`);
-        const data = [];
-        for (const i in response.data.location) {
-            data.push(response.data.location[i]);
-        }
+        const data = response.data.location.map((loc) => loc);
         return data[0].id;
     });
     const requestUrl = rootUrl + 'key=' + config.hefeng.key + '&location=' + id;
     const responseData = await cache.tryGet(
-        ctx.req.param('location') + '_now',
+        'qweather:' + ctx.req.param('location') + ':now',
         async () => {
             const response = await got(requestUrl);
             return response.data;

--- a/lib/routes/qweather/now.ts
+++ b/lib/routes/qweather/now.ts
@@ -12,13 +12,13 @@ const rootUrl = 'https://devapi.qweather.com/v7/weather/now?';
 export const route: Route = {
     path: '/now/:location',
     categories: ['forecast'],
-    example: '/qweather/广州',
+    example: '/qweather/now/广州',
     parameters: { location: 'N' },
     features: {
         requireConfig: [
             {
                 name: 'HEFENG_KEY',
-                description: '',
+                description: '访问 `https://www.qweather.com/` 注册开发API Key。',
             },
         ],
         requirePuppeteer: false,


### PR DESCRIPTION
qweather route example inaccuracy

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/qweather/now/北京
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ x ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
