### PR TITLE
feat: Add AI Daily Report route for Aibase

### DIFF
--- a/lib/routes.test.ts
+++ b/lib/routes.test.ts
@@ -8,6 +8,7 @@ process.env.ALLOW_USER_SUPPLY_UNSAFE_DOMAIN = 'true';
 
 const routes = {
     '/test/:id': '/test/1',
+    '/aibase/daily': '/aibase/daily',
 };
 if (process.env.FULL_ROUTES_TEST) {
     const { namespaces } = await import('@/registry');
@@ -41,6 +42,11 @@ async function checkRSS(response) {
     expect(parsed).toEqual(expect.any(Object));
     expect(parsed.title).toEqual(expect.any(String));
     expect(parsed.title).not.toBe('RSSHub');
+    // For /aibase/daily, check specific title and link
+    if (response.url.endsWith('/aibase/daily')) {
+        expect(parsed.title).toBe('AI日报');
+        expect(parsed.link).toBe('https://www.aibase.com/daily');
+    }
     expect(parsed.description).toEqual(expect.any(String));
     expect(parsed.link).toEqual(expect.any(String));
     expect(parsed.lastBuildDate).toEqual(expect.any(String));

--- a/lib/routes/aibase/daily.ts
+++ b/lib/routes/aibase/daily.ts
@@ -1,0 +1,118 @@
+import { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import { load } from 'cheerio';
+import { rootUrl, buildApiUrl } from './util';
+
+export const route: Route = {
+    path: '/daily',
+    name: 'AI日报',
+    url: 'www.aibase.com/daily',
+    maintainers: ['zreo0'],
+    handler: async (ctx) => {
+        // 每页数量限制
+        const limit = Number.parseInt(ctx.req.query('limit') ?? '30', 10);
+        // 用项目中已有的获取页面方法，获取页面以及 Token
+        const currentUrl = new URL('discover', rootUrl).href;
+        const currentHtml = await ofetch(currentUrl);
+        const $ = load(currentHtml);
+        const logoSrc = $('img.logo').prop('src');
+        const image = logoSrc ? new URL(logoSrc, rootUrl).href : '';
+        const author = $('title').text().split(/_/).pop();
+        const { apiInfoListUrl } = await buildApiUrl($);
+        // 获取资讯列表，解析数据
+        const data: NewsItem[] = await ofetch(apiInfoListUrl, {
+            headers: {
+                accept: 'application/json;charset=utf-8',
+            },
+            query: {
+                pagesize: limit,
+                page: 1,
+                type: 2, // Changed type from 1 to 2 for AI Daily Report
+                isen: 0,
+            },
+        });
+        const items = data.map((item) => ({
+            // 文章标题
+            title: item.title,
+            // 文章链接
+            link: `https://www.aibase.com/zh/news/${item.Id}`,
+            // 文章正文
+            description: item.summary,
+            // 文章发布日期
+            pubDate: parseDate(item.addtime),
+            // 文章作者
+            author: item.author || 'AI Base',
+        }));
+
+        return {
+            title: 'AI日报',
+            description: '每天三分钟关注AI行业趋势',
+            language: 'zh-cn',
+            link: 'https://www.aibase.com/daily',
+            item: items,
+            allowEmpty: true,
+            image,
+            author,
+        };
+    },
+    example: '/aibase/daily',
+    description: '获取 AI 日报',
+    categories: ['new-media', 'popular'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.aibase.com/daily'],
+            target: '/daily',
+        },
+    ],
+};
+
+/** API 返回的资讯结构 */
+interface NewsItem {
+    /** 文章 ID */
+    Id: number;
+    /** 文章标题 */
+    title: string;
+    /** 文章副标题 */
+    subtitle: string;
+    /** 文章简要描述 */
+    description: string;
+    /** 文章主图 */
+    thumb: string;
+    classname: string;
+    /** 正文总结 */
+    summary: string;
+    /** 标签，字符串，样例：[\"人工智能\",\"Hingham高中\"] */
+    tags: string;
+    /** 可能是来源 */
+    sourcename: string;
+    /** 作者 */
+    author: string;
+    status: number;
+    url: string;
+    type: number;
+    added: number;
+    /** 添加时间 */
+    addtime: string;
+    /** 更新时间 */
+    upded: number;
+    updtime: string;
+    isshoulu: number;
+    vurl: string;
+    vsize: number;
+    weight: number;
+    isailog: number;
+    sites: string;
+    categrates: string;
+    /** 访问量 */
+    pv: number;
+}


### PR DESCRIPTION
Adds a new RSS feed for the "AI Daily Report" (AI日报) section of Aibase.

- Creates a new route at `/aibase/daily`.
- The route fetches data from the Aibase API, using `type: 2` to distinguish it from the general news feed (`type: 1`). This was determined through investigation of the site's structure and client-side code.
- The route handler in `lib/routes/aibase/daily.ts` is adapted from the existing `news.ts`.
- Includes updated name, description, and radar entries specific to the AI Daily Report.
- An integration test has been added in `lib/routes.test.ts` to verify the `/aibase/daily` route, checking its title, link, and overall feed structure.

Note: I was unable to run the tests due to an unrelated ESLint `SyntaxError: Unexpected token 'with'` in the testing environment. The test logic itself is believed to be sound and follows existing patterns.

