### PR TITLE
feat(sina): add finance rollnews

### DIFF
--- a/lib/routes/sina/finance/rollnews.ts
+++ b/lib/routes/sina/finance/rollnews.ts
@@ -1,0 +1,59 @@
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+
+import { getRollNewsList, parseArticle, parseRollNewsList } from '../utils';
+
+export const route: Route = {
+    path: '/finance/rollnews/:lid?',
+    categories: ['new-media'],
+    example: '/sina/finance/rollnews',
+    parameters: { lid: '分区 id，见下表，默认为 `2519`' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['finance.sina.com.cn/roll', 'finance.sina.com.cn/'],
+            target: '/finance/rollnews',
+        },
+    ],
+    name: '财经－滚动新闻',
+    maintainers: ['betterandbetterii'],
+    handler,
+    url: 'finance.sina.com.cn/roll',
+    description: `| 财经 | 股市 | 美股 | 中国概念股 | 港股 | 研究报告 | 全球市场 | 外汇 |
+| ---- | ---- | ---- | ---------- | ---- | -------- | -------- | ---- |
+| 2519 | 2671 | 2672 | 2673       | 2674 | 2675     | 2676     | 2487 |`,
+};
+
+async function handler(ctx) {
+    const map = {
+        2519: '财经',
+        2671: '股市',
+        2672: '美股',
+        2673: '中国概念股',
+        2674: '港股',
+        2675: '研究报告',
+        2676: '全球市场',
+        2487: '外汇',
+    };
+
+    const pageid = '384';
+    const { lid = '2519' } = ctx.req.param();
+    const { limit = '50' } = ctx.req.query();
+    const response = await getRollNewsList(pageid, lid, limit);
+    const list = parseRollNewsList(response.data.result.data);
+
+    const out = await Promise.all(list.map((item) => parseArticle(item, cache.tryGet)));
+
+    return {
+        title: `新浪财经－${map[lid] ?? lid}滚动新闻`,
+        link: `https://finance.sina.com.cn/roll/#pageid=${pageid}&lid=${lid}&k=&num=${limit}&page=1`,
+        item: out,
+    };
+}


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/sina/finance/rollnews
/sina/finance/rollnews/2519
/sina/finance/rollnews/2671
/sina/finance/rollnews/2672
/sina/finance/rollnews/2673
/sina/finance/rollnews/2674
/sina/finance/rollnews/2675
/sina/finance/rollnews/2676
/sina/finance/rollnews/2487
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows Script Standard / 跟随路由规范
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] Date and time / 日期和时间
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] Puppeteer

## Note / 说明

- Add sina/finance/rollnews for Sina Finance rolling news (pageid 384), with lid categories parsed from finance.sina.com.cn/roll/.
- Fetches list via https://feed.mix.sina.com.cn/api/roll/get, then parses article pages with existing Sina parser utilities and caches detail
requests via cache.tryGet().
- Includes radar rules for finance.sina.com.cn/roll.
