### PR TITLE
feat(cache): enhance tryGet method to support generic return types

### DIFF
--- a/lib/utils/cache/index.ts
+++ b/lib/utils/cache/index.ts
@@ -71,7 +71,7 @@ export default {
      * @param refresh Whether to renew the cache expiration time when the cache is hit. `true` by default.
      * @returns
      */
-    tryGet: async (key: string, getValueFunc: () => Promise<string | Record<string, any>>, maxAge = config.cache.contentExpire, refresh = true) => {
+    tryGet: async <T extends string | Record<string, any>>(key: string, getValueFunc: () => Promise<T>, maxAge = config.cache.contentExpire, refresh = true) => {
         if (typeof key !== 'string') {
             throw new TypeError('Cache key must be a string');
         }
@@ -87,7 +87,7 @@ export default {
                 v = parsed;
             }
 
-            return v;
+            return v as T;
         } else {
             const value = await getValueFunc();
             cacheModule.set(key, value, maxAge);


### PR DESCRIPTION
Make `tryGet` method can support generic return types. It will not eat the cache object type.

Before:
![image](https://github.com/user-attachments/assets/240746fd-e8e1-4f3f-b87b-488db44eebb0)

After:
![image](https://github.com/user-attachments/assets/effd607f-b413-423d-b995-4ac6fa01e3a2)
