### PR TITLE
feat(route): Add ChatGPT Atlas release notes route

### DIFF
--- a/lib/routes/openai/chatgpt-atlas.ts
+++ b/lib/routes/openai/chatgpt-atlas.ts
@@ -1,9 +1,10 @@
 import { load } from 'cheerio';
 import dayjs from 'dayjs';
 
+import { config } from '@/config';
 import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
-import puppeteer from '@/utils/puppeteer';
+import ofetch from '@/utils/ofetch';
 
 export const route: Route = {
     path: '/chatgpt-atlas/release-notes',
@@ -11,7 +12,7 @@ export const route: Route = {
     example: '/openai/chatgpt-atlas/release-notes',
     features: {
         requireConfig: false,
-        requirePuppeteer: true,
+        requirePuppeteer: false,
         antiCrawler: false,
         supportBT: false,
         supportPodcast: false,
@@ -28,117 +29,52 @@ async function handler() {
     const cacheIn = await cache.tryGet(
         articleUrl,
         async () => {
-            const browser = await puppeteer();
-            const page = await browser.newPage();
-            await page.setRequestInterception(true);
-            page.on('request', (request) => {
-                request.resourceType() === 'document' || request.resourceType() === 'script' ? request.continue() : request.abort();
-            });
-            await page.goto(articleUrl, {
-                waitUntil: 'domcontentloaded',
-            });
-            const html = await page.evaluate(() => document.documentElement.innerHTML);
-            await page.close();
-
-            const $ = load(html);
+            const response = await ofetch(articleUrl);
+            const $ = load(response);
             const articleContent = $('.article-content');
 
             if (articleContent.length === 0) {
-                throw new Error('Failed to find article content. Possible Cloudflare protection.');
+                throw new Error('Failed to find article content.');
             }
 
             const feedTitle = $('h1').first().text();
             const feedDesc = 'ChatGPT Atlas Release Notes';
 
-            const items: DataItem[] = [];
+            const items = $('h1', articleContent)
+                .toArray()
+                .map((element) => {
+                    const $h1 = $(element);
+                    const text = $h1.text().trim();
 
-            articleContent.children('h1').each((_, element) => {
-                const $h1 = $(element);
-                const text = $h1.text().trim();
-
-                const dateMatch = text.match(/(\w+\s+\d+[stndrh]*,\s+\d{4})/i);
-                let pubDate: Date | undefined;
-                if (dateMatch) {
-                    const dateStr = dateMatch[1];
-                    const parsedDate = dayjs(dateStr, ['MMMM Do, YYYY', 'MMMM D, YYYY'], 'en');
-                    if (parsedDate.isValid()) {
-                        pubDate = parsedDate.toDate();
-                    }
-                }
-
-                const buildMatch = text.match(/(?:Build\s*Number\s*:|Build\s*:)\s*(\d+\.\d+\.\d+\.\d+)/i);
-                let buildInfo = '';
-                let titleText = text;
-
-                if (buildMatch) {
-                    buildInfo = `<p>Build: ${buildMatch[1]}</p>`;
-                    titleText = text.replace(buildMatch[0], '').trim();
-                }
-
-                let description = buildInfo;
-
-                $h1.nextUntil('h1').each((_, sib) => {
-                    const $sib = $(sib);
-                    const tagName = sib.tagName.toLowerCase();
-
-                    switch (tagName) {
-                        case 'h2':
-                        case 'h3':
-                        case 'h4':
-                        case 'h5':
-                        case 'h6':
-                            description += `<${tagName}>${$sib.html()?.trim() || ''}</${tagName}>`;
-                            break;
-
-                        case 'ul':
-                        case 'ol': {
-                            const listItems = $sib
-                                .find('li')
-                                .toArray()
-                                .map((li) => {
-                                    const $li = $(li);
-                                    const liHtml = $li.html()?.trim();
-                                    return liHtml ? `<li>${liHtml}</li>` : null;
-                                })
-                                .filter(Boolean);
-                            if (listItems.length > 0) {
-                                description += `<${tagName}>${listItems.join('')}</${tagName}>`;
-                            }
-                            break;
-                        }
-                        case 'p': {
-                            const pHtml = $sib.html()?.trim();
-                            if (pHtml && !pHtml.toLowerCase().includes('public link to lgpl bundle')) {
-                                description += `<p>${pHtml}</p>`;
-                            }
-                            break;
-                        }
-                        case 'br':
-                            description += '<br>';
-                            break;
-                        default: {
-                            const html = $sib.html()?.trim();
-                            if (html) {
-                                description += html;
-                            }
+                    const dateMatch = text.match(/(\w+\s+\d+[stndrh]*,\s+\d{4})/i);
+                    let pubDate: Date | undefined;
+                    if (dateMatch) {
+                        const dateStr = dateMatch[1];
+                        const parsedDate = dayjs(dateStr, ['MMMM Do, YYYY', 'MMMM D, YYYY'], 'en');
+                        if (parsedDate.isValid()) {
+                            pubDate = parsedDate.toDate();
                         }
                     }
-                });
 
-                items.push({
-                    guid: `${articleUrl}#${pubDate ? pubDate.getTime() : titleText}`,
-                    title: titleText,
-                    link: articleUrl,
-                    pubDate,
-                    description,
-                });
-            });
+                    const content = $h1
+                        .nextUntil('h1')
+                        .toArray()
+                        .map((el) => $(el).prop('outerHTML'))
+                        .join('');
+                    const description = content;
 
-            await browser.close();
+                    return {
+                        guid: `${articleUrl}#${pubDate ? pubDate.getTime() : text}`,
+                        title: text,
+                        link: articleUrl,
+                        pubDate,
+                        description,
+                    };
+                }) as DataItem[];
 
             return { feedTitle, feedDesc, items };
         },
-        86400,
+        config.cache.routeExpire,
         false
     );
 


### PR DESCRIPTION
- Add route: /openai/chatgpt-atlas/release-notes
- Parse release notes from OpenAI help center
- Use Puppeteer to bypass Cloudflare protection
- Extract build version, date, and content sections
- Cache results for 24 hours
- Proper resource cleanup (browser.close())

<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/openai/chatgpt-atlas/release-notes
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
