### PR TITLE
feat(route): add ZZU (Zhengzhou University) routes

### DIFF
--- a/lib/routes/zzu/dwzzb.ts
+++ b/lib/routes/zzu/dwzzb.ts
@@ -1,0 +1,85 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import puppeteer from '@/utils/puppeteer';
+
+// 该网页使用了动态解析
+
+export const route: Route = {
+    path: '/dwzzb/:type',
+    categories: ['university'],
+    example: '/zzu/dwzzb/djgz',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: true,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://dwzzb.v.zzu.edu.cn/list.jsp?alias=:type'],
+        },
+    ],
+    name: '郑大党委组织部',
+    maintainers: ['misty'],
+    handler,
+    description: `| 党建工作 | 干部工作 | 人才工作 | 乡村振兴工作 |
+| -------- | -------- | -------- | -------- |
+| djgz     | gbgz     | rcgz     | fpgz     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        djgz: ['党建工作', 'DJGZ'],
+        gbgz: ['干部工作', 'GBGZ'],
+        rcgz: ['人才工作', 'RCGZ'],
+        fpgz: ['乡村振兴工作', 'FPGZ'],
+    };
+
+    const typeAlias = type_dict[type][1];
+    const url = `https://dwzzb.v.zzu.edu.cn/list.jsp?alias=${typeAlias}`;
+
+    // 使用 puppeteer 渲染页面
+    const browser = await puppeteer();
+    const page = await browser.newPage();
+    await page.goto(url, {
+        waitUntil: 'networkidle0',
+        timeout: 30000,
+    });
+
+    // 获取渲染后的页面内容
+    const response = await page.content();
+    await browser.close();
+
+    const $ = load(response);
+
+    // 解析页面内容并提取文章信息
+    const items = $('.newslistCon li')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), url).href;
+            const title = $link.text().trim();
+
+            // 尝试获取发布时间
+            const pubDateText = $element.find('span.time').text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    return {
+        title: `郑大党委组织部-${type_dict[type][0]}`,
+        link: url,
+        item: items,
+    };
+}

--- a/lib/routes/zzu/dwzzb.ts
+++ b/lib/routes/zzu/dwzzb.ts
@@ -16,7 +16,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://dwzzb.v.zzu.edu.cn/list.jsp?alias=:type'],
+            source: ['dwzzb.v.zzu.edu.cn/'],
         },
     ],
     name: '郑大党委组织部',

--- a/lib/routes/zzu/dzb.ts
+++ b/lib/routes/zzu/dzb.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www5.zzu.edu.cn/dzb/index/:type.htm'],
+            source: ['www5.zzu.edu.cn/dzb/'],
         },
     ],
     name: '郑大党政办',

--- a/lib/routes/zzu/dzb.ts
+++ b/lib/routes/zzu/dzb.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大党政办',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 新闻资讯 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         xwzx: [
             '新闻资讯', // 分类名称
             'https://www5.zzu.edu.cn/dzb/index/xwzx.htm',
