### PR TITLE
feat(github): add private feed route for user received events

### DIFF
--- a/lib/routes/github/private-feed.ts
+++ b/lib/routes/github/private-feed.ts
@@ -1,0 +1,188 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import { config } from '@/config';
+
+const typeMapping: Record<string, string> = {
+    push: 'PushEvent',
+    issues: 'IssuesEvent',
+    pullrequest: 'PullRequestEvent',
+    star: 'WatchEvent',
+    fork: 'ForkEvent',
+    create: 'CreateEvent',
+    release: 'ReleaseEvent',
+};
+
+export const route: Route = {
+    path: '/privatefeed/:user/:types?',
+    categories: ['programming'],
+    example: '/github/privatefeed/yihong0618/star,release',
+    parameters: {
+        user: 'GitHub username',
+        types: {
+            description: 'Event types to include, comma separated',
+            default: 'all',
+            options: [
+                {
+                    label: 'All events',
+                    value: 'all',
+                },
+                {
+                    label: 'Create events',
+                    value: 'create',
+                },
+                {
+                    label: 'Fork events',
+                    value: 'fork',
+                },
+                {
+                    label: 'Issues events',
+                    value: 'issues',
+                },
+                {
+                    label: 'Pull request events',
+                    value: 'pullrequest',
+                },
+                {
+                    label: 'Push events',
+                    value: 'push',
+                },
+                {
+                    label: 'Release events',
+                    value: 'release',
+                },
+                {
+                    label: 'Watch events (stars)',
+                    value: 'star',
+                },
+            ],
+        },
+    },
+    features: {
+        requireConfig: [
+            {
+                name: 'GITHUB_ACCESS_TOKEN',
+                optional: true,
+                description: 'GitHub access token to access private events',
+            },
+        ],
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['github.com/:user'],
+            target: '/privatefeed/:user',
+        },
+    ],
+    name: 'User\'s Feed',
+    maintainers: ['RtYkk'],
+    handler,
+};
+
+async function handler(ctx) {
+    const user = ctx.req.param('user');
+    const types = ctx.req.param('types') || 'all';
+
+    // Setup headers with optional authentication
+    const headers: Record<string, string> = {};
+    if (config.github && config.github.access_token) {
+        headers.Authorization = `token ${config.github.access_token}`;
+    }
+
+    const response = await got({
+        method: 'get',
+        url: `https://api.github.com/users/${user}/received_events`,
+        headers,
+        searchParams: {
+            per_page: 30,
+        },
+    });
+
+    // Parse requested event types and map short names to full event types
+    let filteredEventTypes: string[] = [];
+    if (types !== 'all') {
+        filteredEventTypes = types.split(',').map((type) => {
+            const trimmedType = type.trim();
+            return typeMapping[trimmedType] || trimmedType;
+        });
+    }
+
+    const items = response.data
+        .filter((event) => filteredEventTypes.length === 0 || filteredEventTypes.includes(event.type))
+        .map((event) => {
+            const { type, actor, repo, payload, created_at } = event;
+
+            let title = '';
+            let description = '';
+            let link = `https://github.com/${actor.login}`;
+
+            switch (type) {
+                case 'PushEvent':
+                    title = `${actor.login} pushed to ${repo.name}`;
+                    description = `Pushed ${payload.commits?.length || 0} commit(s) to ${repo.name}`;
+                    link = `https://github.com/${repo.name}`;
+                    if (payload.commits && payload.commits.length > 0) {
+                        description += `<br><strong>Latest commit:</strong> ${payload.commits.at(-1).message}`;
+                    }
+                    break;
+                case 'IssuesEvent':
+                    title = `${actor.login} ${payload.action} an issue in ${repo.name}`;
+                    description = `Issue: ${payload.issue?.title || 'Unknown'}`;
+                    link = payload.issue?.html_url || `https://github.com/${repo.name}`;
+                    break;
+                case 'PullRequestEvent':
+                    title = `${actor.login} ${payload.action} a pull request in ${repo.name}`;
+                    description = `PR: ${payload.pull_request?.title || 'Unknown'}`;
+                    link = payload.pull_request?.html_url || `https://github.com/${repo.name}`;
+                    break;
+                case 'WatchEvent':
+                    title = `${actor.login} starred ${repo.name}`;
+                    description = `Starred repository ${repo.name}`;
+                    link = `https://github.com/${repo.name}`;
+                    break;
+                case 'ForkEvent':
+                    title = `${actor.login} forked ${repo.name}`;
+                    description = `Forked repository ${repo.name}`;
+                    link = `https://github.com/${repo.name}`;
+                    break;
+                case 'CreateEvent':
+                    title = `${actor.login} created ${payload.ref_type} in ${repo.name}`;
+                    description = `Created ${payload.ref_type}: ${payload.ref || repo.name}`;
+                    link = `https://github.com/${repo.name}`;
+                    break;
+                case 'ReleaseEvent':
+                    title = `${actor.login} released ${payload.release?.name || payload.release?.tag_name} in ${repo.name}`;
+                    description = payload.release?.body || `Released ${payload.release?.tag_name}`;
+                    link = payload.release?.html_url || `https://github.com/${repo.name}`;
+                    break;
+                default:
+                    title = `${actor.login} performed ${type} in ${repo?.name || 'unknown repository'}`;
+                    description = `Activity type: ${type}`;
+                    link = repo ? `https://github.com/${repo.name}` : `https://github.com/${actor.login}`;
+            }
+
+            return {
+                title,
+                link,
+                description,
+                pubDate: parseDate(created_at),
+                author: actor.login,
+                category: [type],
+            };
+        });
+
+    const typeFilter = types === 'all' ? 'All Events' : `Events: ${types}`;
+    const isAuthenticated = config.github && config.github.access_token;
+    const feedType = isAuthenticated ? 'Private Feed' : 'Public Feed';
+
+    return {
+        title: `${user}'s GitHub ${feedType} - ${typeFilter}`,
+        link: `https://github.com/${user}`,
+        description: `GitHub events received by ${user}${types === 'all' ? '' : ` (filtered: ${types})`}${isAuthenticated ? ' - includes private events' : ' - public events only'}`,
+        item: items,
+    };
+}

