### PR TITLE
fix(route): fix guid for Hacker News

### DIFF
--- a/lib/routes/hackernews/index.ts
+++ b/lib/routes/hackernews/index.ts
@@ -79,7 +79,6 @@ async function handler(ctx) {
             item.upvotes = thing.next().find('.score').text().split(' point')[0];
 
             item.currentComment = thing.find('.comment').text();
-            item.guid = type === 'sources' ? item.guid : `${item.guid}${item.comments === 'discuss' ? '' : `-${item.comments}`}`;
 
             item.description = `<a href="${item.link}">Comments on Hacker News</a> | <a href="${item.origin}">Source</a>`;
 


### PR DESCRIPTION

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例



<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes

```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/hackernews/index/comment
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Current guid for Hacker News has the number of comments in it when the type is not `sources`. This makes the guid change whenever a new comment is created under the post, which shouldn't happen, since the purpose of guid is to not duplicate the article when it is updated.

Quote from [RSS spec](https://www.rssboard.org/rss-2-0-1):

> A frequently asked question about `<guid>`s is how do they compare to
> `<link>`s. Aren't they the same thing? Yes, in some content systems, and
> no in others. In some systems, `<link>` is a permalink to a weblog item.
> However, in other systems, each `<item>` is a synopsis of a longer
> article, `<link>` points to the article, and `<guid>` is the permalink to
> the weblog entry. In all cases, it's recommended that you provide the
> guid, and if possible make it a permalink. This enables aggregators to
> not repeat items, even if there have been editing changes.

