### PR TITLE
fix(route/cjlu/yjsy): use Puppeteer to fetch CJLU Graduate School notices after anti-crawler update

### DIFF
--- a/lib/routes/cjlu/yjsy/index.ts
+++ b/lib/routes/cjlu/yjsy/index.ts
@@ -92,7 +92,7 @@ async function handler(ctx) {
                 excludeResourceTypes.has(request.resourceType()) ? request.abort() : request.continue();
             });
         },
-        gotoConfig: { waitUntil: 'networkidle0' },
+        gotoConfig: { waitUntil: 'networkidle2' },
     });
 
     const cookies = await browser.cookies();


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/cjlu/yjsy/yjstz
/cjlu/yjsy/jstz
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

The CJLU Graduate School website added new anti-crawling measures, causing the original `ofetch`-based route to fail.
And I switch to `Puppeteer` for fetching and parsing page content.
