### PR TITLE
feat(route/mercari): add advanced search route with flexible query pa…

### DIFF
--- a/lib/routes/mercari/keyword.ts
+++ b/lib/routes/mercari/keyword.ts
@@ -55,7 +55,8 @@ export const route: Route = {
 
 async function handler(ctx) {
     const { sort, order, status, keyword } = ctx.req.param();
-    const searchItems = (await fetchSearchItems(MercariSort[sort], MercariOrder[order], MercariStatus[status], keyword)).items;
+    const statusArray = MercariStatus[status] ? [MercariStatus[status]] : [];
+    const searchItems = (await fetchSearchItems(MercariSort[sort], MercariOrder[order], statusArray, keyword)).items;
     const items = await Promise.all(searchItems.map((item) => cache.tryGet(`mercari:${item.id}`, async () => await fetchItemDetail(item.id, item.itemType).then((detail) => formatItemDetail(detail)))));
 
     return {

--- a/lib/routes/mercari/search.ts
+++ b/lib/routes/mercari/search.ts
@@ -1,0 +1,90 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import { fetchSearchItems, fetchItemDetail, formatItemDetail, MercariSort, MercariOrder, MercariStatus } from './util';
+
+export const route: Route = {
+    path: '/search/:query',
+    categories: ['shopping'],
+    example: '/mercari/search/keyword=シャツ&7bd3eacc-ae45-4d73-bc57-a611c9432014=340258ac-e220-4722-8c35-7f73b7382831',
+    parameters: {
+        query: 'Search parameters in URL query string format.',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Search',
+    maintainers: ['yana9i, Tsuyumi25'],
+    url: 'jp.mercari.com',
+    handler,
+};
+
+function parseSearchQuery(queryString: string) {
+    const params = new URLSearchParams(queryString);
+
+    const keyword = params.get('keyword') || '';
+    const sort = MercariSort[params.get('sort') as keyof typeof MercariSort] || MercariSort.default;
+    const order = MercariOrder[params.get('order') as keyof typeof MercariOrder] || MercariOrder.desc;
+
+    const statusMap: Record<string, keyof typeof MercariStatus> = {
+        on_sale: 'onsale',
+        'sold_out|trading': 'soldout',
+    };
+    const statusArray =
+        params
+            .get('status')
+            ?.split(',')
+            .map((s) => MercariStatus[statusMap[s]])
+            .filter(Boolean) || [];
+
+    const attributeIds = [
+        '7bd3eacc-ae45-4d73-bc57-a611c9432014', // 色
+        '47295d80-5839-4237-bbfc-deb44b4e7999', // 割引オプション
+        'f42ae390-04ff-46ea-808b-f5d97cb45db4', // サイズ
+        'd664efe3-ae5a-4824-b729-e789bf93aba9', // 出品形式
+    ];
+
+    const attributes: Array<{ id: string; values: string[] }> = [];
+    for (const id of attributeIds) {
+        const values = params.get(id);
+        if (values) {
+            attributes.push({ id, values: values.split(',') });
+        }
+    }
+
+    const options = {
+        categoryId: params.get('category_id')?.split(',').map(Number),
+        brandId: params.get('brand_id')?.split(',').map(Number),
+        priceMin: params.get('price_min') ? Number(params.get('price_min')) : undefined,
+        priceMax: params.get('price_max') ? Number(params.get('price_max')) : undefined,
+        itemConditionId: params.get('item_condition_id')?.split(',').map(Number),
+        excludeKeyword: params.get('exclude_keyword') || undefined,
+        itemTypes: params
+            .get('item_types')
+            ?.split(',')
+            .map((type) => (type === 'mercari' ? 'ITEM_TYPE_MERCARI' : type === 'beyond' ? 'ITEM_TYPE_BEYOND' : type)),
+        attributes,
+    };
+
+    return { keyword, sort, order, status: statusArray, options };
+}
+
+async function handler(ctx) {
+    const queryString = ctx.req.param('query');
+
+    const { keyword, sort, order, status, options } = parseSearchQuery(queryString);
+    const searchItems = (await fetchSearchItems(sort, order, status, keyword, options)).items;
+
+    const items = await Promise.all(searchItems.map((item) => cache.tryGet(`mercari:${item.id}`, async () => await fetchItemDetail(item.id, item.itemType).then((detail) => formatItemDetail(detail)))));
+
+    return {
+        title: `${keyword} の検索結果`,
+        link: `https://jp.mercari.com/search?${queryString}`,
+        description: `Mercari advanced search results for: ${queryString}`,
+        item: items,
+    };
+}

--- a/lib/routes/mercari/util.ts
+++ b/lib/routes/mercari/util.ts
@@ -6,6 +6,7 @@ import { parseDate } from '@/utils/parse-date';
 import { art } from '@/utils/render';
 import path from 'node:path';
 import { DataItem } from '@/types';
+import logger from '@/utils/logger';
 
 const rootURL = 'https://api.mercari.jp/';
 const rootProductURL = 'https://jp.mercari.com/item/';
@@ -192,7 +193,21 @@ const pageToPageToken = (page: number): string => {
     return `v1:${page}`;
 };
 
-const fetchSearchItems = async (sort: string, order: string, status: string, keyword: string): Promise<SearchResponse> => {
+interface SearchOptions {
+    categoryId?: number[];
+    brandId?: number[];
+    priceMin?: number;
+    priceMax?: number;
+    itemConditionId?: number[];
+    excludeKeyword?: string;
+    itemTypes?: string[];
+    attributes?: Array<{
+        id: string;
+        values: string[];
+    }>;
+}
+
+const fetchSearchItems = async (sort: string, order: string, status: string[], keyword: string, options: SearchOptions = {}): Promise<SearchResponse> => {
     const data = {
         userId: `MERCARI_BOT_${uuidv4()}`,
         pageSize: 120,
@@ -202,24 +217,24 @@ const fetchSearchItems = async (sort: string, order: string, status: string, key
         thumbnailTypes: [],
         searchCondition: {
             keyword,
-            excludeKeyword: '',
+            excludeKeyword: options.excludeKeyword || '',
             sort,
             order,
-            status: [],
+            status: status || [],
             sizeId: [],
-            categoryId: [],
-            brandId: [],
+            categoryId: options.categoryId || [],
+            brandId: options.brandId || [],
             sellerId: [],
-            priceMin: 0,
-            priceMax: 0,
-            itemConditionId: [],
+            priceMin: options.priceMin || 0,
+            priceMax: options.priceMax || 0,
+            itemConditionId: options.itemConditionId || [],
             shippingPayerId: [],
             shippingFromArea: [],
             shippingMethod: [],
             colorId: [],
             hasCoupon: false,
-            attributes: [],
-            itemTypes: [],
+            attributes: options.attributes || [],
+            itemTypes: options.itemTypes || [],
             skuIds: [],
             shopIds: [],
             excludeShippingMethodIds: [],
@@ -240,6 +255,7 @@ const fetchSearchItems = async (sort: string, order: string, status: string, key
         withAuction: true,
     };
 
+    logger.debug(JSON.stringify(data));
     return await fetchFromMercari<SearchResponse>(searchURL, data, 'POST');
 };
 


### PR DESCRIPTION
…rameters

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #18823

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/mercari/create_time/desc/default/東方プロジェクト
/mercari/search/category_id=1733%2C1732%2C1731%2C1734
/mercari/search/brand_id=857%2C16957
/mercari/search/keyword=&f42ae390-04ff-46ea-808b-f5d97cb45db4=edf6afb0-e09f-418c-8e22-29851f802136%2C5aa9be69-3340-4f10-a667-1f29fb11638e
/mercari/search/status=sold_out%7Ctrading%2Con_sale
/mercari/search/item_types=mercari%2Cbeyond
/mercari/search/item_condition_id=1%2C2%2C3%2C4%2C5%2C6
/mercari/search/price_min=372&price_max=4583
/mercari/search/47295d80-5839-4237-bbfc-deb44b4e7999=9df96424-a8c2-414a-bbab-74bd11bd20aa%2CB38F1DC9286E0B80812D9B19DB14298C1FF1116CA8332D9EE9061026635C9088
/mercari/search/d664efe3-ae5a-4824-b729-e789bf93aba9=3b6eac8c-7be5-4c9c-b537-7c05cd3c4905%2CB38F1DC9286E0B80812D9B19DB14298C1FF1116CA8332D9EE9061026635C9088
/mercari/search/7bd3eacc-ae45-4d73-bc57-a611c9432014=340258ac-e220-4722-8c35-7f73b7382831%2Ca167b2a8-e153-43c8-a597-5f858b932df1
/mercari/search/exclude_keyword=example
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
