### PR TITLE
fix: wikipedia/current-events: content extraction and html output

### DIFF
--- a/lib/routes/wikipedia/current-events.ts
+++ b/lib/routes/wikipedia/current-events.ts
@@ -56,7 +56,17 @@ function parseCurrentEventsTemplate(wikitext: string): string | null {
         return null;
     }
 
-    return contentMatch[1].trim();
+    let content = contentMatch[1].trim();
+
+    // Strip comments to detect empty content
+    content = stripComments(content);
+
+    // Check if content is empty or only contains empty bullets (e.g., "*", "**", with whitespace)
+    if (/^\s*\*+\s*$/.test(content)) {
+        return null;
+    }
+
+    return content;
 }
 
 function stripTemplates(wikitext: string): string {
@@ -223,7 +233,6 @@ export function wikiToHtml(wikitext: string): string {
     html = convertExternalLinks(html);
     html = convertTextFormatting(html);
     html = processListsAndLines(html);
-    html = stripComments(html);
 
     return html;
 }


### PR DESCRIPTION
```routes
/wikipedia/current-events
/wikipedia/current-events/includeToday
```

Issues:

  - [x] Content extraction was breaking in case it included a templating instruction:
    - this would lead to truncated content
    - fixed by extending the selection to the whole content minus the closing braces.
  - [x] the html output was non-compliant html:
    - nested lists where converted by having nested `<ul>...</ul>` not belonging to a `<li>...</li>` element.
    - fixed by properly keeping track of the nesting level and embedding the sub-list in their parent element.
  - [x] ensure an empty content page doesn't lead to a entry creation
  - [x] the title date is off by one compared to the content date while local date <> gmt date
    - fixed by using local time to format title
    - we should also use local time to report pubDate to be consistent with title/content date and to be explicit about when the date change happen (i.e. showing the server local time)