### PR TITLE
fix(route): fix hanime1 previews video posters not displaying

### DIFF
--- a/lib/routes/hanime1/previews.ts
+++ b/lib/routes/hanime1/previews.ts
@@ -50,9 +50,9 @@ export const route: Route = {
 
                 // 发布时间 MMDD
                 const rawDate = row.find('.preview-info-cover div').text().trim();
-                // 链接
+                // 视频 选中模态框全局查找
                 const modalSelector = row.find('.trailer-modal-trigger').attr('data-target') || '';
-                const previewVideoLink = modalSelector ? $(modalSelector).find('video source').attr('src') || '' : '';
+                const previewVideoLink = modalSelector ? $(`${modalSelector} video source`).attr('src') || '' : '';
 
                 // 简介
                 const description = row.find('.caption').first().text().trim();
@@ -68,8 +68,11 @@ export const route: Route = {
                     description: `
                     <p>${description} </p>
                     <p>Tags: [${tags.join(', ')}]</p>
+                    <video controls width="100%" poster="${previewImageSrc}">
+                        <source src="${previewVideoLink}" type="video/mp4">
+                        Your browser does not support the video tag.
+                    </video>
                     `,
-                    // image: previewImageSrc,
                     enclosure_url: previewImageSrc,
                     enclosure_type: 'image/jpeg',
                     link: previewVideoLink,


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/hanime1/previews/202504
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? 
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析 (网站未提供具体时间）
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Hanime1 新番预览加载预览图修复
