### PR TITLE
feat(route): add news route for toranoana.jp

### DIFF
--- a/lib/routes/toranoana/namespace.ts
+++ b/lib/routes/toranoana/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'とらのあな',
+    url: 'toranoana.jp',
+    lang: 'ja',
+};

--- a/lib/routes/toranoana/news.ts
+++ b/lib/routes/toranoana/news.ts
@@ -100,7 +100,7 @@ async function handler(ctx): Promise<Data> {
                 title: post.title.rendered,
                 link: post.link,
                 description: $.html(),
-                pubDate: parseDate(post.date),
+                pubDate: parseDate(post.date_gmt),
                 guid: post.link,
                 author: 'とらのあな',
             };

--- a/lib/routes/toranoana/news.ts
+++ b/lib/routes/toranoana/news.ts
@@ -1,0 +1,100 @@
+import { Route, Data, DataItem } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import { load } from 'cheerio';
+
+export const route: Route = {
+    path: '/news/:category?',
+    categories: ['anime'],
+    example: '/toranoana/news/toragen',
+    parameters: { category: 'category' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Category',
+    maintainers: ['Tsuyumi25'],
+    handler,
+    radar: [
+        {
+            title: '総合新着記事',
+            source: ['news.toranoana.jp'],
+            target: '/news',
+        },
+        {
+            title: '女性向け',
+            source: ['news.toranoana.jp/joshi'],
+            target: '/news/joshi',
+        },
+        {
+            title: 'とらのあなイラスト展',
+            source: ['news.toranoana.jp/exhibitions'],
+            target: '/news/exhibition',
+        },
+        {
+            source: ['news.toranoana.jp/category/:category'],
+            target: '/news/:category',
+        },
+    ],
+    description: `
+::: warning TIP
+[総合新着記事](https://news.toranoana.jp)→\`/toranoana/news\`  
+[女性向け](https://news.toranoana.jp/joshi)→\`/toranoana/news/joshi\`  
+[イラスト展](https://news.toranoana.jp/exhibitions)→\`/toranoana/news/exhibition\`  
+[\`https://news.toranoana.jp/category/media\`](https://news.toranoana.jp/category/media)→\`/toranoana/news/media\`
+:::`,
+};
+
+async function handler(ctx): Promise<Data> {
+    const { category = '' } = ctx.req.param();
+    let apiUrl = 'https://news.toranoana.jp/wp-json/wp/v2/posts';
+
+    if (category) {
+        const categoryResponse = await ofetch(`https://news.toranoana.jp/wp-json/wp/v2/categories?slug=${category}`);
+        if (categoryResponse && categoryResponse.length > 0) {
+            apiUrl += `?categories=${categoryResponse[0].id}`;
+        }
+    } else {
+        // exclude category-joshi to get result of general
+        apiUrl += `?categories_exclude=1598`;
+    }
+
+    const posts = await ofetch(apiUrl, {
+        params: {
+            per_page: 20,
+        },
+    });
+
+    if (!posts || !posts.length) {
+        throw new Error('No posts found');
+    }
+
+    const items = posts.map((post) => {
+        const $ = load(post.content.rendered);
+
+        // remove unnecessary title
+        $('h1').first().remove();
+        $('h2').first().remove();
+
+        return {
+            title: post.title.rendered,
+            link: post.link,
+            description: $.html(),
+            pubDate: parseDate(post.date),
+            guid: post.link,
+            author: 'とらのあな',
+        };
+    });
+
+    return {
+        title: category ? `とらのあな総合インフォメーション - ${category}` : 'とらのあな総合インフォメーション',
+        link: category ? `https://news.toranoana.jp/category/${category}` : 'https://news.toranoana.jp/',
+        description: 'とらのあなの最新情報をお届け！同人誌、書籍、コミック、店舗フェア、イラスト展、とらのあな限定版、キャンペーンなど…スペシャルでお得な情報をいち早くチェック！',
+        item: items.filter(Boolean) as DataItem[],
+        language: 'ja',
+    };
+}

--- a/lib/routes/toranoana/news.ts
+++ b/lib/routes/toranoana/news.ts
@@ -82,7 +82,7 @@ async function handler(ctx): Promise<Data> {
         $('h2').first().remove();
 
         let thumbnail = '';
-        if (post._embedded['wp:featuredmedia'][0].source_url) {
+        if (post._embedded && post._embedded['wp:featuredmedia'][0].source_url) {
             thumbnail = post._embedded['wp:featuredmedia'][0].source_url;
         }
 

--- a/lib/routes/toranoana/news.ts
+++ b/lib/routes/toranoana/news.ts
@@ -32,7 +32,7 @@ export const route: Route = {
             target: '/news/joshi',
         },
         {
-            title: 'とらのあなイラスト展',
+            title: 'イラスト展',
             source: ['news.toranoana.jp/exhibitions'],
             target: '/news/exhibition',
         },


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #18386

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/toranoana/news
/toranoana/news/dojin
/toranoana/news/comic
/toranoana/news/media
/toranoana/news/hobby
/toranoana/news/fair
/toranoana/news/shop
/toranoana/news/tuhan
/toranoana/news/toragen
/toranoana/news/etc
/toranoana/news/ebook
/toranoana/news/campaign
/toranoana/news/exhibition
/toranoana/news/shop-fair
/toranoana/news/circle-introduction
/toranoana/news/%e3%81%a8%e3%82%89%e3%81%ae%e3%81%82%e3%81%aax%e9%9f%93%e5%9b%bd
/toranoana/news/pc%e3%82%b2%e3%83%bc%e3%83%a0
/toranoana/news/%e4%b8%80%e8%88%ac%e3%82%b2%e3%83%bc%e3%83%a0
/toranoana/news/joshi
/toranoana/news/%e3%82%a2%e3%83%97%e3%83%aa
/toranoana/news/bl%e5%88%9d%e5%bf%83%e8%80%85%e3%81%ab%e3%81%8a%e3%81%99%e3%81%99%e3%82%81%e3%82%b3%e3%83%9f%e3%83%83%e3%82%af
/toranoana/news/toramatsuri-2020-summer
/toranoana/news/thanksgiving
/toranoana/news/%e3%83%84%e3%82%af%e3%83%ab%e3%83%8e%e3%83%a2%e3%83%aa
/toranoana/news/dojin-enquete
/toranoana/news/b-awesome%e3%83%93%e3%83%bc%e3%82%aa%e3%83%bc%e3%82%b5%e3%83%a0%ef%bc%89%e3%82%a4%e3%83%b3%e3%82%bf%e3%83%93%e3%83%a5%e3%83%bc
/toranoana/news/mail-magazine
/toranoana/news/fantia
/toranoana/news/ec-update
/toranoana/news/%e5%8d%b0%e5%88%b7%e6%89%80%e3%82%a4%e3%83%b3%e3%82%bf%e3%83%93%e3%83%a5%e3%83%bc
/toranoana/news/creatia
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
