### PR TITLE
feat(route): add ai-bot daily-ai-news route

### DIFF
--- a/lib/routes/ai-bot/daily-ai-news.ts
+++ b/lib/routes/ai-bot/daily-ai-news.ts
@@ -1,0 +1,111 @@
+import { load } from 'cheerio';
+
+import type { Data, DataItem, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+type CheerioInstance = ReturnType<typeof load>;
+type CheerioSelection = ReturnType<CheerioInstance>;
+
+interface DateContext {
+    currentYear: number;
+    prevMonth: number;
+    prevDay: number;
+}
+
+function parseDateString(dateStr: string, ctx: DateContext): Date | undefined {
+    // 格式如 "1月9·周五" 或 "12月25·周三"
+    const match = dateStr.match(/(\d+)月(\d+)/);
+    if (!match) {
+        return undefined;
+    }
+
+    const month = Number.parseInt(match[1], 10);
+    const day = Number.parseInt(match[2], 10);
+
+    // 检测跨年：如果当前日期比上一个日期大，说明跨年了
+    if (ctx.prevMonth > 0 && (month > ctx.prevMonth || (month === ctx.prevMonth && day > ctx.prevDay))) {
+        ctx.currentYear--;
+    }
+
+    ctx.prevMonth = month;
+    ctx.prevDay = day;
+
+    return new Date(`${ctx.currentYear}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T08:00:00+08:00`);
+}
+
+function processNewsList($: CheerioInstance, $newsList: CheerioSelection, items: DataItem[], ctx: DateContext): void {
+    let currentDateStr = '';
+    let currentPubDate: Date | undefined;
+
+    $newsList.children().each((_, child) => {
+        const $child = $(child);
+
+        if ($child.hasClass('news-date')) {
+            currentDateStr = $child.text().trim();
+            currentPubDate = parseDateString(currentDateStr, ctx);
+        } else if ($child.hasClass('news-item') && currentDateStr) {
+            const $link = $child.find('h2 a');
+            const title = $link.text().trim();
+            const link = $link.attr('href') || '';
+            const description = $child.find('p.text-muted').html() || '';
+
+            items.push({
+                title,
+                link,
+                description,
+                pubDate: currentPubDate,
+                author: 'AI工具集',
+            });
+        } else if ($child.hasClass('news-list')) {
+            processNewsList($, $child, items, ctx);
+        }
+    });
+}
+
+async function handler(): Promise<Data> {
+    const response = await ofetch('https://ai-bot.cn/daily-ai-news/');
+    const $ = load(response);
+
+    const items: DataItem[] = [];
+    const $firstNewsList = $('.news-list').first();
+
+    const dateCtx: DateContext = {
+        currentYear: new Date().getFullYear(),
+        prevMonth: 0,
+        prevDay: 0,
+    };
+
+    processNewsList($, $firstNewsList, items, dateCtx);
+
+    return {
+        title: '每日AI资讯 | AI工具集',
+        link: 'https://ai-bot.cn/daily-ai-news/',
+        item: items,
+    };
+}
+
+export const route: Route = {
+    path: '/daily-ai-news',
+    categories: ['new-media'],
+    example: '/ai-bot/daily-ai-news',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['ai-bot.cn/daily-ai-news', 'ai-bot.cn/daily-ai-news/'],
+            target: '/daily-ai-news',
+        },
+    ],
+    name: '每日AI资讯',
+    maintainers: ['redwood9'],
+    handler,
+    url: 'ai-bot.cn/daily-ai-news',
+    description: '获取 AI 工具集网站的每日 AI 资讯汇总。',
+};

--- a/lib/routes/ai-bot/namespace.ts
+++ b/lib/routes/ai-bot/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'AI工具集',
+    url: 'ai-bot.cn',
+    lang: 'zh-CN',
+};


### PR DESCRIPTION
**Related issue**  
Close 

**Example route**  
/ai-bot/daily-ai-news

**New Route Checklist**  
- [x] New route  
- [x] Follows [v2 route standard](https://docs.rsshub.app/joinus/advanced/script-standard)  
- [ ] Documentation  
  - [ ] Chinese documentation (if added to docs/routes/)  
  - [ ] English documentation (maintainers can help)  
- [ ] Fulltext supported  
- [ ] Cache supported  
- [ ] Anti-crawler / rate limit  
- [x] New packages: cheerio (for HTML parsing)  
- [x] Date/time parsed  
- [x] Timezone handled (UTC+8)  

**Description**  
- Source: https://ai-bot.cn/daily-ai-news/  
- Parsing logic:  
  - Recursively traverse nested `.news-list` elements  
  - `.news-date` contains the date for subsequent articles (format: "1月9·周五")  
  - `.news-item` contains individual articles with title, link, and description  
- pubDate:  
  - Extract month/day using regex `/(\d+)月(\d+)/`  
  - Year from system time, with cross-year detection (if date increases, year decrements)  
  - Fixed time at 08:00:00 UTC+8  
- Tested locally: http://localhost:1200/ai-bot/daily-ai-news?format=json  
- Output includes title, link, description, pubDate, author  
- Radar rule included in route definition  

**Screenshots/Output Example** (optional but recommended)  
- Paste a snippet of the JSON output or screenshot here (drag & drop image to PR description)