### PR TITLE
fix(routes): 修复 Shopify 路由语言代码不一致的问题

### DIFF
--- a/lib/routes/shopify/apps/[handle].reviews.ts
+++ b/lib/routes/shopify/apps/[handle].reviews.ts
@@ -72,7 +72,7 @@ async function handler(ctx: Context): Promise<Data> {
         title: `Reviews handle:${handle} page:${page} – Shopify App Store`,
         link: `${baseURL}/${handle}/reviews`,
         allowEmpty: true,
-        language: 'en-US',
+        language: 'en-us',
         item: items,
     };
 }

--- a/lib/routes/shopify/apps/search.ts
+++ b/lib/routes/shopify/apps/search.ts
@@ -15,8 +15,11 @@ export const route: Route = {
         {
             source: ['apps.shopify.com/search'],
             target: (_params, url) => {
-                const { searchParams } = new URL(url).searchParams;
-                return searchParams.has('q') ? `/shopify/apps/search/${searchParams.get('q')}` : null;
+                const searchParams = new URL(url).searchParams;
+                if (!searchParams.has('q')) {
+                    return '';
+                }
+                return `/shopify/apps/search/${searchParams.get('q')}`;
             },
         },
     ],
@@ -76,7 +79,7 @@ async function handler(ctx: Context): Promise<Data> {
         link: `https://apps.shopify.com/search?q=${q}`,
         // description: `Search results for "${q}" – Shopify App Store`,
         allowEmpty: true,
-        language: 'en-US',
+        language: 'en-us',
         item: items,
     };
 }


### PR DESCRIPTION
- 修改 language 属性，统一将 'en-US' 更改为 'en-us'
- 改进 `/shopify/apps/search/:q` 路由参数校验逻辑，避免空查询返回无效值

## Example for the Proposed Route(s) / 路由地址示例

```routes
/shopify/apps/flow/reviews
/shopify/apps/search/flow
```
