### PR TITLE
feat(konachan): add SFW option for konachan via /sfw prefix

### DIFF
--- a/lib/routes/konachan/post.ts
+++ b/lib/routes/konachan/post.ts
@@ -3,7 +3,10 @@ import got from '@/utils/got';
 import queryString from 'query-string';
 
 export const route: Route = {
-    path: '/post/popular_recent/:period?',
+    path: [
+        '/post/popular_recent/:period?',       // 对应 konachan.com
+        '/sfw/post/popular_recent/:period?',   // 对应 konachan.net（SFW）
+    ],
     categories: ['picture'],
     view: ViewType.Pictures,
     example: '/konachan/post/popular_recent/1d',
@@ -21,7 +24,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['konachan.com/post'],
+            source: ['konachan.com/post', 'konachan.net/post'],
         },
     ],
     name: 'Popular Recent Posts',
@@ -34,9 +37,12 @@ export const route: Route = {
 
 async function handler(ctx) {
     const { period = '1d' } = ctx.req.param();
+    const fullPath = ctx.req.path(); 
+    const isSfw = fullPath.startsWith('/sfw');
+    const baseUrl = isSfw ? 'https://konachan.net' : 'https://konachan.com';
 
     const response = await got({
-        url: 'https://konachan.com/post/popular_recent.json',
+        url: `${baseUrl}/post/popular_recent.json`,
         searchParams: queryString.stringify({
             period,
         }),
@@ -51,7 +57,7 @@ async function handler(ctx) {
         '1y': 'Last year',
     };
 
-    const mime = {
+    const mime: Record<string, string> = {
         jpg: 'jpeg',
         png: 'png',
     };
@@ -59,30 +65,31 @@ async function handler(ctx) {
     const title = titles[period];
 
     return {
-        title: `${title} - konachan.com`,
-        link: `https://konachan.com/post/popular_recent?period=${period}`,
+        title: `${title} - ${isSfw ? 'konachan.net' : 'konachan.com'}`,
+        link: `${baseUrl}/post/popular_recent?period=${period}`,
         item: posts.map((post) => ({
-            title: post.tags,
-            id: `${ctx.path}#${post.id}`,
-            guid: `${ctx.path}#${post.id}`,
-            link: `https://konachan.com/post/show/${post.id}`,
-            author: post.author,
-            pubDate: new Date(post.created_at * 1e3).toUTCString(),
-            description: (() => {
-                const result = [`<img src="${post.sample_url}" />`];
-                result.push(`<p>Rating:${post.rating}</p> <p>Score:${post.score}</p>`);
-                if (post.source) {
-                    result.push(`<a href="${post.source}">Source</a>`);
-                }
-                if (post.parent_id) {
-                    result.push(`<a href="https://konachan.com/post/show/${post.parent_id}">Parent</a>`);
-                }
-                return result.join('');
-            })(),
-            media: {
-                content: {
-                    url: post.file_url,
-                    type: `image/${mime[post.file_ext]}`,
+        title: post.tags,
+        id: `${ctx.path}#${post.id}`,
+        guid: `${ctx.path}#${post.id}`,
+        link: `${baseUrl}/post/show/${post.id}`,
+        author: post.author,
+        pubDate: new Date(post.created_at * 1e3).toUTCString(),
+        description: (() => {
+            const result: string[] = [];
+            result.push(`<img src="${post.sample_url}" />`);
+            result.push(`<p>Rating: ${post.rating}</p><p>Score: ${post.score}</p>`);
+            if (post.source) {
+                result.push(`<a href="${post.source}">Source</a>`);
+            }
+            if (post.parent_id) {
+                result.push(`<a href="${baseUrl}/post/show/${post.parent_id}">Parent</a>`);
+            }
+            return result.join('');
+        })(),
+        media: {
+            content: {
+                url: post.file_url,
+                type: `image/${mime[post.file_ext]}`,
                 },
                 thumbnail: {
                     url: post.preview_url,

--- a/lib/routes/konachan/post.ts
+++ b/lib/routes/konachan/post.ts
@@ -32,7 +32,7 @@ export const route: Route = {
         },
     ],
     name: 'Popular Recent Posts',
-    maintainers: ['magic-akari', 'NekoAria'],
+    maintainers: ['magic-akari', 'NekoAria', 'sineeeee'],
     description: `| 最近 24 小时    | 最近一周     | 最近一月    | 最近一年     |
 | ------- | -------- | ------- | -------- |
 | 1d | 1w | 1m | 1y |`,

--- a/lib/routes/konachan/post.ts
+++ b/lib/routes/konachan/post.ts
@@ -21,6 +21,10 @@ export const route: Route = {
             ],
             default: '1d',
         },
+        safe_search: {
+            description: '是否使用无r18站点 konachan.net，若是则在路径前加上 `/sfw`，如`/konachan/sfw/post/popular_recent/1d`，若否则默认使用 konachan.com',
+            default: 'false',
+        },
     },
     radar: [
         {


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例



```routes
/konachan/post/popular_recent/1d
/konachan/post/popular_recent/1w
/konachan/post/popular_recent/1m
/konachan/post/popular_recent/1y
/konachan/sfw/post/popular_recent/1d
/konachan/sfw/post/popular_recent/1w
/konachan/sfw/post/popular_recent/1m
/konachan/sfw/post/popular_recent/1y
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- 在原有 lib/routes/konachan/post.ts 基础上新增了 /sfw 前缀，用于切换至 konachan.net（无r18内容版本）站点。
- 原有 /konachan/post/popular_recent/:period? 路由保持不变，继续请求 konachan.com。
- 新增 /konachan/sfw/post/popular_recent/:period? 路由时，自动识别 /sfw 前缀并请求 konachan.net。
- 已在本地验证所有示例路由均可正确输出 RSS，符合脚本规范且无需额外第三方包。
