### PR TITLE
feat(route): add LinuxDo RSS routes

### DIFF
--- a/lib/routes/linux-do/latest.ts
+++ b/lib/routes/linux-do/latest.ts
@@ -1,0 +1,56 @@
+import type { Route } from '@/types';
+import got from '@/utils/got';
+import RSSParser from '@/utils/rss-parser';
+
+export const route: Route = {
+    path: '/latest',
+    categories: ['bbs'],
+    example: '/linux-do/latest',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['linux.do/latest', 'linux.do'],
+            target: '/latest',
+        },
+    ],
+    name: '最新话题',
+    maintainers: ['JackyST0'],
+    handler,
+    description: '获取 LinuxDo 论坛的最新主题',
+};
+
+async function handler() {
+    const rssUrl = 'https://linux.do/latest.rss';
+
+    const response = await got(rssUrl, {
+        headers: {
+            'Accept-Encoding': 'identity',
+        },
+    });
+
+    const feed = await RSSParser.parseString(response.data);
+
+    const items = feed.items.map((item) => ({
+        title: item.title,
+        link: item.link,
+        description: item.content ?? item.description,
+        pubDate: item.pubDate,
+        author: item.creator,
+        category: item.categories,
+    }));
+
+    return {
+        title: 'LinuxDo - 最新话题',
+        link: 'https://linux.do/latest',
+        description: 'LinuxDo Linux 和开源技术社区最新话题',
+        item: items,
+    };
+}

--- a/lib/routes/linux-do/namespace.ts
+++ b/lib/routes/linux-do/namespace.ts
@@ -1,0 +1,19 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'LinuxDo',
+    url: 'linux.do',
+    description: `
+LinuxDo 是一个 Linux 和开源技术社区。
+
+:::tip
+LinuxDo 基于 Discourse 构建，官方提供以下 RSS 订阅源：
+
+- 最新帖子：\`https://linux.do/posts.rss\`
+- 最新话题：\`https://linux.do/latest.rss\`
+- 热门话题：\`https://linux.do/top.rss\`、\`https://linux.do/top/weekly.rss\` 等
+
+RSSHub 对官方 RSS 源进行了整合和优化。
+:::
+    `,
+};

--- a/lib/routes/linux-do/posts.ts
+++ b/lib/routes/linux-do/posts.ts
@@ -1,0 +1,56 @@
+import type { Route } from '@/types';
+import got from '@/utils/got';
+import RSSParser from '@/utils/rss-parser';
+
+export const route: Route = {
+    path: '/posts',
+    categories: ['bbs'],
+    example: '/linux-do/posts',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['linux.do/posts', 'linux.do'],
+            target: '/posts',
+        },
+    ],
+    name: '最新帖子',
+    maintainers: ['JackyST0'],
+    handler,
+    description: '获取 LinuxDo 论坛的最新回复和讨论',
+};
+
+async function handler() {
+    const rssUrl = 'https://linux.do/posts.rss';
+
+    const response = await got(rssUrl, {
+        headers: {
+            'Accept-Encoding': 'identity',
+        },
+    });
+
+    const feed = await RSSParser.parseString(response.data);
+
+    const items = feed.items.map((item) => ({
+        title: item.title,
+        link: item.link,
+        description: item.content ?? item.description,
+        pubDate: item.pubDate,
+        author: item.creator,
+        category: item.categories,
+    }));
+
+    return {
+        title: 'LinuxDo - 最新帖子',
+        link: 'https://linux.do',
+        description: 'LinuxDo Linux 和开源技术社区最新帖子',
+        item: items,
+    };
+}

--- a/lib/routes/linux-do/top.ts
+++ b/lib/routes/linux-do/top.ts
@@ -1,0 +1,70 @@
+import type { Route } from '@/types';
+import got from '@/utils/got';
+import RSSParser from '@/utils/rss-parser';
+
+export const route: Route = {
+    path: '/top/:period?',
+    categories: ['bbs'],
+    example: '/linux-do/top',
+    parameters: {
+        period: '时间范围，可选值为 `all`、`yearly`、`quarterly`、`monthly`、`weekly`、`daily`，默认为 `all`',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['linux.do/top', 'linux.do'],
+            target: '/top',
+        },
+    ],
+    name: '热门话题',
+    maintainers: ['JackyST0'],
+    handler,
+    description: '获取 LinuxDo 论坛的热门话题，支持按时间范围筛选',
+};
+
+async function handler(ctx) {
+    const period = ctx.req.param('period') || 'all';
+
+    const rssUrl = `https://linux.do/top/${period}.rss`;
+
+    const response = await got(rssUrl, {
+        headers: {
+            'Accept-Encoding': 'identity',
+        },
+    });
+
+    const feed = await RSSParser.parseString(response.data);
+
+    const items = feed.items.map((item) => ({
+        title: item.title,
+        link: item.link,
+        description: item.content ?? item.description,
+        pubDate: item.pubDate,
+        author: item.creator,
+        category: item.categories,
+    }));
+
+    const periodName =
+        {
+            all: '全部',
+            yearly: '年度',
+            quarterly: '季度',
+            monthly: '月度',
+            weekly: '周',
+            daily: '日',
+        }[period] || '全部';
+
+    return {
+        title: `LinuxDo - ${periodName}热门话题`,
+        link: `https://linux.do/top/${period}`,
+        description: `LinuxDo Linux 和开源技术社区${periodName}热门话题`,
+        item: items,
+    };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/linux-do/posts
/linux-do/latest
/linux-do/top
/linux-do/top/weekly
/linux-do/top/daily
/linux-do/top/monthly
```

## 路由说明

为 LinuxDo 社区添加 RSS 订阅支持。

### 新增路由

- `/linux-do/posts` - 最新帖子（所有回复）
- `/linux-do/latest` - 最新话题
- `/linux-do/top/:period?` - 热门话题（支持时间范围：all/yearly/quarterly/monthly/weekly/daily）

### 实现方式

LinuxDo 基于 Discourse 构建，官方提供公开的 RSS 源。本实现对官方 RSS 进行了整合和参数化处理。

由于 linux.do 使用 Zstandard 压缩，通过设置 `Accept-Encoding: identity` 请求头避免压缩问题。

### 测试

- [x] 本地测试通过
- [x] 所有路由返回正确的 RSS 格式
- [x] 代码通过 ESLint 检查
- [x] 符合项目规范

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows Script Standard / 跟随路由规范
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] Date and time / 日期和时间
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`