--- a/lib/routes/github/private-feed.ts
+++ b/lib/routes/github/private-feed.ts
@@ -103,6 +103,88 @@ export const route: Route = {
     handler,
 };
 
+function formatEventItem(event: any) {
+    const { type, actor, repo, payload, created_at } = event;
+
+    let title = '';
+    let description = '';
+    let link = '';
+
+    switch (type) {
+        case 'PushEvent':
+            title = `${actor.login} pushed to ${repo.name}`;
+            description = `Pushed ${payload.commits?.length || 0} commit(s) to ${repo.name}`;
+            link = `https://github.com/${repo.name}`;
+            if (payload.commits && payload.commits.length > 0) {
+                description += `<br><strong>Latest commit:</strong> ${payload.commits.at(-1).message}`;
+            }
+            break;
+        case 'PullRequestEvent':
+            title = `${actor.login} ${payload.action} a pull request in ${repo.name}`;
+            description = `PR: ${payload.pull_request?.title || 'Unknown'}`;
+            link = payload.pull_request?.html_url || `https://github.com/${repo.name}`;
+            break;
+        case 'PullRequestReviewCommentEvent':
+            title = `${actor.login} commented on a pull request review in ${repo.name}`;
+            description = `Comment: ${payload.comment?.body?.slice(0, 100) || 'No comment'}...`;
+            link = payload.comment?.html_url || `https://github.com/${repo.name}`;
+            break;
+        case 'IssueCommentEvent':
+            title = `${actor.login} commented on an issue in ${repo.name}`;
+            description = `Comment: ${payload.comment?.body?.slice(0, 100) || 'No comment'}...`;
+            link = payload.comment?.html_url || `https://github.com/${repo.name}`;
+            break;
+        case 'WatchEvent':
+            title = `${actor.login} starred ${repo.name}`;
+            description = `Starred repository ${repo.name}`;
+            link = `https://github.com/${repo.name}`;
+            break;
+        case 'ForkEvent':
+            title = `${actor.login} forked ${repo.name}`;
+            description = `Forked repository ${repo.name}`;
+            link = `https://github.com/${repo.name}`;
+            break;
+        case 'CreateEvent':
+            title = `${actor.login} created ${payload.ref_type} in ${repo.name}`;
+            description = `Created ${payload.ref_type}: ${payload.ref || repo.name}`;
+            link = `https://github.com/${repo.name}`;
+            break;
+        case 'DeleteEvent':
+            title = `${actor.login} deleted ${payload.ref_type} in ${repo.name}`;
+            description = `Deleted ${payload.ref_type}: ${payload.ref}`;
+            link = `https://github.com/${repo.name}`;
+            break;
+        case 'ReleaseEvent':
+            title = `${actor.login} released ${payload.release?.name || payload.release?.tag_name} in ${repo.name}`;
+            description = payload.release?.body || `Released ${payload.release?.tag_name}`;
+            link = payload.release?.html_url || `https://github.com/${repo.name}`;
+            break;
+        case 'PublicEvent':
+            title = `${actor.login} made ${repo.name} public`;
+            description = `Repository ${repo.name} was made public`;
+            link = `https://github.com/${repo.name}`;
+            break;
+        case 'MemberEvent':
+            title = `${actor.login} ${payload.action} as a member of ${repo.name}`;
+            description = `Member ${payload.action} in repository ${repo.name}`;
+            link = `https://github.com/${repo.name}`;
+            break;
+        default:
+            title = `${actor.login} performed ${type} in ${repo?.name || 'unknown repository'}`;
+            description = `Activity type: ${type}`;
+            link = repo ? `https://github.com/${repo.name}` : `https://github.com/${actor.login}`;
+    }
+
+    return {
+        title,
+        link,
+        description,
+        pubDate: parseDate(created_at),
+        author: actor.login,
+        category: [type],
+    };
+}
+
 async function handler(ctx) {
     const user = ctx.req.param('user');
     const types = ctx.req.param('types') || 'all';
@@ -133,87 +215,7 @@ async function handler(ctx) {
 
     const items = response.data
         .filter((event) => filteredEventTypes.length === 0 || filteredEventTypes.includes(event.type))
-        .map((event) => {
-            const { type, actor, repo, payload, created_at } = event;
-
-            let title = '';
-            let description = '';
-            let link = '';
-
-            switch (type) {
-                case 'PushEvent':
-                    title = `${actor.login} pushed to ${repo.name}`;
-                    description = `Pushed ${payload.commits?.length || 0} commit(s) to ${repo.name}`;
-                    link = `https://github.com/${repo.name}`;
-                    if (payload.commits && payload.commits.length > 0) {
-                        description += `<br><strong>Latest commit:</strong> ${payload.commits.at(-1).message}`;
-                    }
-                    break;
-                case 'PullRequestEvent':
-                    title = `${actor.login} ${payload.action} a pull request in ${repo.name}`;
-                    description = `PR: ${payload.pull_request?.title || 'Unknown'}`;
-                    link = payload.pull_request?.html_url || `https://github.com/${repo.name}`;
-                    break;
-                case 'PullRequestReviewCommentEvent':
-                    title = `${actor.login} commented on a pull request review in ${repo.name}`;
-                    description = `Comment: ${payload.comment?.body?.slice(0, 100) || 'No comment'}...`;
-                    link = payload.comment?.html_url || `https://github.com/${repo.name}`;
-                    break;
-                case 'IssueCommentEvent':
-                    title = `${actor.login} commented on an issue in ${repo.name}`;
-                    description = `Comment: ${payload.comment?.body?.slice(0, 100) || 'No comment'}...`;
-                    link = payload.comment?.html_url || `https://github.com/${repo.name}`;
-                    break;
-                case 'WatchEvent':
-                    title = `${actor.login} starred ${repo.name}`;
-                    description = `Starred repository ${repo.name}`;
-                    link = `https://github.com/${repo.name}`;
-                    break;
-                case 'ForkEvent':
-                    title = `${actor.login} forked ${repo.name}`;
-                    description = `Forked repository ${repo.name}`;
-                    link = `https://github.com/${repo.name}`;
-                    break;
-                case 'CreateEvent':
-                    title = `${actor.login} created ${payload.ref_type} in ${repo.name}`;
-                    description = `Created ${payload.ref_type}: ${payload.ref || repo.name}`;
-                    link = `https://github.com/${repo.name}`;
-                    break;
-                case 'DeleteEvent':
-                    title = `${actor.login} deleted ${payload.ref_type} in ${repo.name}`;
-                    description = `Deleted ${payload.ref_type}: ${payload.ref}`;
-                    link = `https://github.com/${repo.name}`;
-                    break;
-                case 'ReleaseEvent':
-                    title = `${actor.login} released ${payload.release?.name || payload.release?.tag_name} in ${repo.name}`;
-                    description = payload.release?.body || `Released ${payload.release?.tag_name}`;
-                    link = payload.release?.html_url || `https://github.com/${repo.name}`;
-                    break;
-                case 'PublicEvent':
-                    title = `${actor.login} made ${repo.name} public`;
-                    description = `Repository ${repo.name} was made public`;
-                    link = `https://github.com/${repo.name}`;
-                    break;
-                case 'MemberEvent':
-                    title = `${actor.login} ${payload.action} as a member of ${repo.name}`;
-                    description = `Member ${payload.action} in repository ${repo.name}`;
-                    link = `https://github.com/${repo.name}`;
-                    break;
-                default:
-                    title = `${actor.login} performed ${type} in ${repo?.name || 'unknown repository'}`;
-                    description = `Activity type: ${type}`;
-                    link = repo ? `https://github.com/${repo.name}` : `https://github.com/${actor.login}`;
-            }
-
-            return {
-                title,
-                link,
-                description,
-                pubDate: parseDate(created_at),
-                author: actor.login,
-                category: [type],
-            };
-        });
+        .map((event) => formatEventItem(event));
 
     const typeFilter = types === 'all' ? 'All Events' : `Events: ${types}`;
     const isAuthenticated = config.github && config.github.access_token;

--- a/lib/routes/github/private-feed.ts
+++ b/lib/routes/github/private-feed.ts
@@ -111,14 +111,14 @@ function formatEventItem(event: any) {
     let link = '';
 
     switch (type) {
-        case 'PushEvent':
+        case 'PushEvent': {
             title = `${actor.login} pushed to ${repo.name}`;
-            description = `Pushed ${payload.commits?.length || 0} commit(s) to ${repo.name}`;
-            link = `https://github.com/${repo.name}`;
-            if (payload.commits && payload.commits.length > 0) {
-                description += `<br><strong>Latest commit:</strong> ${payload.commits.at(-1).message}`;
-            }
+            const branch = payload.ref ? payload.ref.replace('refs/heads/', '') : 'unknown';
+            description = `Pushed ${payload.size || 0} commit(s) to ${branch} in ${repo.name}`;
+            link = payload.commits.at(-1).url.replace('api.github.com/repos/', 'github.com/').replace('/commits/', '/commit/');
+            description += `<br><strong>Latest commit:</strong> ${payload.commits.at(-1).message}`;
             break;
+        }
         case 'PullRequestEvent':
             title = `${actor.login} ${payload.action} a pull request in ${repo.name}`;
             description = `PR: ${payload.pull_request?.title || 'Unknown'}`;

--- a/lib/routes/github/private-feed.ts
+++ b/lib/routes/github/private-feed.ts
@@ -18,9 +18,9 @@ const typeMapping: Record<string, string> = {
 };
 
 export const route: Route = {
-    path: '/privatefeed/:user/:types?',
+    path: '/feed/:user/:types?',
     categories: ['programming'],
-    example: '/github/privatefeed/yihong0618/star,release,pr',
+    example: '/github/feed/yihong0618/star,release,pr',
     parameters: {
         user: 'GitHub username',
         types: {
@@ -95,10 +95,10 @@ export const route: Route = {
     radar: [
         {
             source: ['github.com/:user'],
-            target: '/privatefeed/:user',
+            target: '/feed/:user',
         },
     ],
-    name: 'User\'s Feed',
+    name: "User's Feed",
     maintainers: ['RtYkk'],
     handler,
 };
@@ -189,9 +189,10 @@ async function handler(ctx) {
     const user = ctx.req.param('user');
     const types = ctx.req.param('types') || 'all';
 
-    // Setup headers with optional authentication
+    const isAuthenticated = config.github && config.github.access_token;
+
     const headers: Record<string, string> = {};
-    if (config.github && config.github.access_token) {
+    if (isAuthenticated) {
         headers.Authorization = `token ${config.github.access_token}`;
     }
 
@@ -200,7 +201,7 @@ async function handler(ctx) {
         url: `https://api.github.com/users/${user}/received_events`,
         headers,
         searchParams: {
-            per_page: 30,
+            per_page: 100,
         },
     });
 
@@ -218,7 +219,6 @@ async function handler(ctx) {
         .map((event) => formatEventItem(event));
 
     const typeFilter = types === 'all' ? 'All Events' : `Events: ${types}`;
-    const isAuthenticated = config.github && config.github.access_token;
     const feedType = isAuthenticated ? 'Private Feed' : 'Public Feed';
 
     return {

--- a/lib/routes/github/private-feed.ts
+++ b/lib/routes/github/private-feed.ts
@@ -104,7 +104,7 @@ export const route: Route = {
 };
 
 function formatEventItem(event: any) {
-    const { type, actor, repo, payload, created_at } = event;
+    const { id, type, actor, repo, payload, created_at } = event;
 
     let title = '';
     let description = '';
@@ -126,12 +126,12 @@ function formatEventItem(event: any) {
             break;
         case 'PullRequestReviewCommentEvent':
             title = `${actor.login} commented on a pull request review in ${repo.name}`;
-            description = `Comment: ${payload.comment?.body?.slice(0, 100) || 'No comment'}...`;
+            description = `Comment: ${payload.comment?.body || 'No comment'}`;
             link = payload.comment?.html_url || `https://github.com/${repo.name}`;
             break;
         case 'IssueCommentEvent':
             title = `${actor.login} commented on an issue in ${repo.name}`;
-            description = `Comment: ${payload.comment?.body?.slice(0, 100) || 'No comment'}...`;
+            description = `Comment: ${payload.comment?.body || 'No comment'}`;
             link = payload.comment?.html_url || `https://github.com/${repo.name}`;
             break;
         case 'WatchEvent':
@@ -182,6 +182,7 @@ function formatEventItem(event: any) {
         pubDate: parseDate(created_at),
         author: actor.login,
         category: [type],
+        guid: id,
     };
 }
 


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #14112 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/github/feed/yihong0618
/github/feed/yihong0618/all
/github/feed/yihong0618/star
/github/feed/yihong0618/push
/github/feed/yihong0618/pr
/github/feed/yihong0618/create
/github/feed/yihong0618/release
/github/feed/yihong0618/star,release
/github/feed/yihong0618/push,prcomm,pr
/github/feed/yihong0618/star,release,pr
/github/feed/RtYkk/push,fork,create
/github/feed/yihong0618/star
/github/feed/RtYkk/all
/github/feed/yihong0618/issuecomm,prcomm
/github/feed/RtYkk/release,public,member
/github/feed/yihong0618/fork,delete
/github/feed/RtYkk/star,push
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Added a new GitHub route `/github/privatefeed/:user/:types?` that provides [GitHub user's received events feed](https://github.com/dashboard-feed) with optional filtering by event types.

Features:

- Supports filtering by event types: push, issues, pullrequest, star, fork, create, release
- Multiple event types can be combined with comma separation
- Optional GitHub access token support for accessing private events

The route uses [GitHub's](https://docs.github.com/en/rest/activity/events?apiVersion=2022-11-28#list-events-received-by-the-authenticated-user) `/users/:user/received_events` API endpoint and includes proper error handling and content formatting for different event types. Therefore, due to the GitHub API, this RSS feed will have a certain time delay compared with [homepage](https://github.com/).
