### PR TITLE
fix(route/udn/global): Combine hot articles into default UDN Global feed

### DIFF
--- a/lib/routes/udn/global/index.ts
+++ b/lib/routes/udn/global/index.ts
@@ -44,7 +44,7 @@ async function handler(ctx) {
 
     const $ = load(response.data);
 
-    const categories_conf = {
+    const categoriesConf = {
         hot: {
             articleSelector: '.carousel__list .carousel__item',
             titleExtractor: (e) => e.attr('title').trim(),
@@ -72,11 +72,11 @@ async function handler(ctx) {
 
     let items;
     if (category) {
-        const conf = categories_conf[category];
+        const conf = categoriesConf[category];
         items = getItems(conf);
     } else {
-        const defaultItems = getItems(categories_conf.default);
-        const hotItems = getItems(categories_conf.hot);
+        const defaultItems = getItems(categoriesConf.default);
+        const hotItems = getItems(categoriesConf.hot);
 
         const combinedItems = [...hotItems, ...defaultItems];
         items = [...new Map(combinedItems.map((item) => [item.link, item])).values()];


### PR DESCRIPTION

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/udn/global
/udn/global/hot
/udn/global/editor
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/udn/global
/udn/global/hot
/udn/global/editor
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
This pull request addresses an issue where the default feed was missing articles from the 'hot' category.

Previously, the main feed only contained the 'indexed' list of articles. This change combine both the 'indexed' and 'hot' articles when no specific category is requested, providing a more complete and engaging feed.