### PR TITLE
fix(skeb): resolve Redis cache async issue and refactor request flow

### DIFF
--- a/lib/routes/skeb/works.ts
+++ b/lib/routes/skeb/works.ts
@@ -4,6 +4,7 @@ import ConfigNotFoundError from '@/errors/types/config-not-found';
 import { baseUrl, processWork } from './utils';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
+import logger from '@/utils/logger';
 
 export const route: Route = {
     path: '/works/:username',
@@ -46,32 +47,19 @@ async function handler(ctx): Promise<Data> {
 
     const url = `${baseUrl}/api/users/${username.replace('@', '')}/works`;
 
-    const items = await cache.tryGet(url, async () => {
-        const fetchData = async (retryCount = 0, maxRetries = 3) => {
-            const data = await ofetch(url, {
-                retry: 0,
-                method: 'GET',
-                query: { role: 'creator', sort: 'date', offset: '0' },
-                headers: {
-                    'User-Agent': config.ua,
-                    Cookie: `request_key=${cache.get('skeb:request_key')}`,
-                    Authorization: `Bearer ${config.skeb.bearerToken}`,
-                },
-            }).catch((error) => {
-                if (retryCount >= maxRetries) {
-                    throw new Error('Max retries reached');
-                }
-                const newRequestKey = error.response?._data?.match(/request_key=(.*?);/)?.[1];
-                if (newRequestKey) {
-                    cache.set('skeb:request_key', newRequestKey);
-                    return fetchData(retryCount + 1, maxRetries);
-                }
-                throw error;
-            });
-            return data;
-        };
+    await ensureRequestKey(url);
 
-        const data = await fetchData();
+    const items = await cache.tryGet(url, async () => {
+        const data = await ofetch(url, {
+            retry: 0,
+            method: 'GET',
+            query: { role: 'creator', sort: 'date', offset: '0' },
+            headers: {
+                'User-Agent': config.ua,
+                Cookie: `request_key=${await cache.get('skeb:request_key')}`,
+                Authorization: `Bearer ${config.skeb.bearerToken}`,
+            },
+        });
 
         if (!data || !Array.isArray(data)) {
             throw new Error('Invalid data received from API');
@@ -85,4 +73,34 @@ async function handler(ctx): Promise<Data> {
         link: `${baseUrl}/${username}`,
         item: items as DataItem[],
     };
+}
+
+function hasResponseData(error: unknown): error is { response: { _data: string } } {
+    return error !== null && typeof error === 'object' && 'response' in error && typeof (error as { response?: { _data?: unknown } }).response?._data === 'string';
+}
+
+async function ensureRequestKey(url: string) {
+    if (await cache.get('skeb:request_key')) {
+        return;
+    }
+
+    try {
+        await ofetch(url, {
+            retry: 0,
+            headers: {
+                'User-Agent': config.ua,
+                Authorization: `Bearer ${config.skeb.bearerToken}`,
+            },
+        });
+    } catch (error) {
+        if (hasResponseData(error)) {
+            const newRequestKey = error.response?._data?.match(/request_key=(.*?);/)?.[1];
+            if (newRequestKey) {
+                cache.set('skeb:request_key', newRequestKey);
+                logger.debug(`Retrieved new request_key: ${newRequestKey}`);
+            } else {
+                logger.error('Failed to extract request_key from error response');
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/skeb/works/@brm2_1925
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
- Fix Redis cache async handling by adding await to cache.get() calls
- Refactor request_key management into separate ensureRequestKey function
- Simplify main data fetching flow by removing complex retry logic
- Add proper error type guards and logging for better debugging
- Improve code readability and maintainability

Fixes issue where Skeb works route failed with Redis cache due to cache.get() returning Promise object instead of string value, causing invalid request_key in API calls.
https://github.com/DIYgod/RSSHub/blob/2a1af7dc9039cd7b82e7c447d54187910570614e/lib/utils/cache/memory.ts#L18
https://github.com/DIYgod/RSSHub/blob/2a1af7dc9039cd7b82e7c447d54187910570614e/lib/utils/cache/redis.ts#L34