### PR TITLE
feat: add radar for EN pages on Pixiv

### DIFF
--- a/lib/routes/pixiv/bookmarks.ts
+++ b/lib/routes/pixiv/bookmarks.ts
@@ -23,7 +23,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['www.pixiv.net/users/:id/bookmarks/artworks'],
+            source: ['www.pixiv.net/users/:id/bookmarks/artworks', 'www.pixiv.net/en/users/:id/bookmarks/artworks'],
         },
     ],
     name: 'User Bookmark',

--- a/lib/routes/pixiv/novels.ts
+++ b/lib/routes/pixiv/novels.ts
@@ -41,12 +41,12 @@ refresh_token after Pixiv login, required for accessing R18 novels
     radar: [
         {
             title: 'User Novels (簡介 Basic info)',
-            source: ['www.pixiv.net/users/:id/novels', 'www.pixiv.net/users/:id'],
+            source: ['www.pixiv.net/users/:id/novels', 'www.pixiv.net/users/:id', 'www.pixiv.net/en/users/:id/novels', 'www.pixiv.net/en/users/:id'],
             target: '/user/novels/:id',
         },
         {
             title: 'User Novels (全文 Full text)',
-            source: ['www.pixiv.net/users/:id/novels', 'www.pixiv.net/users/:id'],
+            source: ['www.pixiv.net/users/:id/novels', 'www.pixiv.net/users/:id', 'www.pixiv.net/en/users/:id/novels', 'www.pixiv.net/en/users/:id'],
             target: '/user/novels/:id/true',
         },
     ],

--- a/lib/routes/pixiv/user.ts
+++ b/lib/routes/pixiv/user.ts
@@ -23,7 +23,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['www.pixiv.net/users/:id'],
+            source: ['www.pixiv.net/users/:id', 'www.pixiv.net/en/users/:id'],
         },
     ],
     name: 'User Activity',


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

When the user has selected "English" as their language, many Pixiv URLs contain "en" in their path. This does not occur with Previously, RSSHub Radar did not work on several EN Pixiv routes, because it did not recognize their URL.

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/pixiv/user/:id
/pixiv/user/novels/:id
/pixiv/user/bookmarks/:id

```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
