### PR TITLE
feat: add opengithub-weekly-rank route, display the journal of opengithub o…

### DIFF
--- a/lib/routes/opengithub-trending/namespace.ts
+++ b/lib/routes/opengithub-trending/namespace.ts
@@ -1,0 +1,13 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'opengithub-trending',
+    url: 'github.com/OpenGithubs/github-weekly-rank/',
+    description: `OpenGithubs Weekly 是一个开源项目，
+    旨在每周分享 GitHub 上最受欢迎的开源项目。
+    `,
+    lang: 'zh-CN',
+    zh: {
+        name: 'github每周趋势',
+    },
+};

--- a/lib/routes/opengithub-trending/weekly-rank.ts
+++ b/lib/routes/opengithub-trending/weekly-rank.ts
@@ -1,0 +1,87 @@
+import type { Route } from '@/types';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/weekly',
+    categories: ['programming'],
+    example: '/opengithub-trending/weekly',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['github.com/OpenGithubs/github-weekly-rank'],
+            target: '/opengithub-trending/weekly',
+        },
+    ],
+    name: 'Weekly Rank',
+    maintainers: ['Nemocccc'],
+    description: '追踪 OpenGithubs 每周发布的开源项目排行榜',
+    handler,
+};
+
+async function handler() {
+    const repoUrl = 'https://api.github.com/repos/OpenGithubs/github-weekly-rank/contents';
+
+    const yearResponse = await got(repoUrl);
+    const years = yearResponse.data
+        .filter((item: any) => item.type === 'dir' && /^\d{4}$/.test(item.name))
+        .sort((a: any, b: any) => b.name.localeCompare(a.name))
+        .slice(0, 2);
+
+    const monthPromises = years.map((yearItem: any) =>
+        got(repoUrl + '/' + yearItem.name).then((monthResponse) => ({
+            year: yearItem.name,
+            months: monthResponse.data
+                .filter((item: any) => item.type === 'dir')
+                .sort((a: any, b: any) => b.name.localeCompare(a.name))
+                .slice(0, 3),
+        }))
+    );
+
+    const monthData = await Promise.all(monthPromises);
+
+    const dayPromises = monthData.flatMap(({ year, months }: any) =>
+        months.map((monthItem: any) =>
+            got(repoUrl + '/' + year + '/' + monthItem.name).then((dayResponse) => ({
+                year,
+                month: monthItem.name,
+                days: dayResponse.data
+                    .filter((item: any) => item.type === 'file' && item.name.endsWith('.md'))
+                    .sort((a: any, b: any) => b.name.localeCompare(a.name))
+                    .slice(0, 5),
+            }))
+        )
+    );
+
+    const allDayData = await Promise.all(dayPromises);
+
+    const filePromises = allDayData.flatMap(({ year, month, days }: any) =>
+        days.map((dayItem: any) => {
+            const fileName = dayItem.name.replace('.md', '');
+            const fileUrl = 'https://raw.githubusercontent.com/OpenGithubs/github-weekly-rank/main/' + year + '/' + month + '/' + dayItem.name;
+            return got(fileUrl).then((fileContent) => ({
+                title: 'GitHub Weekly Rank - ' + fileName,
+                description: fileContent.data,
+                link: 'https://github.com/OpenGithubs/github-weekly-rank/blob/main/' + year + '/' + month + '/' + fileName + '.md',
+                pubDate: parseDate(year + '-' + month + '-' + fileName.slice(6)),
+            }));
+        })
+    );
+
+    const items = (await Promise.all(filePromises)).slice(0, 20);
+
+    return {
+        title: 'OpenGithubs Weekly Rank',
+        link: 'https://github.com/OpenGithubs/github-weekly-rank',
+        description: 'OpenGithubs 每周开源项目排行榜',
+        item: items,
+    };
+}


### PR DESCRIPTION
discription / pr描述
I add a new route, about github trending weekly.
tracking the journals update of [opengithub-weekly-rank](https://github.com/OpenGithubs/github-weekly-rank/tree/main)

Involved Issue / 该 PR 相关 Issue
No

Close #

Example for the Proposed Route(s) / 路由地址示例
http://rsshub.app/opengithub-trending/weekly

/opengithub-trending/weekly-rank
New RSS Route Checklist / 新 RSS 路由检查表
[ x ] New Route / 新的路由
[ x ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
 Anti-bot or rate limit / 反爬/频率限制
 If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
 [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
 Parsed / 可以解析
 Correct time zone / 时区正确
 New package added / 添加了新的包
 Puppeteer
Note / 说明
