### PR TITLE
fix(route/reuters): 修复reuters因为ua报错401

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -422,9 +422,6 @@ export type Config = {
     smzdm: {
         cookie?: string;
     };
-    reuters:{
-        ua?: string;
-    };
 };
 
 const value: Config | Record<string, any> = {};
@@ -890,9 +887,6 @@ const calculateValue = () => {
         },
         smzdm: {
             cookie: envs.SMZDM_COOKIE,
-        },
-        reuters:{
-            ua: envs.REUTERS_UA,
         },
     };
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -422,6 +422,9 @@ export type Config = {
     smzdm: {
         cookie?: string;
     };
+    reuters:{
+        ua?: string;
+    };
 };
 
 const value: Config | Record<string, any> = {};
@@ -887,6 +890,9 @@ const calculateValue = () => {
         },
         smzdm: {
             cookie: envs.SMZDM_COOKIE,
+        },
+        reuters:{
+            ua: envs.REUTERS_UA,
         },
     };
 

--- a/lib/routes/reuters/common.ts
+++ b/lib/routes/reuters/common.ts
@@ -6,7 +6,6 @@ import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
 import { art } from '@/utils/render';
 import path from 'node:path';
-import { config } from '@/config';
 
 export const route: Route = {
     path: '/:category/:topic?',

--- a/lib/routes/reuters/common.ts
+++ b/lib/routes/reuters/common.ts
@@ -4,9 +4,9 @@ import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
-import randUserAgent from '@/utils/rand-user-agent';
 import { art } from '@/utils/render';
 import path from 'node:path';
+import { config } from '@/config';
 
 export const route: Route = {
     path: '/:category/:topic?',
@@ -90,7 +90,7 @@ async function handler(ctx) {
 
     const section_id = `/${category}/${topic ? `${topic}/` : ''}`;
 
-    const ua = randUserAgent({ browser: 'chrome', os: 'windows', device: 'desktop' });
+    const ua = config.reuters.ua ?? 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0';
     const browserHeaders = {
         'User-Agent': ua,
         Accept: 'application/json, text/plain, */*',
@@ -131,10 +131,10 @@ async function handler(ctx) {
                             website: 'reuters',
                             ...(useSophi
                                 ? {
-                                      fetch_type: 'sophi',
-                                      sophi_page: '*',
-                                      sophi_widget: 'topic',
-                                  }
+                                    fetch_type: 'sophi',
+                                    sophi_page: '*',
+                                    sophi_widget: 'topic',
+                                }
                                 : {}),
                         }),
                     },
@@ -166,55 +166,55 @@ async function handler(ctx) {
             items.map((item) =>
                 ctx.req.query('fulltext') === 'true'
                     ? cache.tryGet(item.link, async () => {
-                          const detailResponse = await ofetch(item.link, {
-                              headers: browserHeaders,
-                          });
-                          const content = load(detailResponse.data);
+                        const detailResponse = await ofetch(item.link, {
+                            headers: browserHeaders,
+                        });
+                        const content = load(detailResponse.data);
 
-                          if (detailResponse.url.startsWith('https://www.reuters.com/investigates/')) {
-                              const ldJson = JSON.parse(content('script[type="application/ld+json"]').text());
-                              content('.special-report-article-container .container, #slide-dek, #slide-end, .share-in-article-container').remove();
+                        if (detailResponse.url.startsWith('https://www.reuters.com/investigates/')) {
+                            const ldJson = JSON.parse(content('script[type="application/ld+json"]').text());
+                            content('.special-report-article-container .container, #slide-dek, #slide-end, .share-in-article-container').remove();
 
-                              item.title = ldJson.headline;
-                              item.pubDate = parseDate(ldJson.dateCreated);
-                              item.author = ldJson.creator;
-                              item.category = ldJson.keywords;
-                              item.description = content('.special-report-article-container').html();
+                            item.title = ldJson.headline;
+                            item.pubDate = parseDate(ldJson.dateCreated);
+                            item.author = ldJson.creator;
+                            item.category = ldJson.keywords;
+                            item.description = content('.special-report-article-container').html();
 
-                              return item;
-                          }
+                            return item;
+                        }
 
-                          const matches = content('script#fusion-metadata')
-                              .text()
-                              .match(/Fusion.globalContent=({[\S\s]*?});/);
+                        const matches = content('script#fusion-metadata')
+                            .text()
+                            .match(/Fusion.globalContent=({[\S\s]*?});/);
 
-                          if (matches) {
-                              const data = JSON.parse(matches[1]);
+                        if (matches) {
+                            const data = JSON.parse(matches[1]);
 
-                              item.title = data.result.title || item.title;
-                              item.description = art(path.join(__dirname, 'templates/description.art'), {
-                                  result: data.result,
-                              });
-                              item.pubDate = parseDate(data.result.display_time);
-                              item.author = data.result.authors.map((author) => author.name).join(', ');
-                              item.category = data.result.taxonomy.keywords;
+                            item.title = data.result.title || item.title;
+                            item.description = art(path.join(__dirname, 'templates/description.art'), {
+                                result: data.result,
+                            });
+                            item.pubDate = parseDate(data.result.display_time);
+                            item.author = data.result.authors.map((author) => author.name).join(', ');
+                            item.category = data.result.taxonomy.keywords;
 
-                              return item;
-                          }
+                            return item;
+                        }
 
-                          content('.title').remove();
-                          content('.article-metadata').remove();
+                        content('.title').remove();
+                        content('.article-metadata').remove();
 
-                          item.title = content('meta[property="og:title"]').attr('content');
-                          item.pubDate = parseDate(detailResponse.data.match(/"datePublished":"(.*?)","dateModified/)[1]);
-                          item.author = detailResponse.data
-                              .match(/{"@type":"Person","name":"(.*?)"}/g)
-                              .map((p) => p.match(/"name":"(.*?)"/)[1])
-                              .join(', ');
-                          item.description = content('article').html();
+                        item.title = content('meta[property="og:title"]').attr('content');
+                        item.pubDate = parseDate(detailResponse.data.match(/"datePublished":"(.*?)","dateModified/)[1]);
+                        item.author = detailResponse.data
+                            .match(/{"@type":"Person","name":"(.*?)"}/g)
+                            .map((p) => p.match(/"name":"(.*?)"/)[1])
+                            .join(', ');
+                        item.description = content('article').html();
 
-                          return item;
-                      })
+                        return item;
+                    })
                     : item
             )
         );

--- a/lib/routes/reuters/common.ts
+++ b/lib/routes/reuters/common.ts
@@ -90,9 +90,7 @@ async function handler(ctx) {
 
     const section_id = `/${category}/${topic ? `${topic}/` : ''}`;
 
-    const ua = config.reuters.ua ?? 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0';
     const browserHeaders = {
-        'User-Agent': ua,
         Accept: 'application/json, text/plain, */*',
         'Accept-Language': 'en-US,en;q=0.9',
         Referer: 'https://www.reuters.com/',


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/reuters/world
/reuters/legal
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
- [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [ ] Parsed / 可以解析
- [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
- 修复reuters接口`https://www.reuters.com/pf/api/v3/content/fetch/*`会因为`User-Agent`报错401。排查后发现是`randUserAgent`生成的随机UA太老或不符合要求。
- 因为涉及到引用库以及UA版本号的问题，改为使用环境变量`REUTERS_UA`配置。同时提供暂时可用的默认UA`Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0`
- 检查UA中的版本号，如`Chrome/63.0.3239.84`会因为太老报错
- 检查Windows的版本信息，已知`(Windows NT 10.0; Win64; x64) `是符合要求的，但`(Windows NT 6.2;en-US)`不行
