### PR TITLE
fix(route/smartlink): Remove HTML from the title for cnbc

### DIFF
--- a/lib/routes/smartlink/index.ts
+++ b/lib/routes/smartlink/index.ts
@@ -12,7 +12,10 @@ function parseTitle(smartlinkUrl: string): string {
         const dateIndex = pathSegments.findIndex((segment) => dateRegex.test(segment));
 
         // Use the segment after the date if found, otherwise use the last path segment
-        const titleSlug = dateIndex !== -1 && dateIndex < pathSegments.length - 1 ? pathSegments[dateIndex + 1] : pathSegments.at(-1) || '';
+        let titleSlug = dateIndex !== -1 && dateIndex < pathSegments.length - 1 ? pathSegments[dateIndex + 1] : pathSegments.at(-1) || '';
+
+        // Remove .html/.htm extension if present
+        titleSlug = titleSlug.replace(/\.(html?|htm)$/i, '');
 
         // Convert hyphens to spaces and capitalize each word
         return toTitleCase(titleSlug.replaceAll('-', ' '));


### PR DESCRIPTION
…g it when convert to feed title

<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/smartlink/cnbc
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

https://smartlink.bio/api/instagram/cnbc/posts

Original source for cnbc has `html` extension in the link. When parsing title from the url, we should remove the html.


```
{
    "id": "18068808686213106",
    "type": "photo",
    "imageUrl": "https://scontent-atl3-1.cdninstagram.com/v/t51.82787-15/633096458_18556669846013358_8192994272389238195_n.jpg?stp=dst-jpg_e35_tt6&_nc_cat=100&ccb=7-5&_nc_sid=18de74&efg=eyJlZmdfdGFnIjoiRkVFRC5iZXN0X2ltYWdlX3VybGdlbi5DMyJ9&_nc_ohc=TSlIfCeqfIAQ7kNvwE3YrJc&_nc_oc=Adk7FXQF0cyoOSgcLzHmeVrF-lb4LjliDsP38cZ6zCQavV2aHtBbrczWZZoy82dp3vA&_nc_zt=23&_nc_ht=scontent-atl3-1.cdninstagram.com&edm=AM6HXa8EAAAA&_nc_gid=OokH7H-CMeoLAzGoZb2X3w&oh=00_AfsNenZJsBcwxeWMFojgVJFFvmcZiNNZOkGufNFJS0QjQg&oe=6994783C",
    "smartlink": "https://www.cnbc.com/2026/02/12/waymo-begins-deploying-next-gen-ojai-robotaxis-to-extend-its-us-lead.html",
    "displayText": "",
    "created": "2026-02-13T03:00:16Z"
  },
```

Result after the fix

```
<item>
<title>Waymo Begins Deploying Next Gen Ojai Robotaxis to Extend Its Us Lead</title>
<description><p><img src="https://scontent-atl3-1.cdninstagram.com/v/t51.82787-15/633096458_18556669846013358_8192994272389238195_n.jpg?stp=dst-jpg_e35_tt6&amp;_nc_cat=100&amp;ccb=7-5&amp;_nc_sid=18de74&amp;efg=eyJlZmdfdGFnIjoiRkVFRC5iZXN0X2ltYWdlX3VybGdlbi5DMyJ9&amp;_nc_ohc=TSlIfCeqfIAQ7kNvwE3YrJc&amp;_nc_oc=Adk7FXQF0cyoOSgcLzHmeVrF-lb4LjliDsP38cZ6zCQavV2aHtBbrczWZZoy82dp3vA&amp;_nc_zt=23&amp;_nc_ht=scontent-atl3-1.cdninstagram.com&amp;edm=AM6HXa8EAAAA&amp;_nc_gid=OokH7H-CMeoLAzGoZb2X3w&amp;oh=00_AfsNenZJsBcwxeWMFojgVJFFvmcZiNNZOkGufNFJS0QjQg&amp;oe=6994783C" referrerpolicy="no-referrer"></p></description>
<link>https://www.cnbc.com/2026/02/12/waymo-begins-deploying-next-gen-ojai-robotaxis-to-extend-its-us-lead.html</link>
<guid isPermaLink="false">18068808686213106</guid>
<pubDate>Fri, 13 Feb 2026 03:00:16 GMT</pubDate>
</item>
```