### PR TITLE
feat(route): Add RSS feed for latest news from Anthropic (a leading LLM developer).

### DIFF
--- a/lib/routes/anthropic/namespace.ts
+++ b/lib/routes/anthropic/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Anthropic',
+    url: 'anthropic.com',
+    lang: 'en',
+};

--- a/lib/routes/anthropic/news.ts
+++ b/lib/routes/anthropic/news.ts
@@ -1,0 +1,60 @@
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import cache from '@/utils/cache';
+
+export const route: Route = {
+    path: '/news',
+    categories: ['programming'],
+    example: '/anthropic/news',
+    parameters: {},
+    radar: [
+        {
+            source: ['anthropic.com'],
+        },
+    ],
+    name: 'Anthropic News',
+    maintainers: ['etShaw-zh'],
+    handler,
+    url: 'anthropic.com/news',
+};
+
+async function handler() {
+    const link = 'https://anthropic.com/news';
+    const response = await got(link);
+    const $ = load(response.body);
+
+    const list = $('.contentFadeUp a')
+        .toArray()
+        .map((e) => {
+            e = $(e);
+            const title = e.find('h3.PostCard_post-heading__KPsva').text().trim(); // Extract title
+            const href = e.attr('href'); // Extract link
+            const pubDate = e.find('.PostList_post-date__giqsu').text().trim(); // Extract publication date
+            const fullLink = href.startsWith('http') ? href : `https://anthropic.com${href}`; // Complete relative links
+            return {
+                title,
+                link: fullLink,
+                pubDate,
+            };
+        });
+
+    const out = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const response = await got(item.link);
+                const $ = load(response.body);
+
+                item.description = $('.text-b2.PostDetail_post-detail__uTcjp').html() || ''; // Full article content
+
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: 'Anthropic News',
+        link,
+        description: 'Latest news from Anthropic',
+        item: out,
+    };
+}

--- a/lib/routes/anthropic/news.ts
+++ b/lib/routes/anthropic/news.ts
@@ -12,7 +12,7 @@ export const route: Route = {
             source: ['anthropic.com'],
         },
     ],
-    name: 'Anthropic News',
+    name: 'News',
     maintainers: ['etShaw-zh'],
     handler,
     url: 'anthropic.com/news',


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #17959

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/anthropic/news
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This RSS is the latest news related to [Anthropic](https://www.anthropic.com/), a leading LLM developer.