### PR TITLE
fix(route/kemono): improve JSON field parsing with nested string handling

### DIFF
--- a/lib/routes/kemono/const.ts
+++ b/lib/routes/kemono/const.ts
@@ -1,0 +1,9 @@
+const KEMONO_ROOT_URL = 'https://kemono.su';
+const KEMONO_API_URL = `${KEMONO_ROOT_URL}/api/v1`;
+const MIME_TYPE_MAP = {
+    m4a: 'audio/mp4',
+    mp3: 'audio/mpeg',
+    mp4: 'video/mp4',
+} as const;
+
+export { KEMONO_API_URL, KEMONO_ROOT_URL, MIME_TYPE_MAP };

--- a/lib/routes/kemono/index.ts
+++ b/lib/routes/kemono/index.ts
@@ -6,6 +6,8 @@ import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
 import { art } from '@/utils/render';
 import path from 'node:path';
+import { KEMONO_API_URL, KEMONO_ROOT_URL, MIME_TYPE_MAP } from './const';
+import { KemonoPost, KemonoFile, DiscordMessage } from './types';
 
 export const route: Route = {
     path: '/:source?/:id?/:type?',
@@ -62,226 +64,267 @@ export const route: Route = {
 };
 
 function parseJsonField(field: any): any {
-    if (typeof field === 'string') {
-        try {
-            let parsed = JSON.parse(field);
-            if (typeof parsed === 'string') {
-                try {
-                    parsed = JSON.parse(parsed);
-                } catch {
-                    return field;
-                }
-            }
-            return parsed;
-        } catch {
-            return field;
+    if (typeof field !== 'string') {
+        return field;
+    }
+
+    try {
+        let parsedData = JSON.parse(field);
+        if (typeof parsedData === 'string') {
+            parsedData = JSON.parse(parsedData);
+        }
+        return parsedData;
+    } catch {
+        return field;
+    }
+}
+
+function buildApiUrl(source: string, userId?: string, contentType?: string): string {
+    if (source === 'posts') {
+        return `${KEMONO_API_URL}/posts`;
+    }
+
+    if (source === 'discord' && userId) {
+        return `${KEMONO_API_URL}/discord/channel/lookup/${userId}`;
+    }
+
+    if (!userId) {
+        throw new Error('User ID is required for non-posts sources');
+    }
+
+    const basePath = `${KEMONO_API_URL}/${source}/user/${userId}`;
+    return contentType ? `${basePath}/${contentType}` : basePath;
+}
+
+function buildFrontendUrl(source: string, userId?: string, contentType?: string): string {
+    if (source === 'posts') {
+        return `${KEMONO_ROOT_URL}/posts`;
+    }
+
+    if (source === 'discord' && userId) {
+        return `${KEMONO_ROOT_URL}/${source}/server/${userId}`;
+    }
+
+    if (!userId) {
+        throw new Error('User ID is required for non-posts sources');
+    }
+
+    const basePath = `${KEMONO_ROOT_URL}/${source}/user/${userId}`;
+    return contentType ? `${basePath}/${contentType}` : basePath;
+}
+
+async function fetchUserProfile(source: string, userId: string): Promise<string> {
+    try {
+        const profileUrl = `${KEMONO_API_URL}/${source}/user/${userId}/profile`;
+        const response = await got({ method: 'get', url: profileUrl });
+        return response.data.name || 'Unknown User';
+    } catch {
+        return 'Unknown User';
+    }
+}
+
+function processPostFiles(post: KemonoPost): KemonoFile[] {
+    const files: KemonoFile[] = [];
+
+    if (post.file) {
+        const parsedFile = parseJsonField(post.file);
+        if (parsedFile && typeof parsedFile === 'object' && 'path' in parsedFile) {
+            files.push({
+                name: parsedFile.name || 'Unnamed File',
+                path: parsedFile.path,
+                extension: extractFileExtension(parsedFile.path),
+            });
         }
     }
-    return field;
+
+    if (Array.isArray(post.attachments)) {
+        for (const attachment of post.attachments) {
+            const parsedAttachment = parseJsonField(attachment);
+            if (parsedAttachment && typeof parsedAttachment === 'object' && 'path' in parsedAttachment) {
+                files.push({
+                    name: parsedAttachment.name || 'Unnamed Attachment',
+                    path: parsedAttachment.path,
+                    extension: extractFileExtension(parsedAttachment.path),
+                });
+            }
+        }
+    }
+
+    return files;
 }
 
-function buildUrl(apiUrl: string, isPosts: boolean, source: string, id: string, type?: string): string {
-    if (isPosts) {
-        return `${apiUrl}/posts`;
-    }
-    if (source === 'discord') {
-        return `${apiUrl}/discord/channel/lookup/${id}`;
-    }
-    if (type) {
-        return `${apiUrl}/${source}/user/${id}/${type}`;
-    }
-    return `${apiUrl}/${source}/user/${id}`;
+function extractFileExtension(filePath: string): string {
+    return filePath.replace(/.*\./, '').toLowerCase();
 }
 
-function buildLink(isPosts: boolean, rootUrl: string, source: string, id: string, type?: string): string {
-    if (isPosts) {
-        return `${rootUrl}/posts`;
-    }
-    if (source === 'discord') {
-        return `${rootUrl}/${source}/server/${id}`;
-    }
-    if (type) {
-        return `${rootUrl}/${source}/user/${id}/${type}`;
-    }
-    return `${rootUrl}/${source}/user/${id}`;
+function generateEnclosureInfo(htmlContent: string): { enclosure_url?: string; enclosure_type?: string } {
+    const $ = load(htmlContent);
+    let enclosureInfo = {};
+
+    $('audio source, video source').each(function () {
+        const src = $(this).attr('src');
+        if (!src) {
+            return;
+        }
+
+        const extension = extractFileExtension(src);
+        const mimeType = MIME_TYPE_MAP[extension as keyof typeof MIME_TYPE_MAP];
+
+        if (mimeType) {
+            enclosureInfo = {
+                enclosure_url: new URL(src, KEMONO_ROOT_URL).toString(),
+                enclosure_type: mimeType,
+            };
+            return false;
+        }
+    });
+
+    return enclosureInfo;
 }
 
-async function getAuthor(profileUrl: string) {
-    const profileResponse = await got({ method: 'get', url: profileUrl });
-    return profileResponse.data.name;
+async function processDiscordMessages(channels: any[], limit: number) {
+    const items = await Promise.all(
+        channels.map((channel) =>
+            cache.tryGet(`discord_${channel.id}`, async () => {
+                const channelResponse = await got({
+                    method: 'get',
+                    url: `${KEMONO_ROOT_URL}/api/v1/discord/channel/${channel.id}?o=0`,
+                });
+
+                return channelResponse.data
+                    .filter((message: DiscordMessage) => message.content || message.attachments)
+                    .slice(0, limit)
+                    .map((message: DiscordMessage) => ({
+                        title: message.content || 'Discord Message',
+                        description: art(path.join(__dirname, 'templates/discord.art'), { i: message }),
+                        author: `${message.author.username}#${message.author.discriminator}`,
+                        pubDate: parseDate(message.published),
+                        category: channel.name,
+                        guid: `kemono:discord:${message.server}:${message.channel}:${message.id}`,
+                        link: `https://discord.com/channels/${message.server}/${message.channel}/${message.id}`,
+                    }));
+            })
+        )
+    );
+
+    return items.flat();
+}
+
+function processAnnouncements(announcements: any[], authorName: string, source: string, userId: string, limit: number) {
+    return announcements.slice(0, limit).map((announcement) => ({
+        title: `Announcement from ${announcement.published ? parseDate(announcement.published).toDateString() : 'Unknown Date'}`,
+        description: `<div>${announcement.content || ''}</div>`,
+        author: authorName,
+        pubDate: parseDate(announcement.published),
+        guid: `kemono:${source}:${userId}:announcement:${announcement.hash}`,
+        link: `${KEMONO_ROOT_URL}/${source}/user/${userId}/announcements`,
+    }));
+}
+
+function processFancards(fancards: any[], authorName: string, source: string, userId: string, limit: number) {
+    return fancards.slice(0, limit).map((fancard) => {
+        const imageUrl = `${fancard.server}${fancard.path}`;
+
+        return {
+            title: `Fancard ${fancard.id}`,
+            description: `<img src="${imageUrl}" alt="Fancard ${fancard.id}" />`,
+            author: authorName,
+            pubDate: parseDate(fancard.added),
+            guid: `kemono:${source}:${userId}:fancard:${fancard.id}`,
+            link: imageUrl,
+            enclosure_url: imageUrl,
+            enclosure_type: fancard.mime,
+        };
+    });
+}
+
+function processPosts(posts: KemonoPost[], authorName: string, limit: number) {
+    return posts
+        .filter((post) => post.content || post.attachments)
+        .slice(0, limit)
+        .map((post) => {
+            const files = processPostFiles(post);
+            const postWithFiles = { ...post, files };
+
+            const filesHtml = art(path.join(__dirname, 'templates/source.art'), { i: postWithFiles });
+            let description = post.content ? `<div>${post.content}</div>` : '';
+
+            const $ = load(description);
+            const kemonoFileElements = load(filesHtml)('img, a, audio, video')
+                .toArray()
+                .map((el) => $(el).prop('outerHTML')!);
+
+            let replacementCount = 0;
+            const fanboxRegex = /downloads\.fanbox\.cc/;
+            $('a').each(function () {
+                const link = $(this).attr('href');
+                if (link && fanboxRegex.test(link)) {
+                    $(this).replaceWith(kemonoFileElements[replacementCount] || '');
+                    replacementCount++;
+                }
+            });
+
+            description = (kemonoFileElements[0] || '') + $.html();
+            for (const fileElement of kemonoFileElements.slice(replacementCount + 1)) {
+                description += fileElement;
+            }
+
+            return {
+                title: post.title || 'Untitled Post',
+                description,
+                author: authorName,
+                pubDate: parseDate(post.published),
+                guid: `${KEMONO_API_URL}/${post.service}/user/${post.user}/post/${post.id}`,
+                link: `${KEMONO_ROOT_URL}/${post.service}/user/${post.user}/post/${post.id}`,
+                ...generateEnclosureInfo(description),
+            };
+        });
 }
 
 async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 25;
-    const source = ctx.req.param('source') ?? 'posts';
-    const id = ctx.req.param('id');
-    const type = ctx.req.param('type');
-    const isPosts = source === 'posts';
+    const source = ctx.req.param('source') || 'posts';
+    const userId = ctx.req.param('id');
+    const contentType = ctx.req.param('type');
 
-    const rootUrl = 'https://kemono.su';
-    const apiUrl = `${rootUrl}/api/v1`;
-    const profileUrl = source ? `${apiUrl}/${source}/user/${id}/profile` : '';
-    const currentUrl = buildUrl(apiUrl, isPosts, source, id, type);
+    const isPostsMode = source === 'posts';
+    const isDiscordMode = source === 'discord';
 
-    const response = await got({ method: 'get', url: currentUrl });
-    const author = isPosts || source === 'discord' ? '' : await getAuthor(profileUrl);
-    const image = isPosts || source === 'discord' ? `${rootUrl}/favicon.ico` : `https://img.kemono.su/icons/${source}/${id}`;
+    try {
+        const apiUrl = buildApiUrl(source, userId, contentType);
+        const frontendUrl = buildFrontendUrl(source, userId, contentType);
 
-    let items, title;
+        const response = await got({ method: 'get', url: apiUrl });
 
-    if (source === 'discord') {
-        title = `Posts of ${id} from Discord | Kemono`;
+        const authorName = isPostsMode || isDiscordMode || !userId ? '' : await fetchUserProfile(source, userId);
 
-        items = await Promise.all(
-            response.data.map((channel) =>
-                cache.tryGet(channel.id, async () => {
-                    const channelResponse = await got({
-                        method: 'get',
-                        url: `${rootUrl}/api/v1/discord/channel/${channel.id}?o=0`,
-                    });
+        const iconUrl = isPostsMode || isDiscordMode ? `${KEMONO_ROOT_URL}/favicon.ico` : `https://img.kemono.su/icons/${source}/${userId}`;
 
-                    return channelResponse.data
-                        .filter((i) => i.content || i.attachments)
-                        .slice(0, limit)
-                        .map((i) => ({
-                            title: i.content,
-                            description: art(path.join(__dirname, 'templates/discord.art'), { i }),
-                            author: `${i.author.username}#${i.author.discriminator}`,
-                            pubDate: parseDate(i.published),
-                            category: channel.name,
-                            guid: `kemono:${source}:${i.server}:${i.channel}:${i.id}`,
-                            link: `https://discord.com/channels/${i.server}/${i.channel}/${i.id}`,
-                        }));
-                })
-            )
-        );
-        items = items.flat();
-    } else if (type === 'announcements') {
-        title = `Announcements of ${author} from ${source} | Kemono`;
+        let items: any[];
+        let title: string;
 
-        items = response.data.slice(0, limit).map((announcement) => ({
-            title: `Announcement from ${announcement.published ? parseDate(announcement.published).toDateString() : 'Unknown Date'}`,
-            description: `<div>${announcement.content}</div>`,
-            author,
-            pubDate: parseDate(announcement.published),
-            guid: `kemono:${source}:${id}:announcement:${announcement.hash}`,
-            link: `${rootUrl}/${source}/user/${id}/announcements`,
-        }));
-    } else if (type === 'fancards') {
-        title = `Fancards of ${author} from ${source} | Kemono`;
+        if (isDiscordMode) {
+            title = `Posts of ${userId} from Discord | Kemono`;
+            items = await processDiscordMessages(response.data, limit);
+        } else if (contentType === 'announcements') {
+            title = `Announcements of ${authorName} from ${source} | Kemono`;
+            items = processAnnouncements(response.data, authorName, source, userId, limit);
+        } else if (contentType === 'fancards') {
+            title = `Fancards of ${authorName} from ${source} | Kemono`;
+            items = processFancards(response.data, authorName, source, userId, limit);
+        } else {
+            title = isPostsMode ? 'Kemono Posts' : `Posts of ${authorName} from ${source} | Kemono`;
+            const posts = isPostsMode ? response.data.posts : response.data;
+            items = processPosts(posts, authorName, limit);
+        }
 
-        items = response.data.slice(0, limit).map((fancard) => {
-            const imageUrl = `${fancard.server}${fancard.path}`;
-
-            return {
-                title: `Fancard ${fancard.id}`,
-                description: `<img src="${imageUrl}" />`,
-                author,
-                pubDate: parseDate(fancard.added),
-                guid: `kemono:${source}:${id}:fancard:${fancard.id}`,
-                link: imageUrl,
-                enclosure_url: imageUrl,
-                enclosure_type: fancard.mime,
-            };
-        });
-    } else {
-        title = isPosts ? 'Kemono Posts' : `Posts of ${author} from ${source} | Kemono`;
-
-        const responseData = isPosts ? response.data.posts : response.data;
-        items = responseData
-            .filter((i) => i.content || i.attachments)
-            .slice(0, limit)
-            .map((i) => {
-                if (i.file) {
-                    i.file = parseJsonField(i.file);
-                }
-
-                if (i.attachments && Array.isArray(i.attachments)) {
-                    i.attachments = i.attachments.map((attachment) => parseJsonField(attachment));
-                }
-
-                i.files = [];
-
-                if (i.file && typeof i.file === 'object' && 'path' in i.file) {
-                    i.files.push({
-                        name: i.file.name,
-                        path: i.file.path,
-                        extension: i.file.path.replace(/.*\./, '').toLowerCase(),
-                    });
-                }
-
-                if (i.attachments && Array.isArray(i.attachments)) {
-                    for (const attachment of i.attachments) {
-                        if (attachment && typeof attachment === 'object' && 'path' in attachment) {
-                            i.files.push({
-                                name: attachment.name,
-                                path: attachment.path,
-                                extension: attachment.path.replace(/.*\./, '').toLowerCase(),
-                            });
-                        }
-                    }
-                }
-
-                const filesHTML = art(path.join(__dirname, 'templates/source.art'), { i });
-                let $ = load(filesHTML);
-                const kemonoFiles = $('img, a, audio, video').map(function () {
-                    return $(this).prop('outerHTML')!;
-                });
-                let desc = '';
-                if (i.content) {
-                    desc += `<div>${i.content}</div>`;
-                }
-                $ = load(desc);
-                let count = 0;
-                const regex = /downloads.fanbox.cc/;
-                $('a').each(function () {
-                    const link = $(this).attr('href');
-                    if (regex.test(link!)) {
-                        count++;
-                        $(this).replaceWith(kemonoFiles[count]);
-                    }
-                });
-                desc = (kemonoFiles.length > 0 ? kemonoFiles[0] : '') + $.html();
-                for (const kemonoFile of kemonoFiles.slice(count + 1)) {
-                    desc += kemonoFile;
-                }
-
-                let enclosureInfo = {};
-                load(desc)('audio source, video source').each(function () {
-                    const src = $(this).attr('src') ?? '';
-                    const mimeType =
-                        {
-                            m4a: 'audio/mp4',
-                            mp3: 'audio/mpeg',
-                            mp4: 'video/mp4',
-                        }[src.replace(/.*\./, '').toLowerCase()] || null;
-
-                    if (mimeType === null) {
-                        return;
-                    }
-
-                    enclosureInfo = {
-                        enclosure_url: new URL(src, rootUrl).toString(),
-                        enclosure_type: mimeType,
-                    };
-                });
-
-                return {
-                    title: i.title,
-                    description: desc,
-                    author,
-                    pubDate: parseDate(i.published),
-                    guid: `${apiUrl}/${i.service}/user/${i.user}/post/${i.id}`,
-                    link: `${rootUrl}/${i.service}/user/${i.user}/post/${i.id}`,
-                    ...enclosureInfo,
-                };
-            });
+        return {
+            title,
+            image: iconUrl,
+            link: frontendUrl,
+            item: items,
+        };
+    } catch (error) {
+        throw new Error(`Failed to fetch data from Kemono: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
-
-    return {
-        title,
-        image,
-        link: buildLink(isPosts, rootUrl, source, id, type),
-        item: items,
-    };
 }

--- a/lib/routes/kemono/index.ts
+++ b/lib/routes/kemono/index.ts
@@ -16,7 +16,7 @@ export const route: Route = {
     parameters: {
         source: 'Source, see below, Posts by default',
         id: 'User id, can be found in URL',
-        type: 'Content type: announcements or fancards (optional)',
+        type: 'Content type: announcements or fancards',
     },
     features: {
         requireConfig: false,

--- a/lib/routes/kemono/types.ts
+++ b/lib/routes/kemono/types.ts
@@ -1,0 +1,31 @@
+interface KemonoPost {
+    id: string;
+    title: string;
+    content: string;
+    published: string;
+    service: string;
+    user: string;
+    file?: any;
+    attachments?: any[];
+}
+
+interface KemonoFile {
+    name: string;
+    path: string;
+    extension: string;
+}
+
+interface DiscordMessage {
+    id: string;
+    content: string;
+    published: string;
+    author: {
+        username: string;
+        discriminator: string;
+    };
+    server: string;
+    channel: string;
+    attachments?: any[];
+}
+
+export type { KemonoPost, KemonoFile, DiscordMessage };


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/kemono/patreon/11666662
/kemono/fanbox/24961447/announcements
/kemono/fanbox/24961447/fancards
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Specifically, some of the server data appears to have formatting inconsistencies during storage. Taking Patreon user 11666662 as an example, here is some of the data retrieved through the `https://kemono.su/api/v1/patreon/user/11666662/posts` endpoint:

```
[
  {
    "id": "129116313",
    "user": "11666662",
    "service": "patreon",
    "title": "Skrik_png+line_art",
    "content": "",
    "embed": "\"{}\"",
    "shared_file": false,
    "added": "2025-05-19T18:29:51.301674",
    "published": "2025-05-16T14:59:37",
    "edited": "2025-05-16T14:59:37",
    "file": "\"{\\\"name\\\": \\\"s803_k_png.png\\\", \\\"path\\\": \\\"/d7/50/d750b24ec8e57fb751198c7e461cb5bb5b5dd3319b3e8d7b627b13591e2679ac.png\\\"}\"",
    "attachments": [
      "\"{\\\"name\\\": \\\"s803_k_png.png\\\", \\\"path\\\": \\\"/d7/50/d750b24ec8e57fb751198c7e461cb5bb5b5dd3319b3e8d7b627b13591e2679ac.png\\\"}\"",
      "\"{\\\"name\\\": \\\"s803_line_png.png\\\", \\\"path\\\": \\\"/5f/ec/5fec9bd0e44d33e738d663137d995f827222e02131f9734ff7407691b3a3ce94.png\\\"}\""
    ],
    "poll": null,
    "captions": null,
    "tags": null
  },
  {
    "id": "129116267",
    "user": "11666662",
    "service": "patreon",
    "title": "Skirk_2k_uncensored",
    "content": "<p></p>",
    "embed": "\"{}\"",
    "shared_file": false,
    "added": "2025-05-19T18:29:42.500070",
    "published": "2025-05-16T14:58:58",
    "edited": "2025-05-16T14:58:58",
    "file": "\"{\\\"name\\\": \\\"s803_2k_uncensored_png.png\\\", \\\"path\\\": \\\"/9a/ee/9aee46a61669ad61eb468a71128c35ec7651530bda3ac90a6912a5b2d51d32bc.png\\\"}\"",
    "attachments": [
      "\"{\\\"name\\\": \\\"s803_2k_uncensored_png.png\\\", \\\"path\\\": \\\"/9a/ee/9aee46a61669ad61eb468a71128c35ec7651530bda3ac90a6912a5b2d51d32bc.png\\\"}\""
    ],
    "poll": null,
    "captions": null,
    "tags": null
  },
  {
    "id": "126555783",
    "user": "11666662",
    "service": "patreon",
    "title": "evelyn_png+line_art",
    "content": "",
    "embed": {},
    "shared_file": false,
    "added": "2025-04-13T21:23:22.921904",
    "published": "2025-04-13T11:18:33",
    "edited": "2025-04-13T11:18:33",
    "file": {
      "name": "s802_k_line.png",
      "path": "/2e/7e/2e7ee247ae45ffd268c4b34533f7c65341e31797c8886b52e415c54ff9a5a3ba.png"
    },
    "attachments": [
      {
        "name": "s802_k_line.png",
        "path": "/2e/7e/2e7ee247ae45ffd268c4b34533f7c65341e31797c8886b52e415c54ff9a5a3ba.png"
      },
      {
        "name": "s802_k_h.png",
        "path": "/fb/15/fb1579a4d321d22f3f70119443537dabfbfad1c9cd9c3bf368df7c2d2ed435e6.png"
      },
      {
        "name": "s802_k_no_h.png",
        "path": "/a0/f4/a0f46fd8a23315effb367f6ee8679bfb3c753eabe092a129e2d2f63eca93ddfc.png"
      }
    ],
    "poll": null,
    "captions": null,
    "tags": null
  },
  ...
]
```

As you can see from the data above, the `file` and `attachments` fields in the first two entries have incorrect formatting. These fields contain extra escape characters and quotation marks, while the format in the third entry is correct.

I am not sure if this issue is limited to this artist's data or if other artists' data might have similar problems. This formatting error causes the page `https://kemono.su/patreon/user/11666662` to fail to load properly, likely because it depends on data returned from the `https://kemono.su/api/v1/patreon/user/11666662/posts-legacy` endpoint, which cannot return data properly due to these formatting errors.