### PR TITLE
fix(route/cosplaytele): revert to iterative content fetching due to WP JSON API being disabled

### DIFF
--- a/lib/routes/cosplaytele/article.ts
+++ b/lib/routes/cosplaytele/article.ts
@@ -1,12 +1,20 @@
+import { load } from 'cheerio';
+import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
-import { WPPost } from './types';
 
-function loadArticle(item: WPPost) {
+async function loadArticle(link) {
+    const resp = await got(link);
+    const article = load(resp.body);
+
+    const title = article('h1.entry-title').text().trim();
+    const description = article('.entry-content').html() ?? '';
+    const pubDate = parseDate(article('time')[0].attribs.datetime);
+
     return {
-        title: item.title.rendered,
-        description: item.content.rendered,
-        pubDate: parseDate(item.date_gmt),
-        link: item.link,
+        title,
+        description,
+        pubDate,
+        link,
     };
 }
 

--- a/lib/routes/cosplaytele/latest.ts
+++ b/lib/routes/cosplaytele/latest.ts
@@ -1,8 +1,9 @@
 import { Route } from '@/types';
+import cache from '@/utils/cache';
 import got from '@/utils/got';
+import { load } from 'cheerio';
 import { SUB_NAME_PREFIX, SUB_URL } from './const';
 import loadArticle from './article';
-import { WPPost } from './types';
 
 export const route: Route = {
     path: '/',
@@ -31,11 +32,19 @@ export const route: Route = {
 
 async function handler(ctx) {
     const limit = Number.parseInt(ctx.req.query('limit')) || 20;
-    const { data: posts } = await got(`${SUB_URL}wp-json/wp/v2/posts?per_page=${limit}`);
+    const response = await got(SUB_URL);
+    const $ = load(response.body);
+    const itemRaw = $('#content .post-item').slice(0, limit).toArray();
 
     return {
         title: `${SUB_NAME_PREFIX} - Latest`,
         link: SUB_URL,
-        item: posts.map((post) => loadArticle(post as WPPost)),
+        item: await Promise.all(
+            itemRaw.map((e) => {
+                const item = $(e);
+                const link = item.find('h5.post-title a').attr('href');
+                return cache.tryGet(link, () => loadArticle(link));
+            })
+        ),
     };
 }

--- a/lib/routes/cosplaytele/tag.ts
+++ b/lib/routes/cosplaytele/tag.ts
@@ -1,8 +1,9 @@
 import { Route } from '@/types';
+import cache from '@/utils/cache';
 import got from '@/utils/got';
+import { load } from 'cheerio';
 import { SUB_NAME_PREFIX, SUB_URL } from './const';
 import loadArticle from './article';
-import { WPPost } from './types';
 
 export const route: Route = {
     path: '/tag/:tag',
@@ -34,14 +35,19 @@ async function handler(ctx) {
     const tag = ctx.req.param('tag');
     const tagUrl = `${SUB_URL}tag/${tag}/`;
 
-    const {
-        data: [{ id: tagId }],
-    } = await got(`${SUB_URL}wp-json/wp/v2/tags?slug=${tag}`);
-    const { data: posts } = await got(`${SUB_URL}wp-json/wp/v2/posts?tags=${tagId}&per_page=${limit}`);
+    const response = await got(tagUrl);
+    const $ = load(response.body);
+    const itemRaw = $('#content .post-item').slice(0, limit).toArray();
 
     return {
         title: `${SUB_NAME_PREFIX} - Tag: ${tag}`,
         link: tagUrl,
-        item: posts.map((post) => loadArticle(post as WPPost)),
+        item: await Promise.all(
+            itemRaw.map((e) => {
+                const item = $(e);
+                const link = item.find('h5.post-title a').attr('href');
+                return cache.tryGet(link, () => loadArticle(link));
+            })
+        ),
     };
 }


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/cosplaytele
/cosplaytele/category/cosplay
/cosplaytele/tag/aqua
/cosplaytele/popular/7
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
