### PR TITLE
fix: 修复 `/readhub/daily` 路由 logo 和标题显示的问题

### DIFF
--- a/lib/routes/readhub/daily.ts
+++ b/lib/routes/readhub/daily.ts
@@ -58,7 +58,7 @@ async function handler(ctx) {
 
     return {
         item: items,
-        title: `${author} - ${subtitle}`,
+        title: `${author} - ${route.name}`,
         link: currentUrl,
         description: $('meta[name="description"]').prop('content'),
         language: 'zh',

--- a/lib/routes/readhub/daily.ts
+++ b/lib/routes/readhub/daily.ts
@@ -53,7 +53,7 @@ async function handler(ctx) {
 
     const author = $('meta[name="application-name"]').prop('content');
     const subtitle = $('meta[property="og:title"]').prop('content');
-    const image = 'https://readhub-oss.nocode.com/static/readhub.png';
+    const image = 'https://readhub.cn/icons/icon-192x192.png';
     const icon = new URL($('link[rel="apple-touch-icon"]').prop('href'), rootUrl);
 
     return {


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

- 修复了 `/readhub/daily` 路由 logo 显示不正确的问题
- 修复了 `/readhub/daily` 路由 标题 中出现重复的 ` - Readhub` 的问题

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/readhub/daily
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Readhub daily 这个路由下手动配置的 image 图片是一张长图，而非方形，导致 logo 显示不全，怪怪的，改成了官网的方形 icon 图。