### PR TITLE
fix(zaobao): remove google ads buttons

### DIFF
--- a/lib/routes/zaobao/util.ts
+++ b/lib/routes/zaobao/util.ts
@@ -100,6 +100,7 @@ const parseList = async (
                 $1('.overlay-microtransaction').remove();
                 $1('#video-freemium-player').remove();
                 $1('script').remove();
+                $1('.bff-google-ad').remove();
 
                 let articleBodyNode = $1('.articleBody');
                 if (articleBodyNode.length === 0) {


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/zaobao/realtime/china
/zaobao/realtime/singapore
/zaobao/realtime/world
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This PR removes the `button` (and `div`) elements that are used for display Google Ads by Zaobao that are not sanitized properly. They are being displayed by some RSS readers as a dangling eye-sore.

Before:

```html
<p>知情人士称，美国将把驻华外交使团规模削减高达10%。</p><p>据香港《南华早报》星期四（2月20日）报道，关于此次史无前例的削减行动，驻中国大陆和香港的美国外交官以及当地雇员，可能最早会在星期五（21日）收到关于规模削减的通知。</p><p>报道引述要求匿名的知情人士称，驻北京的大使馆，驻广州、上海、沈阳和武汉的总领事馆，以及驻港澳总领事馆将受到削减行动的影响。</p><div id="dfp-ad-imu1-wrapper" class="bff-google-ad google-ad flex w-full flex-row justify-center overflow-x-hidden my-[16px]"> <button class="min-w-[300px]" id="dfp-ad-imu1"></button> </div><p>报道称，目前尚不清楚受削减行动影响的人员是否会被调派到外交部门的其他单位，但预计会有裁员行动。美国国务院尚未置评。</p><p>路透社上星期引述消息人士报道，作为总统特朗普努力整顿美国外交使团的一部分，特朗普政府已要求美国驻世界各地的大使馆做好人员削减的准备。自特朗普1月20日上任后，特朗普和他的亿万富翁盟友马斯克一直在努力削减两人认为是浪费金钱的美国政府开支。</p><p>路透社报道，美国在中国有大量外交人员，而驻北京的外交人员办公地点占地10英亩，由六栋建筑组成，其中包括一座2016年竣工的新附楼。</p><div id="dfp-ad-midarticlespecial-wrapper" class="bff-google-ad google-ad flex w-full flex-row justify-center overflow-x-hidden my-[16px]"> <button class="w-full" id="dfp-ad-midarticlespecial"></button> </div><p>美国驻华大使馆和领事馆官网中文版资料显示，近50个不同联邦机构的1300多名美国员工和本地雇员，在位于北京的美国大使馆办公。</p> 
```
After:

```
<p>知情人士称，美国将把驻华外交使团规模削减高达10%。</p><p>据香港《南华早报》星期四（2月20日）报道，关于此次史无前例的削减行动，驻中国大陆和香港的美国外交官以及当地雇员，可能最早会在星期五（21日）收到关于规模削减的通知。</p><p>报道引述要求匿名的知情人士称，驻北京的大使馆，驻广州、上海、沈阳和武汉的总领事馆，以及驻港澳总领事馆将受到削减行动的影响。</p><p>报道称，目前尚不清楚受削减行动影响的人员是否会被调派到外交部门的其他单位，但预计会有裁员行动。美国国务院尚未置评。</p><p>路透社上星期引述消息人士报道，作为总统特朗普努力整顿美国外交使团的一部分，特朗普政府已要求美国驻世界各地的大使馆做好人员削减的准备。自特朗普1月20日上任后，特朗普和他的亿万富翁盟友马斯克一直在努力削减两人认为是浪费金钱的美国政府开支。</p><p>路透社报道，美国在中国有大量外交人员，而驻北京的外交人员办公地点占地10英亩，由六栋建筑组成，其中包括一座2016年竣工的新附楼。</p><p>美国驻华大使馆和领事馆官网中文版资料显示，近50个不同联邦机构的1300多名美国员工和本地雇员，在位于北京的美国大使馆办公。</p> 
```