### PR TITLE
feat(route/meteoblue): add namespace and weather news route

### DIFF
--- a/lib/routes/meteoblue/namespace.ts
+++ b/lib/routes/meteoblue/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'meteoblue',
+    url: 'meteoblue.com',
+    lang: 'en',
+    description: 'Weather forecasts, climate data, and meteorological news from meteoblue',
+};

--- a/lib/routes/meteoblue/weathernews.ts
+++ b/lib/routes/meteoblue/weathernews.ts
@@ -1,0 +1,75 @@
+import { Route } from '@/types';
+import { load } from 'cheerio';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/weathernews',
+    name: 'Weather News',
+    maintainers: ['tssujt'],
+    handler,
+    example: '/meteoblue/weathernews',
+    categories: ['blog'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    description: 'Weather news and articles from meteoblue',
+};
+
+async function handler() {
+    const baseUrl = 'https://www.meteoblue.com';
+    const url = `${baseUrl}/en/blog/article/weathernews`;
+
+    const response = await ofetch(url);
+    const $ = load(response);
+
+    // Extract articles from the page using the actual HTML structure
+    const articles = $('article[itemprop="blogPost"]')
+        .toArray()
+        .map((element) => {
+            const $article = $(element);
+
+            // Get title and link from h3 > a
+            const $link = $article.find('h3[itemprop="headline"] a[itemprop="mainEntityOfPage"]');
+            const title = $link.text().trim();
+            const link = $link.attr('href');
+
+            if (!title || !link) {
+                return null;
+            }
+
+            // Get date from time element
+            const $time = $article.find('time[itemprop="datePublished"]');
+            const dateText = $time.attr('datetime') || '';
+
+            // Extract author from the time element text
+            const $authorMeta = $article.find('meta[itemprop="author"]');
+            const author = $authorMeta.attr('content')?.trim() || 'meteoblue';
+
+            // Get description from itemprop="description"
+            const $description = $article.find('div[itemprop="description"]');
+            const description = $description.text().trim() || title;
+
+            return {
+                title,
+                link: link.startsWith('http') ? link : `${baseUrl}${link}`,
+                pubDate: dateText ? parseDate(dateText) : undefined,
+                author,
+                description,
+            };
+        })
+        .filter(Boolean);
+
+    return {
+        title: 'meteoblue Weather News',
+        link: url,
+        description: 'Latest weather news and articles from meteoblue',
+        item: articles,
+        allowEmpty: true,
+    };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/meteoblue/weathernews
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
