### PR TITLE
fix nhentai

### DIFF
--- a/lib/routes/nhentai/util.ts
+++ b/lib/routes/nhentai/util.ts
@@ -103,7 +103,10 @@ const parseSimpleDetail = ($ele) => {
     const link = new URL($ele.attr('href'), baseUrl).href;
     const thumb = $ele.children('img');
     const thumbSrc = thumb.attr('data-src') || thumb.attr('src');
-    const highResoThumbSrc = thumbSrc.replace('thumb', '1').replace(/t(\d+)\.nhentai\.net/, 'i$1.nhentai.net');
+    const highResoThumbSrc = thumbSrc
+        .replace('thumb', '1')
+        .replace(/t(\d+)\.nhentai\.net/, 'i$1.nhentai.net')
+        .replace('.webp.webp', '.webp');
     return {
         title: $ele.children('.caption').text(),
         link,


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/nhentai/index/language/chinese
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

有时候，源站的略缩图会带上冗余的`.webp`后缀，将转换得到错误的高清图片地址。这个patch临时修复了这一情况。

一个错误的rss.xml片段如下：

```
<?xml version="1.0" encoding="UTF-8"?>
<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
    <channel>
        <title>nhentai - language - chinese</title>
        <link>https://nhentai.net/language/chinese/</link>
        <atom:link href="http://rsshub.i7mc.com/nhentai/index/language/chinese" rel="self"
            type="application/rss+xml" />
        <description>hentai - Powered by RSSHub</description>
        <generator>RSSHub</generator>
        <webMaster>contact@rsshub.app (RSSHub)</webMaster>
        <language>en</language>
        <lastBuildDate>Tue, 04 Mar 2025 11:13:23 GMT</lastBuildDate>
        <ttl>5</ttl>
        <item>
            <title>[Wolfanine] Special Order (Tavern of Spear)翻译</title>
            <description>&lt;img src="https://i4.nhentai.net/galleries/3261955/1.webp.webp"
                referrerpolicy="no-referrer"&gt;</description>
            <link>https://nhentai.net/g/560035/</link>
            <guid isPermaLink="false">https://nhentai.net/g/560035/</guid>
        </item>
        <item>
            <title>[エフ屋 (メッシィ)] FUTANARI ITOKO EXTRA 2 [黄记汉化组] [DL版]［英雄去码］</title>
            <description>&lt;img src="https://i4.nhentai.net/galleries/3261943/1.webp.webp"
                referrerpolicy="no-referrer"&gt;</description>
            <link>https://nhentai.net/g/560030/</link>
            <guid isPermaLink="false">https://nhentai.net/g/560030/</guid>
        </item>
```

