### PR TITLE
feat(route): add minecraft news

### DIFF
--- a/lib/routes/minecraft/news.ts
+++ b/lib/routes/minecraft/news.ts
@@ -1,0 +1,53 @@
+import got from 'got';
+import { Route } from '@/types';
+export const route: Route = {
+    path: '/news',
+    categories: ['game'],
+    example: '/minecraft/news',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['minecraft.net/en-us/articles', 'minecraft.net/'],
+        },
+    ],
+    maintainers: ['OutlinedArc217'],
+    url: 'minecraft.net/',
+    description: 'Catch up on the latest articles',
+    zh: {
+        name: 'Minecraft近期新闻',
+    },
+};
+
+export async function getData() {
+    const jsonUrl = 'https://www.minecraft.net/content/minecraftnet/language-masters/en-us/articles/jcr:content/root/container/image_grid_a.articles.page-1.json';
+    const baseUrl = 'https://www.minecraft.net';
+    const response = await got(jsonUrl, {
+        headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+            'Accept': 'application/json',
+            'Referer': 'https://www.minecraft.net/en-us/articles'
+        }
+    });
+    const data = JSON.parse(response.body);
+    const items = data.article_grid.map((article: any) => ({
+        title: article.default_tile.title || 'No title available',
+        link: new URL(article.article_url, baseUrl).href,
+    }));
+    return {
+        title: 'Minecraft News',
+        link: baseUrl,
+        description: 'Catch up on the latest articles',
+        item: items.map((item: any) => ({
+            title: item.title,
+            link: item.link,
+        })),
+    };
+}


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
minecraft/news
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [X] New Route / 新的路由
  - [X] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [X] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
