### PR TITLE
fix: nhentai route

### DIFF
--- a/lib/routes/nhentai/index.ts
+++ b/lib/routes/nhentai/index.ts
@@ -17,6 +17,7 @@ export const route: Route = {
         antiCrawler: true,
         supportBT: true,
         nsfw: true,
+        requirePuppeteer: true,
     },
     radar: [
         {

--- a/lib/routes/nhentai/search.ts
+++ b/lib/routes/nhentai/search.ts
@@ -12,6 +12,7 @@ export const route: Route = {
     features: {
         antiCrawler: true,
         supportBT: true,
+        requirePuppeteer: true,
         nsfw: true,
     },
     radar: [


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #20145

## Example for the Proposed Route(s) / 路由地址示例

```routes
/nhentai/index/language/chinese
```

## Note / 说明

由于nhentai路由的反爬策略导致ofetch方式已经失效数月，因此切换到Puppeteer方式，期望获得长时间的稳定性。