@@ -40,7 +40,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -50,7 +50,7 @@ async function handler(ctx) {
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.attr('title') || $link.text().trim();
 
             // 尝试获取发布时间
@@ -63,12 +63,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大党政办-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大党政办-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/dzb.ts
+++ b/lib/routes/zzu/dzb.ts
@@ -1,0 +1,74 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/dzb/:type',
+    categories: ['university'],
+    example: '/zzu/dzb/xwzx',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://www5.zzu.edu.cn/dzb/index/:type.htm'],
+        },
+    ],
+    name: '郑大党政办',
+    maintainers: ['misty'],
+    handler,
+    description: `| 新闻资讯 | 通知公告 |
+| -------- | -------- |
+| xwzx     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        xwzx: [
+            '新闻资讯', // 分类名称
+            'https://www5.zzu.edu.cn/dzb/index/xwzx.htm',
+        ],
+        tzgg: ['通知公告', 'https://www5.zzu.edu.cn/dzb/index/tzgg.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.new_list3 dd')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.attr('title') || $link.text().trim();
+
+            // 尝试获取发布时间
+            const pubDateText = $element.find('span.fr.gray').text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大党政办-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/dzb.ts
+++ b/lib/routes/zzu/dzb.ts
@@ -32,10 +32,7 @@ export const route: Route = {
 async function handler(ctx) {
     const type = ctx.req.param('type');
     const typeDict = {
-        xwzx: [
-            '新闻资讯', // 分类名称
-            'https://www5.zzu.edu.cn/dzb/index/xwzx.htm',
-        ],
+        xwzx: ['新闻资讯', 'https://www5.zzu.edu.cn/dzb/index/xwzx.htm'],
         tzgg: ['通知公告', 'https://www5.zzu.edu.cn/dzb/index/tzgg.htm'],
     };
 

--- a/lib/routes/zzu/gs.ts
+++ b/lib/routes/zzu/gs.ts
@@ -32,10 +32,7 @@ export const route: Route = {
 async function handler(ctx) {
     const type = ctx.req.param('type');
     const typeDict = {
-        xwzx: [
-            '新闻资讯', // 分类名称
-            'https://gs.zzu.edu.cn/index/yjsyxw.htm',
-        ],
+        xwzx: ['新闻资讯', 'https://gs.zzu.edu.cn/index/yjsyxw.htm'],
         tzgg: ['通知公告', 'https://gs.zzu.edu.cn/index/yjsygg.htm'],
     };
 
@@ -51,10 +48,10 @@ async function handler(ctx) {
             const $element = $(element);
             const $link = $element.find('a').first();
             const link = new URL($link.attr('href'), typeDict[type][1]).href;
-            const title = $link.attr('title') || $link.text().trim();
+            const title = $link.text().trim();
 
             // 获取发布时间
-            const pubDateText = $element.find('span').text().trim();
+            const pubDateText = $element.find('span').text().trim().replaceAll(/[[\]]/g, '');
 
             return {
                 title,

--- a/lib/routes/zzu/gs.ts
+++ b/lib/routes/zzu/gs.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大研究生院',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 新闻资讯 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         xwzx: [
             '新闻资讯', // 分类名称
             'https://gs.zzu.edu.cn/index/yjsyxw.htm',
@@ -40,7 +40,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -50,7 +50,7 @@ async function handler(ctx) {
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.attr('title') || $link.text().trim();
 
             // 获取发布时间
@@ -63,12 +63,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大研究生院-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大研究生院-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/gs.ts
+++ b/lib/routes/zzu/gs.ts
@@ -1,0 +1,74 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/gs/:type',
+    categories: ['university'],
+    example: '/zzu/gs/xwzx',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://gs.zzu.edu.cn/'],
+        },
+    ],
+    name: '郑大研究生院',
+    maintainers: ['misty'],
+    handler,
+    description: `| 新闻资讯 | 通知公告 |
+| -------- | -------- |
+| xwzx     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        xwzx: [
+            '新闻资讯', // 分类名称
+            'https://gs.zzu.edu.cn/index/yjsyxw.htm',
+        ],
+        tzgg: ['通知公告', 'https://gs.zzu.edu.cn/index/yjsygg.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.r_list ul li')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.attr('title') || $link.text().trim();
+
+            // 获取发布时间
+            const pubDateText = $element.find('span').text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大研究生院-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/gs.ts
+++ b/lib/routes/zzu/gs.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://gs.zzu.edu.cn/'],
+            source: ['gs.zzu.edu.cn/'],
         },
     ],
     name: '郑大研究生院',

