### PR TITLE
feat(route): add huya

### DIFF
--- a/lib/routes/huya/maintainer.ts
+++ b/lib/routes/huya/maintainer.ts
@@ -1,0 +1,3 @@
+export default {
+    '/huya/room/:id': ['SettingDust'],
+};

--- a/lib/routes/huya/namespace.ts
+++ b/lib/routes/huya/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '虎牙直播',
+    url: 'www.huya.com',
+    lang: 'zh-CN',
+};

--- a/lib/routes/huya/radar.ts
+++ b/lib/routes/huya/radar.ts
@@ -1,0 +1,13 @@
+export default {
+    'huya.com': {
+        _name: '虎牙直播',
+        '.': [
+            {
+                title: '直播间开播',
+                docs: 'https://docs.rsshub.app/live.html#hu-ya-zhi-bo',
+                source: ['/:id', '/'],
+                target: '/huya/room/:id',
+            },
+        ],
+    },
+};

--- a/lib/routes/huya/room.ts
+++ b/lib/routes/huya/room.ts
@@ -1,0 +1,108 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/room/:id',
+    categories: ['live'],
+    example: '/huya/room/11336726',
+    parameters: { id: '直播间 id, 可在主播直播间页 URL 中找到' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['huya.com/:id', 'huya.com/'],
+        },
+    ],
+    name: '直播间开播',
+    maintainers: ['SettingDust'],
+    handler,
+};
+
+async function handler(ctx) {
+    const id = ctx.req.param('id');
+    let data;
+    let item;
+    let room_info;
+
+    try {
+        // 尝试通过虎牙API获取直播间信息
+        const response = await got({
+            method: 'get',
+            url: `https://open.huya.com/index.php?m=Stream&do=getStreamInfo&roomId=${id}`,
+            headers: {
+                Referer: `https://www.huya.com/${id}`,
+            },
+        });
+
+        if (!response.data.data) {
+            throw new Error('Invalid response');
+        }
+
+        data = response.data.data;
+        room_info = data.info;
+
+        if (data.isOn === 1) {
+            item = [
+                {
+                    title: `开播: ${room_info.introduction}`,
+                    pubDate: new Date(room_info.startTime * 1000).toUTCString(),
+                    guid: room_info.startTime,
+                    link: `https://www.huya.com/${id}`,
+                },
+            ];
+        }
+    } catch (e) {
+        // 如果API调用失败，尝试通过页面抓取
+        const response = await got({
+            method: 'get',
+            url: `https://www.huya.com/${id}`,
+            headers: {
+                Referer: `https://www.huya.com/${id}`,
+            },
+        });
+
+        const html = response.data;
+        
+        // 从页面中提取直播间信息
+        const match = html.match(/"stream":\s*({.*?}),\s*"isOn"/);
+        if (match) {
+            try {
+                const streamInfo = JSON.parse(match[1]);
+                room_info = {
+                    nick: streamInfo.nick || '',
+                    introduction: streamInfo.introduction || '',
+                    screenshot: streamInfo.screenshot || '',
+                    startTime: streamInfo.startTime || Math.floor(Date.now() / 1000),
+                };
+
+                const isLive = html.includes('"isOn":1') || html.includes('"isOn": 1');
+                if (isLive) {
+                    item = [
+                        {
+                            title: `开播: ${room_info.introduction}`,
+                            pubDate: new Date(room_info.startTime * 1000).toUTCString(),
+                            guid: room_info.startTime,
+                            link: `https://www.huya.com/${id}`,
+                        },
+                    ];
+                }
+            } catch (err) {
+                console.error('解析页面数据失败:', err);
+            }
+        }
+    }
+
+    return {
+        title: room_info ? `${room_info.nick}的虎牙直播间` : `虎牙直播间 ${id}`,
+        image: room_info?.screenshot,
+        link: `https://www.huya.com/${id}`,
+        item,
+        allowEmpty: true,
+    };
+}

