### PR TITLE
feat(route): add TCTMD conference news

### DIFF
--- a/lib/routes/tctmd/conference-news.ts
+++ b/lib/routes/tctmd/conference-news.ts
@@ -20,18 +20,18 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['tctmd.com/news/conference-news'],
+            source: ['www.tctmd.com/news/conference-news'],
         },
     ],
     name: 'Conference News',
     maintainers: ['ChuYinan2023'],
     handler,
-    url: 'tctmd.com/news/conference-news',
+    url: 'www.tctmd.com/news/conference-news',
 };
 
 async function handler() {
     const rootUrl = 'https://www.tctmd.com';
-    const currentUrl = `${rootUrl}/news/conference-news`;
+    const currentUrl = `${rootUrl}/search?keyword=&f%5B0%5D=news_subtype%3AConference%20News&f%5B1%5D=type%3Anews`;
 
     const response = await got({
         method: 'get',
@@ -40,88 +40,56 @@ async function handler() {
 
     const $ = load(response.data);
 
-    const items = [];
+    const items = $('.views-row article.news-teaser')
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+            const $link = $el.find('h2.algolia-search--title a').first();
+            const href = $link.attr('href');
+            if (!href) {
+                return null;
+            }
 
-    // 1. Extract the featured article (article.hub-featured-teaser)
-    const featured = $('article.hub-featured-teaser');
-    if (featured.length) {
-        const $link = featured.find('h2 a, h1 a, .hub-title a').first();
-        const href = $link.attr('href');
-        if (href) {
-            items.push({
+            return {
                 title: $link.text().trim(),
                 link: href.startsWith('http') ? href : `${rootUrl}${href}`,
-                pubDate: featured.find('time').attr('datetime') ? parseDate(featured.find('time').attr('datetime')) : undefined,
-                author: featured.find('.node-meta__text a').text().trim() || undefined,
-            });
-        }
-    }
+                pubDate: $el.find('time.datetime').attr('datetime') ? parseDate($el.find('time.datetime').attr('datetime')!) : undefined,
+                author: $el.find('.author__container--name').text().trim() || undefined,
+                image: $el.find('.field--name-field-teaser-image img').attr('src') || undefined,
+            };
+        })
+        .filter(Boolean);
 
-    // 2. Extract list articles (.view-content .item-list li)
-    for (const el of $('.view-content .item-list li').toArray()) {
-        const $el = $(el);
-        const $link = $el.find('.hub-title a').first();
-        const href = $link.attr('href');
-        if (!href) {
-            continue;
-        }
-
-        const title = $el.find('.hub-title a span').text().trim() || $link.text().trim();
-        const datetime = $el.find('time').attr('datetime');
-        const author = $el.find('.node-meta__text a').text().trim();
-        const img = $el.find('.editor-pick-image img').first();
-        const imgSrc = img.attr('src') || img.attr('data-src') || '';
-
-        items.push({
-            title,
-            link: href.startsWith('http') ? href : `${rootUrl}${href}`,
-            pubDate: datetime ? parseDate(datetime) : undefined,
-            author: author || undefined,
-            image: imgSrc || undefined,
-        });
-    }
-
-    // 3. Fetch full article content with caching
     const fullItems = await Promise.all(
         items.map((item) =>
             cache.tryGet(item.link, async () => {
-                try {
-                    const detailResponse = await got({
-                        method: 'get',
-                        url: item.link,
-                    });
-                    const content = load(detailResponse.data);
+                const detailResponse = await got({
+                    method: 'get',
+                    url: item.link,
+                });
+                const content = load(detailResponse.data);
 
-                    // Extract article body
-                    const articleBody = content('.field--name-field-body-content').html() || content('.field--name-body').html() || content('.node__content .field--name-field-body').html() || '';
+                const articleBody = content('.field--name-field-body-content').html() || '';
+                const introText = content('.field--name-field-intro-text').text().trim();
 
-                    // Extract intro text / summary
-                    const subhead = content('.field--name-field-intro-text').text().trim() || content('.field--name-field-subhead').text().trim();
+                if (articleBody) {
+                    item.description = (introText ? `<p><strong>${introText}</strong></p>` : '') + articleBody;
+                } else if (introText) {
+                    item.description = introText;
+                }
 
-                    // Build description: subhead + body content
-                    if (articleBody) {
-                        item.description = (subhead ? `<p><strong>${subhead}</strong></p>` : '') + articleBody;
-                    } else if (subhead) {
-                        item.description = subhead;
+                if (!item.pubDate) {
+                    const detailTime = content('time').first().attr('datetime');
+                    if (detailTime) {
+                        item.pubDate = parseDate(detailTime);
                     }
+                }
 
-                    // Extract more precise date from detail page if not already present
-                    if (!item.pubDate) {
-                        const detailTime = content('time').first().attr('datetime');
-                        if (detailTime) {
-                            item.pubDate = parseDate(detailTime);
-                        }
+                if (!item.author) {
+                    const detailAuthor = content('.node-meta__text a').first().text().trim();
+                    if (detailAuthor) {
+                        item.author = detailAuthor;
                     }
-
-                    // Extract author from detail page if not already present
-                    if (!item.author) {
-                        const detailAuthor = content('.node-meta__text a').first().text().trim();
-                        if (detailAuthor) {
-                            item.author = detailAuthor;
-                        }
-                    }
-                } catch {
-                    // If fetching detail fails, keep the item with list-page info only
                 }
 
                 return item;
@@ -132,7 +100,7 @@ async function handler() {
     return {
         title: 'TCTMD - Conference News',
         description: 'Latest conference news coverage from TCTMD, the leading source for interventional cardiology news',
-        link: currentUrl,
+        link: `${rootUrl}/news/conference-news`,
         image: 'https://www.tctmd.com/themes/tctmd/logo.svg',
         item: fullItems,
     };

--- a/lib/routes/tctmd/namespace.ts
+++ b/lib/routes/tctmd/namespace.ts
@@ -2,7 +2,7 @@ import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
     name: 'TCTMD',
-    url: 'tctmd.com',
+    url: 'www.tctmd.com',
     description: 'Cardiovascular news, education, and clinical trial coverage from the Cardiovascular Research Foundation',
     lang: 'en',
 };

--- a/lib/routes/tctmd/radar.ts
+++ b/lib/routes/tctmd/radar.ts
@@ -1,7 +1,0 @@
-export const radar = [
-    {
-        title: 'Conference News',
-        source: ['tctmd.com/news/conference-news'],
-        target: '/tctmd/conference-news',
-    },
-];


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/tctmd/conference-news
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add RSS feed support for [TCTMD](https://www.tctmd.com) Conference News section.

TCTMD is the leading source for interventional cardiology news and education from the Cardiovascular Research Foundation.

### Route: `/tctmd/conference-news`

- Scrapes the conference news listing page
- Extracts featured article + list articles (title, link, date, author, thumbnail)
- Fetches full article content for each item with caching (`cache.tryGet`)
- Uses `cheerio` for HTML parsing, `got` for HTTP requests
- Date/time parsed from `<time datetime="">` elements (UTC, ISO 8601)
- No anti-bot measures encountered; no Puppeteer needed
- No new packages added