--- a/lib/routes/zzu/jwc.ts
+++ b/lib/routes/zzu/jwc.ts
@@ -32,10 +32,7 @@ export const route: Route = {
 async function handler(ctx) {
     const type = ctx.req.param('type');
     const typeDict = {
-        xwkd: [
-            '新闻快递', // 分类名称
-            'https://www5.zzu.edu.cn/jwc/index/xwkd.htm',
-        ],
+        xwkd: ['新闻快递', 'https://www5.zzu.edu.cn/jwc/index/xwkd.htm'],
         tzgg: ['通知公告', 'https://www5.zzu.edu.cn/jwc/index/tzgg.htm'],
     };
 
@@ -46,12 +43,12 @@ async function handler(ctx) {
     // 解析页面内容并提取文章信息
     const list = $('ul.list li')
         .toArray()
-        .slice(0, 20)
+        .slice(0, 15)
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a.tit').first();
             const link = new URL($link.attr('href'), typeDict[type][1]).href;
-            const title = $link.attr('title') || $link.text().trim();
+            const title = $link.text().trim();
 
             // 获取发布时间
             const pubDateText = $element.find('span').last().text().trim();

--- a/lib/routes/zzu/jwc.ts
+++ b/lib/routes/zzu/jwc.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大教务部',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 新闻快递 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         xwkd: [
             '新闻快递', // 分类名称
             'https://www5.zzu.edu.cn/jwc/index/xwkd.htm',
@@ -40,7 +40,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -50,7 +50,7 @@ async function handler(ctx) {
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a.tit').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.attr('title') || $link.text().trim();
 
             // 获取发布时间
@@ -63,12 +63,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大教务部-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大教务部-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/jwc.ts
+++ b/lib/routes/zzu/jwc.ts
@@ -1,0 +1,74 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/jwc/:type',
+    categories: ['university'],
+    example: '/zzu/jwc/xwkd',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://www5.zzu.edu.cn/jwc/'],
+        },
+    ],
+    name: '郑大教务部',
+    maintainers: ['misty'],
+    handler,
+    description: `| 新闻快递 | 通知公告 |
+| -------- | -------- |
+| xwkd     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        xwkd: [
+            '新闻快递', // 分类名称
+            'https://www5.zzu.edu.cn/jwc/index/xwkd.htm',
+        ],
+        tzgg: ['通知公告', 'https://www5.zzu.edu.cn/jwc/index/tzgg.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('ul.list li')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a.tit').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.attr('title') || $link.text().trim();
+
+            // 获取发布时间
+            const pubDateText = $element.find('span').last().text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大教务部-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/jwc.ts
+++ b/lib/routes/zzu/jwc.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www5.zzu.edu.cn/jwc/'],
+            source: ['www5.zzu.edu.cn/jwc/'],
         },
     ],
     name: '郑大教务部',

--- a/lib/routes/zzu/kjc.ts
+++ b/lib/routes/zzu/kjc.ts
@@ -32,10 +32,7 @@ export const route: Route = {
 async function handler(ctx) {
     const type = ctx.req.param('type');
     const typeDict = {
-        xwzx: [
-            '新闻资讯', // 分类名称
-            'https://www7.zzu.edu.cn/kjc/index/kydt.htm',
-        ],
+        xwzx: ['新闻资讯', 'https://www7.zzu.edu.cn/kjc/index/kydt.htm'],
         tzgg: ['通知公告', 'https://www7.zzu.edu.cn/kjc/index/tzgg.htm'],
     };
 
@@ -46,7 +43,7 @@ async function handler(ctx) {
     // 解析页面内容并提取文章信息
     const list = $('.list_guild')
         .toArray()
-        .slice(0, 20)
+        .slice(0, 14)
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();

--- a/lib/routes/zzu/kjc.ts
+++ b/lib/routes/zzu/kjc.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www7.zzu.edu.cn/kjc/'],
+            source: ['www7.zzu.edu.cn/kjc/'],
         },
     ],
     name: '郑大科研院',

--- a/lib/routes/zzu/kjc.ts
+++ b/lib/routes/zzu/kjc.ts
@@ -6,7 +6,7 @@ import got from '@/utils/got';
 export const route: Route = {
     path: '/kjc/:type',
     categories: ['university'],
-    example: '/zzu/kjc/xwzx',
+    example: '',
     parameters: { type: '分类名' },
     features: {
         requireConfig: false,
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大科研院',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 新闻资讯 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         xwzx: [
             '新闻资讯', // 分类名称
             'https://www7.zzu.edu.cn/kjc/index/kydt.htm',
@@ -40,7 +40,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -50,7 +50,7 @@ async function handler(ctx) {
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.attr('title') || $link.text().trim();
 
             // 获取发布时间
@@ -63,12 +63,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大科研院-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大科研院-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/kjc.ts
+++ b/lib/routes/zzu/kjc.ts
@@ -1,0 +1,74 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/kjc/:type',
+    categories: ['university'],
+    example: '/zzu/kjc/xwzx',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://www7.zzu.edu.cn/kjc/'],
+        },
+    ],
+    name: '郑大科研院',
+    maintainers: ['misty'],
+    handler,
+    description: `| 新闻资讯 | 通知公告 |
+| -------- | -------- |
+| xwzx     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        xwzx: [
+            '新闻资讯', // 分类名称
+            'https://www7.zzu.edu.cn/kjc/index/kydt.htm',
+        ],
+        tzgg: ['通知公告', 'https://www7.zzu.edu.cn/kjc/index/tzgg.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.list_guild')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.attr('title') || $link.text().trim();
+
+            // 获取发布时间
+            const pubDateText = $element.find('span').text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大科研院-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/namespace.ts
+++ b/lib/routes/zzu/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '郑州大学',
+    url: 'www.zzu.edu.cn',
+    lang: 'zh-CN',
+};

--- a/lib/routes/zzu/news.ts
+++ b/lib/routes/zzu/news.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['news.zzu.edu.cn/:type.htm'],
+            source: ['news.zzu.edu.cn/'],
         },
     ],
     name: '郑大新闻网',

