### PR TITLE
fix(route/ehentai): update thumbnail fetching and parsing logic

### DIFF
--- a/lib/routes/ehentai/ehapi.ts
+++ b/lib/routes/ehentai/ehapi.ts
@@ -29,8 +29,8 @@ function ehgot(url) {
 function ehgot_thumb(cache, thumb_url) {
     return cache.tryGet(thumb_url, async () => {
         try {
-            const buffer = await got({ method: 'get', url: thumb_url, headers });
-            const data = new Buffer.from(buffer.rawBody).toString('base64');
+            const buffer = await got({ method: 'get', responseType: 'buffer', url: thumb_url, headers });
+            const data = buffer.body.toString('base64');
             const ext = path.extname(thumb_url).slice(1);
             return `data:image/${ext};base64,${data}`;
         } catch (error) {
@@ -72,7 +72,7 @@ async function parsePage(cache, data, get_bittorrent = false, embed_thumb = fals
 
     async function parseElement(cache, element) {
         const el = $(element);
-        const title = el.find('div.glink').html();
+        const title = el.find('.glink').html();
         const rawDate = el.find('div[id^="posted_"]').text();
         const pubDate = rawDate ? timezone(rawDate, 0) : rawDate;
         let el_a;


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #19496

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/ehentai/favorites/6/favorited/0/bittorrent=true&embed_thumb=true
/ehentai/search/f_search=language%3Achinese%24+other%3A"full+color%24"+other%3Auncensored%24&advsearch=1&f_sto=on&f_spf=20&f_srdd=4/0/bittorrent=true&embed_thumb=true
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