--- a/lib/routes/huya/router.ts
+++ b/lib/routes/huya/router.ts
@@ -1,0 +1,110 @@
+// 修改router.ts文件，使用art模板渲染描述
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import { art } from '@/utils/render';
+import path from 'node:path';
+
+export const route: Route = {
+    path: '/room/:id',
+    categories: ['live'],
+    example: '/huya/room/11336726',
+    parameters: { id: '直播间 id, 可在主播直播间页 URL 中找到' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['huya.com/:id', 'huya.com/'],
+        },
+    ],
+    name: '直播间开播',
+    maintainers: ['SettingDust'],
+    handler,
+};
+
+async function handler(ctx) {
+    const id = ctx.req.param('id');
+    let roomInfo = null;
+    let item = null;
+
+    try {
+        // 尝试通过页面抓取获取直播间信息
+        const response = await got(`https://www.huya.com/${id}`, {
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+                Referer: 'https://www.huya.com',
+            },
+        });
+
+        const html = response.body;
+        
+        // 提取页面标题
+        const titleMatch = html.match(/<title>(.*?)<\/title>/);
+        const pageTitle = titleMatch ? titleMatch[1] : `虎牙直播间 ${id}`;
+        
+        // 提取主播昵称
+        let nick = '';
+        const nickMatch = pageTitle.match(/^(.*?)直播_/);
+        if (nickMatch) {
+            nick = nickMatch[1];
+        }
+        
+        // 检查是否在线
+        const isLiveMatch = html.match(/ISLIVE\s*=\s*'(\d+)'/);
+        const isLive = isLiveMatch && isLiveMatch[1] === '1';
+        
+        // 提取直播间标题
+        const introMatch = html.match(/introduction\s*:\s*'([^']*?)'/);
+        const introduction = introMatch ? introMatch[1] : '';
+        
+        // 提取直播间截图
+        const screenshotMatch = html.match(/screenshot\s*:\s*'([^']*?)'/);
+        const screenshot = screenshotMatch ? screenshotMatch[1] : '';
+        
+        // 提取开播时间
+        const startTimeMatch = html.match(/startTime\s*:\s*'?(\d+)'?/);
+        const startTime = startTimeMatch ? parseInt(startTimeMatch[1]) : Math.floor(Date.now() / 1000);
+        
+        // 构建房间信息
+        roomInfo = {
+            nick: nick || `虎牙用户${id}`,
+            introduction: introduction || pageTitle,
+            screenshot: screenshot,
+            startTime: startTime
+        };
+        
+        if (isLive) {
+            item = [
+                {
+                    title: `开播: ${roomInfo.introduction}`,
+                    pubDate: parseDate(roomInfo.startTime * 1000),
+                    guid: roomInfo.startTime.toString(),
+                    link: `https://www.huya.com/${id}`,
+                    description: art(path.join(__dirname, 'templates/description.art'), {
+                        screenshot: roomInfo.screenshot,
+                        nick: roomInfo.nick,
+                        introduction: roomInfo.introduction,
+                        startTime: new Date(roomInfo.startTime * 1000).toLocaleString(),
+                    }),
+                    author: roomInfo.nick,
+                },
+            ];
+        }
+    } catch (e) {
+        throw new Error('获取直播间信息失败');
+    }
+
+    return {
+        title: roomInfo ? `${roomInfo.nick}的虎牙直播间` : `虎牙直播间 ${id}`,
+        image: roomInfo?.screenshot,
+        link: `https://www.huya.com/${id}`,
+        item,
+        allowEmpty: true,
+    };
+}

--- a/lib/routes/huya/templates/description.art
+++ b/lib/routes/huya/templates/description.art
@@ -1,0 +1,4 @@
+<img src="{{ screenshot }}" />
+<p>主播：{{ nick }}</p>
+<p>直播间标题：{{ introduction }}</p>
+<p>开播时间：{{ startTime }}</p>


### PR DESCRIPTION
Add HuYa Live Router

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```
/huya/room/:id
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [X] New Route / 新的路由
  - [X] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [X] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [X] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

## 路由路径

```
/huya/room/:id
```

## 参数说明

| 参数 | 说明 |
| ---- | ---- |
| id | 必选，虎牙直播间房间号，可在主播直播间页 URL 中找到 |

本路由通过以下方式获取虎牙直播间信息：

1. 通过页面抓取方式获取直播间信息
2. 从页面中提取主播昵称、直播间标题、截图、开播时间等信息
3. 根据直播状态生成 RSS 内容
4. 使用 art-template 渲染描述内容

### 代码结构

按照 RSSHub 脚本标准规范，本路由包含以下文件：

- `router.ts`: 路由处理逻辑
- `maintainer.ts`: 路由维护者信息
- `radar.ts`: RSSHub Radar 规则
- `templates/description.art`: 描述内容模板
