### PR TITLE
chore(flake): update to pnpm 10 to fix building issue

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,11 @@
       # Helper to define the RSSHub package
       makeRSSHub = pkgs:
         let
-          pnpm = pkgs.pnpm_9;
+          pnpm = pkgs.pnpm_10;
           deps = pnpm.fetchDeps {
             pname = "rsshub";
             src = ./.;
-            hash = "sha256-ErMPvlOIDqn03s2P+tzbQbYPZFEax5P61O1DJputvo4=";
+            hash = "sha256-QG1cIkZh+qBA5Dipt0iDLuQpEOI45wdFhuG/CTcRVU8=";
             fetcherVersion = 2;
           };
         in


### PR DESCRIPTION
## Note / 说明

Original pnpm 9 causes: 
>  ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "patchedDependencies" configuration doesn't match the value found in the lockfile

And pnpm 10 works fine.