### PR TITLE
fix(blizzard): 新闻路由报错不能使用

### DIFF
--- a/lib/routes/blizzard/news.ts
+++ b/lib/routes/blizzard/news.ts
@@ -27,14 +27,15 @@ export const route: Route = {
   | Diablo II: Resurrected | diablo2             |
   | Diablo III             | diablo3             |
   | Diablo IV              | diablo4             |
-  | Diablo: Immortal       | diablo-immortal     |
+  | Diablo Immortal        | diablo-immortal     |
   | Hearthstone            | hearthstone         |
   | Heroes of the Storm    | heroes-of-the-storm |
   | Overwatch 2            | overwatch           |
   | StarCraft: Remastered  | starcraft           |
   | StarCraft II           | starcraft2          |
   | World of Warcraft      | world-of-warcraft   |
-  | Warcraft III: Reforged | warcraft3           |
+  | Warcraft 3: Reforged   | warcraft3           |
+  | Warcraft Rumble        | warcraft-rumble     |
   | Battle.net             | battlenet           |
   | BlizzCon               | blizzcon            |
   | Inside Blizzard        | blizzard            |
@@ -59,49 +60,137 @@ export const route: Route = {
   | 繁體中文           | zh-tw |`,
 };
 
+const GAME_MAP = {
+    diablo2: {
+        key: 'diablo2',
+        value: 'diablo-2-resurrected',
+        id: 'blt54fbd3787a705054',
+    },
+    diablo3: {
+        key: 'diablo3',
+        value: 'diablo-3',
+        id: 'blt2031aef34200656d',
+    },
+    diablo4: {
+        key: 'diablo4',
+        value: 'diablo-4',
+        id: 'blt795c314400d7ded9',
+    },
+    'diablo-immortal': {
+        key: 'diablo-immortal',
+        value: 'diablo-immortal',
+        id: 'blt525c436e4a1b0a97',
+    },
+    hearthstone: {
+        key: 'hearthstone',
+        value: 'hearthstone',
+        id: 'blt5cfc6affa3ca0638',
+    },
+    'heroes-of-the-storm': {
+        key: 'heroes-of-the-storm',
+        value: 'heroes-of-the-storm',
+        id: 'blt2e50e1521bb84dc6',
+    },
+    overwatch: {
+        key: 'overwatch',
+        value: 'overwatch',
+        id: 'blt376fb94931906b6f',
+    },
+    starcraft: {
+        key: 'starcraft',
+        value: 'starcraft',
+        id: 'blt81d46fcb05ab8811',
+    },
+    starcraft2: {
+        key: 'starcraft2',
+        value: 'starcraft-2',
+        id: 'bltede2389c0a8885aa',
+    },
+    'world-of-warcraft': {
+        key: 'world-of-warcraft',
+        value: 'world-of-warcraft',
+        id: 'blt2caca37e42f19839',
+    },
+    warcraft3: {
+        key: 'warcraft3',
+        value: 'warcraft-3',
+        id: 'blt24859ba8086fb294',
+    },
+    'warcraft-rumble': {
+        key: 'warcraft-rumble',
+        value: 'warcraft-rumble',
+        id: 'blte27d02816a8ff3e1',
+    },
+    battlenet: {
+        key: 'battlenet',
+        value: 'battle-net',
+        id: 'blt90855744d00cd378',
+    },
+    blizzcon: {
+        key: 'blizzcon',
+        value: 'blizzcon',
+        id: 'bltec70ad0ea4fd6d1d',
+    },
+    blizzard: {
+        key: 'blizzard',
+        value: 'blizzard',
+        id: 'blt500c1f8b5470bfdb',
+    },
+};
+
+function getSearchParams(category = 'all') {
+    return category === 'all'
+        ? Object.values(GAME_MAP)
+              .map((item) => `feedCxpProductIds[]=${item.id}`)
+              .join('&')
+        : `feedCxpProductIds[]=${GAME_MAP[category].id}`;
+}
+
 async function handler(ctx) {
-    const category = ctx.req.param('category') || '';
+    const category = GAME_MAP[ctx.req.param('category')]?.key || 'all';
     const language = ctx.req.param('language') || 'en-us';
+    const rootUrl = `https://news.blizzard.com/${language}`;
+    const currentUrl = category === 'all' ? rootUrl : `${rootUrl}/?filter=${GAME_MAP[category].value}`;
+    const apiUrl = `${rootUrl}/api/news/blizzard`;
+    let rssTitle = '';
 
-    const rootUrl = 'https://news.blizzard.com';
-    const currentUrl = `${rootUrl}/${language}/${category}`;
-    const apiUrl = `${rootUrl}/${language}/blog/list`;
-    const response = await got(apiUrl, {
-        searchParams: {
-            community: category === '' ? 'all' : category,
+    const {
+        data: {
+            feed: { contentItems: response },
         },
+    } = await got(`${apiUrl}?${getSearchParams(category)}`);
+
+    const list = response.map((item) => {
+        const content = item.properties;
+        rssTitle = category === 'all' ? 'All News' : content.cxpProduct.title; // 这个是用来填充 RSS 订阅源频道级别 title，没别的地方能拿到了(而且会根据语言切换)
+        return {
+            title: content.title,
+            link: content.newsUrl,
+            author: content.author,
+            category: content.category,
+            guid: content.newsId,
+            description: content.summary,
+            pubDate: content.lastUpdated,
+        };
     });
-
-    const $ = load(response.data.html, null, false);
-
-    const list = $('.FeaturedArticle-text > a, .ArticleListItem > article > a')
-        .slice(0, ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 30)
-        .toArray()
-        .map((item) => {
-            item = $(item);
-            return {
-                title: item.text(),
-                link: `${rootUrl}${item.attr('href')}`,
-            };
-        });
 
     const items = await Promise.all(
         list.map((item) =>
-            cache.tryGet(item.link, async () => {
-                const detailResponse = await got(item.link);
-                const content = load(detailResponse.data);
-
-                item.author = content('.ArticleDetail-bylineAuthor').text();
-                item.description = content('.ArticleDetail-headingImageBlock').html() + content('.ArticleDetail-content').html();
-                item.pubDate = content('.ArticleDetail-subHeadingLeft time').attr('timestamp');
-
-                return item;
+            cache.tryGet(item.guid, async () => {
+                try {
+                    const { data: response } = await got(item.link);
+                    const $ = load(response);
+                    item.description = $('.Content').html();
+                    return item;
+                } catch {
+                    return item;
+                }
             })
         )
     );
 
     return {
-        title: $('title').text(),
+        title: rssTitle,
         link: currentUrl,
         item: items,
     };

--- a/lib/routes/blizzard/news.ts
+++ b/lib/routes/blizzard/news.ts
@@ -176,7 +176,7 @@ async function handler(ctx) {
 
     const items = await Promise.all(
         list.map((item) =>
-            cache.tryGet(item.guid, async () => {
+            cache.tryGet(item.link, async () => {
                 try {
                     const { data: response } = await got(item.link);
                     const $ = load(response);


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #17790

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/blizzard/news
/blizzard/news/zh-tw
/blizzard/news/zh-tw/starcraft2
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
此次更换了 api 请求新闻的方式，api 接口里有个 newsUrl 指向网页，但有些网址会被重定向跳转，例如：
1. [接口返回的地址](https://news.blizzard.com/zh-tw/article/23762796/2-4) 实际上会被重定向：[真实地址](https://news.blizzard.com/zh-tw/article/23762796/ii-2-4)
2. [接口返回的地址](https://news.blizzard.com/zh-tw/article/24146047/%E9%87%8D%E6%BA%AB%E5%88%BA%E6%BF%80%E6%88%B0%E9%AC%A5) 实际上会被重定向：[真实地址](https://news.blizzard.com/zh-tw/article/24146047/%E5%9C%A8%E3%80%8A%E9%AC%A5%E9%99%A3%E7%89%B9%E6%94%BB%E3%80%8B%EF%BC%9A%E7%B6%93%E5%85%B8%E6%A8%A1%E5%BC%8F%E9%AB%94%E9%A9%97%E6%98%94%E6%97%A5%E7%BE%8E%E5%A5%BD)

但实际不影响使用，只是这类接口返回的地址可能会返回英文版的 description，我认为是小部分链接才会如此所以是可以接受的。我也观察了整个api接口数据以及页面结构数据，都是没有返回我提到的真实链接的…
