### PR TITLE
fix(route/bilibili/video): fallback to dynamic api

### DIFF
--- a/lib/routes/bilibili/utils.ts
+++ b/lib/routes/bilibili/utils.ts
@@ -295,7 +295,14 @@ export const renderOGVDescription = (embed: boolean, img: string, description: s
     return rendered;
 };
 
-export const getVideoUrl = (bvid?: string) => (bvid ? `https://www.bilibili.com/blackboard/newplayer.html?isOutside=true&autoplay=true&danmaku=true&muted=false&highQuality=true&bvid=${bvid}` : undefined);
+export function getVideoUrl(bvid: string): string;
+export function getVideoUrl(bvid?: string): string | undefined;
+export function getVideoUrl(bvid?: string): string | undefined {
+    if (!bvid) {
+        return;
+    }
+    return `https://www.bilibili.com/blackboard/newplayer.html?isOutside=true&autoplay=true&danmaku=true&muted=false&highQuality=true&bvid=${bvid}`;
+}
 export const getLiveUrl = (roomId?: string) => (roomId ? `https://www.bilibili.com/blackboard/live/live-activity-player.html?cid=${roomId}` : undefined);
 
 export default {

--- a/lib/routes/bilibili/utils.ts
+++ b/lib/routes/bilibili/utils.ts
@@ -298,10 +298,7 @@ export const renderOGVDescription = (embed: boolean, img: string, description: s
 export function getVideoUrl(bvid: string): string;
 export function getVideoUrl(bvid?: string): string | undefined;
 export function getVideoUrl(bvid?: string): string | undefined {
-    if (!bvid) {
-        return;
-    }
-    return `https://www.bilibili.com/blackboard/newplayer.html?isOutside=true&autoplay=true&danmaku=true&muted=false&highQuality=true&bvid=${bvid}`;
+    return bvid ? `https://www.bilibili.com/blackboard/newplayer.html?isOutside=true&autoplay=true&danmaku=true&muted=false&highQuality=true&bvid=${bvid}` : undefined;
 }
 export const getLiveUrl = (roomId?: string) => (roomId ? `https://www.bilibili.com/blackboard/live/live-activity-player.html?cid=${roomId}` : undefined);
 

--- a/lib/routes/bilibili/video.ts
+++ b/lib/routes/bilibili/video.ts
@@ -1,3 +1,4 @@
+import type { Context } from 'hono';
 import JSONbig from 'json-bigint';
 import { DataItem, Route, ViewType } from '@/types';
 import got from '@/utils/got';
@@ -5,7 +6,7 @@ import { parseDate } from '@/utils/parse-date';
 import cache from './cache';
 import utils, { getVideoUrl } from './utils';
 import logger from '@/utils/logger';
-import { BilibiliWebDynamicResponse } from './api-interface';
+import type { BilibiliWebDynamicResponse } from './api-interface';
 
 export const route: Route = {
     path: '/user/video/:uid/:embed?',
@@ -32,7 +33,7 @@ export const route: Route = {
     handler,
 };
 
-async function handler(ctx) {
+async function handler(ctx: Context) {
     const uid = ctx.req.param('uid');
     const embed = !ctx.req.param('embed');
     const cookie = await cache.getCookie();

--- a/lib/routes/bilibili/video.ts
+++ b/lib/routes/bilibili/video.ts
@@ -1,8 +1,11 @@
-import { Route, ViewType } from '@/types';
+import JSONbig from 'json-bigint';
+import { DataItem, Route, ViewType } from '@/types';
 import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
 import cache from './cache';
 import utils, { getVideoUrl } from './utils';
 import logger from '@/utils/logger';
+import { BilibiliWebDynamicResponse } from './api-interface';
 
 export const route: Route = {
     path: '/user/video/:uid/:embed?',
@@ -50,37 +53,81 @@ async function handler(ctx) {
         },
     });
     const data = response.data;
+    let fallbackItem: DataItem[] | undefined;
     if (data.code) {
-        logger.error(JSON.stringify(data.data));
-        throw new Error(`Got error code ${data.code} while fetching: ${data.message}`);
+        try {
+            // Fallback to get video from dynamic API
+            const params = utils.addDmVerifyInfo(`host_mid=${uid}&platform=web&features=itemOpusStyle,listOnlyfans,opusBigCover,onlyfansVote`, utils.getDmImgList());
+            const response = await got(`https://api.bilibili.com/x/polymer/web-dynamic/v1/feed/space?${params}`, {
+                headers: {
+                    Referer: `https://space.bilibili.com/${uid}/`,
+                    Cookie: cookie,
+                },
+            });
+            const body = JSONbig.parse(response.body);
+            if (body?.code === -352) {
+                throw new Error('Request failed, please try again.');
+            }
+            const items = (body as BilibiliWebDynamicResponse)?.data?.items.filter((item) => item.modules.module_dynamic?.major?.type === 'MAJOR_TYPE_ARCHIVE');
+            if (items && items.length > 0) {
+                fallbackItem = items.map((item) => {
+                    const dynamic = item?.modules?.module_dynamic?.major?.archive;
+                    const author = item?.modules?.module_author;
+
+                    const aid = dynamic?.aid;
+                    const bvid = dynamic?.bvid;
+
+                    const data: DataItem = {
+                        title: dynamic?.title ?? '',
+                        description: !aid && !bvid ? '' : utils.renderUGCDescription(embed, '', '', aid, undefined, bvid),
+                        pubDate: author?.pub_ts ? parseDate(author.pub_ts, 'X') : undefined,
+                        link: author?.pub_ts && author.pub_ts > utils.bvidTime && bvid ? `https://www.bilibili.com/video/${bvid}` : `https://www.bilibili.com/video/av${aid}`,
+                        author: name ?? undefined,
+                        attachments: bvid
+                            ? [
+                                  {
+                                      url: getVideoUrl(bvid),
+                                      mime_type: 'text/html',
+                                  },
+                              ]
+                            : undefined,
+                    };
+                    return data;
+                });
+            }
+        } catch {
+            logger.error(JSON.stringify(data.data));
+            throw new Error(`Got error code ${data.code} while fetching: ${data.message}`);
+        }
     }
 
     return {
         title: `${name} 的 bilibili 空间`,
         link: `https://space.bilibili.com/${uid}`,
         description: `${name} 的 bilibili 空间`,
-        image: face,
-        logo: face,
-        icon: face,
+        image: face ?? undefined,
+        logo: face ?? undefined,
+        icon: face ?? undefined,
         item:
-            data.data &&
-            data.data.list &&
-            data.data.list.vlist &&
-            data.data.list.vlist.map((item) => ({
-                title: item.title,
-                description: utils.renderUGCDescription(embed, item.pic, item.description, item.aid, undefined, item.bvid),
-                pubDate: new Date(item.created * 1000).toUTCString(),
-                link: item.created > utils.bvidTime && item.bvid ? `https://www.bilibili.com/video/${item.bvid}` : `https://www.bilibili.com/video/av${item.aid}`,
-                author: name,
-                comments: item.comment,
-                attachments: item.bvid
-                    ? [
-                          {
-                              url: getVideoUrl(item.bvid),
-                              mime_type: 'text/html',
-                          },
-                      ]
-                    : undefined,
-            })),
+            fallbackItem ??
+            (data.data &&
+                data.data.list &&
+                data.data.list.vlist &&
+                data.data.list.vlist.map((item) => ({
+                    title: item.title,
+                    description: utils.renderUGCDescription(embed, item.pic, item.description, item.aid, undefined, item.bvid),
+                    pubDate: new Date(item.created * 1000).toUTCString(),
+                    link: item.created > utils.bvidTime && item.bvid ? `https://www.bilibili.com/video/${item.bvid}` : `https://www.bilibili.com/video/av${item.aid}`,
+                    author: name,
+                    comments: item.comment,
+                    attachments: item.bvid
+                        ? [
+                              {
+                                  url: getVideoUrl(item.bvid),
+                                  mime_type: 'text/html',
+                              },
+                          ]
+                        : undefined,
+                }))),
     };
 }


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/bilibili/user/dynamic/7957044
/bilibili/user/video/7957044
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

I find that dynamic API may be less susceptible to anti-crawling restrictions. Please let me know if I am wrong.

The following is a comparison of the results at the same time

![CleanShot 2025-05-08 at 23 48 23@2x](https://github.com/user-attachments/assets/39842295-b958-4e14-a067-be00a814c167)

![CleanShot 2025-05-08 at 23 48 34@2x](https://github.com/user-attachments/assets/6c24eb83-848a-49c2-bc18-8c3235d2fbfb)

