### PR TITLE
feat(route): Add Canada.ca

### DIFF
--- a/lib/routes/canada.ca/namespace.ts
+++ b/lib/routes/canada.ca/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Canada.ca',
+    url: 'www.canada.ca',
+    description: 'Government of Canada news by department',
+    lang: 'en',
+};

--- a/lib/routes/canada.ca/news.ts
+++ b/lib/routes/canada.ca/news.ts
@@ -1,0 +1,118 @@
+import { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import { load } from 'cheerio';
+
+export const route: Route = {
+    path: '/news/:lang/:department?',
+    categories: ['government'],
+    example: '/canada.ca/news/en/departmentfinance',
+    parameters: { lang: 'Language, en or fr', department: '(optional) dprtmnt query value' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        // Department of Finance
+        {
+            source: [
+                'www.canada.ca/:lang/department-finance.html',
+                'www.canada.ca/:lang/ministere-finances.html',
+                'www.canada.ca/:lang/department-finance/news/*',
+                'www.canada.ca/:lang/ministere-finances/nouvelles/*',
+                'www.canada.ca/:lang/news/advanced-news-search/news-results.html?_=1721141835413&dprtmnt=departmentfinance&start=&end=',
+                'www.canada.ca/:lang/nouvelles/recherche-avancee-de-nouvelles/resultats-de-nouvelles.html?_=1727880781502&typ=&dprtmnt=departmentfinance&mnstr=&start=&end=',
+            ],
+            target: '/news/:lang/departmentfinance',
+        },
+        // Innovation, Science and Economic Development Canada
+        {
+            source: [
+                'ised-isde.canada.ca/site/ised/:lang',
+                'ised-isde.canada.ca/site/isde/:lang',
+                'www.canada.ca/:lang/innovation-science-economic-development/news/*',
+                'www.canada.ca/:lang/innovation-sciences-developpement-economique/nouvelles/*',
+                'www.canada.ca/:lang/news/advanced-news-search/news-results.html?_=&dprtmnt=departmentofindustry&start=&end=',
+                'www.canada.ca/:lang/nouvelles/recherche-avancee-de-nouvelles/resultats-de-nouvelles.html?_=&dprtmnt=departmentofindustry&start=&end=',
+            ],
+            target: '/news/:lang/departmentofindustry',
+        },
+        // All news
+        {
+            source: ['www.canada.ca/:lang/news/advanced-news-search/news-results.html', 'www.canada.ca/:lang/nouvelles/recherche-avancee-de-nouvelles/resultats-de-nouvelles.html'],
+            target: '/news/:lang',
+        },
+    ],
+    name: 'News by Department',
+    maintainers: ['elibroftw'],
+    handler,
+    description: 'News from specific Canadian government departments',
+};
+
+async function handler(ctx) {
+    const lang = ctx.req.param('lang');
+    const department = ctx.req.param('department');
+
+    const baseUrl = 'https://www.canada.ca';
+    const pathMap = {
+        en: '/en/news/advanced-news-search/news-results.html',
+        fr: '/fr/nouvelles/recherche-avancee-de-nouvelles/resultats-de-nouvelles.html',
+    };
+    const departmentLinks = {
+        en: {
+            departmentfinance: 'https://www.canada.ca/en/department-finance.html',
+            departmentofindustry: 'https://ised-isde.canada.ca/site/ised/en',
+        },
+        fr: {
+            departmentfinance: 'https://www.canada.ca/fr/ministere-finances.html',
+            departmentofindustry: 'https://ised-isde.canada.ca/site/isde/fr',
+        },
+    };
+    const path = pathMap[lang];
+
+    const currentUrl = department ? `${baseUrl}${path}?dprtmnt=${department}` : `${baseUrl}${path}`;
+
+    const response = await ofetch(currentUrl);
+    const $ = load(response);
+
+    const list = $('article.item')
+        .toArray()
+        .map((item) => {
+            const $item = $(item);
+            const $link = $item.find('h3 a');
+            const title = $link.text().trim();
+            const link = $link.attr('href');
+            if (!link) {
+                return null;
+            }
+            const pubDateStr = $item.find('time').attr('datetime');
+            const pubDate = pubDateStr ? parseDate(pubDateStr) : undefined;
+            const pText = $item.find('p').text();
+            const departmentMatch = pText.match(/^([^|]+)\|/);
+            const departmentName = departmentMatch ? departmentMatch[1].trim() : '';
+            const categoryMatch = pText.match(/\| ([^|]+) \|/);
+            const categoryStr = categoryMatch ? categoryMatch[1].trim() : '';
+            const description = $item.find('p').last().text().trim();
+
+            return {
+                title,
+                link: link.startsWith('http') ? link : `${baseUrl}${link}`,
+                pubDate,
+                category: categoryStr ? [categoryStr] : [],
+                description,
+                author: departmentName,
+            };
+        })
+        .filter((item) => item !== null);
+
+    return {
+        title: department ? `${department.toUpperCase()} Canada` : 'Government of Canada News',
+        link: department ? departmentLinks[lang][department] : currentUrl,
+        item: list,
+        language: lang,
+    };
+}


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/canada.ca/news/en/departmentfinance
/canada.ca/news/fr/departmentfinance
/canada.ca/news/en/departmentofindustry
/canada.ca/news/fr/departmentofindustry
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/canada.ca/news/en/departmentfinance
/canada.ca/news/fr/departmentfinance
/canada.ca/news/en/departmentofindustry
/canada.ca/news/fr/departmentofindustry
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

How to do fallback targets? I want to match exact URLs for some routes `www.canada.ca/:lang/news/advanced-news-search/news-results.html?_=1721141835413&dprtmnt=departmentfinance&start=&end=` but if these are not matched, then I want my last radar item to get matched. Right now only the catch all is matching.

Alternatively, I would be also be interested in matching the query parameter `dprtmnt`