### PR TITLE
fix: image of readhub daily should be square

### DIFF
--- a/lib/routes/readhub/daily.ts
+++ b/lib/routes/readhub/daily.ts
@@ -53,7 +53,7 @@ async function handler(ctx) {
 
     const author = $('meta[name="application-name"]').prop('content');
     const subtitle = $('meta[property="og:title"]').prop('content');
-    const image = 'https://readhub-oss.nocode.com/static/readhub.png';
+    const image = 'https://readhub.cn/icons/icon-192x192.png';
     const icon = new URL($('link[rel="apple-touch-icon"]').prop('href'), rootUrl);
 
     return {


### PR DESCRIPTION
## 描述

Readhub daily 这个路由下手动配置的 image 图片是一张长图，而非方形，导致 logo 显示不全，怪怪的，改成了官网的方形 icon 图。

## Fix
- 修复了 `/readhub/daily` 路由 logo 显示不正确的问题