### PR TITLE
feat(route): 添加中国无线电协会业余无线电分会考试信息路由

### DIFF
--- a/lib/routes/crac/exam.ts
+++ b/lib/routes/crac/exam.ts
@@ -1,0 +1,49 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/exam',
+    categories: ['government'],
+    example: '/exam',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '中国无线电协会业余无线电分会-考试信息',
+    maintainers: ['admxj'],
+    handler,
+};
+
+async function handler() {
+    const baseUrl = 'http://82.157.138.16:8091/CRAC';
+
+    const response = await got({
+        method: 'post',
+        url: `${baseUrl}/app/exam_advice/examAdviceList`,
+        body: { req: { type: '0', page_no: '1', page_size: '10000' } },
+    });
+
+    const list = response.data.res.list.map((item) => {
+        const id = Buffer.from(item.id).toString('base64');
+        const type = Buffer.from(item.type).toString('base64');
+        const link = `${baseUrl}/crac/pages/list_detail.html?id=${id}&type=${type}`;
+        return {
+            title: item.name,
+            link,
+            pubDate: item.createDate,
+            startDate: item.exam.signUpStartDate,
+            examType: item.examType,
+            description: item.content,
+        };
+    });
+
+    return {
+        title: '考试信息-中国无线电协会业余无线电分会',
+        link: 'http://82.157.138.16:8091/CRAC/crac/pages/list_examMsg.html',
+        item: list,
+    };
+}


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/crac/exam
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
