### PR TITLE
fix(route/xiaoyuzhou): bring HTML description back

### DIFF
--- a/lib/routes/xiaoyuzhou/podcast.ts
+++ b/lib/routes/xiaoyuzhou/podcast.ts
@@ -78,15 +78,14 @@ async function handler(ctx) {
         itunes_item_image: (item.image || item.podcast?.image)?.smallPicUrl,
     }));
 
-    // JSON no longer return 'shownotes'
-    // and 'description' don't contain image tag, only return text
-    // so fetch HTML content from episode page
     episodes = await Promise.all(
         episodes.map((item) =>
             cache.tryGet(item.link, async () => {
-                const data = await ofetch(item.link);
-                $ = load(data);
-                item.description = $('article').html() || item.title;
+                const eid = item.link.match(/episode\/([a-zA-Z0-9]+)/)[1];
+                const episodeLink = `https://www.xiaoyuzhoufm.com/_next/data/${page_data.buildId}/episode/${eid}.json`;
+                const response = await ofetch(episodeLink);
+                const episodeItem = response.pageProps.episode;
+                item.description = episodeItem.shownotes || episodeItem.description || episodeItem.title || '';
                 return item as DataItem;
             })
         )

--- a/lib/routes/xiaoyuzhou/podcast.ts
+++ b/lib/routes/xiaoyuzhou/podcast.ts
@@ -74,6 +74,7 @@ async function handler(ctx) {
         itunes_duration: item.duration,
         enclosure_type: 'audio/mpeg',
         link: `https://www.xiaoyuzhoufm.com/episode/${item.eid}`,
+        eid: item.eid,
         pubDate: parseDate(item.pubDate),
         itunes_item_image: (item.image || item.podcast?.image)?.smallPicUrl,
     }));
@@ -81,8 +82,7 @@ async function handler(ctx) {
     episodes = await Promise.all(
         episodes.map((item) =>
             cache.tryGet(item.link, async () => {
-                const eid = item.link.match(/episode\/([a-zA-Z0-9]+)/)[1];
-                const episodeLink = `https://www.xiaoyuzhoufm.com/_next/data/${page_data.buildId}/episode/${eid}.json`;
+                const episodeLink = `https://www.xiaoyuzhoufm.com/_next/data/${page_data.buildId}/episode/${item.eid}.json`;
                 const response = await ofetch(episodeLink);
                 const episodeItem = response.pageProps.episode;
                 item.description = episodeItem.shownotes || episodeItem.description || episodeItem.title || '';

--- a/lib/routes/xiaoyuzhou/podcast.ts
+++ b/lib/routes/xiaoyuzhou/podcast.ts
@@ -1,7 +1,8 @@
-import { Route, ViewType } from '@/types';
+import { DataItem, Route, ViewType } from '@/types';
 import ofetch from '@/utils/ofetch';
 import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
+import cache from '@/utils/cache';
 
 export const route: Route = {
     path: '/podcast/:id',
@@ -67,16 +68,29 @@ async function handler(ctx) {
         }
     }
 
-    const episodes = page_data.props.pageProps.podcast.episodes.map((item) => ({
+    let episodes = page_data.props.pageProps.podcast.episodes.map((item) => ({
         title: item.title,
         enclosure_url: item.enclosure.url,
         itunes_duration: item.duration,
         enclosure_type: 'audio/mpeg',
         link: `https://www.xiaoyuzhoufm.com/episode/${item.eid}`,
         pubDate: parseDate(item.pubDate),
-        description: item.description.replaceAll('\n', '<br>') || item.shownotes,
         itunes_item_image: (item.image || item.podcast?.image)?.smallPicUrl,
     }));
+
+    // JSON no longer return 'shownotes'
+    // and 'description' don't contain image tag, only return text
+    // so fetch HTML content from episode page
+    episodes = await Promise.all(
+        episodes.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const data = await ofetch(item.link);
+                $ = load(data);
+                item.description = $('article').html() || item.title;
+                return item as DataItem;
+            })
+        )
+    );
 
     return {
         title: page_data.props.pageProps.podcast.title,

--- a/lib/routes/xiaoyuzhou/podcast.ts
+++ b/lib/routes/xiaoyuzhou/podcast.ts
@@ -24,7 +24,7 @@ export const route: Route = {
         },
     ],
     name: '播客',
-    maintainers: ['hondajojo', 'jtsang4', 'pseudoyu'],
+    maintainers: ['hondajojo', 'jtsang4', 'pseudoyu', 'cscnk52'],
     handler,
     url: 'xiaoyuzhoufm.com/',
 };


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/xiaoyuzhou/podcast/61dcea054b459868c4d04153
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

xiaoyuzhou is delete `shownotes` attribute, only left `description`, but this attribute only contains text, not HTML code:

![image](https://github.com/user-attachments/assets/7ffd198b-b789-4898-bcc5-428de75461e2)
they're only description text, not full HTML content. And that's why i temporary mark #19120 as WIP.

This PR is going to fetch shownotes from episode page.

Now should look good:

![image](https://github.com/user-attachments/assets/45dfddcd-ba17-4b66-9250-f60f20729b24)

And the old code can't handle empty shownotes:

![image](https://github.com/user-attachments/assets/0bb1a904-c2d1-4575-a380-db6b70914b49)

