### PR TITLE
fix(route/baoyu): handle HTTP redirect for feed.xml

### DIFF
--- a/lib/routes/baoyu/index.ts
+++ b/lib/routes/baoyu/index.ts
@@ -2,7 +2,7 @@ import { load } from 'cheerio';
 
 import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
-import got from '@/utils/got';
+import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 import parser from '@/utils/rss-parser';
 
@@ -17,7 +17,7 @@ export const route: Route = {
     ],
     url: 'baoyu.io/',
     name: 'Blog',
-    maintainers: ['liyaozhong'],
+    maintainers: ['liyaozhong', 'Circloud'],
     handler,
     description: '宝玉 - 博客文章',
 };
@@ -26,15 +26,16 @@ async function handler() {
     const rootUrl = 'https://baoyu.io';
     const feedUrl = `${rootUrl}/feed.xml`;
 
-    const feed = await parser.parseURL(feedUrl);
+    const response = await ofetch(feedUrl);
+    const feed = await parser.parseString(response);
 
     const items = await Promise.all(
         feed.items.map((item) => {
             const link = item.link;
 
             return cache.tryGet(link as string, async () => {
-                const response = await got(link);
-                const $ = load(response.data);
+                const response = await ofetch(link as string);
+                const $ = load(response);
 
                 const container = $('.container');
                 const content = container.find('.prose').html() || '';


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/baoyu/blog
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fixes the "Non-whitespace before first tag" error when accessing the /baoyu/blog route

### Cause of the bug
The feed URL provided by [original website](https://baoyu.io/) for parsing the post link `https://baoyu.io/feed.xml` returns HTTP 301 redirect to `https://s.baoyu.io/feed.xml`.
The `parser.parseURL()` method uses Node.js native http/https modules which don't follow redirects automatically, causing it to try parsing the redirect response as XML.

### Solution
Changed from `parser.parseURL()` to `ofetch()` + `parser.parseString()` which follow redirection.