### PR TITLE
feat(route)!: standardized the szse stock disclosure url

### DIFF
--- a/lib/routes/szse/disclosure/listed-notice.ts
+++ b/lib/routes/szse/disclosure/listed-notice.ts
@@ -24,20 +24,11 @@ function isValidDate(dateString: string): boolean {
 export const handler = async (ctx: Context): Promise<Data> => {
     const { category = '' } = ctx.req.param();
     const limit: number = Number.parseInt(ctx.req.query('limit') ?? '50', 10);
-    const query: string = ctx.req.param('query') ?? '';
     const queries: Record<string, string> = {
-        stock: '',
-        beginDate: '',
-        endDate: '',
+        stock: ctx.req.param('stock') ?? '',
+        beginDate: ctx.req.query('beginDate') ?? '',
+        endDate: ctx.req.query('endDate') ?? '',
     };
-    if (query) {
-        for (const pair of query.split('&')) {
-            const [key, value] = pair.split('=');
-            if (key) {
-                queries[key] = value;
-            }
-        }
-    }
     if (queries.beginDate && !isValidDate(queries.beginDate)) {
         throw new Error('Invalid beginDate format. Expected YYYY-MM-DD');
     }
@@ -121,13 +112,13 @@ export const handler = async (ctx: Context): Promise<Data> => {
 };
 
 export const route: Route = {
-    path: '/disclosure/listed/notice/:query?',
+    path: ['/disclosure/listed/notice/:query?', '/disclosure/listed/notice/stock/:stock/:query?'],
     name: '上市公司公告',
     url: 'www.szse.cn',
     maintainers: ['nczitzk'],
     handler,
     example: '/szse/disclosure/listed/notice',
-    parameters: { query: 'Filter options. can filte by "stock","beginDate","endDate". example:"stock=000001&beginDate=2025-07-01&endDate=2025-08-30"' },
+    parameters: { query: 'Filter options. can filter by "beginDate","endDate". example:"?beginDate=2025-07-01&endDate=2025-08-30"', stock: 'Stock identifier. 6 digital numbers' },
     description: undefined,
     categories: ['finance'],
     features: {


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/szse/disclosure/listed/notice
/szse/disclosure/listed/notice/stock/000001
/szse/disclosure/listed/notice/stock/000002?beginDate=2025-01-01&endDate=2025-07-01
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [X] New Route / 新的路由
  - [X] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [X] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [X] Parsed / 可以解析
  - [X] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This PR added support for specifying stock directly in the route path for `/szse/disclosure/listed/notice`, improving clarity and usability.
Also, it refactored parameter handling to use query strings for beginDate and endDate, removing the old query string parsing logic.

The old URL for fetching stock notice of 000001 is:

```
/szse/disclosure/listed/notice/stock=000001
```

The above URL format is not compliant with HTTP/URI RFCs, because `=` is not valid in the path segment (it should be used in query strings, which starts with `?`). This makes the route ambiguous and inconsistent with standard RESTful conventions. My FreshRSS instance rejects this feed due to this issue.

The new path format fixes this issue:

```
/szse/disclosure/listed/notice/stock/000001
```

I initially tried switching the URL to `?stock=000001`, but it seems like RSSHub’s caching mechanism does not support custom query parameters for route differentiation - `?stock=000002` will hit the cache `?stock=000001` (unless adding a `limit` query to bypass the cache). Because of this limitation, I had to introduce a new dedicated route with stock as a path parameter.