### PR TITLE
修复类型定义错误的问题

### DIFF
--- a/lib/routes/zsxq/group.ts
+++ b/lib/routes/zsxq/group.ts
@@ -58,6 +58,6 @@ async function handler(ctx: Context): Promise<Data> {
         description: group.description,
         image: group.background_url,
         link: `https://wx.zsxq.com/dweb2/index/group/${groupId}`,
-        item: generateTopicDataItem(topics),
+        item: generateTopicDataItem(groupId, topics),
     };
 }

--- a/lib/routes/zsxq/types.ts
+++ b/lib/routes/zsxq/types.ts
@@ -30,6 +30,7 @@ interface BasicTopic {
     reading_count: number;
     rewards_count: number;
     topic_id: number;
+    topic_uid: string;
     type: string;
     user_specific: {
         liked: false;
@@ -147,7 +148,7 @@ export interface TopicImage {
 
 export type Topic = TalkTopic | QATopic | TaskTopic | SolutionTopic;
 
-export type ResponseData = UserInfo | GroupInfo | Topic[];
+export type ResponseData = UserInfo | GroupInfo | { topics: Topic[] };
 
 export type UserInfoResponse = BasicResponse<UserInfo>;
 

--- a/lib/routes/zsxq/utils.ts
+++ b/lib/routes/zsxq/utils.ts
@@ -34,11 +34,11 @@ function parseTopicContent(text: string = '', images: TopicImage[] = []) {
     return result;
 }
 
-export function generateTopicDataItem(topics: Topic[]): DataItem[] {
+export function generateTopicDataItem(groupId: string, topics: Topic[]): DataItem[] {
     return topics.map((topic) => {
         let description: string | undefined;
         let title = '';
-        const url = `https://wx.zsxq.com/topic/${topic.topic_id}`;
+        const url = `https://wx.zsxq.com/group/${groupId}/topic/${topic.topic_uid}`;
         switch (topic.type) {
             case 'talk':
                 title = topic.talk?.text?.split('\n')[0] ?? '文章';


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zsxq/group
```

## Note / 说明
返回数据示例
```
{
        "topic_id": 55188121485854154,
        "topic_uid": "55188121485854154",
        "group": {
          "group_id": 15555452541582,
          "name": "阿杰的 comfyui 知识库",
          "type": "pay",
          "background_url": "https://images.zsxq.com/Flou5KrgvnJi363VRgDLOGIHvfkP?e=1767196799&token=kIxbL07-8jAj8w1n4s9zv64FuZZNEATmlU_Vm6zD:qaUxipTfKLvTxFTftULJb6UWLTU="
        }
}
```

1. 修复内容
- 1. ts 使用 IEEE 754 双精度浮点数的问题， 原代码使用的 topic_id: number, 由于精度丢失导致topic_id 不正确，返回的json有 topic_uid 是字符串格式，故使用 topic_uid 来替代
- 2. link 地址有误， 格式应该为 `https://wx.zsxq.com/group/${groupId}/topic/${topic.topic_uid}`
- 3. ResponseData 的定义的数据格式类型有误