### PR TITLE
fix: ensure build directory exists for CF worker build

### DIFF
--- a/scripts/workflow/build-routes.ts
+++ b/scripts/workflow/build-routes.ts
@@ -101,6 +101,10 @@ export type RoutePath =
 ${uniquePaths.map((path) => `  | \`${path}\``).join('\n')};
 `;
 
+// Ensure output directory exists
+const buildDir = path.join(__dirname, '../../assets/build');
+fs.mkdirSync(buildDir, { recursive: true });
+
 // For Worker build, only output routes-worker.js with filtered namespaces
 // For regular build, output all files
 if (isWorkerBuild) {


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Fixes Cloudflare Worker deployment issue where build directory doesn't exist.

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## Note / 说明

Creates the output directory recursively before writing routes-worker.js to prevent ENOENT errors during build step.