### PR TITLE
feat: add updated to linkedin company post items

### DIFF
--- a/lib/routes/linkedin/posts.ts
+++ b/lib/routes/linkedin/posts.ts
@@ -58,6 +58,7 @@ export const route: Route = {
                 description: post.text,
                 link: post.link,
                 pubDate: post.date,
+                updated: post.date,
             })),
         };
     },


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Following up from PR https://github.com/DIYgod/RSSHub/pull/18799

## Example for the Proposed Route(s) / 路由地址示例

```routes
/linkedin/company/google/posts
```

## Note / 说明
Adding `updated` tag so that feed can work properly with RSS connectors, see: https://learn.microsoft.com/en-us/connectors/rss/#known-issues-and-limitations

> RSS feeds that do not include an "updated" tag for feed items will not function with the trigger when the sinceProperty is set to "UpdatedOn" value.
