### PR TITLE
fix: title selector

### DIFF
--- a/lib/routes/natgeo/natgeo.ts
+++ b/lib/routes/natgeo/natgeo.ts
@@ -16,7 +16,7 @@ async function loadContent(link) {
         .replaceAll(/&nbsp;/gi, ' ')
         .trim();
 
-    $('.splide__arrows, .slide-control').remove();
+    $('.splide__arrows, .slide-control, [class^="ad-"], style').remove();
 
     let description = ($('article').eq(0).html() ?? '') + ($('article').eq(1).html() ?? '');
     if (/photo|gallery/.test(link)) {

--- a/lib/routes/natgeo/natgeo.ts
+++ b/lib/routes/natgeo/natgeo.ts
@@ -23,7 +23,7 @@ async function loadContent(link) {
         description = $('#content-album').html() + description;
     }
     return {
-        title: $('title').text(),
+        title: $('h1.content-title').text().trim(),
         pubDate: parseDate(dtStr),
         description,
         category: $('.content-tag a')


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

This PR updates the title selector so it doesn't include the website name in article titles.


Before (unnecessarily includes website name):

```
document.querySelector('title')
<title>​泰國收藏家為什麼要將270公斤巨魚當成寶貝？ - 國家地理雜誌官方網站｜探索自然、科學與文化的最佳權​</title>​
```

After (clean article title):

```
document.querySelector('h1.content-title')
<h1 class=​"content-title text-black">​ 泰國收藏家為什麼要將270公斤巨魚當成寶貝？ ​</h1>​
```

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/natgeo/environment/article
```
