### PR TITLE
feat(route/geocaching): add lang param, update response structure

### DIFF
--- a/lib/routes/geocaching/blogs.ts
+++ b/lib/routes/geocaching/blogs.ts
@@ -3,10 +3,24 @@ import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
-    path: '/blogs',
+    path: '/blogs/:language?',
     categories: ['blog'],
-    example: '/geocaching/blogs',
-    parameters: {},
+    example: '/geocaching/blogs/en',
+    parameters: {
+        language: {
+            description: 'language',
+            default: 'en',
+            options: [
+                { value: 'en', label: 'English' },
+                { value: 'de', label: 'Deutsch' },
+                { value: 'fr', label: 'Français' },
+                { value: 'es', label: 'Español' },
+                { value: 'nl', label: 'Nederlands' },
+                { value: 'cs', label: 'Čeština' },
+                { value: 'all', label: 'Not Specified' },
+            ],
+        },
+    },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -21,35 +35,72 @@ export const route: Route = {
         },
     ],
     name: 'Official Blogs',
-    maintainers: ['HankChow'],
+    maintainers: ['HankChow', 'Konano'],
     handler,
     url: 'geocaching.com/blog/',
 };
 
+const languageToCategory = { de: 140, fr: 138, es: 702, nl: 737, cs: 1404 };
+const languageToLabel = { de: 'Deutsch', fr: 'Français', es: 'Español', nl: 'Nederlands', cs: 'Čeština' };
+
 async function handler(ctx) {
     const baseUrl = 'https://www.geocaching.com';
-    const { data: response } = await got(`${baseUrl}/blog/wp-json/wp/v2/posts`, {
-        searchParams: {
-            per_page: ctx.req.query('limit') ?? 100,
-            _embed: 1,
-        },
+    const language = ctx.req.param('language') ?? 'en';
+    const searchParams = {
+        per_page: 20,
+        _embed: 1,
+        _fields: ['id', 'title', 'link', 'guid', 'excerpt', 'date_gmt', 'modified_gmt', '_embedded', '_links'],
+    };
+
+    if (language === 'en') {
+        searchParams.categories_exclude = Object.values(languageToCategory).join(',');
+    } else if (language !== 'all') {
+        searchParams.categories = languageToCategory[language];
+    }
+
+    // console.log(searchParams);
+
+    const { data: response } = await got(`${baseUrl}/blog/wp-json/wp/v2/posts`, { searchParams });
+    const items = response.map((item) => {
+        const media = item._embedded['wp:featuredmedia'][0];
+        const mediaDetails = media?.media_details;
+        return {
+            title: item.title.rendered.trim(),
+            link: item.link,
+            guid: item.guid.rendered,
+            description: item.excerpt.rendered,
+            pubDate: parseDate(item.date_gmt),
+            updated: parseDate(item.modified_gmt),
+            author: item._embedded.author[0].name,
+            category: item._embedded['wp:term'][0].map((category) => category.name.trim()),
+            media: media
+                ? {
+                      content: {
+                          url: media.source_url,
+                          type: media.mime_type,
+                          height: mediaDetails.height,
+                          width: mediaDetails.width,
+                          fileSize: mediaDetails.filesize,
+                      },
+                      thumbnail: {
+                          url: mediaDetails.sizes.large.source_url,
+                          height: mediaDetails.sizes.large.height,
+                          width: mediaDetails.sizes.large.width,
+                      },
+                  }
+                : undefined,
+        };
     });
 
-    const items = response.map((item) => ({
-        title: item.title.rendered,
-        link: item.link,
-        guid: item.guid.rendered,
-        description: item.content.rendered,
-        pubDate: parseDate(item.date_gmt),
-        author: item._embedded.author[0].name,
-        category: item._embedded['wp:term'][0].map((category) => category.name),
-    }));
-
     return {
-        title: 'Geocaching Blog',
+        title: language in languageToLabel ? `Geocaching Blog - ${languageToLabel[language]}` : 'Geocaching Blog',
         link: `${baseUrl}/blog/`,
-        image: `${baseUrl}/blog/favicon.ico`,
-        description: 'Geocaching 博客更新',
+        language: language in languageToCategory ? language : 'en',
+        image: 'https://i.ytimg.com/vi_webp/G28VxvBoSLQ/maxresdefault.webp',
+        icon: `${baseUrl}/blog/favicon.ico`,
+        logo: `${baseUrl}/blog/favicon.ico`,
+        description: 'Geocaching Official Blog',
         item: items,
+        allowEmpty: true,
     };
 }

--- a/lib/routes/geocaching/blogs.ts
+++ b/lib/routes/geocaching/blogs.ts
@@ -46,7 +46,13 @@ const languageToLabel = { de: 'Deutsch', fr: 'Français', es: 'Español', nl: 'N
 async function handler(ctx) {
     const baseUrl = 'https://www.geocaching.com';
     const language = ctx.req.param('language') ?? 'en';
-    const searchParams = {
+    const searchParams: {
+        per_page: number;
+        _embed: number;
+        _fields: string[];
+        categories_exclude?: string;
+        categories?: number;
+    } = {
         per_page: 20,
         _embed: 1,
         _fields: ['id', 'title', 'link', 'guid', 'excerpt', 'date_gmt', 'modified_gmt', '_embedded', '_links'],

--- a/lib/routes/geocaching/blogs.ts
+++ b/lib/routes/geocaching/blogs.ts
@@ -60,8 +60,12 @@ async function handler(ctx) {
 
     if (language === 'en') {
         searchParams.categories_exclude = Object.values(languageToCategory).join(',');
-    } else if (language !== 'all') {
+    } else if (language in languageToCategory) {
         searchParams.categories = languageToCategory[language];
+    } else if (language === 'all') {
+        // do nothing
+    } else {
+        throw new Error(`Unsupported language: ${language}`);
     }
 
     // console.log(searchParams);

--- a/lib/routes/geocaching/templates/blogs.art
+++ b/lib/routes/geocaching/templates/blogs.art
@@ -1,6 +1,0 @@
-<div>
-  <img src="{{ image }}" />
-</div>
-<div>
-{{@ description }}
-</div>


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #18137

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/geocaching/blogs
/geocaching/blogs/en
/geocaching/blogs/de
/geocaching/blogs/fr
/geocaching/blogs/es
/geocaching/blogs/nl
/geocaching/blogs/cs
/geocaching/blogs/all
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add language parameter to blogs route and update response structure.