### PR TITLE
feat(route/github): enhance /repos route with optional parameters for…

### DIFF
--- a/lib/routes/github/repos.ts
+++ b/lib/routes/github/repos.ts
@@ -1,13 +1,17 @@
 import { Route } from '@/types';
 import got from '@/utils/got';
 import { config } from '@/config';
-import queryString from 'query-string';
 
 export const route: Route = {
-    path: '/repos/:user',
+    path: '/repos/:user/:type?/:sort?/:direction?',
     categories: ['programming'],
     example: '/github/repos/DIYgod',
-    parameters: { user: 'GitHub username' },
+    parameters: {
+        user: 'GitHub username',
+        type: 'Type of repository, can be `all`, `owner`, `member`, `public`, `private`, `forks`, `sources`',
+        sort: 'Sort by `created`, `updated`, `pushed`, `full_name`',
+        direction: 'Sort direction, can be `asc` or `desc`',
+    },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -28,20 +32,46 @@ export const route: Route = {
 
 async function handler(ctx) {
     const user = ctx.req.param('user');
-
-    const headers = {};
+    const type = ctx.req.param('type') || 'all';
+    const sort = ctx.req.param('sort') || 'created';
+    const direction = ctx.req.param('direction') || 'desc';
+    let headers = {};
     if (config.github && config.github.access_token) {
-        headers.Authorization = `token ${config.github.access_token}`;
+        headers = {
+            ...headers,
+            Authorization: `token ${config.github.access_token}`,
+        };
     }
     const response = await got({
         method: 'get',
         url: `https://api.github.com/users/${user}/repos`,
-        searchParams: queryString.stringify({
-            sort: 'created',
-        }),
+        searchParams: {
+            type,
+            sort,
+            direction,
+        },
         headers,
     });
-    const data = response.data;
+    const data = response.data.filter((item) => {
+        switch (type) {
+            case 'all':
+                return true;
+            case 'owner':
+                return item.owner.login === user;
+            case 'member':
+                return item.owner.login !== user;
+            case 'public':
+                return item.private === false;
+            case 'private':
+                return item.private === true;
+            case 'forks':
+                return item.fork === true;
+            case 'sources':
+                return item.fork === false;
+            default:
+                return true;
+        }
+    });
     return {
         allowEmpty: true,
         title: `${user}'s GitHub repositories`,

--- a/lib/routes/github/repos.ts
+++ b/lib/routes/github/repos.ts
@@ -3,14 +3,13 @@ import got from '@/utils/got';
 import { config } from '@/config';
 
 export const route: Route = {
-    path: '/repos/:user/:type?/:sort?/:direction?',
+    path: '/repos/:user/:type?/:sort?',
     categories: ['programming'],
     example: '/github/repos/DIYgod',
     parameters: {
         user: 'GitHub username',
         type: 'Type of repository, can be `all`, `owner`, `member`, `public`, `private`, `forks`, `sources`',
         sort: 'Sort by `created`, `updated`, `pushed`, `full_name`',
-        direction: 'Sort direction, can be `asc` or `desc`',
     },
     features: {
         requireConfig: false,
@@ -34,7 +33,6 @@ async function handler(ctx) {
     const user = ctx.req.param('user');
     const type = ctx.req.param('type') || 'all';
     const sort = ctx.req.param('sort') || 'created';
-    const direction = ctx.req.param('direction') || 'desc';
     let headers = {};
     if (config.github && config.github.access_token) {
         headers = {
@@ -48,7 +46,6 @@ async function handler(ctx) {
         searchParams: {
             type,
             sort,
-            direction,
         },
         headers,
     });


### PR DESCRIPTION
… type, sort, and direction

- Updated the route to accept optional parameters: type, sort, and direction.
- Added filtering logic for repository types: all, owner, member, public, private, forks, and sources.
- Improved documentation for parameters to clarify usage.

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/github/repos/DIYgod/all/created
/github/repos/DIYgod/owner/created
/github/repos/DIYgod/sources/created
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
