### PR TITLE
fix(route/smartlink): Preserve queryparams for image URL to work in smartlink

### DIFF
--- a/lib/routes/smartlink/index.ts
+++ b/lib/routes/smartlink/index.ts
@@ -62,7 +62,7 @@ async function handler(ctx) {
     const items = parsedData.map((item) => ({
         title: getTitle(item),
         link: item.smartlink.split('?')[0],
-        description: `<p><img src="${item.imageUrl.split('?')[0]}"></p>`,
+        description: `<p><img src="${item.imageUrl}"></p>`,
         pubDate: item.created,
         guid: item.id,
     }));


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/smartlink/bloombergbusiness
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

image URL without query params does not work https://scontent-atl3-2.cdninstagram.com/v/t51.75761-15/504395160_18512643616057819_8198275713847525084_n.jpg

Need to preserve the whole URL

https://scontent-atl3-2.cdninstagram.com/v/t51.75761-15/504395160_18512643616057819_8198275713847525084_n.jpg?stp=dst-jpg_e35_tt6&_nc_cat=100&ccb=1-7&_nc_sid=18de74&_nc_ohc=Jw-gKsJFN7IQ7kNvwEMMWNO&_nc_oc=Adl3IajRRrqy_Ox8gYejkXzp7yBU1HKfZIGH2eH91QgDACxFvGq0VVx7SAdr2Lmg1q4&_nc_zt=23&_nc_ht=scontent-atl3-2.cdninstagram.com&edm=AM6HXa8EAAAA&_nc_gid=zJXfexst5YK6U6_UN6ydGw&oh=00_AfMbYEggCl_quY3GgpGSe4ghn2wvHMbi7WqKV3WRyRQC2Q&oe=684B8B49