### PR TITLE
feat(route): add TechCrunch category route

### DIFF
--- a/lib/routes/techcrunch/category.ts
+++ b/lib/routes/techcrunch/category.ts
@@ -1,0 +1,48 @@
+import { Route } from '@/types';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import { art } from '@/utils/render';
+import path from 'node:path';
+
+const host = 'https://techcrunch.com';
+export const route: Route = {
+    path: '/category/:category_id',
+    categories: ['new-media'],
+    example: '/techcrunch/category/577047203',
+    parameters: {
+        category_id: '分类id',
+    },
+    name: 'Category',
+    maintainers: ['MilliumOrion'],
+    handler,
+    description: `Use the category ID to retrieve a list of articles, category ID.  
+From the page source of \`https://techcrunch.com/category/***\`, locate the \`{category_id}\`  
+Example:  
+\`html\` -> \`head\` -> \`<link rel="alternate" title="JSON" type="application/json" href="https://techcrunch.com/wp-json/wp/v2/categories/{category_id}">\``,
+};
+
+async function handler(ctx) {
+    const category_id = ctx.req.param('category_id');
+    const { data } = await got(`${host}/wp-json/wp/v2/posts?categories=${category_id}`);
+    const items = data.map((item) => {
+        const head = item.yoast_head_json;
+        const $ = load(item.content.rendered, null, false);
+        return {
+            title: item.title.rendered,
+            description: art(path.join(__dirname, 'templates/description.art'), {
+                head,
+                rendered: $.html(),
+            }),
+            link: item.link,
+            pubDate: parseDate(item.date_gmt),
+        };
+    });
+
+    return {
+        title: 'TechCrunch',
+        link: host,
+        description: 'Reporting on the business of technology, startups, venture capital funding, and Silicon Valley.',
+        item: items,
+    };
+}

--- a/lib/routes/techcrunch/category.ts
+++ b/lib/routes/techcrunch/category.ts
@@ -7,11 +7,11 @@ import path from 'node:path';
 
 const host = 'https://techcrunch.com';
 export const route: Route = {
-    path: '/category/:category_id',
+    path: '/category/:categoryId',
     categories: ['new-media'],
     example: '/techcrunch/category/577047203',
     parameters: {
-        category_id: '分类id',
+        categoryId: '分类id',
     },
     name: 'Category',
     maintainers: ['MilliumOrion'],
@@ -23,7 +23,7 @@ Example:
 };
 
 async function handler(ctx) {
-    const categoryId = ctx.req.param('category_id');
+    const categoryId = ctx.req.param('categoryId');
     const { data } = await got(`${host}/wp-json/wp/v2/posts?categories=${categoryId}`);
     const items = data.map((item) => {
         const head = item.yoast_head_json;

--- a/lib/routes/techcrunch/category.ts
+++ b/lib/routes/techcrunch/category.ts
@@ -23,8 +23,8 @@ Example:
 };
 
 async function handler(ctx) {
-    const category_id = ctx.req.param('category_id');
-    const { data } = await got(`${host}/wp-json/wp/v2/posts?categories=${category_id}`);
+    const categoryId = ctx.req.param('category_id');
+    const { data } = await got(`${host}/wp-json/wp/v2/posts?categories=${categoryId}`);
     const items = data.map((item) => {
         const head = item.yoast_head_json;
         const $ = load(item.content.rendered, null, false);


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/techcrunch/category/577047203
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
