### PR TITLE
fix(route/twreporter): Prevent crash when hero_image or og_image is m…

### DIFF
--- a/lib/routes/twreporter/fetch-article.ts
+++ b/lib/routes/twreporter/fetch-article.ts
@@ -30,11 +30,14 @@ export default async function fetch(slug: string) {
         authors += '；' + photographers;
     }
 
-    const bannerImage = post.hero_image.resized_targets.desktop.url;
+    // Prioritize hero_image, but fall back to og_image if it's missing
+    const imageSource = post.hero_image ?? post.og_image;
+    const bannerImage = imageSource?.resized_targets.desktop.url;
     const caption = post.leading_image_description;
-    const bannerDescription = post.hero_image.description;
+    const bannerDescription = imageSource?.description ?? '';
     const ogDescription = post.og_description;
-    const banner = art(path.join(__dirname, 'templates/image.art'), { image: bannerImage, description: bannerDescription, caption });
+    // Only render the banner if we successfully found an image URL
+    const banner = imageSource ? art(path.join(__dirname, 'templates/image.art'), { image: bannerImage, description: bannerDescription, caption }) : '';
 
     function format(type, content) {
         let block = '';


### PR DESCRIPTION
…issing

The original code directly accessed nested properties on `post.hero_image`, which is not guaranteed to exist. This cause a TypeError when the image object was nil.

This commit introduces safe access by:
- Prioritizing `hero_image` but falling back to `og_image`
- Only rendering the banner if a valid image URL was resolved

<!-- 
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/twreporter/newest
/twreporter/category/world
```

## New RSS Route Checklist / 新 RSS 路由检查表
  
- [ ] New Route / 新的路由
  - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
