### PR TITLE
refactor: generate JSON data for namespace-centric docs

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -60,8 +60,8 @@ jobs:
             - name: Update docs
               if: steps.check-docs-env.outputs.defined == 'true'
               run: |
-                  cp -r ./assets/build/docs/en/* ./rsshub-docs/src/routes
-                  cp -r ./assets/build/docs/zh/* ./rsshub-docs/src/zh/routes
+                  cp ./assets/build/docs/routes.json ./rsshub-docs/src/public/routes.json
+                  cp ./assets/build/docs/categories.json ./rsshub-docs/src/public/categories.json
                   cp ./lib/types.ts ./rsshub-docs/.vitepress/theme/types.ts
                   cp ./scripts/workflow/data.ts ./rsshub-docs/.vitepress/config/data.ts
             - name: Commit docs


### PR DESCRIPTION
Refactor the documentation generation workflow to output namespace-centric JSON data instead of category-based markdown files.

- Replace Markdown file generation with JSON output for better integration
- Generate routes.json with all route data organized by namespace
- Generate categories.json for category metadata
- Update GitHub Actions workflow to copy JSON files instead of Markdown