### PR TITLE
fix(route/gov): Update selectors to adapt to the revised webpages (#18548)

### DIFF
--- a/lib/routes/gov/cn/news/index.ts
+++ b/lib/routes/gov/cn/news/index.ts
@@ -20,11 +20,11 @@ export const route: Route = {
         supportScihub: false,
     },
     name: '政府新闻',
-    maintainers: ['EsuRt', 'howfool'],
+    maintainers: ['EsuRt', 'howfool', 'zll17'],
     handler,
-    description: `| 政务部门 | 滚动新闻 | 新闻要闻 | 国务院新闻 | 国务院工作会议 | 政策文件 |
-| :------: | :------: | :------: | :--------: | :------------: | :------: |
-|    bm    |    gd    |    yw    |     gwy    |     gwyzzjg    |  zhengce |`,
+    description: `| 政务部门 | 新闻要闻 | 国务院新闻 | 国务院工作会议 | 最新政策 |
+| :------: | :------: | :--------: | :------------: | :------: |
+|    bm    |    yw    |     gwy    |     gwyzzjg    |  zhengce |`,
 };
 
 async function handler(ctx) {
@@ -35,24 +35,19 @@ async function handler(ctx) {
     let list = '';
     switch (uid) {
         case 'bm':
-            url = `${originDomain}/lianbo/bumen/index.htm`;
+            url = `${originDomain}/lianbo/bumen/home_0.htm`;
             title = '中国政府网 - 部门政务';
             break;
         case 'yw':
             url = `${originDomain}/yaowen/index.htm`;
             title = '中国政府网 - 新闻要闻';
             break;
-        case 'gd':
-            // 因 /xinwen/gundong.htm 被重定向到 /yaowen/index.htm, 所以这里直接用要闻的代替了
-            url = `${originDomain}/yaowen/index.htm`;
-            title = '中国政府网 - 滚动新闻';
-            break;
         case 'gwy':
             url = `${originDomain}/pushinfo/v150203/`;
             title = '中国政府网 - 国务院信息';
             break;
         case 'zhengce':
-            url = 'http://sousuo.gov.cn/s.htm?t=zhengcelibrary';
+            url = `${originDomain}/zhengce/zuixin/home_0.htm`;
             title = '中国政府网 - 政策文件';
             break;
         case 'gwyzzjg':
@@ -64,13 +59,8 @@ async function handler(ctx) {
     }
     const listData = await got.get(url);
     const $ = load(listData.data);
-    if (url.includes('zhengcelibrary')) {
-        list = $('.dys_middle_result_content_item');
-    } else if (url.includes('bumen')) {
-        list = $('.infolist li');
-    } else {
-        list = $('.news_box .list li:not(.line)');
-    }
+
+    list = $('.news_box .list li');
 
     return {
         title,


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #18548 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/gov/cn/news/bm    
/gov/cn/news/yw    
/gov/cn/news/gwy    
/gov/cn/news/gwyzzjg    
/gov/cn/news/zhengce 
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
网站改版后，原分支"gd(滚动)"会被重定向到"yw(要闻)"，因此删除分支"gd(滚动)"