### PR TITLE
feat(route): 添加36kr频道的简略版

### DIFF
--- a/lib/routes/36kr/lite.ts
+++ b/lib/routes/36kr/lite.ts
@@ -35,7 +35,7 @@ async function handler(ctx) {
 
     const data = JSON.parse(response.data.match(/"itemList":(\[.*?])/)[1]);
 
-    let items = data
+    const items = data
         .slice(0, ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 30)
         .filter((item) => item.itemType !== 0)
         .map((item) => {

--- a/lib/routes/36kr/lite.ts
+++ b/lib/routes/36kr/lite.ts
@@ -1,0 +1,58 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+import { rootUrl } from './utils';
+
+export const route: Route = {
+    path: '/lite/information/:category',
+    categories: ['new-media'],
+    example: '/36kr/lite/information/AI',
+    parameters: {
+        category: '分类，必填项.参考官网网址，区分大小写',
+    },
+    name: '资讯频道',
+    maintainers: ['MilliumOrion'],
+    description: `| 最新 | 推荐 | 创投 | 财经 | 汽车 | AI | 科技 | 自助报道 |
+| ------- | -------- | -------- | -------- | -------- | --------| -------- | -------- |
+| web_news | web_recommend | contact | ccs | travel | AI | technology | aireport |`,
+    handler,
+};
+
+async function handler(ctx) {
+
+    const category = ctx.req.param('category') ?? 'web_news';
+
+    const currentUrl = `${rootUrl}/information/${category}`;
+
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+    });
+
+    const $ = load(response.data);
+
+    const data = JSON.parse(response.data.match(/"itemList":(\[.*?])/)[1]);
+
+    let items = data
+        .slice(0, ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 30)
+        .filter((item) => item.itemType !== 0)
+        .map((item) => {
+            item = item.templateMaterial ?? item;
+            return {
+                title: item.widgetTitle.replaceAll(/<\/?em>/g, ''),
+                author: item.author ?? item.authorRoute,
+                pubDate: parseDate(item.publishTime),
+                link: `${rootUrl}/p/${item.itemId}`,
+                description: item.summary ?? '',
+            };
+        });
+
+
+    return {
+        title: `36氪 - ${$('title').text().split('_')[0]}`,
+        link: currentUrl,
+        item: items,
+    };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/36kr/lite/information/AI
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
- [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [x] Parsed / 可以解析
- [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- 原本的`/36kr`路由会抓取所有文章的内容，短时间内访问多个频道后会触发反爬。
- 添加`/36kr/lite/information/:category`路由，跳过抓取文章，而直接使用频道列表中的简短总结作为`description`
