### PR TITLE
fix(routes/udn/global): Correctly serialize multi-element article content

### DIFF
--- a/lib/routes/udn/global/index.ts
+++ b/lib/routes/udn/global/index.ts
@@ -81,7 +81,11 @@ async function handler(ctx) {
                 item.pubDate = timezone(parseDate(content('meta[property="article:published_time"]').attr('content')), +8);
 
                 const mainImage = content('.article-content__focus').html();
-                const articleBodyHtml = content('.article-content__editor').find('p, figure, h2, .video-container').html();
+                const articleBodyHtml = content('.article-content__editor')
+                    .find('p, figure, h2, .video-container')
+                    .toArray()
+                    .map((e) => content.html(e))
+                    .join('');
 
                 item.description = mainImage + articleBodyHtml;
                 item.category = content('meta[name="news_keywords"]').attr('content').split(',');

--- a/lib/routes/udn/global/tag.ts
+++ b/lib/routes/udn/global/tag.ts
@@ -63,7 +63,11 @@ async function handler(ctx) {
                 item.pubDate = timezone(parseDate(content('meta[property="article:published_time"]').attr('content')), +8);
 
                 const mainImage = content('.article-content__focus').html();
-                const articleBodyHtml = content('.article-content__editor').find('p, figure, h2, .video-container').html();
+                const articleBodyHtml = content('.article-content__editor')
+                    .find('p, figure, h2, .video-container')
+                    .toArray()
+                    .map((e) => content.html(e))
+                    .join('');
 
                 item.description = mainImage + articleBodyHtml;
                 item.category = content('meta[name="news_keywords"]').attr('content').split(',');


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/udn/global
/udn/global/editor
/udn/global/tag
/udn/global/tag/深度專欄
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
After #20178 was merged, I discovered a small follow-up bug. The line using `.html()` to get the article body was only returning the content of the first element (`<p>`, `<figure>`, etc.) in the selection, causing the rest of the article content to be missing.

This was a result of trying to avoid `.toString()`. It turns out that `.html()` on a multi-element selection only acts on the first item.

This commit fixes that issue by replacing `.html()` with a `.toArray().map().join('')` chain. This correctly iterates over all selected elements and concatenates their full HTML, ensuring the entire article body is included in the description.

Sorry for the oversight on the last one. This should fully resolve the issue. Thanks for your time!