### PR TITLE
fix(route/github): Fix URL link error in events

### DIFF
--- a/lib/routes/github/eventapi.ts
+++ b/lib/routes/github/eventapi.ts
@@ -34,10 +34,7 @@ function formatEventItem(event: any) {
             description = `Pushed ${commitCount}to ${branch} in ${repo.name}`;
 
             if (payload.commits) {
-                link = payload.commits.at(-1).url.replace(
-                    /https:\/\/api\.github\.com\/repos\/([^/]+)\/([^/]+)\/commits\/(\d+)/,
-                    'https://github.com/$1/$2/commit/$3'
-                );
+                link = payload.commits.at(-1).url.replace(/https:\/\/api\.github\.com\/repos\/([^/]+)\/([^/]+)\/commits\/(\d+)/, 'https://github.com/$1/$2/commit/$3');
                 description += `<br><strong>Latest commit:</strong> ${payload.commits.at(-1).message}`;
             } else {
                 link = `https://github.com/${repo.name}/commit/${payload.head}`;
@@ -47,10 +44,7 @@ function formatEventItem(event: any) {
         case 'PullRequestEvent':
             title = `${actor.login} ${payload.action} a pull request in ${repo.name}`;
             if (payload.pull_request) {
-                link = payload.pull_request.url.replace(
-                    /https:\/\/api\.github\.com\/repos\/([^/]+)\/([^/]+)\/pulls\/(\d+)/,
-                    'https://github.com/$1/$2/pull/$3'
-                );
+                link = payload.pull_request.url.replace(/https:\/\/api\.github\.com\/repos\/([^/]+)\/([^/]+)\/pulls\/(\d+)/, 'https://github.com/$1/$2/pull/$3');
                 description = `PR: ${link}`;
             } else {
                 link = `https://github.com/${repo.name}`;


### PR DESCRIPTION
<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

None

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/github/feed/yihong0618
/github/user_event/mslxl
/github/org_event/RSSNext
/github/repo_event/DIYgod/RSSHub
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

In the previous PR https://github.com/DIYgod/RSSHub/pull/20330, I mistakenly placed the API link for requesting PR information in the link for the RSS item. This PR fixes that error. Additionally, I found that in the original code, when the username or repository contains "commits," it would be incorrectly replaced with "commit" in the push event. This PR also addresses that issue.