### PR TITLE
feat(route): add uscardforum top-category (with puppeteer)

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -1764,6 +1764,9 @@ router.get('/dykszx/news/:type?', lazyloadRouteHandler('./routes/dykszx/news'));
 // Fashion Network
 router.get('/fashionnetwork/headline/:country?', lazyloadRouteHandler('./routes/fashionnetwork/headline.js'));
 
+// 美卡论坛
+router.get('/uscardforum/top-category/:categoryID/:period?', lazyloadRouteHandler('./routes/uscardforum/top-category'));
+
 // Deprecated: DO NOT ADD ANY NEW ROUTES HERE
 
 module.exports = router;

--- a/lib/routes/uscardforum/namespace.ts
+++ b/lib/routes/uscardforum/namespace.ts
@@ -1,0 +1,33 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'uscardforum',
+    url: 'uscardforum.com',
+    description: `
+:::tip
+UsCardForum is a Chinese community focused on U.S. credit cards, bank accounts, rebates, deals, and daily life in North America.
+
+It is built with Discourse and supports some official RSS feeds:
+
+-   Latest posts: \`https://www.uscardforum.com/posts.rss\`
+-   Category-specific: \`https://www.uscardforum.com/c/credit-cards/1.rss\`
+-   Tag-specific: \`https://www.uscardforum.com/tag/amex.rss\`
+
+This namespace provides **enhanced RSS for Top Posts** in any category, supporting filtering by time period (daily/weekly/monthly/yearly).
+:::`,
+    zh: {
+        name: '美卡论坛',
+        description: `
+:::tip
+美卡论坛是一个专注于美国信用卡、银行账户、返现、羊毛信息和北美生活的中文社区。
+
+网站使用 Discourse 构建，并支持一些内置 RSS 源：
+
+-   全站最新帖子：\`https://www.uscardforum.com/posts.rss\`
+-   指定分类订阅：\`https://www.uscardforum.com/c/credit-cards/1.rss\`
+-   指定标签订阅：\`https://www.uscardforum.com/tag/amex.rss\`
+
+本命名空间扩展了对热门帖子排行的支持，允许按"分类 + 时间范围（日/周/月/年）"订阅。
+:::`,
+    },
+};

--- a/lib/routes/uscardforum/top-category.ts
+++ b/lib/routes/uscardforum/top-category.ts
@@ -1,0 +1,147 @@
+import { Route, Data, DataItem } from '@/types';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import cache from '@/utils/cache';
+import puppeteer from '@/utils/puppeteer';
+import logger from '@/utils/logger';
+
+export const route: Route = {
+    path: '/top-category/:categoryID/:period?',
+    categories: ['bbs'],
+    example: '/uscardforum/top-category/33/daily',
+    parameters: {
+        categoryID: '美卡论坛分类 ID，例如 33 是 Jobs',
+        period: '时间范围，可选: daily（今日）、weekly（本周，默认）、monthly（本月）、yearly（本年）',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: true,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['uscardforum.com/c/:categoryID/l/top', 'uscardforum.com/c/:categoryID/l/top?period=:period'],
+            target: '/top-category/:categoryID/:period?',
+        },
+    ],
+    name: '分类热门帖子',
+    maintainers: ['xiaojiou176'],
+    handler,
+};
+
+async function handler(ctx): Promise<Data> {
+    const { categoryID, period = 'weekly' } = ctx.req.param();
+    const baseUrl = 'https://www.uscardforum.com';
+    const url = `${baseUrl}/c/${categoryID}/l/top?period=${period}`;
+
+    const browser = await puppeteer();
+    const page = await browser.newPage();
+
+    // 拦截非必须资源，加快加载速度
+    await page.setRequestInterception(true);
+    page.on('request', (request) => {
+        const type = request.resourceType();
+        if (['document', 'script', 'xhr'].includes(type)) {
+            request.continue();
+        } else {
+            request.abort();
+        }
+    });
+
+    try {
+        logger.http(`Requesting ${url}`);
+        await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+
+        const content = await page.content();
+        const $ = load(content);
+        await page.close();
+
+        const categoryName =
+            $('.category-name').text().trim() ||
+            $('h1')
+                .text()
+                .trim()
+                .replace(/热门帖子/, '') ||
+            `分类 ${categoryID}`;
+
+        const list: DataItem[] = [];
+        $('.topic-list tbody tr').each((_, el) => {
+            const title = $(el).find('a.title').text().trim();
+            const href = $(el).find('a.title').attr('href');
+
+            if (!href) {
+                return;
+            }
+
+            const link = baseUrl + href;
+            const author = $(el).find('.posters .poster img').attr('title') || 'Unknown';
+            const replies = $(el).find('td.num.posts').text().trim();
+            const views = $(el).find('td.num.views').text().trim();
+            const pubDate = $(el).find('td.num.activity time').attr('datetime');
+
+            list.push({
+                title: `[${author}] ${title}`,
+                link,
+                description: `Replies: ${replies} · Views: ${views}`,
+                author,
+                pubDate: pubDate ? parseDate(pubDate) : undefined,
+                guid: link,
+            });
+        });
+
+        const items = await Promise.all(
+            list.map((item) =>
+                cache.tryGet(item.link as string, async () => {
+                    try {
+                        const postPage = await browser.newPage();
+                        await postPage.setRequestInterception(true);
+                        postPage.on('request', (req) => {
+                            const type = req.resourceType();
+                            if (['document', 'script', 'xhr'].includes(type)) {
+                                req.continue();
+                            } else {
+                                req.abort();
+                            }
+                        });
+
+                        logger.http(`Requesting ${item.link}`);
+                        await postPage.goto(item.link as string, { waitUntil: 'domcontentloaded', timeout: 60000 });
+                        await new Promise((resolve) => setTimeout(resolve, 2000));
+
+                        const postContent = await postPage.content();
+                        const post$ = load(postContent);
+                        await postPage.close();
+
+                        const content = post$('.topic-body .cooked').first().html();
+                        const originalDescription = item.description;
+
+                        if (content) {
+                            item.description = `
+                                <p>${originalDescription}</p>
+                                <hr />
+                                ${content}
+                            `;
+                        }
+
+                        return item;
+                    } catch (error) {
+                        logger.error(`Error fetching post content for ${item.link}: ${error}`);
+                        return item;
+                    }
+                })
+            )
+        ).then((items) => items.filter(Boolean) as DataItem[]);
+
+        return {
+            title: `美卡论坛 - ${categoryName} 热门帖子（${period}）`,
+            link: url,
+            item: items,
+        };
+    } finally {
+        await browser.close();
+    }
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #（如果没有关联 issue 可以空着）

## Example for the Proposed Route(s) / 路由地址示例

```routes
/uscardforum/top-category/33
/uscardforum/top-category/33/daily
/uscardforum/top-category/33/weekly
/uscardforum/top-category/33/monthly
/uscardforum/top-category/33/yearly

New RSS Route Checklist / 新 RSS 路由检查表

 New Route / 新的路由
 Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
 Documentation / 文档说明（已添加 namespace.ts）
 Full text / 全文获取
 Use cache / 使用缓存
 Anti-bot or rate limit / 反爬/频率限制
 If yes, do your code reflect this sign? / 是否有对应措施（已使用 puppeteer）
 [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
 Parsed / 可以解析
 Correct time zone / 时区正确
 New package added / 添加了新的包
 Puppeteer
Note / 说明

基于 puppeteer 实现了美卡论坛的分类热门贴子抓取，支持按 period 参数订阅（daily/weekly/monthly/yearly）。 内容为完整贴文，带缓存。适用于反爬严厉的 discourse 系论坛。