### PR TITLE
feat(route): add bvisness.me blog route

### DIFF
--- a/lib/routes/bvisness/blog.ts
+++ b/lib/routes/bvisness/blog.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    name: 'Blog',
+    categories: ['blog'],
+    maintainers: ['raxod502'],
+    path: '/blog',
+    example: '/bvisness/blog',
+    handler,
+    radar: [
+        {
+            source: ['bvisness.me'],
+            target: '/blog',
+        },
+    ],
+};
+
+async function handler() {
+    const response = await ofetch('https://bvisness.me/');
+    const $ = load(response);
+
+    const items = $('article')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const a = item.find('a').first();
+            return {
+                title: a.text(),
+                link: new URL(a.attr('href'), 'https://bvisness.me/').href,
+                pubDate: parseDate(item.find('time').attr('datetime')),
+            };
+        });
+
+    return {
+        title: 'Ben Visness Blog',
+        link: 'https://bvisness.me/',
+        item: items,
+    };
+}

--- a/lib/routes/bvisness/namespace.ts
+++ b/lib/routes/bvisness/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Ben Visness',
+    url: 'bvisness.me',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

n/a

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/bvisness/blog
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Website gives ISO formatted dates but no times or timezones. I just use `parseDate` and it defaults to assuming UTC, which I think is okay.

I didn't retrieve article content. This might be more complicated because some of the blog posts are actually hosted on different sites, which the blog site links to.
