### PR TITLE
fix(route/hpoi/info): 更新了页面解析逻辑

### DIFF
--- a/lib/routes/hpoi/info.ts
+++ b/lib/routes/hpoi/info.ts
@@ -35,13 +35,7 @@ async function handler(ctx) {
     const { type = 'all' } = ctx.req.param();
     const baseUrl = 'https://www.hpoi.net';
     const reqUrl = `${baseUrl}/user/home/ajax`;
-    const response = await got.post(reqUrl, {
-        form: {
-            page: 1,
-            type: 'info',
-            catType: type,
-        },
-    });
+    const response = await got.post(`${reqUrl}?page=1&type=info&catType=${type}`);
     const $ = load(response.data);
 
     const items = $('.home-info')

--- a/lib/routes/hpoi/info.ts
+++ b/lib/routes/hpoi/info.ts
@@ -80,7 +80,7 @@ async function handler(ctx) {
 
     const $ = load(response.data);
 
-    const items = $('.home-info').map((_, ele) => {
+    const items = $('.home-info').toArray().map((ele) => {
         const $item = load(ele);
         const leftNode = $item('.overlay-container');
         const relativeLink = leftNode.find('a').first().attr('href');
@@ -100,9 +100,7 @@ async function handler(ctx) {
         };
     });
 
-    const items1 = items.toArray();
-
-    const items2 = filterSet.size > 0 ? items1.filter((e) => filterSet.has(e.typeName)) : items1;
+    const items2 = filterSet.size > 0 ? items.filter((e) => filterSet.has(e.typeName)) : items;
 
     const typeToLabel = {
         all: '全部',

--- a/lib/routes/hpoi/info.ts
+++ b/lib/routes/hpoi/info.ts
@@ -4,17 +4,27 @@ import { load } from 'cheerio';
 import { parseRelativeDate } from '@/utils/parse-date';
 
 export const route: Route = {
-    path: '/info/:type?',
+    path: '/info/:type?/:catType?',
     categories: ['anime'],
-    example: '/hpoi/info/all',
+    example: '/hpoi/info/all/hobby|model',
     parameters: {
         type: {
-            description: '分类',
+            description: '情报类型',
             options: [
                 { value: 'all', label: '全部' },
-                { value: 'hobby', label: '手办' },
-                { value: 'model', label: '模型' },
+                { value: 'confirm', label: '制作' },
+                { value: 'official_pic', label: '官图更新' },
+                { value: 'preorder', label: '开订' },
+                { value: 'delay', label: '延期' },
+                { value: 'release', label: '出荷' },
+                { value: 'reorder', label: '再版' },
+                { value: 'hobby', label: '手办(拟废弃, 无效果)' },
+                { value: 'model', label: '动漫模型(拟废弃, 无效果)' },
             ],
+            default: 'all',
+        },
+        include: {
+            description: '手办分类过滤, 使用|分割, 支持的分类见下表',
             default: 'all',
         },
     },
@@ -28,47 +38,88 @@ export const route: Route = {
     },
     name: '情报',
     maintainers: ['sanmmm DIYgod'],
+    description: `::: tip
+  情报类型中的*手办*、*模型*只是为了兼容, 实际效果等同于**全部**, 如果只需要**手办**类型的情报, 可以使用参数*catType*, e.g. /hpoi/info/all/hobby
+:::
+
+|  手办   | 动漫模型 | 真实模型 | 毛绒布偶 | doll娃娃 | GK/其他 |
+| ------ | ------- | ------- | ------- | ------- | ------ |
+| hobby  |  model  |  real   | moppet  |  doll   | gkdiy  |`,
     handler,
 };
 
 async function handler(ctx) {
-    const { type = 'all' } = ctx.req.param();
+    const { type = 'all', catType = 'all' } = ctx.req.param();
     const baseUrl = 'https://www.hpoi.net';
     const reqUrl = `${baseUrl}/user/home/ajax`;
-    const response = await got.post(`${reqUrl}?page=1&type=info&catType=${type}`);
+
+    const classMap = {
+        all: '全部',
+        hobby: '手办',
+        model: '动漫模型',
+        real: '真实模型',
+        moppet: '毛绒布偶',
+        doll: 'doll娃娃',
+        gkdiy: 'GK/其他',
+    };
+
+    const filterArr = catType.split('|').sort();
+
+    const filterSet = new Set(filterArr.map((e: string) => classMap[e]));
+    if (catType.includes('all')) {
+        filterSet.clear();
+    }
+
+    let finalType = type;
+    if (['hobby', 'model'].includes(type)) {
+        finalType = 'all';
+    }
+
+    const url = `${reqUrl}?page=1&type=info&subType=${finalType}`;
+    const response = await got.post(url);
+
     const $ = load(response.data);
 
-    const items = $('.home-info')
-        .map((_, ele) => {
-            const $item = load(ele);
-            const leftNode = $item('.overlay-container');
-            const relativeLink = leftNode.find('a').first().attr('href');
-            const typeName = leftNode.find('.type-name').first().text();
-            const imgUrl = leftNode.find('img').first().attr('src');
-            const rightNode = $item('.home-info-content');
-            const infoType = rightNode.find('.user-name').contents()[0].data;
-            const infoTitle = rightNode.find('.user-content').text();
-            const infoTime = rightNode.find('.type-time').text();
-            return {
-                title: infoTitle,
-                pubDate: parseRelativeDate(infoTime),
-                link: `${baseUrl}/${relativeLink}`,
-                category: infoType,
-                description: [`类型:${typeName}`, infoTitle, `更新内容: ${infoType}`, `<img src="${imgUrl}"/>`].join('<br/>'),
-            };
-        })
-        .get();
+    const items = $('.home-info').map((_, ele) => {
+        const $item = load(ele);
+        const leftNode = $item('.overlay-container');
+        const relativeLink = leftNode.find('a').first().attr('href');
+        const typeName = leftNode.find('.type-name').first().text().trim();
+        const imgUrl = leftNode.find('img').first().attr('src');
+        const rightNode = $item('.home-info-content');
+        const infoType = rightNode.find('.user-name').contents()[0].data.trim();
+        const infoTitle = rightNode.find('.user-content').text();
+        const infoTime = rightNode.find('.type-time').text();
+        return {
+            title: infoTitle,
+            pubDate: parseRelativeDate(infoTime),
+            link: `${baseUrl}/${relativeLink}`,
+            category: infoType,
+            typeName,
+            description: [`类型:${typeName}`, infoTitle, `更新内容: ${infoType}`, `<img src="${imgUrl}"/>`].join('<br/>'),
+        };
+    });
+
+    const items1 = items.toArray();
+
+    const items2 = filterSet.size > 0 ? items1.filter((e) => filterSet.has(e.typeName)) : items1;
 
     const typeToLabel = {
         all: '全部',
-        hobby: '手办',
-        model: '模型',
+        confirm: '制作',
+        official_pic: '官图更新',
+        preorder: '开订',
+        delay: '延期',
+        release: '出荷',
+        reorder: '再版',
     };
-    const title = `手办维基 - 情报 - ${typeToLabel[type]}`;
+    const title = `手办维基 - 情报 - ${typeToLabel[finalType]}`;
+    const catTypeName = filterSet.size > 0 ? filterArr.join('|') : 'all';
     return {
         title,
-        link: `${baseUrl}/user/home?type=info&catType=${type}`,
+        link: `${baseUrl}/user/home?type=info&subType=${type}&catType=${catTypeName}`,
         description: title,
-        item: items,
+        item: items2,
+        allowEmpty: true,
     };
 }

--- a/lib/routes/hpoi/info.ts
+++ b/lib/routes/hpoi/info.ts
@@ -23,7 +23,7 @@ export const route: Route = {
             ],
             default: 'all',
         },
-        include: {
+        catType: {
             description: '手办分类过滤, 使用|分割, 支持的分类见下表',
             default: 'all',
         },


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/hpoi/info/all
/hpoi/info/confirm
/hpoi/info/official
/hpoi/info/preorder
/hpoi/info/delay
/hpoi/info/release
/hpoi/info/reorder
/hpoi/info/hobby
/hpoi/info/model
/hpoi/info/all/hobby
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
参照 PR #18996 下的[回复](https://github.com/DIYgod/RSSHub/pull/18996#discussion_r2071866392), 更新了页面的解析逻辑, 现在支持获取不同类型的情报; 原有的`hobby`、`model`选项 现在已经无效, 如果只想获取`hobby`、`model`类型的情况, 需要使用新的路由(e.g. /hpoi/info/all/hobby|model)；但`got.post`无法携带任何`payload`的问题仍然没有发现原因，所以使用`queryParams`来获取信息