### PR TITLE
fix(route/zsxq/group): fix topic id Double Precision Floating-point bug

### DIFF
--- a/lib/routes/zsxq/group.ts
+++ b/lib/routes/zsxq/group.ts
@@ -58,6 +58,6 @@ async function handler(ctx: Context): Promise<Data> {
         description: group.description,
         image: group.background_url,
         link: `https://wx.zsxq.com/dweb2/index/group/${groupId}`,
-        item: generateTopicDataItem(topics, groupId),
+        item: generateTopicDataItem(topics),
     };
 }

--- a/lib/routes/zsxq/utils.ts
+++ b/lib/routes/zsxq/utils.ts
@@ -34,11 +34,11 @@ function parseTopicContent(text: string = '', images: TopicImage[] = []) {
     return result;
 }
 
-export function generateTopicDataItem(topics: Topic[], groupId?: string): DataItem[] {
+export function generateTopicDataItem(topics: Topic[]): DataItem[] {
     return topics.map((topic) => {
         let description: string | undefined;
         let title = '';
-        const url = groupId ? `https://wx.zsxq.com/group/${groupId}/topic/${topic.topic_uid}` : `https://wx.zsxq.com/topic/${topic.topic_uid}`;
+        const url = `https://wx.zsxq.com/group/${topic.group.group_id}/topic/${topic.topic_uid}`;
         switch (topic.type) {
             case 'talk':
                 title = topic.talk?.text?.split('\n')[0] ?? '文章';


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zsxq/group/48888828515858
```

## Note / 说明
修改内容:
1. 由于ts number双精度浮点数的问题，将topic_id 修改为 topic_uid
2. 修改访问链接地址
测试
需要提供 zsxq_access_token 的 cookie 值