### PR TITLE
fix(route): Fix 403 issue on 18comic route by using API calls instead of directly fetching the webpage.

### DIFF
--- a/lib/routes/18comic/album.ts
+++ b/lib/routes/18comic/album.ts
@@ -66,7 +66,7 @@ async function handler(ctx) {
     } else {
         results = await Promise.all(
             apiResult.series.map((item, index) =>
-                cache.tryGet(`18comic:album:${domain}:${item.id}`, async () => {
+                cache.tryGet(`18comic:album:${item.id}`, async () => {
                     const chapterApiUrl = `${getApiUrl()}/chapter?id=${item.id}`;
                     const chapterResult = await processApiItems(chapterApiUrl);
                     const result = {};

--- a/lib/routes/18comic/album.ts
+++ b/lib/routes/18comic/album.ts
@@ -1,10 +1,7 @@
 import { Route } from '@/types';
-import cache from '@/utils/cache';
-import got from '@/utils/got';
-import { load } from 'cheerio';
-import { parseDate } from '@/utils/parse-date';
-
-import { defaultDomain, getRootUrl } from './utils';
+import { defaultDomain, getApiUrl, getRootUrl, processApiItems } from './utils';
+import { art } from '@/utils/render';
+import path from 'node:path';
 
 export const route: Route = {
     path: '/album/:id',
@@ -37,71 +34,67 @@ async function handler(ctx) {
     const id = ctx.req.param('id');
     const { domain = defaultDomain } = ctx.req.query();
     const rootUrl = getRootUrl(domain);
-
     const currentUrl = `${rootUrl}/album/${id}`;
+    let apiUrl = getApiUrl();
 
-    const response = await got({
-        method: 'get',
-        url: currentUrl,
-    });
+    apiUrl = `${apiUrl}/album?id=${id}`;
 
-    const $ = load(response.data);
+    const apiResult = await processApiItems(apiUrl);
 
-    const category = $('span[data-type="tags"]')
-        .first()
-        .find('a')
-        .toArray()
-        .map((c) => $(c).text());
-    const author = $('span[data-type="author"]')
-        .first()
-        .find('a')
-        .toArray()
-        .map((a) => $(a).text())
-        .join(', ');
-
-    let items = $('.btn-toolbar')
-        .first()
-        .find('a')
-        .toArray()
-        .map((item) => {
-            item = $(item);
-
-            return {
-                title: item.text(),
-                link: `${rootUrl}${item.attr('href')}`,
-                guid: `https://18comic.org${item.attr('href')}`,
-                pubDate: parseDate(item.find('.hidden-xs').text()),
-            };
+    const category = apiResult.tags;
+    const author = apiResult.author.join(', ');
+    const description = apiResult.description;
+    const addTime = apiResult.addtime;
+    let results: any[] = [];
+    if (apiResult.series.length === 0) {
+        results.push({
+            title: apiResult.name,
+            link: `${rootUrl}/photo/${id}`,
+            guid: `${rootUrl}/photo/${id}`,
+            updated: new Date(addTime * 1000),
+            pubDate: new Date(addTime * 1000),
+            category,
+            author,
+            description: art(path.join(__dirname, 'templates/description.art'), {
+                introduction: description,
+                // 于取图片，因为专辑的图片会被分割排序，所以只取封面图
+                images: [`https://cdn-msp3.${domain}/media/albums/${id}_3x4.jpg`],
+                cover: `https://cdn-msp3.${domain}/media/albums/${id}_3x4.jpg`,
+                category,
+            }),
         });
-
-    items = await Promise.all(
-        items.map((item) =>
-            cache.tryGet(item.guid, async () => {
-                const detailResponse = await got({
-                    method: 'get',
-                    url: item.link,
+    } else {
+        results = await Promise.all(
+            apiResult.series.map(async (item, index) => {
+                apiUrl = `${getApiUrl()}/chapter?id=${item.id}`;
+                const chapterResult = await processApiItems(apiUrl);
+                const result = {};
+                const chapterNum = index + 1;
+                result.title = `第${String(chapterNum)}話 ${item.name === '' ? `${String(chapterNum)}` : item.name}`;
+                result.link = `${rootUrl}/photo/${item.id}`;
+                result.guid = `${rootUrl}/photo/${item.id}`;
+                result.updated = new Date(chapterResult.addtime * 1000);
+                result.pubDate = addTime;
+                result.category = category;
+                result.author = author;
+                result.description = art(path.join(__dirname, 'templates/description.art'), {
+                    introduction: description,
+                    // 于取图片，因为专辑的图片会被分割排序，所以只取封面图
+                    images: [`https://cdn-msp3.${domain}/media/albums/${item.id}_3x4.jpg`],
+                    cover: `https://cdn-msp3.${domain}/media/albums/${item.id}_3x4.jpg`,
+                    category,
                 });
-
-                const content = load(detailResponse.data);
-
-                content('.tab-content').remove();
-
-                item.author = author;
-                item.category = category;
-                item.description = `<img src="${content('.thumb-overlay-albums img[data-original]')
-                    .toArray()
-                    .map((image) => content(image).attr('data-original'))
-                    .join('"><img src="')}">`;
-
-                return item;
+                return result;
             })
-        )
-    );
+        );
+        results = results.reverse();
+    }
 
     return {
-        title: $('title').text(),
-        link: currentUrl,
-        item: items,
-        description: $('meta[property="og:description"]').attr('content'),
+        title: `${apiResult.name} - 禁漫天堂`,
+        link: currentUrl.replace(/\?$/, ''),
+        item: results,
+        allowEmpty: true,
+        description,
     };
 }

--- a/lib/routes/18comic/namespace.ts
+++ b/lib/routes/18comic/namespace.ts
@@ -5,6 +5,7 @@ export const namespace: Namespace = {
     url: '18comic.org',
     description: `::: tip
 禁漫天堂有多个备用域名，本路由默认使用域名 \`https://jmcomic.me\`，若该域名无法访问，可以通过在路由最后加上 \`?domain=<域名>\` 指定路由访问的域名。如指定备用域名为 \`https://jmcomic1.me\`，则在所有禁漫天堂路由最后加上 \`?domain=jmcomic1.me\` 即可，此时路由为 [\`/18comic?domain=jmcomic1.me\`](https://rsshub.app/18comic?domain=jmcomic1.me)
+由于网页版有防爬虫机制，建议使用 API 模式获取数据，API 模式可以通过在路由最后加上 \`?api=true\` 开启。目前仅支持搜索路由开启 API 模式，其他路由暂不支持。
 :::`,
     lang: 'zh-CN',
 };

--- a/lib/routes/18comic/namespace.ts
+++ b/lib/routes/18comic/namespace.ts
@@ -5,7 +5,6 @@ export const namespace: Namespace = {
     url: '18comic.org',
     description: `::: tip
 禁漫天堂有多个备用域名，本路由默认使用域名 \`https://jmcomic.me\`，若该域名无法访问，可以通过在路由最后加上 \`?domain=<域名>\` 指定路由访问的域名。如指定备用域名为 \`https://jmcomic1.me\`，则在所有禁漫天堂路由最后加上 \`?domain=jmcomic1.me\` 即可，此时路由为 [\`/18comic?domain=jmcomic1.me\`](https://rsshub.app/18comic?domain=jmcomic1.me)
-由于网页版有防爬虫机制，建议使用 API 模式获取数据，API 模式可以通过在路由最后加上 \`?api=true\` 开启。目前仅支持搜索路由开启 API 模式，其他路由暂不支持。
 :::`,
     lang: 'zh-CN',
 };

--- a/lib/routes/18comic/search.ts
+++ b/lib/routes/18comic/search.ts
@@ -39,63 +39,67 @@ export const route: Route = {
 :::`,
 };
 
-async function handlerForApi({ domain, limit, currentUrl, rootUrl, keyword, category, order }) {
-    let page = 1;
+async function handlerApiWithPage(params, page, total, fetchedTotal, filteredTotal) {
+    const { domain, limit, rootUrl, keyword, category, order } = params;
     const results: any[] = [];
-    let total = null;
-    let fetchedTotal = 0;
-    while (true) {
-        let apiUrl = getApiUrl();
-        apiUrl = `${apiUrl}/search?search_query=${keyword}&o=${order}&page=${page}`;
-        // eslint-disable-next-line no-await-in-loop
-        let apiResult = await ProcessApiItems(apiUrl);
-        total ??= apiResult.total;
-        const fetchItemsLength = apiResult.content.length;
-        fetchedTotal += fetchItemsLength;
-        let filteredItemsByCategory = apiResult.content;
-        // Filter items by category if not 'all'
-        if (category !== 'all') {
-            filteredItemsByCategory = apiResult.content.filter((item) => item.category.title === apiMapCategory(category));
-        }
-        filteredItemsByCategory = filteredItemsByCategory.slice(0, limit - results.length);
-        // eslint-disable-next-line no-await-in-loop
-        const tempResults = await Promise.all(
-            filteredItemsByCategory.map((item) =>
-                cache.tryGet(item.id, async () => {
-                    const tempResult = {};
-                    tempResult.title = item.name;
-                    tempResult.link = `${rootUrl}/album/${item.id}`;
-                    tempResult.guid = `18comic:/album/${item.id}`;
-                    tempResult.updated = parseDate(item.update_at);
-                    apiUrl = `${getApiUrl()}/album?id=${item.id}`;
-                    apiResult = await ProcessApiItems(apiUrl);
-                    tempResult.pubDate = new Date(apiResult.addtime * 1000);
-                    tempResult.category = apiResult.tags.map((tag) => tag);
-                    tempResult.author = apiResult.author.map((a) => a).join(', ');
-                    tempResult.description = art(path.join(__dirname, 'templates/description.art'), {
-                        introduction: apiResult.description,
-                        images: [
-                            `https://cdn-msp3.${domain}/media/albums/${item.id}_3x4.jpg`,
-                            // 取得的预览图片会被分割排序，所以先只取封面图
-                            // `https://cdn-msp3.${domain}/media/photos/${item.id}/00001.webp`,
-                            // `https://cdn-msp3.${domain}/media/photos/${item.id}/00002.webp`,
-                            // `https://cdn-msp3.${domain}/media/photos/${item.id}/00003.webp`,
-                        ],
-                        cover: `https://cdn-msp3.${domain}/media/albums/${item.id}_3x4.jpg`,
-                        category: tempResult.category,
-                    });
-                    return tempResult;
-                })
-            )
-        );
-        results.push(...tempResults);
-
-        if (fetchedTotal < (total ?? 0) && results.length < limit) {
-            page++;
-        } else {
-            break;
-        }
+    let apiUrl = getApiUrl();
+    apiUrl = `${apiUrl}/search?search_query=${keyword}&o=${order}&page=${page}`;
+    let apiResult = await ProcessApiItems(apiUrl);
+    total ??= apiResult.total;
+    const fetchItemsLength = apiResult.content.length;
+    fetchedTotal += fetchItemsLength;
+    let filteredItemsByCategory = apiResult.content;
+    // Filter items by category if not 'all'
+    if (category !== 'all') {
+        filteredItemsByCategory = apiResult.content.filter((item) => item.category.title === apiMapCategory(category));
     }
+    filteredItemsByCategory = filteredItemsByCategory.slice(0, limit - filteredTotal);
+    filteredTotal = filteredTotal + filteredItemsByCategory.length;
+    const tempResults = await Promise.all(
+        filteredItemsByCategory.map((item) =>
+            cache.tryGet(item.id, async () => {
+                const tempResult = {};
+                tempResult.title = item.name;
+                tempResult.link = `${rootUrl}/album/${item.id}`;
+                tempResult.guid = `18comic:/album/${item.id}`;
+                tempResult.updated = parseDate(item.update_at);
+                apiUrl = `${getApiUrl()}/album?id=${item.id}`;
+                apiResult = await ProcessApiItems(apiUrl);
+                tempResult.pubDate = new Date(apiResult.addtime * 1000);
+                tempResult.category = apiResult.tags.map((tag) => tag);
+                tempResult.author = apiResult.author.map((a) => a).join(', ');
+                tempResult.description = art(path.join(__dirname, 'templates/description.art'), {
+                    introduction: apiResult.description,
+                    images: [
+                        `https://cdn-msp3.${domain}/media/albums/${item.id}_3x4.jpg`,
+                        // 取得的预览图片会被分割排序，所以先只取封面图
+                        // `https://cdn-msp3.${domain}/media/photos/${item.id}/00001.webp`,
+                        // `https://cdn-msp3.${domain}/media/photos/${item.id}/00002.webp`,
+                        // `https://cdn-msp3.${domain}/media/photos/${item.id}/00003.webp`,
+                    ],
+                    cover: `https://cdn-msp3.${domain}/media/albums/${item.id}_3x4.jpg`,
+                    category: tempResult.category,
+                });
+                return tempResult;
+            })
+        )
+    );
+    results.push(...tempResults);
+
+    if (fetchedTotal < (total ?? 0) && filteredTotal < limit) {
+        const nextPageResult = await handlerApiWithPage(params, page + 1, total, fetchedTotal, filteredTotal);
+        results.push(...nextPageResult);
+    }
+    return results;
+}
+
+async function handlerForApi(params) {
+    const { currentUrl, keyword } = params;
+    const results: any[] = [];
+    const total = null;
+    const fetchedTotal = 0;
+    const filteredTotal = 0;
+    results.push(...(await handlerApiWithPage(params, 1, total, fetchedTotal, filteredTotal)));
     return {
         title: `Search Results For '${keyword}' - 禁漫天堂`,
         link: currentUrl.replace(/\?$/, ''),
@@ -116,7 +120,7 @@ async function handler(ctx) {
     const currentUrl = `${rootUrl}/search/${option}${category === 'all' ? '' : `/${category}`}${keyword ? `?search_query=${keyword}` : '?'}${time === 'a' ? '' : `&t=${time}`}${order === 'mr' ? '' : `&o=${order}`}`;
     const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 20;
     if (api) {
-        return await handlerForApi({ domain, limit, currentUrl, rootUrl, keyword, category, order });
+        return await handlerForApi({ domain, limit, currentUrl, rootUrl, keyword, category, order, page: 1 });
     }
 
     return await ProcessItems(ctx, currentUrl, rootUrl);

--- a/lib/routes/18comic/search.ts
+++ b/lib/routes/18comic/search.ts
@@ -62,7 +62,7 @@ async function handler(ctx) {
     filteredItemsByCategory = filteredItemsByCategory.slice(0, limit);
     const results = await Promise.all(
         filteredItemsByCategory.map((item) =>
-            cache.tryGet(item.id, async () => {
+            cache.tryGet(`18comic:search:${domain}:${item.id}`, async () => {
                 const result = {};
                 result.title = item.name;
                 result.link = `${rootUrl}/album/${item.id}`;

--- a/lib/routes/18comic/search.ts
+++ b/lib/routes/18comic/search.ts
@@ -1,5 +1,5 @@
 import { Route } from '@/types';
-import { apiMapCategory, defaultDomain, getApiUrl, getRootUrl, ProcessApiItems, ProcessItems } from './utils';
+import { apiMapCategory, defaultDomain, getApiUrl, getRootUrl, processApiItems } from './utils';
 import { parseDate } from '@/utils/parse-date';
 import { art } from '@/utils/render';
 import path from 'node:path';
@@ -39,36 +39,41 @@ export const route: Route = {
 :::`,
 };
 
-async function handlerApiWithPage(params, page, total, fetchedTotal, filteredTotal) {
-    const { domain, limit, rootUrl, keyword, category, order } = params;
-    const results: any[] = [];
+async function handler(ctx) {
+    const option = ctx.req.param('option') ?? 'photos';
+    const category = ctx.req.param('category') ?? 'all';
+    const keyword = ctx.req.param('keyword') ?? '';
+    const time = ctx.req.param('time') ?? 'a';
+    const { domain = defaultDomain } = ctx.req.query();
+    const rootUrl = getRootUrl(domain);
+    let order = ctx.req.param('order') ?? 'mr';
+    const currentUrl = `${rootUrl}/search/${option}${category === 'all' ? '' : `/${category}`}${keyword ? `?search_query=${keyword}` : '?'}${time === 'a' ? '' : `&t=${time}`}${order === 'mr' ? '' : `&o=${order}`}`;
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 20;
+
     let apiUrl = getApiUrl();
-    apiUrl = `${apiUrl}/search?search_query=${keyword}&o=${order}&page=${page}`;
-    let apiResult = await ProcessApiItems(apiUrl);
-    total ??= apiResult.total;
-    const fetchItemsLength = apiResult.content.length;
-    fetchedTotal += fetchItemsLength;
+    order = time === 'a' ? order : `${order}_${time}`;
+    apiUrl = `${apiUrl}/search?search_query=${keyword}&o=${order}`;
+    let apiResult = await processApiItems(apiUrl);
     let filteredItemsByCategory = apiResult.content;
     // Filter items by category if not 'all'
     if (category !== 'all') {
         filteredItemsByCategory = apiResult.content.filter((item) => item.category.title === apiMapCategory(category));
     }
-    filteredItemsByCategory = filteredItemsByCategory.slice(0, limit - filteredTotal);
-    filteredTotal = filteredTotal + filteredItemsByCategory.length;
-    const tempResults = await Promise.all(
+    filteredItemsByCategory = filteredItemsByCategory.slice(0, limit);
+    const results = await Promise.all(
         filteredItemsByCategory.map((item) =>
             cache.tryGet(item.id, async () => {
-                const tempResult = {};
-                tempResult.title = item.name;
-                tempResult.link = `${rootUrl}/album/${item.id}`;
-                tempResult.guid = `18comic:/album/${item.id}`;
-                tempResult.updated = parseDate(item.update_at);
+                const result = {};
+                result.title = item.name;
+                result.link = `${rootUrl}/album/${item.id}`;
+                result.guid = `18comic:/album/${item.id}`;
+                result.updated = parseDate(item.update_at);
                 apiUrl = `${getApiUrl()}/album?id=${item.id}`;
-                apiResult = await ProcessApiItems(apiUrl);
-                tempResult.pubDate = new Date(apiResult.addtime * 1000);
-                tempResult.category = apiResult.tags.map((tag) => tag);
-                tempResult.author = apiResult.author.map((a) => a).join(', ');
-                tempResult.description = art(path.join(__dirname, 'templates/description.art'), {
+                apiResult = await processApiItems(apiUrl);
+                result.pubDate = new Date(apiResult.addtime * 1000);
+                result.category = apiResult.tags.map((tag) => tag);
+                result.author = apiResult.author.map((a) => a).join(', ');
+                result.description = art(path.join(__dirname, 'templates/description.art'), {
                     introduction: apiResult.description,
                     images: [
                         `https://cdn-msp3.${domain}/media/albums/${item.id}_3x4.jpg`,
@@ -78,50 +83,17 @@ async function handlerApiWithPage(params, page, total, fetchedTotal, filteredTot
                         // `https://cdn-msp3.${domain}/media/photos/${item.id}/00003.webp`,
                     ],
                     cover: `https://cdn-msp3.${domain}/media/albums/${item.id}_3x4.jpg`,
-                    category: tempResult.category,
+                    category: result.category,
                 });
-                return tempResult;
+                return result;
             })
         )
     );
-    results.push(...tempResults);
 
-    if (fetchedTotal < (total ?? 0) && filteredTotal < limit) {
-        const nextPageResult = await handlerApiWithPage(params, page + 1, total, fetchedTotal, filteredTotal);
-        results.push(...nextPageResult);
-    }
-    return results;
-}
-
-async function handlerForApi(params) {
-    const { currentUrl, keyword } = params;
-    const results: any[] = [];
-    const total = null;
-    const fetchedTotal = 0;
-    const filteredTotal = 0;
-    results.push(...(await handlerApiWithPage(params, 1, total, fetchedTotal, filteredTotal)));
     return {
         title: `Search Results For '${keyword}' - 禁漫天堂`,
         link: currentUrl.replace(/\?$/, ''),
         item: results,
         allowEmpty: true,
     };
-}
-
-async function handler(ctx) {
-    const option = ctx.req.param('option') ?? 'photos';
-    const category = ctx.req.param('category') ?? 'all';
-    const keyword = ctx.req.param('keyword') ?? '';
-    const time = ctx.req.param('time') ?? 'a';
-    const order = ctx.req.param('order') ?? 'mr';
-    const { domain = defaultDomain } = ctx.req.query();
-    const { api = false } = ctx.req.query();
-    const rootUrl = getRootUrl(domain);
-    const currentUrl = `${rootUrl}/search/${option}${category === 'all' ? '' : `/${category}`}${keyword ? `?search_query=${keyword}` : '?'}${time === 'a' ? '' : `&t=${time}`}${order === 'mr' ? '' : `&o=${order}`}`;
-    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 20;
-    if (api) {
-        return await handlerForApi({ domain, limit, currentUrl, rootUrl, keyword, category, order, page: 1 });
-    }
-
-    return await ProcessItems(ctx, currentUrl, rootUrl);
 }

--- a/lib/routes/18comic/search.ts
+++ b/lib/routes/18comic/search.ts
@@ -62,7 +62,7 @@ async function handler(ctx) {
     filteredItemsByCategory = filteredItemsByCategory.slice(0, limit);
     const results = await Promise.all(
         filteredItemsByCategory.map((item) =>
-            cache.tryGet(`18comic:search:${domain}:${item.id}`, async () => {
+            cache.tryGet(`18comic:search:${item.id}`, async () => {
                 const result = {};
                 result.title = item.name;
                 result.link = `${rootUrl}/album/${item.id}`;

--- a/lib/routes/18comic/utils.ts
+++ b/lib/routes/18comic/utils.ts
@@ -6,10 +6,14 @@ import { art } from '@/utils/render';
 import path from 'node:path';
 import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
+import md5 from '@/utils/md5';
+import CryptoJS from 'crypto-js';
 
 const defaultDomain = 'jmcomic1.me';
 // list of address: https://jmcomic2.bet
 const allowDomain = new Set(['18comic.vip', '18comic.org', 'jmcomic.me', 'jmcomic1.me', 'jm-comic3.art', 'jm-comic.club', 'jm-comic2.ark']);
+
+const apiDomain = 'www.cdnblackmyth.club';
 
 const getRootUrl = (domain) => {
     if (!config.feature.allow_user_supply_unsafe_domain && !allowDomain.has(domain)) {
@@ -17,6 +21,72 @@ const getRootUrl = (domain) => {
     }
 
     return `https://${domain}`;
+};
+
+const apiMapCategory = (category) => {
+    switch (category) {
+        case 'another':
+            return '其他漫畫';
+        case 'doujin':
+            return '同人';
+        case 'hanman':
+            return '韓漫';
+        case 'meiman':
+            return '美漫';
+        case 'short':
+            return '短篇';
+        case 'single':
+            return '單本';
+        default:
+            return null;
+    }
+};
+
+const getApiUrl = () => `https://${apiDomain}`;
+
+// using api to fetch data
+const ProcessApiItems = async (apiUrl) => {
+    apiUrl = apiUrl.replace(/\?$/, '');
+    // get timestamp using javascript native api
+    const ts = Date.now();
+    const tokenParam = `${ts},1.7.5`;
+    // md5 from {token ts + "18comicAPP"
+    let token = `${ts}18comicAPP`;
+    token = md5(token);
+
+    const response = await got(apiUrl, {
+        headers: {
+            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+            token,
+            tokenparam: tokenParam,
+        },
+    });
+
+    // decode base64
+    const encryptedWordArray = CryptoJS.enc.Base64.parse(response.data.data);
+
+    // to md5 hex string , this string must be 32 bytes , because it is used as key for AES-256
+    const md5HexStr = CryptoJS.MD5(ts + '185Hcomic3PAPP7R').toString(); // hex 字串
+
+    // convert string to WordArray that can be used as key for AES
+    const key = CryptoJS.enc.Utf8.parse(md5HexStr); // 32 bytes => AES-256
+
+    // create a CipherParams object from the encrypted WordArray
+    const cipherParams = CryptoJS.lib.CipherParams.create({
+        ciphertext: encryptedWordArray,
+    });
+
+    // decrypt the CipherParams object using AES in ECB mode with PKCS7 padding
+    const decrypted = CryptoJS.AES.decrypt(cipherParams, key, {
+        mode: CryptoJS.mode.ECB,
+        padding: CryptoJS.pad.Pkcs7,
+    });
+
+    // convert the decrypted WordArray to a UTF-8 string , the result is a JSON string
+    const resultJson = decrypted.toString(CryptoJS.enc.Utf8);
+
+    const result = JSON.parse(resultJson);
+    return result;
 };
 
 const ProcessItems = async (ctx, currentUrl, rootUrl) => {
@@ -82,4 +152,4 @@ const ProcessItems = async (ctx, currentUrl, rootUrl) => {
     };
 };
 
-export { defaultDomain, getRootUrl, ProcessItems };
+export { defaultDomain, getRootUrl, ProcessItems, getApiUrl, ProcessApiItems, apiMapCategory };

--- a/lib/routes/18comic/utils.ts
+++ b/lib/routes/18comic/utils.ts
@@ -45,7 +45,7 @@ const apiMapCategory = (category) => {
 const getApiUrl = () => `https://${apiDomain}`;
 
 // using api to fetch data
-const ProcessApiItems = async (apiUrl) => {
+const processApiItems = async (apiUrl: string) => {
     apiUrl = apiUrl.replace(/\?$/, '');
     // get timestamp using javascript native api
     const ts = Date.now();
@@ -56,7 +56,6 @@ const ProcessApiItems = async (apiUrl) => {
 
     const response = await got(apiUrl, {
         headers: {
-            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
             token,
             tokenparam: tokenParam,
         },
@@ -152,4 +151,4 @@ const ProcessItems = async (ctx, currentUrl, rootUrl) => {
     };
 };
 
-export { defaultDomain, getRootUrl, ProcessItems, getApiUrl, ProcessApiItems, apiMapCategory };
+export { defaultDomain, getRootUrl, ProcessItems, getApiUrl, processApiItems, apiMapCategory };


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

None

## Example for the Proposed Route(s) / 路由地址示例

```routes
/18comic/search/photos/all/test
/18comic/album/616448
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

The previous 18comic route returned a 403 error, likely due to 18comic's anti-bot detection.
To bypass this restriction, an API mode has been added to use API requests instead of fetching the website directly.

Currently it just support route of search

