### PR TITLE
feat(route): 新增新余学院官网通知及图书馆通知路由

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -1519,6 +1519,11 @@ router.get('/ornl/news', lazyloadRouteHandler('./routes/ornl/news'));
 // 信阳师范学院 自考办
 router.get('/xynu/zkb/:category', lazyloadRouteHandler('./routes/universities/xynu/zkb'));
 
+// 新余学院 学校通知
+router.get('/xyu/index/tzgg/:page?', lazyloadRouteHandler('./routes/universities/xyu/notices'));
+// 新余学院 图书馆通知公告
+router.get('/xyu/library/:page?', lazyloadRouteHandler('./routes/xyu/library'));
+
 // DailyArt
 router.get('/dailyart/:language?', lazyloadRouteHandler('./routes/dailyart/index'));
 

--- a/lib/routes/xyu/library.ts
+++ b/lib/routes/xyu/library.ts
@@ -1,0 +1,65 @@
+import { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/library/:page?',
+    categories: ['university'],
+    example: '/xyu/library',
+    parameters: { page: '页码，默认为 1' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '新余学院图书馆通知公告',
+    maintainers: [],
+    handler,
+    url: 'lib.xyc.edu.cn/index/tzgg.htm',
+    radar: [
+        {
+            source: ['lib.xyc.edu.cn/index/tzgg.htm', 'lib.xyc.edu.cn/index/tzgg/:page.htm'],
+            target: '/library',
+        },
+    ],
+};
+
+async function handler(ctx) {
+    const page = ctx.req.param('page') ?? '1';
+    const baseUrl = 'https://lib.xyc.edu.cn';
+    const url = page && page > 1 ? `${baseUrl}/index/tzgg/${page}.htm` : `${baseUrl}/index/tzgg.htm`;
+
+    const response = await ofetch(url);
+    const $ = load(response);
+
+    const items = $('.text-list ul li')
+        .toArray()
+        .map((item) => {
+            const $item = $(item);
+            const $link = $item.find('a');
+            const title = $link.attr('title') || $link.text().trim();
+            const relativeUrl = $link.attr('href');
+            const link = relativeUrl ? new URL(relativeUrl, baseUrl).href : '';
+            // 提取日期
+            const dateText = $item.find('.date').text().trim() || $item.text().match(/\d{4}-\d{2}-\d{2}/)?.[0] || '';
+            const pubDate = dateText ? parseDate(dateText, 'YYYY-MM-DD') : new Date();
+
+            return {
+                title,
+                link,
+                pubDate,
+                description: title,
+            };
+        })
+        .filter((item): item is NonNullable<typeof item> => Boolean(item.title && item.link));
+
+    return {
+        title: '新余学院图书馆通知公告',
+        link: url,
+        item: items,
+    };
+}

--- a/lib/routes/xyu/namespace.ts
+++ b/lib/routes/xyu/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '新余学院',
+    url: 'xyc.edu.cn',
+    lang: 'zh-CN',
+};

--- a/lib/routes/xyu/notices.ts
+++ b/lib/routes/xyu/notices.ts
@@ -1,0 +1,117 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+export const route: Route = {
+    path: '/index/tzgg/:page?',
+    categories: ['university'],
+    example: '/xyu/index/tzgg',
+    parameters: {
+        page: '页码，可选，默认为第1页',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.xyc.edu.cn/index/tzgg.htm', 'www.xyc.edu.cn/index/tzgg/:page.htm'],
+        },
+    ],
+    name: '官网通知公告',
+    handler,
+    url: 'www.xyc.edu.cn/index/tzgg.htm',
+};
+
+async function handler(ctx) {
+    const page = ctx.req.param('page') || '';
+    const baseUrl = 'https://www.xyc.edu.cn';
+    const url = page && page > 1 ? `${baseUrl}/index/tzgg/${page}.htm` : `${baseUrl}/index/tzgg.htm`;
+
+    const response = await ofetch(url).catch(() => null);
+    if (!response) {
+        return {
+            title: '新余学院 - 通知公告',
+            link: url,
+            item: [],
+        };
+    }
+
+    const $ = load(response);
+
+    const list = $('.text-list ul li')
+        .toArray()
+        .map((item) => {
+            const currentItem = $(item);
+            const link = currentItem.find('a').attr('href');
+            if (!link) {
+                return null;
+            }
+
+            const title = currentItem.find('.list-tx h3').text().trim();
+            const description = currentItem.find('.list-tx p').text().trim();
+            const day = currentItem.find('.date p').text().trim();
+            const yearMonth = currentItem.find('.date span').text().trim();
+            const dateText = `${yearMonth}-${day.padStart(2, '0')}`;
+
+            return {
+                title,
+                link: new URL(link, baseUrl).href,
+                description: description || title,
+                pubDate: timezone(parseDate(dateText, 'YYYY-MM-DD'), +8),
+            };
+        })
+        .filter(Boolean)
+        .slice(0, 20);
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                try {
+                    const detailResponse = await ofetch(item.link).catch(() => null);
+                    if (!detailResponse) {
+                        return {
+                            ...item,
+                            description: '该通知无法直接预览，请点击原文链接查看',
+                        };
+                    }
+
+                    const $$ = load(detailResponse);
+                    const content = $$('.v_news_content, .content, .article-content').html() || $$('body').html();
+
+                    if (content) {
+                        const $content = load(content);
+                        $content('a').each(function () {
+                            const a = $(this);
+                            const href = a.attr('href');
+                            if (href && !href.startsWith('http')) {
+                                a.attr('href', new URL(href, baseUrl).href);
+                            }
+                        });
+                        item.description = $content.html();
+                    }
+
+                    return item;
+                } catch {
+                    return {
+                        ...item,
+                        description: '该通知无法直接预览，请点击原文链接查看',
+                    };
+                }
+            })
+        )
+    );
+
+    return {
+        title: '新余学院 - 通知公告',
+        link: url,
+        item: items,
+    };
+}


### PR DESCRIPTION

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/xyu/index/tzgg
/xyu/library
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
