### PR TITLE
feat: add Kitty changelog route

### DIFF
--- a/lib/routes/kovidgoyal/kitty/changelog.ts
+++ b/lib/routes/kovidgoyal/kitty/changelog.ts
@@ -1,0 +1,83 @@
+import { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/kitty/changelog',
+    categories: ['program-update'],
+    example: '/kovidgoyal/kitty/changelog',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['sw.kovidgoyal.net/kitty/changelog/'],
+            target: '/kitty/changelog',
+        },
+    ],
+    name: 'Changelog',
+    maintainers: ['xbot'],
+    handler,
+    url: 'sw.kovidgoyal.net/kitty/changelog/',
+};
+
+async function handler() {
+    const url = 'https://sw.kovidgoyal.net/kitty/changelog/';
+    const response = await ofetch(url);
+    const $ = load(response);
+
+    // Find the "Detailed list of changes" section
+    const detailedSection = $('#detailed-list-of-changes');
+
+    const items = detailedSection
+        .find('section[id^="id"]')
+        .toArray()
+        .map((section) => {
+            const $section = $(section);
+
+            // Extract version and date from h3 title
+            const titleText = $section.find('h3').first().text().trim();
+            const versionMatch = titleText.match(/^([\d.]+)\s*\[([^\]]+)\]/);
+
+            if (!versionMatch) {
+                return null;
+            }
+
+            const version = versionMatch[1];
+            const dateStr = versionMatch[2];
+
+            // Extract changelog items from the ul list
+            const changelogItems = $section
+                .find('ul.simple li')
+                .toArray()
+                .map((li) => $(li).html())
+                .filter(Boolean);
+
+            // Create description from changelog items
+            const description = changelogItems.length > 0 ? '<ul>' + changelogItems.map((item) => `<li>${item}</li>`).join('') + '</ul>' : 'No changelog items available.';
+
+            return {
+                title: `Kitty ${version}`,
+                description,
+                link: `${url}#${$section.attr('id')}`,
+                pubDate: parseDate(dateStr, 'YYYY-MM-DD'),
+                guid: `kitty-${version}`,
+            };
+        })
+        .filter(Boolean);
+
+    return {
+        title: 'Kitty Changelog',
+        link: url,
+        description: 'Changelog for Kitty terminal emulator',
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/kovidgoyal/namespace.ts
+++ b/lib/routes/kovidgoyal/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: "Kovid's software projects",
+    url: 'sw.kovidgoyal.net',
+    lang: 'en',
+};


### PR DESCRIPTION
- Create new route handler for Kitty terminal changelog
- Implement parsing of version history and change details
- Add namespace definition for Kitty terminal

The new route fetches and parses the detailed changelog from Kitty's website, providing structured data including version numbers, release dates, and change items in a format suitable for RSS consumption.

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes

```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/kovidgoyal/kitty/changelog
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
