### PR TITLE
fix: A bug fix ,fix nhentai image link error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,50 +1,10 @@
 services:
-    rsshub:
-        # two ways to enable puppeteer:
-        # * comment out marked lines, then use this image instead: diygod/rsshub:chromium-bundled
-        # * (consumes more disk space and memory) leave everything unchanged
-        image: diygod/rsshub
-        restart: always
-        ports:
-            - "1200:1200"
-        environment:
-            NODE_ENV: production
-            CACHE_TYPE: redis
-            REDIS_URL: "redis://redis:6379/"
-            PUPPETEER_WS_ENDPOINT: "ws://browserless:3000" # marked
-        healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:1200/healthz"]
-            interval: 30s
-            timeout: 10s
-            retries: 3
-        depends_on:
-            - redis
-            - browserless # marked
-
-    browserless: # marked
-        image: browserless/chrome # marked
-        restart: always # marked
-        ulimits: # marked
-            core: # marked
-                hard: 0 # marked
-                soft: 0 # marked
-        healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:3000/pressure"]
-            interval: 30s
-            timeout: 10s
-            retries: 3
-
-    redis:
-        image: redis:alpine
-        restart: always
-        volumes:
-            - redis-data:/data
-        healthcheck:
-            test: ["CMD", "redis-cli", "ping"]
-            interval: 30s
-            timeout: 10s
-            retries: 5
-            start_period: 5s
-
-volumes:
-    redis-data:
+  rsshub:
+    image: diygod/rsshub
+    ports:
+      - '1200:1200'
+    environment:
+      - NODE_ENV=production
+      - CACHE_TYPE=memory
+    volumes:
+      - ./lib:/app/lib

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,50 @@
 services:
-  rsshub:
-    image: diygod/rsshub
-    ports:
-      - '1200:1200'
-    environment:
-      - NODE_ENV=production
-      - CACHE_TYPE=memory
-    volumes:
-      - ./lib:/app/lib
+    rsshub:
+        # two ways to enable puppeteer:
+        # * comment out marked lines, then use this image instead: diygod/rsshub:chromium-bundled
+        # * (consumes more disk space and memory) leave everything unchanged
+        image: diygod/rsshub
+        restart: always
+        ports:
+            - "1200:1200"
+        environment:
+            NODE_ENV: production
+            CACHE_TYPE: redis
+            REDIS_URL: "redis://redis:6379/"
+            PUPPETEER_WS_ENDPOINT: "ws://browserless:3000" # marked
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:1200/healthz"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+        depends_on:
+            - redis
+            - browserless # marked
+
+    browserless: # marked
+        image: browserless/chrome # marked
+        restart: always # marked
+        ulimits: # marked
+            core: # marked
+                hard: 0 # marked
+                soft: 0 # marked
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:3000/pressure"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+
+    redis:
+        image: redis:alpine
+        restart: always
+        volumes:
+            - redis-data:/data
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 5s
+
+volumes:
+    redis-data:

--- a/lib/routes/nhentai/util.ts
+++ b/lib/routes/nhentai/util.ts
@@ -133,7 +133,9 @@ const getDetail = async (simple) => {
         .toArray()
         .map((ele) => new URL($(ele).attr('data-src'), baseUrl).href)
         .map((src) => src.replace(/(.+)(\d+)t\.(.+)/, (_, p1, p2, p3) => `${p1}${p2}.${p3}`)) // thumb to high-quality
-        .map((src) => src.replace(/t(\d+)\.nhentai\.net/, 'i$1.nhentai.net'));
+        .map((src) => src.replace(/t(\d+)\.nhentai\.net/, 'i$1.nhentai.net'))
+        .map((src) => src.replace(/\.(jpg|png|gif)\.webp$/, '.$1')) // 移除重複的.webp後綴
+        .map((src) => src.replace(/\.webp\.webp$/, '.webp')); // 處理.webp.webp的情況
 
     return {
         ...simple,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

修复了nhentai路由中图片URL处理的问题：
1. 修复了图片URL中重复.webp后缀的问题
2. 保留了原本就是.webp格式的图片
3. 处理了.webp.webp的特殊情况

修改内容：
1. 在`lib/routes/nhentai/util.ts`中添加了新的URL处理逻辑
2. 使用正则表达式处理不同类型的图片URL
3. 确保不会影响正常的.webp图片

测试方法：
1. 使用Docker环境测试
2. 验证不同类型的图片URL
3. 确认缓存清除后的效果


原始
![image](https://github.com/user-attachments/assets/4b35e12e-c30b-48c3-b6e2-5e8edb7b28a2)
修正後
![image](https://github.com/user-attachments/assets/5f0c56e6-a282-41e4-afcb-e6e671148232)

可能需要清理redis 當中的內容 再請求才能生效