### PR TITLE
docs: fix example of '30secondsofcode'

### DIFF
--- a/lib/routes/30secondsofcode/category.ts
+++ b/lib/routes/30secondsofcode/category.ts
@@ -5,7 +5,7 @@ import { processList } from './utils';
 export const route: Route = {
     path: '/category/:category?/:subCategory?',
     categories: ['programming'],
-    example: '/category/css/interactivity',
+    example: '/30secondsofcode/category/css/interactivity',
     parameters: {
         category: {
             description: 'Main Category. For Complete list visit site "https://www.30secondsofcode.org/collections/p/1/"',


### PR DESCRIPTION
Current example in documentation is 'https://rsshub.app/category/css/interactivity' wish is invalid.

Correct example is 'https://rsshub.app/30secondsofcode/category/css/interactivity'.

![image](https://github.com/user-attachments/assets/5439b823-b356-4611-87b4-88ccabf9b3bb)
