### PR TITLE
fix: increase worker integration test timeout to 60s

### DIFF
--- a/lib/worker.worker.test.ts
+++ b/lib/worker.worker.test.ts
@@ -27,12 +27,12 @@ describe('Worker Integration Tests', () => {
             expect(text).toContain('<?xml');
             expect(text).toContain('<rss');
             expect(text).toContain('Test 1');
-        }, 30000);
+        }, 60000);
 
         it('should respond to / with welcome page', async () => {
             const response = await worker.fetch('/');
             expect(response.status).toBe(200);
-        }, 30000);
+        }, 60000);
 
         it('should return error for unknown routes', async () => {
             const response = await worker.fetch('/nonexistent/route/12345');


### PR DESCRIPTION
## Summary

Increase test timeout for the first two worker integration tests from 30 seconds to 60 seconds. These tests were timing out in CI environments because the Worker initialization takes longer than expected in certain conditions.

## Test Plan

- Run `npm run vitest:coverage` to verify all tests pass
- Tests should complete successfully without timeout errors

## Changes

```routes
NOROUTE
```