### PR TITLE
fix(route/njxzc): handle absolute URLs and update library page selectors

### DIFF
--- a/lib/routes/njxzc/lib.ts
+++ b/lib/routes/njxzc/lib.ts
@@ -68,23 +68,24 @@ async function handler() {
 
                 if ($('.wp_error_msg').length > 0) {
                     item.description = '您当前ip并非校内地址，该信息仅允许校内地址访问';
-                } else if ($('.wp_pdf_player').length > 0) {
-                    const pdfSrc = $('.wp_pdf_player').attr('pdfsrc') || '';
-                    const pdfUrl = pdfSrc.startsWith('http') ? pdfSrc : new URL(pdfSrc, host).href;
-                    item.description = `<a href="${pdfUrl}">附件下载</a>`;
                 } else {
-                    const contentHtml = $('.wp_articlecontent').html();
-                    if (contentHtml) {
-                        const $content = load(contentHtml);
-                        $content('a').each(function () {
-                            const a = $(this);
-                            const href = a.attr('href');
-                            if (href && !href.startsWith('http')) {
-                                a.attr('href', new URL(href, host).href);
-                            }
-                        });
-                        item.description = $content.html() || '';
-                    }
+                    const $content = $('.wp_articlecontent');
+                    // Convert wp_pdf_player iframes to download links
+                    $content.find('.wp_pdf_player').each(function () {
+                        const $iframe = $(this);
+                        const pdfSrc = $iframe.attr('pdfsrc') || '';
+                        const pdfUrl = pdfSrc.startsWith('http') ? pdfSrc : new URL(pdfSrc, host).href;
+                        $iframe.replaceWith(`<p><a href="${pdfUrl}">附件下载</a></p>`);
+                    });
+                    // Fix relative URLs
+                    $content.find('a').each(function () {
+                        const $a = $(this);
+                        const href = $a.attr('href');
+                        if (href && !href.startsWith('http')) {
+                            $a.attr('href', new URL(href, host).href);
+                        }
+                    });
+                    item.description = $content.html() || '';
                     const title = $('.arti_title').text().trim();
                     if (title) {
                         item.title = title;

--- a/lib/routes/njxzc/utils/index.ts
+++ b/lib/routes/njxzc/utils/index.ts
@@ -29,29 +29,28 @@ async function getNoticeList(ctx, url, host, titleSelector, dateSelector, conten
         list.map((item) =>
             cache.tryGet(item.link, async () => {
                 const response = await ofetch(item.link);
-                if (!response || (response.status >= 300 && response.status < 400)) {
-                    return {
-                        ...item,
-                        description: '该通知无法直接预览，请点击原文链接↑查看',
-                    };
-                }
                 const $ = load(response);
 
                 if ($('.wp_error_msg').length > 0) {
                     item.description = '您当前ip并非校内地址，该信息仅允许校内地址访问';
-                } else if ($('.wp_pdf_player').length > 0) {
-                    item.description = '该通知无法直接预览，请点击原文链接↑查看';
                 } else {
-                    const contentHtml = $(contentSelector.content).html();
-                    const $content = load(contentHtml);
-                    $content('a').each(function () {
-                        const a = $(this);
-                        const href = a.attr('href');
+                    const $content = $(contentSelector.content);
+                    // Convert wp_pdf_player iframes to download links
+                    $content.find('.wp_pdf_player').each(function () {
+                        const $iframe = $(this);
+                        const pdfSrc = $iframe.attr('pdfsrc') || '';
+                        const pdfUrl = pdfSrc.startsWith('http') ? pdfSrc : new URL(pdfSrc, host).href;
+                        $iframe.replaceWith(`<p><a href="${pdfUrl}">附件下载</a></p>`);
+                    });
+                    // Fix relative URLs
+                    $content.find('a').each(function () {
+                        const $a = $(this);
+                        const href = $a.attr('href');
                         if (href && !href.startsWith('http')) {
-                            a.attr('href', new URL(href, host).href);
+                            $a.attr('href', new URL(href, host).href);
                         }
                     });
-                    item.description = $content.html();
+                    item.description = $content.html() || '';
                     item.title = $(contentSelector.title).text();
                     const dateText = $(contentSelector.date).text().replace('编辑：', '').replace('发布日期：', '').replace('发布时间：', '');
                     item.pubDate = timezone(parseDate(dateText, 'YYYY-MM-DD'), +8);


### PR DESCRIPTION
- Fix URL concatenation in utils to handle absolute URLs properly
- Rewrite lib.ts handler for new library page layout with updated selectors

<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/njxzc/tzgg                                                                                                                       
/njxzc/libtzgg  
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This PR fixes two issues with the njxzc routes:                                                                                   
                                                                                                                                  
1. /njxzc/tzgg - URL concatenation error: Some links on the page are absolute URLs (e.g., pointing to xxgk.njxzc.edu.cn), but the code blindly concatenated host + href, resulting in malformed URLs like https://www.njxzc.edu.cnhttps://xxgk.njxzc.edu.cn/....    
Fixed by checking if href starts with http before concatenating.                                                                  
2. /njxzc/libtzgg - Empty route due to layout change: The library page (lib.njxzc.edu.cn/pxyhd/list.htm) structure has changed completely:                                                                                                                       
- Old: li.news items with a inside and .news_meta for date                                                                      
- New: a.btt-2 items containing .btt-4 for title and .tm-1/.tm-2 for date                                                                                                                                                                                   
Rewrote the handler with updated selectors to match the new layout.  