### PR TITLE
docs: Add Dashboard (Static RSS/Widget Dashboard) to Related Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ RSSHub delivers millions of contents aggregated from all kinds of sources, our v
 - [RSSAid](https://github.com/LeetaoGoooo/RSSAid) | RSSHub Radar for Android platform built with Flutter.
 - [DocSearch](https://github.com/Fatpandac/DocSearch) | Link RSSHub DocSearch into Raycast.
 - [Awesome RSSHub Routes](https://github.com/JackyST0/awesome-rsshub-routes) | Curated list of RSS feeds and RSSHub routes.
+- [Dashboard](https://github.com/Rozhovetskyi/Dashboard) | Lightweight, customizable, client - side RSS feeds dashboard.
 
 ## Contribute
 


### PR DESCRIPTION
I'm suggesting the addition of "Dashboard" to the Related Projects section.

It is a static, client-side RSS reader and widget manager. Since it has no backend, it relies on browser storage for persistence and can be run locally or hosted via GitHub Pages.

Technical Details:

Architecture: 100% client-side (Vanilla JS / Materialize CSS).
Storage: LocalStorage for settings, feed lists, and layout.
Features: Tabbed thematic organization, RSS/Google News support, and custom HTML widgets.
Portability: No installation or build steps required; supports JSON import/export for configuration.

Links:

Repository: https://github.com/Rozhovetskyi/Dashboard/
Demo: https://rozhovetskyi.github.io/Dashboard/demo