### PR TITLE
fix(routes/mercari): set cache max age to routeExpire

### DIFF
--- a/lib/routes/mercari/keyword.ts
+++ b/lib/routes/mercari/keyword.ts
@@ -1,3 +1,4 @@
+import { config } from '@/config';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 
@@ -58,7 +59,9 @@ async function handler(ctx) {
     const { sort, order, status, keyword } = ctx.req.param();
     const statusArray = MercariStatus[status] ? [MercariStatus[status]] : [];
     const searchItems = (await fetchSearchItems(MercariSort[sort], MercariOrder[order], statusArray, keyword)).items;
-    const items = await Promise.all(searchItems.map((item) => cache.tryGet(`mercari:${item.id}`, async () => await fetchItemDetail(item.id, item.itemType).then((detail) => formatItemDetail(detail)))));
+    const items = await Promise.all(
+        searchItems.map((item) => cache.tryGet(`mercari:${item.id}`, async () => await fetchItemDetail(item.id, item.itemType).then((detail) => formatItemDetail(detail)), config.cache.routeExpire, false))
+    );
 
     return {
         title: `${keyword} の検索結果`,

--- a/lib/routes/mercari/search.ts
+++ b/lib/routes/mercari/search.ts
@@ -1,3 +1,4 @@
+import { config } from '@/config';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 
@@ -87,7 +88,9 @@ async function handler(ctx) {
     const { keyword, sort, order, status, options } = parseSearchQuery(queryString);
     const searchItems = (await fetchSearchItems(sort, order, status, keyword, options)).items;
 
-    const items = await Promise.all(searchItems.map((item) => cache.tryGet(`mercari:${item.id}`, async () => await fetchItemDetail(item.id, item.itemType).then((detail) => formatItemDetail(detail)))));
+    const items = await Promise.all(
+        searchItems.map((item) => cache.tryGet(`mercari:${item.id}`, async () => await fetchItemDetail(item.id, item.itemType).then((detail) => formatItemDetail(detail)), config.cache.routeExpire, false))
+    );
 
     return {
         title: `${keyword} の検索結果`,


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
/mercari/create_time/desc/default/test
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Item description and price may change, and it can be critical to get the latest price, otherwise the item may be bought by others.

However, it's still useful to cache the result, as it might be used by other routes (e.g. different keywords or sorting parameters).