### PR TITLE
fix(163/music/djradio): add option for info

### DIFF
--- a/lib/routes/163/music/djradio.ts
+++ b/lib/routes/163/music/djradio.ts
@@ -6,6 +6,8 @@ import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 import { art } from '@/utils/render';
 import path from 'node:path';
+import cache from '@/utils/cache';
+import { config } from '@/config';
 
 export const route: Route = {
     path: '/music/djradio/:id/:info?',
@@ -25,36 +27,39 @@ export const route: Route = {
     handler,
 };
 
+const ProcessFeed = (id, limit, offset) =>
+    cache.tryGet(
+        `163:music:djradio:${id}:${limit}:${offset}`,
+        async () =>
+            await got.post('https://music.163.com/api/dj/program/byradio', {
+                headers: {
+                    Referer: 'https://music.163.com/',
+                },
+                form: {
+                    radioId: id,
+                    limit,
+                    offset,
+                },
+            }),
+        config.cache.routeExpire,
+        false
+    );
+
 async function handler(ctx) {
     const id = ctx.req.param('id');
     const info = !ctx.req.param('info');
 
-    const ProcessFeed = (limit, offset) =>
-        got.post('https://music.163.com/api/dj/program/byradio', {
-            headers: {
-                Referer: 'https://music.163.com/',
-            },
-            form: {
-                radioId: id,
-                limit,
-                offset,
-            },
-        });
-
-    const response = await ProcessFeed(1, 0);
+    const response = await ProcessFeed(id, 1, 0);
 
     const programs = response.data.programs || [];
     const { radio, dj } = programs[0] || { radio: {}, dj: {} };
     const count = response.data.count || 0;
 
-    const countPage = [];
-    for (let i = 0; i < Math.ceil(count / 500); i++) {
-        countPage.push(i);
-    }
+    const countPage = Array.from({ length: Math.ceil(count / 500) }, (_, i) => i);
 
     const items = await Promise.all(
         countPage.map(async (item) => {
-            const response = await ProcessFeed(500, item * 500);
+            const response = await ProcessFeed(id, 500, item * 500);
             const programs = response.data.programs || [];
             const list = programs.map((pg) => {
                 const description = (pg.description || '').split('\n').map((p) => p);

--- a/lib/routes/163/music/djradio.ts
+++ b/lib/routes/163/music/djradio.ts
@@ -58,12 +58,10 @@ async function handler(ctx) {
             const list = programs.map((pg) => {
                 const description = (pg.description || '').split('\n').map((p) => p);
                 const duration = Math.trunc(pg.duration / 1000);
-                const mm_ss_duration = `${(duration / 60).toFixed(0).padStart(2, '0')}:${(duration % 60).toFixed(0).padStart(2, '0')}`;
 
                 const html = art(path.join(__dirname, '../templates/music/djradio-content.art'), {
                     pg,
                     description,
-                    itunes_duration: mm_ss_duration,
                 });
 
                 return {

--- a/lib/routes/163/music/djradio.ts
+++ b/lib/routes/163/music/djradio.ts
@@ -8,10 +8,10 @@ import { art } from '@/utils/render';
 import path from 'node:path';
 
 export const route: Route = {
-    path: '/music/djradio/:id',
+    path: '/music/djradio/:id/:info?',
     categories: ['multimedia'],
     example: '/163/music/djradio/347317067',
-    parameters: { id: '节目 id, 可在电台节目页 URL 中找到' },
+    parameters: { id: '节目 id, 可在电台节目页 URL 中找到', info: '默认在正文尾部显示节目相关信息，任意值为不显示' },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -27,6 +27,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const id = ctx.req.param('id');
+    const info = !ctx.req.param('info');
 
     const ProcessFeed = (limit, offset) =>
         got.post('https://music.163.com/api/dj/program/byradio', {
@@ -58,10 +59,13 @@ async function handler(ctx) {
             const list = programs.map((pg) => {
                 const description = (pg.description || '').split('\n').map((p) => p);
                 const duration = Math.trunc(pg.duration / 1000);
+                const mm_ss_duration = `${(duration / 60).toFixed(0).padStart(2, '0')}:${(duration % 60).toFixed(0).padStart(2, '0')}`;
 
                 const html = art(path.join(__dirname, '../templates/music/djradio-content.art'), {
                     pg,
                     description,
+                    itunes_duration: mm_ss_duration,
+                    info,
                 });
 
                 return {

--- a/lib/routes/163/templates/music/djradio-content.art
+++ b/lib/routes/163/templates/music/djradio-content.art
@@ -4,3 +4,10 @@
     <p>{{$value}}</p>
     {{/each}}
 </div>
+{{ if info }}
+<div>
+    <audio src="https://music.163.com/song/media/outer/url?id={{pg.mainTrackId}}.mp3" controls="controls"></audio>
+    <p>时长: {{itunes_duration}}</p>
+    <p><a href="https://music.163.com/program/{{pg.id}}">查看节目</a></p>
+</div>
+{{ /if }}

--- a/lib/routes/163/templates/music/djradio-content.art
+++ b/lib/routes/163/templates/music/djradio-content.art
@@ -4,8 +4,3 @@
     <p>{{$value}}</p>
     {{/each}}
 </div>
-<div>
-    <audio src="https://music.163.com/song/media/outer/url?id={{pg.mainTrackId}}.mp3" controls="controls"></audio>
-    <p>时长: {{itunes_duration}}</p>
-    <p><a href="https://music.163.com/program/{{pg.id}}">查看节目</a></p>
-</div>


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

None

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/163/music/djradio/312
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/163/music/djradio/312
/163/music/djradio/312/0
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
in most cast,the djradio route was subscribe by some podcast app, and because the app support `enclosure` tag, the link in the description is duplicate, this PR aim to remove duplicate part for the route.

duplicate example:
![image](https://github.com/user-attachments/assets/06ae873b-93a5-49af-8a43-f9298b10ab5b)

update: this has changed to option
