### PR TITLE
fix(nuist): update bulletin route for new website structure

### DIFF
--- a/lib/routes/nuist/bulletin.ts
+++ b/lib/routes/nuist/bulletin.ts
@@ -97,7 +97,7 @@ async function handler(ctx) {
             const pubDate = dateMatch ? parseDate(dateMatch[1]) : null;
 
             // 尝试从 .wjj 提取分类，如果提取不到则回退到 map 中的标题
-            const categoryText = item.find('.wjj').attr('title') || item.find('.wjj').text().trim();
+            const categoryText = item.find('.wjj a').attr('title') || item.find('.wjj a').text().trim();
             const category = categoryText || info.title;
 
             // 提取作者：从 .arti_bm a 中提取


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/nuist/bulletin/default
/nuist/bulletin/wjgg
/nuist/bulletin/kyxx
```


New RSS Route Checklist / 新 RSS 路由检查表
 * [ ] New Route / 新的路由
   * [x] Follows Script Standard / 跟随 路由规范
 * [ ] Anti-bot or rate limit / 反爬/频率限制
   * [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
 * [ ] Date and time / 日期和时间
   * [x] Parsed / 可以解析
   * [x] Correct time zone / 时区正确
 * [ ] New package added / 添加了新的包
 * [ ] Puppeteer
Note / 说明
The official website of NUIST Bulletin has been updated from a static .htm structure (with ID-based routing) to a new structure. The previous route was returning 404.
This PR fixes the issue by:
 * Updating the map to use filename-based routing (e.g., wjgg.htm instead of IDs like 791).
 * Updating the selector logic to use a[href*="content.jsp"], which is more stable for the new table/list layout.
 * Updating the documentation description.
Tested locally, and date parsing is working correctly for the new format.