### PR TITLE
feat(minecraft-version): Add English to extension

### DIFF
--- a/lib/routes/minecraft/version.ts
+++ b/lib/routes/minecraft/version.ts
@@ -155,7 +155,7 @@ async function handler(ctx?: Context) {
 
     const title = (
         `Minecraft Java${i18n[lang].version}`
-        `${versionType === 'all' ? '' : (i18n[lang.typeName[versionType] ?? versionType)}`
+        `${versionType === 'all' ? '' : (i18n[lang].typeName[versionType] ?? versionType)}`
         `${i18n[lang].title_ending}`
     );
 


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例


```routes
NOROUTE
```

## Note / 说明

Add English language parameter to Minecraft Version extension. Set `en` as default as it described in manifest.

This pull request includes changes to add language support and improve internationalization for the Minecraft version route. The most important changes include adding a new language parameter, updating descriptions, and implementing internationalization for version types and titles.

Language support:

* [`lib/routes/minecraft/version.ts`](diffhunk://#diff-a201d14decf4dea497de84a0d5faa826ba58fb17f8b63d256894323bcdb7e974L6-R25): Added a new optional `lang` parameter to the route path and example to support language selection.
* [`lib/routes/minecraft/version.ts`](diffhunk://#diff-a201d14decf4dea497de84a0d5faa826ba58fb17f8b63d256894323bcdb7e974L6-R25): Updated the `parameters` section to include the new `lang` parameter with options for Chinese and English.

Internationalization:

* [`lib/routes/minecraft/version.ts`](diffhunk://#diff-a201d14decf4dea497de84a0d5faa826ba58fb17f8b63d256894323bcdb7e974L33-R54): Updated the `description` section to include both English and Chinese translations for version types and link types.
* [`lib/routes/minecraft/version.ts`](diffhunk://#diff-a201d14decf4dea497de84a0d5faa826ba58fb17f8b63d256894323bcdb7e974L54-R91): Introduced an `i18n` object to handle internationalized strings for version types, titles, and updates in both English and Chinese.
* [`lib/routes/minecraft/version.ts`](diffhunk://#diff-a201d14decf4dea497de84a0d5faa826ba58fb17f8b63d256894323bcdb7e974R149-R168): Modified the `handler` function to use the `i18n` object for generating titles and descriptions based on the selected language.