### PR TITLE
feat(routes): Support fetching by different publication cycle and flitering by votes for Huggingfce papers.

### DIFF
--- a/lib/routes/huggingface/daily-papers.ts
+++ b/lib/routes/huggingface/daily-papers.ts
@@ -57,7 +57,7 @@ async function handler(ctx) {
             url = `https://huggingface.co/papers/week/${new Date().getFullYear()}-W52`;
             break;
         case 'month':
-            url = 'https://huggingface.co/papers/month/' + new Date().toISOString().slice(0, 7);
+            url = `https://huggingface.co/papers/month/${new Date().toISOString().slice(0, 7)}`;
             break;
         default:
             throw new Error(`Invalid cycle: ${cycle}`);
@@ -72,7 +72,7 @@ async function handler(ctx) {
         .map((item) => ({
             title: item.title,
             link: `https://arxiv.org/abs/${item.paper.id}`,
-            description: item.paper.summary.replaceAll('\n', ' ') + `\n Upvotes: ${item.paper.upvotes}`,
+            description: item.paper.summary.replaceAll('\n', ' '),
             pubDate: parseDate(item.publishedAt),
             author: item.paper.authors.map((author) => author.name).join(', '),
             upvotes: item.paper.upvotes,

--- a/lib/routes/huggingface/daily-papers.ts
+++ b/lib/routes/huggingface/daily-papers.ts
@@ -4,10 +4,10 @@ import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
-    path: '/daily-papers',
+    path: '/daily-papers/:cycle?/:voteFliter?',
     categories: ['programming'],
-    example: '/huggingface/daily-papers',
-    parameters: {},
+    example: '/huggingface/daily-papers/week/50',
+    parameters: { cycle: 'The publication cycle you want to follow. Choose from: date, week, month. Default: date', voteFliter: 'Filter papers by vote count.' },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -18,25 +18,61 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['huggingface.co/papers', 'huggingface.co/'],
+            source: ['huggingface.co/papers/:cycle'],
+            target: '/daily-papers/:cycle',
         },
     ],
     name: 'Daily Papers',
-    maintainers: ['zeyugao'],
+    maintainers: ['zeyugao', 'ovo-tim'],
     handler,
     url: 'huggingface.co/papers',
 };
 
-async function handler() {
-    const { body: response } = await got('https://huggingface.co/papers');
+interface Paper {
+    id: string;
+    summary: string;
+    upvotes: number;
+    authors: { name: string }[];
+}
+
+interface DailyPaperItem {
+    title: string;
+    paper: Paper;
+    publishedAt: string;
+}
+
+interface PapersData {
+    dailyPapers: DailyPaperItem[];
+}
+
+async function handler(ctx) {
+    const { cycle = 'date', voteFliter = '0' } = ctx.req.param();
+    let url: string;
+    switch (cycle) {
+        case 'date':
+            url = 'https://huggingface.co/papers';
+            break;
+        case 'week':
+            // We don't actually need to get the week number, because huggingface.co/papers/week/YYYY-W52 will redirect to the latest week
+            url = `https://huggingface.co/papers/week/${new Date().getFullYear()}-W52`;
+            break;
+        case 'month':
+            url = 'https://huggingface.co/papers/month/' + new Date().toISOString().slice(0, 7);
+            break;
+        default:
+            throw new Error(`Invalid cycle: ${cycle}`);
+    }
+
+    const { body: response } = await got(url);
     const $ = load(response);
-    const papers = $('main > div[data-target="DailyPapers"]').data('props');
+    const papers = $('main > div[data-target="DailyPapers"]').data('props') as PapersData;
 
     const items = papers.dailyPapers
+        .filter((item) => item.paper.upvotes >= voteFliter)
         .map((item) => ({
             title: item.title,
             link: `https://arxiv.org/abs/${item.paper.id}`,
-            description: item.paper.summary.replaceAll('\n', ' '),
+            description: item.paper.summary.replaceAll('\n', ' ') + `\n Upvotes: ${item.paper.upvotes}`,
             pubDate: parseDate(item.publishedAt),
             author: item.paper.authors.map((author) => author.name).join(', '),
             upvotes: item.paper.upvotes,

--- a/lib/routes/huggingface/daily-papers.ts
+++ b/lib/routes/huggingface/daily-papers.ts
@@ -76,7 +76,6 @@ async function handler(ctx) {
             pubDate: parseDate(item.publishedAt),
             author: item.paper.authors.map((author) => author.name).join(', '),
             upvotes: item.paper.upvotes,
-            comments: `https://huggingface.co/papers/${item.paper.id}`,
         }))
         .sort((a, b) => b.upvotes - a.upvotes);
 

--- a/lib/routes/huggingface/daily-papers.ts
+++ b/lib/routes/huggingface/daily-papers.ts
@@ -76,6 +76,7 @@ async function handler(ctx) {
             pubDate: parseDate(item.publishedAt),
             author: item.paper.authors.map((author) => author.name).join(', '),
             upvotes: item.paper.upvotes,
+            comments: `https://huggingface.co/papers/${item.paper.id}`,
         }))
         .sort((a, b) => b.upvotes - a.upvotes);
 


### PR DESCRIPTION
Support fetching by different publication cycle and flitering by votes for Huggingfce papers.

## Example for the Proposed Route(s) / 路由地址示例
```routes
/huggingface/daily-papers
/huggingface/daily-papers/month/50
/huggingface/daily-papers/week
/huggingface/daily-papers/week/10
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`