--- a/lib/routes/zzu/news.ts
+++ b/lib/routes/zzu/news.ts
@@ -24,7 +24,7 @@ export const route: Route = {
     name: '郑大新闻网',
     maintainers: ['amandus1990'],
     handler,
-    description: `| 要问速递 | 教学科研 | 基层动态 | 媒体郑大 |
+    description: `| 要闻速递 | 教学科研 | 基层动态 | 媒体郑大 |
 | -------- | -------- | -------- | -------- |
 | ywsd     | jxky     | jcdt     | mtzd     |`,
 };
@@ -48,7 +48,7 @@ async function handler(ctx) {
     // 解析页面内容并提取文章信息
     const list = $('.new-item')
         .toArray()
-        .slice(0, 20)
+        .slice(0, 15)
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('h3 a').first();

--- a/lib/routes/zzu/news.ts
+++ b/lib/routes/zzu/news.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大新闻网',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 要问速递 | 教学科研 | 基层动态 | 媒体郑大 |
 | -------- | -------- | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         ywsd: [
             '要闻速递', // 分类名称
             'https://news.zzu.edu.cn/ywsd.htm', // 郑大新闻网链接
@@ -42,7 +42,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -52,7 +52,7 @@ async function handler(ctx) {
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('h3 a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.attr('title') || $link.text().trim();
 
             // 尝试获取发布时间
@@ -69,12 +69,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大新闻网-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大新闻网-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/news.ts
+++ b/lib/routes/zzu/news.ts
@@ -1,0 +1,80 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/news/:type',
+    categories: ['university'],
+    example: '/zzu/news/ywsd',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['news.zzu.edu.cn/:type.htm'],
+        },
+    ],
+    name: '郑大新闻网',
+    maintainers: ['misty'],
+    handler,
+    description: `| 要问速递 | 教学科研 | 基层动态 | 媒体郑大 |
+| -------- | -------- | -------- | -------- |
+| ywsd     | jxky     | jcdt     | mtzd     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        ywsd: [
+            '要闻速递', // 分类名称
+            'https://news.zzu.edu.cn/ywsd.htm', // 郑大新闻网链接
+        ],
+        jxky: ['教学科研', 'https://news.zzu.edu.cn/jxky.htm'],
+        jcdt: ['基层动态', 'https://news.zzu.edu.cn/jcdt.htm'],
+        mtzd: ['媒体郑大', 'https://news.zzu.edu.cn/mtzd.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.new-item')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('h3 a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.attr('title') || $link.text().trim();
+
+            // 尝试获取发布时间
+            const pubDateText = $element.find('.new-date').text().trim();
+
+            // 尝试获取描述
+            const description = $element.find('p a').text().trim() || '';
+
+            return {
+                title,
+                link,
+                description,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大新闻网-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/rsc.ts
+++ b/lib/routes/zzu/rsc.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www5.zzu.edu.cn/rsc/'],
+            source: ['www5.zzu.edu.cn/rsc/'],
         },
     ],
     name: '郑大人事部',

--- a/lib/routes/zzu/rsc.ts
+++ b/lib/routes/zzu/rsc.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大人事部',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 人事要闻 | 通知公告 | 招聘公告 |
 | -------- | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         rsyw: [
             '人事要闻', // 分类名称
             'https://www5.zzu.edu.cn/rsc/xwgg1/rsyw.htm',
@@ -41,7 +41,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -51,7 +51,7 @@ async function handler(ctx) {
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.attr('title') || $link.text().trim();
 
             // 获取发布时间
@@ -64,12 +64,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大人事部-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大人事部-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/rsc.ts
+++ b/lib/routes/zzu/rsc.ts
@@ -47,7 +47,7 @@ async function handler(ctx) {
     // 解析页面内容并提取文章信息
     const list = $('.list_guild')
         .toArray()
-        .slice(0, 20)
+        .slice(0, 14)
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();

--- a/lib/routes/zzu/rsc.ts
+++ b/lib/routes/zzu/rsc.ts
@@ -1,0 +1,75 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/rsc/:type',
+    categories: ['university'],
+    example: '/zzu/rsc/rsyw',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://www5.zzu.edu.cn/rsc/'],
+        },
+    ],
+    name: '郑大人事部',
+    maintainers: ['misty'],
+    handler,
+    description: `| 人事要闻 | 通知公告 | 招聘公告 |
+| -------- | -------- | -------- |
+| rsyw     | tzgg     | zpxx     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        rsyw: [
+            '人事要闻', // 分类名称
+            'https://www5.zzu.edu.cn/rsc/xwgg1/rsyw.htm',
+        ],
+        tzgg: ['通知公告', 'https://www5.zzu.edu.cn/rsc/xwgg1/tzgg.htm'],
+        zpxx: ['招聘公告', 'https://www5.zzu.edu.cn/rsc/index/zpxx.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.list_guild')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.attr('title') || $link.text().trim();
+
+            // 获取发布时间
+            const pubDateText = $element.find('span').text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大人事部-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/ss.ts
+++ b/lib/routes/zzu/ss.ts
@@ -1,0 +1,75 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/ss/:type',
+    categories: ['university'],
+    example: '/zzu/ss/xwzx',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://www5.zzu.edu.cn/ss/'],
+        },
+    ],
+    name: '郑大社科院',
+    maintainers: ['misty'],
+    handler,
+    description: `| 新闻资讯 | 通知公告 |
+| -------- | -------- |
+| xwzx     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        xwzx: [
+            '新闻资讯', // 分类名称
+            'https://www5.zzu.edu.cn/ss/index/skxw.htm',
+        ],
+        tzgg: ['通知公告', 'https://www5.zzu.edu.cn/ss/index/tzgg.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.list_notice > a')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const link = new URL($element.attr('href'), type_dict[type][1]).href;
+            const title = $element.find('h3').text().trim();
+
+            // 获取发布时间 (格式: MM-DD，需要补全年份)
+            const pubDateText = $element.find('time').text().trim();
+            const currentYear = new Date().getFullYear();
+            const pubDate = pubDateText ? `${currentYear}-${pubDateText}` : null;
+
+            return {
+                title,
+                link,
+                pubDate,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大社科院-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/ss.ts
+++ b/lib/routes/zzu/ss.ts
@@ -46,7 +46,7 @@ async function handler(ctx) {
     // 解析页面内容并提取文章信息
     const list = $('.list_notice > a')
         .toArray()
-        .slice(0, 20)
+        .slice(0, 10)
         .map((element) => {
             const $element = $(element);
             const link = new URL($element.attr('href'), typeDict[type][1]).href;

--- a/lib/routes/zzu/ss.ts
+++ b/lib/routes/zzu/ss.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www5.zzu.edu.cn/ss/'],
+            source: ['www5.zzu.edu.cn/ss/'],
         },
     ],
     name: '郑大社科院',
@@ -32,10 +32,7 @@ export const route: Route = {
 async function handler(ctx) {
     const type = ctx.req.param('type');
     const typeDict = {
-        xwzx: [
-            '新闻资讯', // 分类名称
-            'https://www5.zzu.edu.cn/ss/index/skxw.htm',
-        ],
+        xwzx: ['新闻资讯', 'https://www5.zzu.edu.cn/ss/index/skxw.htm'],
         tzgg: ['通知公告', 'https://www5.zzu.edu.cn/ss/index/tzgg.htm'],
     };
 
@@ -52,10 +49,20 @@ async function handler(ctx) {
             const link = new URL($element.attr('href'), typeDict[type][1]).href;
             const title = $element.find('h3').text().trim();
 
-            // 获取发布时间 (格式: MM-DD，需要补全年份)
+            // 获取发布时间
+            // xwzx: 格式为 MM-DD，需要补全年份
+            // tzgg: 格式为 yyyy-mm-dd，直接使用
             const pubDateText = $element.find('time').text().trim();
-            const currentYear = new Date().getFullYear();
-            const pubDate = pubDateText ? `${currentYear}-${pubDateText}` : null;
+            let pubDate = null;
+
+            if (pubDateText) {
+                if (type === 'xwzx') {
+                    const currentYear = new Date().getFullYear();
+                    pubDate = `${currentYear}-${pubDateText}`;
+                } else {
+                    pubDate = pubDateText;
+                }
+            }
 
             return {
                 title,

--- a/lib/routes/zzu/ss.ts
+++ b/lib/routes/zzu/ss.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大社科院',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 新闻资讯 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         xwzx: [
             '新闻资讯', // 分类名称
             'https://www5.zzu.edu.cn/ss/index/skxw.htm',
@@ -40,7 +40,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -49,7 +49,7 @@ async function handler(ctx) {
         .slice(0, 20)
         .map((element) => {
             const $element = $(element);
-            const link = new URL($element.attr('href'), type_dict[type][1]).href;
+            const link = new URL($element.attr('href'), typeDict[type][1]).href;
             const title = $element.find('h3').text().trim();
 
             // 获取发布时间 (格式: MM-DD，需要补全年份)
@@ -64,12 +64,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大社科院-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大社科院-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/student.ts
+++ b/lib/routes/zzu/student.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大学生处',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 新闻资讯 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         xwzx: [
             '新闻资讯', // 分类名称
             'https://www5.zzu.edu.cn/student/xwzx.htm',
@@ -40,7 +40,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -50,7 +50,7 @@ async function handler(ctx) {
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.find('span').text().trim();
 
             // 获取发布时间
@@ -63,12 +63,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大学生处-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大学生处-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/student.ts
+++ b/lib/routes/zzu/student.ts
@@ -32,10 +32,7 @@ export const route: Route = {
 async function handler(ctx) {
     const type = ctx.req.param('type');
     const typeDict = {
-        xwzx: [
-            '新闻资讯', // 分类名称
-            'https://www5.zzu.edu.cn/student/xwzx.htm',
-        ],
+        xwzx: ['新闻资讯', 'https://www5.zzu.edu.cn/student/xwzx.htm'],
         tzgg: ['通知公告', 'https://www5.zzu.edu.cn/student/tzgg.htm'],
     };
 
@@ -46,20 +43,21 @@ async function handler(ctx) {
     // 解析页面内容并提取文章信息
     const list = $('.part-list ul li')
         .toArray()
-        .slice(0, 20)
+        .slice(0, 10)
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
             const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.find('span').text().trim();
 
-            // 获取发布时间
+            // 获取发布时间 (格式: yyyy年mm月dd日)
             const pubDateText = $element.find('em').text().trim();
+            const pubDate = pubDateText ? new Date(pubDateText.replace(/年(\d+)月(\d+)日/, '$1-$2-$3')) : null;
 
             return {
                 title,
                 link,
-                pubDate: pubDateText || null,
+                pubDate,
             };
         });
 

--- a/lib/routes/zzu/student.ts
+++ b/lib/routes/zzu/student.ts
@@ -1,0 +1,74 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/student/:type',
+    categories: ['university'],
+    example: '/zzu/student/xwzx',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://www5.zzu.edu.cn/student/'],
+        },
+    ],
+    name: '郑大学生处',
+    maintainers: ['misty'],
+    handler,
+    description: `| 新闻资讯 | 通知公告 |
+| -------- | -------- |
+| xwzx     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        xwzx: [
+            '新闻资讯', // 分类名称
+            'https://www5.zzu.edu.cn/student/xwzx.htm',
+        ],
+        tzgg: ['通知公告', 'https://www5.zzu.edu.cn/student/tzgg.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.part-list ul li')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.find('span').text().trim();
+
+            // 获取发布时间
+            const pubDateText = $element.find('em').text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大学生处-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/student.ts
+++ b/lib/routes/zzu/student.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www5.zzu.edu.cn/student/'],
+            source: ['www5.zzu.edu.cn/student/'],
         },
     ],
     name: '郑大学生处',
@@ -52,7 +52,17 @@ async function handler(ctx) {
 
             // 获取发布时间 (格式: yyyy年mm月dd日)
             const pubDateText = $element.find('em').text().trim();
-            const pubDate = pubDateText ? new Date(pubDateText.replace(/年(\d+)月(\d+)日/, '$1-$2-$3')) : null;
+            let pubDate = null;
+
+            if (pubDateText) {
+                const match = pubDateText.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
+                if (match) {
+                    const year = match[1];
+                    const month = match[2].padStart(2, '0');
+                    const day = match[3].padStart(2, '0');
+                    pubDate = `${year}-${month}-${day}`;
+                }
+            }
 
             return {
                 title,

--- a/lib/routes/zzu/tzhb.ts
+++ b/lib/routes/zzu/tzhb.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www5.zzu.edu.cn/tzhb/index/:type.htm'],
+            source: ['www5.zzu.edu.cn/tzhb/'],
         },
     ],
     name: '郑大党委统战部',

--- a/lib/routes/zzu/tzhb.ts
+++ b/lib/routes/zzu/tzhb.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大党委统战部',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 工作动态 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         gzdt: [
             '工作动态', // 分类名称
             'https://www5.zzu.edu.cn/tzhb/index/gzdt.htm',
@@ -40,7 +40,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -50,7 +50,7 @@ async function handler(ctx) {
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.find('em').text().trim();
 
             // 获取发布时间
@@ -63,12 +63,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大党委统战部-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大党委统战部-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/tzhb.ts
+++ b/lib/routes/zzu/tzhb.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['hhttps://www5.zzu.edu.cn/tzhb/index/:type.htm'],
+            source: ['https://www5.zzu.edu.cn/tzhb/index/:type.htm'],
         },
     ],
     name: '郑大党委统战部',
@@ -32,10 +32,7 @@ export const route: Route = {
 async function handler(ctx) {
     const type = ctx.req.param('type');
     const typeDict = {
-        gzdt: [
-            '工作动态', // 分类名称
-            'https://www5.zzu.edu.cn/tzhb/index/gzdt.htm',
-        ],
+        gzdt: ['工作动态', 'https://www5.zzu.edu.cn/tzhb/index/gzdt.htm'],
         tzgg: ['通知公告', 'https://www5.zzu.edu.cn/tzhb/index/tzgg1.htm'],
     };
 
@@ -46,7 +43,7 @@ async function handler(ctx) {
     // 解析页面内容并提取文章信息
     const list = $('.main_conR li')
         .toArray()
-        .slice(0, 20)
+        .slice(0, 15)
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();

--- a/lib/routes/zzu/tzhb.ts
+++ b/lib/routes/zzu/tzhb.ts
@@ -1,0 +1,74 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/tzhb/:type',
+    categories: ['university'],
+    example: '/zzu/tzhb/gzdt',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['hhttps://www5.zzu.edu.cn/tzhb/index/:type.htm'],
+        },
+    ],
+    name: '郑大党委统战部',
+    maintainers: ['misty'],
+    handler,
+    description: `| 工作动态 | 通知公告 |
+| -------- | -------- |
+| gzdt     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        gzdt: [
+            '工作动态', // 分类名称
+            'https://www5.zzu.edu.cn/tzhb/index/gzdt.htm',
+        ],
+        tzgg: ['通知公告', 'https://www5.zzu.edu.cn/tzhb/index/tzgg1.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.main_conR li')
+        .toArray()
+        .slice(0, 20)
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.find('em').text().trim();
+
+            // 获取发布时间
+            const pubDateText = $element.find('span').text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大党委统战部-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/xbx.ts
+++ b/lib/routes/zzu/xbx.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www5.zzu.edu.cn/xbx/index/:type.htm'],
+            source: ['www5.zzu.edu.cn/xbx/'],
         },
     ],
     name: '郑大校长办',

--- a/lib/routes/zzu/xbx.ts
+++ b/lib/routes/zzu/xbx.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大校长办',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 新闻资讯 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         xwzx: [
             '新闻资讯', // 分类名称
             'https://www5.zzu.edu.cn/xbx/index/xwzx.htm',
@@ -40,7 +40,7 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
@@ -50,7 +50,7 @@ async function handler(ctx) {
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.attr('title') || $link.text().trim();
 
             // 尝试获取发布时间
@@ -63,12 +63,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大校长办-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大校长办-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/xbx.ts
+++ b/lib/routes/zzu/xbx.ts
@@ -1,0 +1,74 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/xbx/:type',
+    categories: ['university'],
+    example: '/zzu/xbx/xwzx',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://www5.zzu.edu.cn/xbx/index/:type.htm'],
+        },
+    ],
+    name: '郑大校长办',
+    maintainers: ['misty'],
+    handler,
+    description: `| 新闻资讯 | 通知公告 |
+| -------- | -------- |
+| xwzx     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        xwzx: [
+            '新闻资讯', // 分类名称
+            'https://www5.zzu.edu.cn/xbx/index/xwzx.htm',
+        ],
+        tzgg: ['通知公告', 'https://www5.zzu.edu.cn/xbx/index/tzgg.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.new_list3 dd')
+        .slice(0, 20)
+        .toArray()
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.attr('title') || $link.text().trim();
+
+            // 尝试获取发布时间
+            const pubDateText = $element.find('span.fr.gray').text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大校长办-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/xuan.ts
+++ b/lib/routes/zzu/xuan.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www5.zzu.edu.cn/xuan/:type.htm'],
+            source: ['www5.zzu.edu.cn/xuan/'],
         },
     ],
     name: '郑大党委宣传部',

--- a/lib/routes/zzu/xuan.ts
+++ b/lib/routes/zzu/xuan.ts
@@ -1,0 +1,74 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/xuan/:type',
+    categories: ['university'],
+    example: '/zzu/xuan/gzdt',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://www5.zzu.edu.cn/xuan/:type.htm'],
+        },
+    ],
+    name: '郑大党委宣传部',
+    maintainers: ['misty'],
+    handler,
+    description: `| 工作动态 | 通知公告 |
+| -------- | -------- |
+| gzdt     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        gzdt: [
+            '工作动态', // 分类名称
+            'https://www5.zzu.edu.cn/xuan/gzdt.htm',
+        ],
+        tzgg: ['通知公告', 'https://www5.zzu.edu.cn/xuan/tzgg.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.list ul li')
+        .slice(0, 20)
+        .toArray()
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.attr('title') || $link.text().trim();
+
+            // 尝试获取发布时间
+            const pubDateText = $element.find('i').text().trim();
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大党委宣传部-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/xuan.ts
+++ b/lib/routes/zzu/xuan.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大党委宣传部',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 工作动态 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         gzdt: [
             '工作动态', // 分类名称
             'https://www5.zzu.edu.cn/xuan/gzdt.htm',
@@ -40,17 +40,17 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
     const list = $('.list ul li')
-        .slice(0, 20)
+        .slice(0, 18)
         .toArray()
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.attr('title') || $link.text().trim();
 
             // 尝试获取发布时间
@@ -63,12 +63,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大党委宣传部-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大党委宣传部-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }

--- a/lib/routes/zzu/zcycwb.ts
+++ b/lib/routes/zzu/zcycwb.ts
@@ -18,7 +18,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www5.zzu.edu.cn/zcycwb/'],
+            source: ['www5.zzu.edu.cn/zcycwb/'],
         },
     ],
     name: '郑大资产与财务部',

--- a/lib/routes/zzu/zcycwb.ts
+++ b/lib/routes/zzu/zcycwb.ts
@@ -1,0 +1,74 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+
+export const route: Route = {
+    path: '/zcycwb/:type',
+    categories: ['university'],
+    example: '/zzu/zcycwb/xwzx',
+    parameters: { type: '分类名' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['https://www5.zzu.edu.cn/zcycwb/'],
+        },
+    ],
+    name: '郑大资产与财务部',
+    maintainers: ['misty'],
+    handler,
+    description: `| 新闻资讯 | 通知公告 |
+| -------- | -------- |
+| xwzx     | tzgg     |`,
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type');
+    const type_dict = {
+        xwzx: [
+            '新闻资讯', // 分类名称
+            'https://www5.zzu.edu.cn/zcycwb/xwdt.htm',
+        ],
+        tzgg: ['通知公告', 'https://www5.zzu.edu.cn/zcycwb/tzgg.htm'],
+    };
+
+    // 获取页面内容
+    const response = await got(type_dict[type][1]);
+    const $ = load(response.data);
+
+    // 解析页面内容并提取文章信息
+    const list = $('.list ul li')
+        .slice(0, 20)
+        .toArray()
+        .map((element) => {
+            const $element = $(element);
+            const $link = $element.find('a').first();
+            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const title = $link.attr('title') || $link.text().trim();
+
+            // 获取发布时间 (格式: [yyyy-mm-dd])
+            const pubDateText = $element.find('i').text().trim().replaceAll(/[[\]]/g, '');
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText || null,
+            };
+        });
+
+    // 保留结构以便将来扩展，当前直接返回列表项
+    const items = list.map((item) => item);
+
+    return {
+        title: `郑大资产与财务部-${type_dict[type][0]}`,
+        link: type_dict[type][1],
+        item: items,
+    };
+}

--- a/lib/routes/zzu/zcycwb.ts
+++ b/lib/routes/zzu/zcycwb.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         },
     ],
     name: '郑大资产与财务部',
-    maintainers: ['misty'],
+    maintainers: ['amandus1990'],
     handler,
     description: `| 新闻资讯 | 通知公告 |
 | -------- | -------- |
@@ -31,7 +31,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = ctx.req.param('type');
-    const type_dict = {
+    const typeDict = {
         xwzx: [
             '新闻资讯', // 分类名称
             'https://www5.zzu.edu.cn/zcycwb/xwdt.htm',
@@ -40,17 +40,17 @@ async function handler(ctx) {
     };
 
     // 获取页面内容
-    const response = await got(type_dict[type][1]);
+    const response = await got(typeDict[type][1]);
     const $ = load(response.data);
 
     // 解析页面内容并提取文章信息
     const list = $('.list ul li')
-        .slice(0, 20)
+        .slice(0, 15)
         .toArray()
         .map((element) => {
             const $element = $(element);
             const $link = $element.find('a').first();
-            const link = new URL($link.attr('href'), type_dict[type][1]).href;
+            const link = new URL($link.attr('href'), typeDict[type][1]).href;
             const title = $link.attr('title') || $link.text().trim();
 
             // 获取发布时间 (格式: [yyyy-mm-dd])
@@ -63,12 +63,9 @@ async function handler(ctx) {
             };
         });
 
-    // 保留结构以便将来扩展，当前直接返回列表项
-    const items = list.map((item) => item);
-
     return {
-        title: `郑大资产与财务部-${type_dict[type][0]}`,
-        link: type_dict[type][1],
-        item: items,
+        title: `郑大资产与财务部-${typeDict[type][0]}`,
+        link: typeDict[type][1],
+        item: list,
     };
 }


### PR DESCRIPTION
Add routes for Zhengzhou University departments:

- news: 新闻网 (要闻速递、教学科研、基层动态、媒体郑大)
- tzhb: 党委统战部 (工作动态、通知公告)
- dzb: 党政办 (新闻资讯、通知公告)
- dwzzb: 党委组织部 (党建工作、干部工作、人才工作、乡村振兴工作)
- xuan: 党委宣传部 (工作动态、通知公告)
- rsc: 人事部 (人事要闻、通知公告、招聘公告)
- jwc: 教务部 (新闻快递、通知公告)
- student: 学生处 (新闻资讯、通知公告)
- kjc: 科研院 (新闻资讯、通知公告)
- ss: 社科院 (新闻资讯、通知公告)
- zcycwb: 资产与财务部 (新闻资讯、通知公告)
- gs: 研究生院 (新闻资讯、通知公告)
- xbx: 校长办 (新闻资讯、通知公告)

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zzu/news/ywsd
/zzu/news/jxky
/zzu/news/jcdt
/zzu/news/mtzd
/zzu/rsc/rsyw
/zzu/rsc/tzgg
/zzu/rsc/zpxx
/zzu/ss/xwzx
/zzu/ss/tzgg
/zzu/student/xwzx
/zzu/student/tzgg
/zzu/tzhb/gzdt
/zzu/tzhb/tzgg
/zzu/xbx/xwzx
/zzu/xbx/tzgg
/zzu/xuan/gzdt
/zzu/xuan/tzgg
/zzu/zcycwb/xwzx
/zzu/zcycwb/tzgg
/zzu/kjc/xwzx
/zzu/kjc/tzgg
/zzu/jwc/xwkd
/zzu/jwc/tzgg
/zzu/gs/xwzx
/zzu/gs/tzgg
/zzu/dzb/xwzx
/zzu/dzb/tzgg
/zzu/dwzzb/djgz
/zzu/dwzzb/gbgz
/zzu/dwzzb/rcgz
/zzu/dwzzb/fpgz
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
