### PR TITLE
feat(route): add kfyqzc open registration route

### DIFF
--- a/lib/routes/ptyqm/kfyqzc.ts
+++ b/lib/routes/ptyqm/kfyqzc.ts
@@ -1,0 +1,97 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+
+const baseUrl = 'http://www.ptyqm.com';
+const listUrl = `${baseUrl}/category/kfyqzc/`;
+type ListItem = {
+    title: string;
+    link: string;
+    pubDate: Date | undefined;
+    category: string[];
+};
+
+export const route: Route = {
+    path: '/kfyqzc',
+    categories: ['blog'],
+    example: '/ptyqm/kfyqzc',
+    radar: [
+        {
+            source: ['www.ptyqm.com/category/kfyqzc/'],
+            target: '/kfyqzc',
+        },
+    ],
+    name: '开放注册',
+    maintainers: ['onlyMyKazari'],
+    handler,
+    description: 'PT邀请网开放注册栏目，提供 PT 站点开注信息。',
+};
+
+async function handler(ctx) {
+    const { data } = await got(listUrl);
+    const $ = load(data);
+
+    const list = $('#main article[id^="post-"]')
+        .slice(0, ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 20)
+        .toArray()
+        .map((item) => {
+            const article = $(item);
+            const link = article.find('h2.entry-title a').attr('href');
+
+            return {
+                title: article.find('h2.entry-title a').text(),
+                link,
+                pubDate: parseDate(article.find('time').first().attr('datetime')),
+                category: article
+                    .find('.post-tag a')
+                    .toArray()
+                    .map((tag) => $(tag).text().trim())
+                    .filter(Boolean),
+            };
+        })
+        .filter((item): item is ListItem => Boolean(item.link));
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const { data: detail } = await got(item.link);
+                const $ = load(detail);
+
+                const content = $('.entry-content').first().clone();
+                content.find('.entry-meta, .single-cat-tag, .single-tag, .entry-more').remove();
+                content.find('img').each((_, element) => {
+                    const node = $(element);
+                    const src = node.attr('src');
+                    const dataSrc = node.attr('data-src') ?? node.attr('data-original');
+                    if (src?.startsWith('data:image') && dataSrc) {
+                        node.attr('src', dataSrc);
+                    }
+                });
+
+                const category = [
+                    ...new Set([
+                        ...(item.category ?? []),
+                        ...$('.single-cat-tag a, .single-tag a')
+                            .toArray()
+                            .map((tag) => $(tag).text().trim())
+                            .filter(Boolean),
+                    ]),
+                ];
+
+                item.description = content.html();
+                item.category = category;
+
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: 'PT邀请码网 - 开放注册',
+        link: listUrl,
+        item: items,
+    };
+}

--- a/lib/routes/ptyqm/namespace.ts
+++ b/lib/routes/ptyqm/namespace.ts
@@ -1,0 +1,9 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'PT邀请码网',
+    url: 'www.ptyqm.com',
+    categories: ['blog'],
+    description: 'PT站开放注册与邀请码信息。',
+    lang: 'zh-CN',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

none

## Example for the Proposed Route(s) / 路由地址示例

```routes
/ptyqm/kfyqzc
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## 说明

新增 `PT邀请码网` 路由：
- 路径：`/ptyqm/kfyqzc`
- 目标页面：`http://www.ptyqm.com/category/kfyqzc/`
- 功能：抓取开注栏目列表，进入详情页提取正文并缓存；`pubDate` 以列表页发布时间为准；提取文章标签到 `category` 字段。
- 未新增依赖，未使用 Puppeteer。

## Note

Added a new route for **PT邀请码网**:

- Path: `/ptyqm/kfyqzc`
- Target page: `http://www.ptyqm.com/category/kfyqzc/`
- Functionality:
  - Fetches the open-registration post list from the category page
  - Retrieves and caches article details
  - Uses publication time from the list page as `pubDate`
  - Extracts post tags into the `category` field
- No new dependencies added
- Puppeteer is not used

