### PR TITLE
feat(route): add Folo verification for bfl/announcements

### DIFF
--- a/lib/routes/bfl/announcements.ts
+++ b/lib/routes/bfl/announcements.ts
@@ -83,10 +83,8 @@ async function handler(): Promise<Data> {
     // 并行获取所有文章的完整描述
     const items: DataItem[] = await Promise.all(preliminaryItems.map((item) => fetchDescription(item)));
 
-    const feedDescription = $('head meta[name="description"]').attr('content')?.trim() || 'Latest announcements from Black Forest Labs (bfl.ai).';
-
     // Folo 验证码
-    const verificationString = ' feedId:153814816828039168+userId:42122329111016448';
+    const verificationString = 'feedId:153814816828039168+userId:42122329111016448';
     return {
         title: feedTitle,
         link: listPageUrl,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue
## Example for the Proposed Route(s) / 路由地址示例
```routes
/bfl/announcements
````

## New RSS Route Checklist / 新 RSS 路由检查表

  - [ ] New Route / 新的路由
  - [x] Follows [[Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [[路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-sta%3C/1%3Endard)](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
  - [ ] Documentation / 文档说明 *(此功能增加无需修改文档 / No documentation changes required for this feature)*
  - [x] Full text / 全文获取
  - [x] Use cache / 使用缓存
  - [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
  - [x] [[Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)](https://docs.rsshub.app/joinus/advanced/pub-date) / [[日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] New package added / 添加了新的包
  - [ ] `Puppeteer`

## Note / 说明

This PR adds a verification string to the description of the `/bfl/announcements` feed. This is for ownership verification in the Folo RSS reader app (`follow.is`).

No changes were made to the core data fetching logic.