### PR TITLE
增加 ShanghaiTech University /上海科技大学

### DIFF
--- a/lib/routes/namespace.ts
+++ b/lib/routes/namespace.ts
@@ -1,0 +1,14 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'ShanghaiTech University',
+    url: 'shanghaitech.edu.cn',
+    description: `
+    :::tip
+    This is the RSS feed for ShanghaiTech University news updates
+    :::`,
+    
+    zh: {
+        name: '上海科技大学',
+    },
+};

--- a/lib/routes/news.ts
+++ b/lib/routes/news.ts
@@ -1,0 +1,71 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/:category?',
+    categories: ['university'],
+    example: '/shanghaitech/1004',
+    parameters: { 
+        category: 'Category ID, see below:\n  - `1001`: News\n  - `1004`: Notices\n  Default is 1001 (News)' 
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['shanghaitech.edu.cn/:category/list.htm', 'shanghaitech.edu.cn/'],
+            target: '/:category',
+        },
+    ],
+    name: 'University Updates',
+    maintainers: ['YourGitHubUsername'],
+    handler: async (ctx) => {
+        const { category = '1001' } = ctx.req.param();
+        const baseUrl = 'https://www.shanghaitech.edu.cn';
+        const pageUrl = `${baseUrl}/${category}/list.htm`;
+
+        const response = await got(pageUrl);
+        const $ = load(response.data);
+
+        const list = $('li.news')
+            .map((_, item) => {
+                const $item = $(item);
+                const link = $item.find('a.news_box').attr('href');
+                const imgElem = $item.find('.news_imgs img');
+                
+                // Create description with image if it exists
+                let description = $item.find('.news_text').text().trim();
+                if (imgElem.length > 0) {
+                    const imgUrl = baseUrl + imgElem.attr('src');
+                    description = `<img src="${imgUrl}" /><br/>${description}`;
+                }
+
+                return {
+                    title: $item.find('.news_title').text().trim(),
+                    link: baseUrl + link,
+                    description: description,
+                    pubDate: parseDate($item.find('.news_times').text().trim()),
+                };
+            })
+            .get();
+
+        const titleMap = {
+            '1001': '上海科技大学新闻',
+            '1004': '上海科技大学通知公告',
+            'cmsj': '上海科技大学媒体聚焦',
+        };
+
+        return {
+            title: titleMap[category] || '上海科技大学信息',
+            link: pageUrl,
+            item: list,
+        };
+    },
+};

--- a/lib/routes/slst.ts
+++ b/lib/routes/slst.ts
@@ -1,0 +1,85 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import { resolve } from 'url';
+
+export const route: Route = {
+    path: '/slst/:type?',
+    categories: ['university'],
+    example: '/shanghaitech/slst/news',
+    parameters: { 
+        type: 'Type of posts, see below:\n  - `news`: 学院新闻\n  - `research`: 科研进展\n  - `notice`: 通知公告\n  Default is news' 
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['slst.shanghaitech.edu.cn/:type/list.htm', 'slst.shanghaitech.edu.cn/'],
+            target: '/slst/:type',
+        },
+    ],
+    name: 'SLST News',
+    maintainers: ['Jaaayden'],
+    handler: async (ctx) => {
+        const { type = 'news' } = ctx.req.param();
+        const baseUrl = 'https://slst.shanghaitech.edu.cn';
+        
+        // Map type to actual URL path
+        const pathMap = {
+            news: '/news/list.htm',
+            research: '/researchprogress/list.htm',
+            notice: '/notice/list.htm',
+        };
+        
+        const pageUrl = `${baseUrl}${pathMap[type] || pathMap.news}`;
+
+        const response = await got(pageUrl);
+        const $ = load(response.data);
+
+        const list = $('.news_list.list2 .news')
+            .map((_, item) => {
+                const $item = $(item);
+                const $link = $item.find('.news_title a');
+                const title = $link.text().trim();
+                const link = $link.attr('href');
+                const dateStr = $item.find('.news_meta').text().trim();
+
+                // 处理链接
+                let absoluteLink = '';
+                if (link) {
+                    if (link.startsWith('http')) {
+                        absoluteLink = link;
+                    } else {
+                        absoluteLink = resolve(baseUrl, link);
+                    }
+                }
+
+                return {
+                    title,
+                    link: absoluteLink,
+                    pubDate: parseDate(dateStr),
+                };
+            })
+            .get()
+            .filter((item) => item.title && item.link);
+
+        const titleMap = {
+            news: '上海科技大学生命学院 - 学院新闻',
+            research: '上海科技大学生命学院 - 科研进展',
+            notice: '上海科技大学生命学院 - 通知公告',
+        };
+
+        return {
+            title: titleMap[type] || '上海科技大学生命学院新闻',
+            link: pageUrl,
+            item: list,
+        };
+    },
+};


### PR DESCRIPTION
Involved Issue / 该 PR 相关 Issue
Close #
Example for the Proposed Route(s) / 路由地址示例
notice
New RSS Route Checklist / 新 RSS 路由检查表
[x] New Route / 新的路由
[x] Follows Script Standard / 跟随 路由规范
[x] Documentation / 文档说明
[x] Full text / 全文获取
[x] Use cache / 使用缓存
[x] Anti-bot or rate limit / 反爬/频率限制
[x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
[x] Date and time / 日期和时间
[x] Parsed / 可以解析
[x] Correct time zone / 时区正确
[ ] New package added / 添加了新的包
[ ] Puppeteer
Note / 说明
添加了上海科技大学的 RSS 订阅路由:
主站新闻和通知:
/shanghaitech/1001: 新闻
/shanghaitech/1004: 通知公告
/shanghaitech/cmsj: 媒体聚焦
生命科学与技术学院:
/shanghaitech/slst: 默认显示学院新闻
/shanghaitech/slst/news: 学院新闻
/shanghaitech/slst/research: 科研进展
/shanghaitech/slst/notice: 通知公告
所有内容均已实现全文抓取，并正确解析了发布日期。代码遵循了 RSSHub 的路由规范。