### PR TITLE
route: 添加东南大学网络空间安全学院通知公告

### DIFF
--- a/lib/routes/seu/cyber/index.ts
+++ b/lib/routes/seu/cyber/index.ts
@@ -1,0 +1,78 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/cyber/tzgg',
+    categories: ['university'],
+    example: '/seu/cyber/tzgg',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['cyber.seu.edu.cn/tzgg/list.htm', 'cyber.seu.edu.cn/'],
+        },
+    ],
+    name: '网络空间安全学院 - 通知公告',
+    maintainers: [''],
+    handler,
+    description: '东南大学网络空间安全学院通知公告',
+};
+
+async function handler() {
+    const host = 'https://cyber.seu.edu.cn';
+    const link = `${host}/tzgg/list.htm`;
+
+    const { data: response } = await got(link);
+    const $ = load(response);
+
+    const list = $('#wp_news_w6 ul.wp_article_list li.list_item')
+        .toArray()
+        .map((item) => {
+            const e = $(item);
+            const a = e.find('.Article_Title a');
+            const title = a.text().trim();
+            const href = a.attr('href');
+            const dateText = e.find('.Article_PublishDate').text().trim();
+
+            return {
+                title,
+                link: new URL(href || '', host).href,
+                pubDate: parseDate(dateText),
+                description: '',
+            };
+        });
+
+    const out = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                try {
+                    const response = await got(item.link);
+                    const $ = load(response.data);
+
+                    item.description = $('.wp_articlecontent').html() || $('.article-content').html() || $('.main-text').html() || $('article').html() || '';
+
+                    return item;
+                } catch {
+                    return item;
+                }
+            })
+        )
+    );
+
+    return {
+        link,
+        title: '东南大学网络空间安全学院 - 通知公告',
+        description: '东南大学网络空间安全学院通知公告RSS',
+        item: out,
+    };
+}


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

无相关Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
/seu/cyber/tzgg
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
- [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Documentation / 文档说明
- [x] Full text / 全文获取
- [x] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [x] Parsed / 可以解析
- [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

添加了东南大学网络空间安全学院通知公告的RSS订阅源，支持从 https://cyber.seu.edu.cn/tzgg/list.htm 获取最新通知公告。

路由功能：
- 自动抓取通知公告列表
- 解析标题、链接和发布时间
- 支持缓存机制提升性能
- 提取通知详细内容

路由地址：`/seu/cyber/tzgg`