### PR TITLE
fix(utils): refactor parseRelativeDate to support dynamic reference

### DIFF
--- a/lib/utils/parse-date.test.ts
+++ b/lib/utils/parse-date.test.ts
@@ -54,6 +54,7 @@ describe('parseRelativeDate', () => {
         it('handles vague quantifiers (x / 几)', () => {
             // "几" maps to 3
             expect(p('几分钟前')).toBe(NOW_TIMESTAMP - 3 * minute);
+            expect(p('幾分鐘前')).toBe(NOW_TIMESTAMP - 3 * minute);
             expect(p('数秒前')).toBe(NOW_TIMESTAMP - 3 * second);
 
             // "x" maps to 3
@@ -79,6 +80,7 @@ describe('parseRelativeDate', () => {
             expect(p('in 10m')).toBe(NOW_TIMESTAMP + 10 * minute);
             expect(p('2 hours later')).toBe(NOW_TIMESTAMP + 2 * hour);
             expect(p('10分钟后')).toBe(NOW_TIMESTAMP + 10 * minute);
+            expect(p('10 分鐘後')).toBe(NOW_TIMESTAMP + 10 * minute);
         });
 
         it('handles mixed units', () => {
@@ -101,6 +103,7 @@ describe('parseRelativeDate', () => {
             // Strict past rule: If input weekday is Same as today, go back 1 week.
             expect(p('Monday')).toBe(PREVIOUS_MONDAY);
             expect(p('周一')).toBe(PREVIOUS_MONDAY);
+            expect(p('星期一')).toBe(PREVIOUS_MONDAY);
         });
 
         it('handles "Monday 3pm" (Strict Past)', () => {
@@ -145,6 +148,8 @@ describe('parseRelativeDate', () => {
             expect(p('昨晚8点')).toBe(YESTERDAY_START + 20 * hour);
             // "周五下午3点" -> Last Friday 15:00
             expect(p('周五下午3点')).toBe(LAST_FRIDAY + 15 * hour);
+            // https://github.com/DIYgod/RSSHub/issues/20878
+            expect(p('昨天 23:01')).toBe(YESTERDAY_START + 23 * hour + 1 * minute);
         });
 
         it('handles 12am / 12pm edge cases', () => {

--- a/lib/utils/parse-date.ts
+++ b/lib/utils/parse-date.ts
@@ -40,7 +40,7 @@ interface UnitPattern {
 
 // === Pre-compiled Regular Expressions ===
 
-const REGEX_JUST_NOW = /^(?:just\s?now|刚刚)$/i;
+const REGEX_JUST_NOW = /^(?:just\s?now|刚刚|剛剛)$/i;
 const REGEX_AGO = /(.*)(?:ago|[之以]?前)$/i;
 const REGEX_IN = /^(?:in\s*)(.*)|(.*)(?:\s*later|\s*after|[之以]?[后後])$/i;
 const REGEX_STICKY_AMPM = /(\d+)\s*(a|p)m$/i;


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #20878 #20877

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/latepost
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Refactored `parseRelativeDate` in `lib/utils/parse-date.ts` to address multiple parsing issues and logic errors.

**Key Changes:**

1.  **Dynamic Reference Date**: Fixed an issue where keywords like "Yesterday" were calculated based on server start time instead of invocation time.
2.  **Strict Past Weekdays**: Implemented logic to ensure weekdays (e.g., "Monday") always resolve to the most recent past occurrence (or today) relative to the current date, avoiding future dates.
3.  **Enhanced Semantic Support**:
    - Added support for sticky AM/PM formats (e.g., `3pm`, `Today 3pm`).
    - Added support for Chinese contextual modifiers (e.g., `明早` -> Tomorrow Morning, `昨晚` -> Yesterday Evening).
    - Improved handling of vague quantifiers (e.g., `just now`, `x days ago`, `几分钟前`).