### PR TITLE
add huya live

### DIFF
--- a/lib/routes/huya/live.ts
+++ b/lib/routes/huya/live.ts
@@ -1,0 +1,108 @@
+import { Route } from '@/types';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import logger from '@/utils/logger';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/live/:id',
+    categories: ['live'],
+    example: '/huya/live/10188',
+    parameters: { id: '直播间ID，可在直播间URL中找到' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['huya.com/:id'],
+            target: '/live/:id',
+        },
+    ],
+    name: '直播间',
+    maintainers: ['DIYgod'],
+    handler,
+};
+
+async function handler(ctx) {
+    const id = ctx.req.param('id');
+    let room_info = null;
+
+    try {
+        const response = await got(`https://www.huya.com/${id}`, {
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+            },
+        });
+
+        const html = response.body;
+        logger.debug(`页面抓取成功，内容长度: ${html.length}`);
+        
+        // 提取页面标题
+        const titleMatch = html.match(/<title>(.*?)<\/title>/);
+        let pageTitle = titleMatch ? titleMatch[1] : `虎牙直播间 ${id}`;
+        
+        // 提取主播昵称
+        let nick = '';
+        const nickMatch = pageTitle.match(/^(.*?)直播_/);
+        if (nickMatch) {
+            nick = nickMatch[1];
+        }
+                        
+        // 提取TT_ROOM_DATA结构化数据
+        const ttRoomDataMatch = html.match(/var TT_ROOM_DATA = (\{.*?\});/s);
+        const isLive = ttRoomDataMatch ? JSON.parse(ttRoomDataMatch[1]).isOn : false;
+        
+        // 提取TT_ROOM_DATA中的直播间标题
+        const ttRoomData = ttRoomDataMatch ? JSON.parse(ttRoomDataMatch[1]) : {};
+        const introduction = ttRoomData.introduction || '';
+        
+        // 提取直播间截图
+        const screenshotMatch = html.match(/screenshot\s*:\s*'([^']*?)'/);
+        const screenshot = screenshotMatch ? screenshotMatch[1] : '';
+        
+        // 提取开播时间
+        const startTimeMatch = html.match(/startTime\s*:\s*'?(\d+)'?/);
+        const startTime = startTimeMatch ? parseInt(startTimeMatch[1]) : Math.floor(Date.now() / 1000);
+        
+        // 构建房间信息
+        room_info = {
+            nick: nick || `虎牙用户${id}`,
+            introduction: introduction || pageTitle,
+            screenshot: screenshot,
+            startTime: startTime
+        };
+        
+        let item = [];
+        if (isLive) {
+            item = [
+                {
+                    title: room_info.introduction,
+                    pubDate: parseDate(room_info.startTime * 1000),
+                    guid: room_info.startTime,
+                    link: `https://www.huya.com/${id}`,
+                },
+            ];
+        }
+
+        return {
+            title: room_info ? `${room_info.nick}的虎牙直播间` : `虎牙直播间 ${id}`,
+            image: room_info?.screenshot,
+            link: `https://www.huya.com/${id}`,
+            item,
+            allowEmpty: true,
+        };
+    } catch (e) {
+        logger.error('页面抓取失败:', e.message);
+        return {
+            title: `虎牙直播间 ${id}`,
+            link: `https://www.huya.com/${id}`,
+            item: [],
+            allowEmpty: true,
+        };
+    }
+} 

--- a/lib/routes/huya/namespace.ts
+++ b/lib/routes/huya/namespace.ts
@@ -1,0 +1,14 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '虎牙直播',
+    url: 'huya.com',
+    description: `
+:::tip
+虎牙直播是一个游戏直播平台，提供游戏直播、赛事直播、娱乐直播等服务。
+:::
+    `,
+    zh: {
+        name: '虎牙直播',
+    },
+}; 


### PR DESCRIPTION
add huya live

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/huya/live/10188
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [X] New Route / 新的路由
  - [X] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [X] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
本路由用于获取虎牙直播间的开播状态，支持通过房间号获取直播信息，并生成符合 RSS 标准的订阅源。

### 路由路径

```
/huya/live/:id
```

## 参数说明

| 参数 | 说明 |
| ---- | ---- |
| id | 必选，虎牙直播间房间号，可在主播直播间页 URL 中找到 |