### PR TITLE
docs: fix tip wrapper in document

### DIFF
--- a/lib/routes/kuaishou/profile.ts
+++ b/lib/routes/kuaishou/profile.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     url: 'kuaishou.com/profile/:principalId',
     description: `:::tip
 The profile page of the user, which contains the user's information, videos, and other information.
-    :::`,
+:::`,
     handler,
 };
 


### PR DESCRIPTION


<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例


```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
The extra indentation causes failure of parsing during Docs rendering. The parser will wrap the latter content until the next `:::` into tips