### PR TITLE
fix(route/dailypush): use puppeteer

### DIFF
--- a/lib/routes/bilibili/cache.ts
+++ b/lib/routes/bilibili/cache.ts
@@ -38,7 +38,7 @@ const getCookie = (disableConfig = false) => {
         let waitForRequest = new Promise<string>((resolve) => {
             resolve('');
         });
-        const { destory } = await getPuppeteerPage('https://space.bilibili.com/1/dynamic', {
+        const { destroy } = await getPuppeteerPage('https://space.bilibili.com/1/dynamic', {
             onBeforeLoad: (page) => {
                 waitForRequest = new Promise<string>((resolve) => {
                     page.on('requestfinished', async (request) => {
@@ -54,7 +54,7 @@ const getCookie = (disableConfig = false) => {
         });
         const cookieString = await waitForRequest;
         logger.debug(`Got bilibili cookie: ${cookieString}`);
-        await destory();
+        await destroy();
         return cookieString;
     });
 };

--- a/lib/routes/cjlu/yjsy/index.ts
+++ b/lib/routes/cjlu/yjsy/index.ts
@@ -86,7 +86,7 @@ async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 10;
     const url = `${host}index/${cate}.htm`;
 
-    const { page, destory, browser } = await getPuppeteerPage(url, {
+    const { page, destroy, browser } = await getPuppeteerPage(url, {
         onBeforeLoad: async (page) => {
             await page.setExtraHTTPHeaders(headers);
             await page.setUserAgent(headers['User-Agent']);
@@ -102,7 +102,7 @@ async function handler(ctx) {
     const cookieString = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
 
     const response = await page.content();
-    await destory();
+    await destroy();
 
     const $ = load(response);
 

--- a/lib/routes/dailypush/all.ts
+++ b/lib/routes/dailypush/all.ts
@@ -42,7 +42,7 @@ async function handler(ctx) {
     const { sort = '' } = ctx.req.param();
     const url = sort ? `${BASE_URL}/${sort}` : BASE_URL;
 
-    const { page, destory } = await getPuppeteerPage(url, {
+    const { page, destroy } = await getPuppeteerPage(url, {
         onBeforeLoad: async (page) => {
             await page.setRequestInterception(true);
             page.on('request', (request) => {
@@ -65,6 +65,6 @@ async function handler(ctx) {
             item: items,
         };
     } finally {
-        await destory();
+        await destroy();
     }
 }

--- a/lib/routes/dailypush/all.ts
+++ b/lib/routes/dailypush/all.ts
@@ -3,7 +3,7 @@ import { load } from 'cheerio';
 import type { Route } from '@/types';
 import puppeteer from '@/utils/puppeteer';
 
-import { BASE_URL, enhanceItemsWithSummaries, parseArticles } from './utils';
+import { BASE_URL, enhanceItemsWithSummaries, fetchPageHtml, parseArticles } from './utils';
 
 export const route: Route = {
     path: '/:sort?',
@@ -44,16 +44,7 @@ async function handler(ctx) {
 
     const browser = await puppeteer();
     try {
-        const page = await browser.newPage();
-        await page.setRequestInterception(true);
-        page.on('request', (request) => {
-            request.resourceType() === 'document' ? request.continue() : request.abort();
-        });
-
-        await page.goto(url, { waitUntil: 'domcontentloaded' });
-        const html = await page.content();
-        await page.close();
-
+        const html = await fetchPageHtml(browser, url, 'article');
         const $ = load(html);
         const list = parseArticles($, BASE_URL);
         const items = await enhanceItemsWithSummaries(browser, list);

--- a/lib/routes/dailypush/tags.ts
+++ b/lib/routes/dailypush/tags.ts
@@ -1,7 +1,7 @@
 import { load } from 'cheerio';
 
 import type { Route } from '@/types';
-import { getPuppeteerPage } from '@/utils/puppeteer';
+import puppeteer from '@/utils/puppeteer';
 
 import { BASE_URL, enhanceItemsWithSummaries, parseArticles } from './utils';
 
@@ -43,20 +43,21 @@ async function handler(ctx) {
     const { tag, sort = 'trending' } = ctx.req.param();
     const url = `${BASE_URL}/${tag}/${sort}`;
 
-    const { page, destroy } = await getPuppeteerPage(url, {
-        onBeforeLoad: async (page) => {
-            await page.setRequestInterception(true);
-            page.on('request', (request) => {
-                request.resourceType() === 'document' ? request.continue() : request.abort();
-            });
-        },
-    });
+    const browser = await puppeteer();
     try {
-        const html = await page.content();
-        const $ = load(html);
+        const page = await browser.newPage();
+        await page.setRequestInterception(true);
+        page.on('request', (request) => {
+            request.resourceType() === 'document' ? request.continue() : request.abort();
+        });
 
+        await page.goto(url, { waitUntil: 'domcontentloaded' });
+        const html = await page.content();
+        await page.close();
+
+        const $ = load(html);
         const list = parseArticles($, BASE_URL);
-        const items = await enhanceItemsWithSummaries(list);
+        const items = await enhanceItemsWithSummaries(browser, list);
 
         const pageTitle = $('title').text() || `DailyPush - ${tag.charAt(0).toUpperCase() + tag.slice(1)}`;
 
@@ -66,6 +67,6 @@ async function handler(ctx) {
             item: items,
         };
     } finally {
-        await destroy();
+        await browser.close();
     }
 }

--- a/lib/routes/dailypush/tags.ts
+++ b/lib/routes/dailypush/tags.ts
@@ -43,7 +43,7 @@ async function handler(ctx) {
     const { tag, sort = 'trending' } = ctx.req.param();
     const url = `${BASE_URL}/${tag}/${sort}`;
 
-    const { page, destory } = await getPuppeteerPage(url, {
+    const { page, destroy } = await getPuppeteerPage(url, {
         onBeforeLoad: async (page) => {
             await page.setRequestInterception(true);
             page.on('request', (request) => {
@@ -66,6 +66,6 @@ async function handler(ctx) {
             item: items,
         };
     } finally {
-        await destory();
+        await destroy();
     }
 }

--- a/lib/routes/dailypush/tags.ts
+++ b/lib/routes/dailypush/tags.ts
@@ -3,7 +3,7 @@ import { load } from 'cheerio';
 import type { Route } from '@/types';
 import puppeteer from '@/utils/puppeteer';
 
-import { BASE_URL, enhanceItemsWithSummaries, parseArticles } from './utils';
+import { BASE_URL, enhanceItemsWithSummaries, fetchPageHtml, parseArticles } from './utils';
 
 export const route: Route = {
     path: '/tag/:tag/:sort?',
@@ -45,16 +45,7 @@ async function handler(ctx) {
 
     const browser = await puppeteer();
     try {
-        const page = await browser.newPage();
-        await page.setRequestInterception(true);
-        page.on('request', (request) => {
-            request.resourceType() === 'document' ? request.continue() : request.abort();
-        });
-
-        await page.goto(url, { waitUntil: 'domcontentloaded' });
-        const html = await page.content();
-        await page.close();
-
+        const html = await fetchPageHtml(browser, url, 'article');
         const $ = load(html);
         const list = parseArticles($, BASE_URL);
         const items = await enhanceItemsWithSummaries(browser, list);

--- a/lib/routes/dailypush/utils.ts
+++ b/lib/routes/dailypush/utils.ts
@@ -25,7 +25,7 @@ export interface ArticleItem {
  */
 export async function fetchHtmlWithPuppeteer(url: string): Promise<string> {
     logger.http(`Requesting ${url}`);
-    const { page, destory } = await getPuppeteerPage(url, {
+    const { page, destroy } = await getPuppeteerPage(url, {
         onBeforeLoad: async (page) => {
             await page.setRequestInterception(true);
             page.on('request', (request) => {
@@ -36,7 +36,7 @@ export async function fetchHtmlWithPuppeteer(url: string): Promise<string> {
     try {
         return await page.content();
     } finally {
-        await destory();
+        await destroy();
     }
 }
 

--- a/lib/routes/dailypush/utils.ts
+++ b/lib/routes/dailypush/utils.ts
@@ -234,38 +234,41 @@ export async function enhanceItemsWithSummaries(items: ArticleItem[]): Promise<D
     const itemsWithoutUrl: DataItem[] = items.filter((item) => item.dailyPushUrl === undefined);
 
     const browser = await puppeteer();
-    const enhancedItems: DataItem[] = [];
 
     try {
         // Sequential fetching required to avoid multiple concurrent Puppeteer sessions (AGENTS.md Rule 43)
+        let chain: Promise<DataItem[]> = Promise.resolve([]);
         for (const item of itemsWithUrl) {
-            // eslint-disable-next-line no-await-in-loop
-            const enhanced = await cache.tryGet(item.dailyPushUrl!, async () => {
-                const page = await browser.newPage();
-                await page.setRequestInterception(true);
-                page.on('request', (request) => {
-                    request.resourceType() === 'document' ? request.continue() : request.abort();
-                });
+            chain = chain.then((acc) =>
+                cache
+                    .tryGet(item.dailyPushUrl!, async () => {
+                        const page = await browser.newPage();
+                        await page.setRequestInterception(true);
+                        page.on('request', (request) => {
+                            request.resourceType() === 'document' ? request.continue() : request.abort();
+                        });
 
-                try {
-                    logger.http(`Requesting ${item.dailyPushUrl}`);
-                    await page.goto(item.dailyPushUrl!, { waitUntil: 'domcontentloaded' });
-                    const html = await page.content();
-                    const $ = load(html);
-                    const summary = $('p.font-ibm-plex-sans.leading-relaxed').first();
-                    if (summary.length > 0 && summary.text().trim()) {
-                        item.description = summary.text().trim();
-                    }
-                } catch {
-                    // If fetching article page fails, keep the original description
-                } finally {
-                    await page.close();
-                }
+                        try {
+                            logger.http(`Requesting ${item.dailyPushUrl}`);
+                            await page.goto(item.dailyPushUrl!, { waitUntil: 'domcontentloaded' });
+                            const html = await page.content();
+                            const $ = load(html);
+                            const summary = $('p.font-ibm-plex-sans.leading-relaxed').first();
+                            if (summary.length > 0 && summary.text().trim()) {
+                                item.description = summary.text().trim();
+                            }
+                        } catch {
+                            // If fetching article page fails, keep the original description
+                        } finally {
+                            await page.close();
+                        }
 
-                return item;
-            });
-            enhancedItems.push(enhanced);
+                        return item;
+                    })
+                    .then((enhanced) => [...acc, enhanced])
+            );
         }
+        const enhancedItems = await chain;
 
         return [...enhancedItems, ...itemsWithoutUrl];
     } finally {

--- a/lib/routes/dailypush/utils.ts
+++ b/lib/routes/dailypush/utils.ts
@@ -73,14 +73,14 @@ function extractAuthor(article: ReturnType<CheerioAPI>): DataItem['author'] {
         return undefined;
     }
 
-    // Get all content spans (exclude separator spans with '•')
+    // Get all content spans (exclude separator spans with "•")
     const allSpans = container.find('span');
     const contentSpans: string[] = [];
 
     for (let i = 0; i < allSpans.length; i++) {
         const $span = allSpans.eq(i);
         const text = $span.text().trim();
-        // Skip separator spans (contain only '•' or have separator classes)
+        // Skip separator spans (contain only "•" or have separator classes)
         if (text !== '•' && !$span.hasClass('text-slate-300') && !$span.hasClass('dark:text-slate-600')) {
             contentSpans.push(text);
         }
@@ -160,14 +160,14 @@ function extractPubDate(article: ReturnType<CheerioAPI>): Date | undefined {
         return undefined;
     }
 
-    // Get all content spans (exclude separator spans with '•')
+    // Get all content spans (exclude separator spans with "•")
     const allSpans = container.find('span');
     const contentSpans: string[] = [];
 
     for (let i = 0; i < allSpans.length; i++) {
         const $span = allSpans.eq(i);
         const text = $span.text().trim();
-        // Skip separator spans (contain only '•' or have separator classes)
+        // Skip separator spans (contain only "•" or have separator classes)
         if (text !== '•' && !$span.hasClass('text-slate-300') && !$span.hasClass('dark:text-slate-600')) {
             contentSpans.push(text);
         }
@@ -265,29 +265,24 @@ export async function enhanceItemsWithSummaries(browser: Browser, items: Article
     const itemsWithUrl = items.filter((item) => item.dailyPushUrl !== undefined);
     const itemsWithoutUrl: DataItem[] = items.filter((item) => item.dailyPushUrl === undefined);
 
-    // Sequential fetching required to avoid multiple concurrent Puppeteer sessions (AGENTS.md Rule 43)
-    let chain: Promise<DataItem[]> = Promise.resolve([]);
-    for (const item of itemsWithUrl) {
-        chain = chain.then((acc) =>
-            cache
-                .tryGet(item.dailyPushUrl!, async () => {
-                    try {
-                        const html = await fetchPageHtml(browser, item.dailyPushUrl!, 'p.font-ibm-plex-sans.leading-relaxed');
-                        const $ = load(html);
-                        const summary = $('p.font-ibm-plex-sans.leading-relaxed').first();
-                        if (summary.length > 0 && summary.text().trim()) {
-                            item.description = summary.text().trim();
-                        }
-                    } catch {
-                        // If fetching article page fails, keep the original description
+    const enhancedItems = await Promise.all(
+        itemsWithUrl.map((item) =>
+            cache.tryGet(item.dailyPushUrl!, async () => {
+                try {
+                    const html = await fetchPageHtml(browser, item.dailyPushUrl!, 'p.font-ibm-plex-sans.leading-relaxed');
+                    const $ = load(html);
+                    const summary = $('p.font-ibm-plex-sans.leading-relaxed').first();
+                    if (summary.length > 0 && summary.text().trim()) {
+                        item.description = summary.text().trim();
                     }
+                } catch {
+                    // If fetching article page fails, keep the original description
+                }
 
-                    return item;
-                })
-                .then((enhanced) => [...acc, enhanced])
-        );
-    }
-    const enhancedItems = await chain;
+                return item;
+            })
+        )
+    );
 
     return [...enhancedItems, ...itemsWithoutUrl];
 }

--- a/lib/routes/dailypush/utils.ts
+++ b/lib/routes/dailypush/utils.ts
@@ -1,6 +1,6 @@
 import type { CheerioAPI } from 'cheerio';
 import { load } from 'cheerio';
-import type { Browser } from 'rebrowser-puppeteer';
+import type { Browser, Page } from 'rebrowser-puppeteer';
 
 import type { DataItem } from '@/types';
 import cache from '@/utils/cache';
@@ -18,6 +18,38 @@ export interface ArticleItem {
     description?: string;
     articleUrl: string;
     dailyPushUrl?: string;
+}
+
+const allowedRequestTypes = new Set(['document']);
+
+async function preparePage(page: Page) {
+    await page.setRequestInterception(true);
+    page.on('request', (request) => {
+        if (allowedRequestTypes.has(request.resourceType())) {
+            request.continue();
+            return;
+        }
+
+        request.abort();
+    });
+}
+
+export async function fetchPageHtml(browser: Browser, url: string, waitForSelector?: string): Promise<string> {
+    const page = await browser.newPage();
+    await preparePage(page);
+
+    try {
+        logger.http(`Requesting ${url}`);
+        await page.goto(url, { waitUntil: 'domcontentloaded' });
+
+        if (waitForSelector) {
+            await page.waitForSelector(waitForSelector);
+        }
+
+        return await page.content();
+    } finally {
+        await page.close();
+    }
 }
 
 /**
@@ -239,16 +271,8 @@ export async function enhanceItemsWithSummaries(browser: Browser, items: Article
         chain = chain.then((acc) =>
             cache
                 .tryGet(item.dailyPushUrl!, async () => {
-                    const page = await browser.newPage();
-                    await page.setRequestInterception(true);
-                    page.on('request', (request) => {
-                        request.resourceType() === 'document' ? request.continue() : request.abort();
-                    });
-
                     try {
-                        logger.http(`Requesting ${item.dailyPushUrl}`);
-                        await page.goto(item.dailyPushUrl!, { waitUntil: 'domcontentloaded' });
-                        const html = await page.content();
+                        const html = await fetchPageHtml(browser, item.dailyPushUrl!, 'p.font-ibm-plex-sans.leading-relaxed');
                         const $ = load(html);
                         const summary = $('p.font-ibm-plex-sans.leading-relaxed').first();
                         if (summary.length > 0 && summary.text().trim()) {
@@ -256,8 +280,6 @@ export async function enhanceItemsWithSummaries(browser: Browser, items: Article
                         }
                     } catch {
                         // If fetching article page fails, keep the original description
-                    } finally {
-                        await page.close();
                     }
 
                     return item;

--- a/lib/routes/iwara/ranking.ts
+++ b/lib/routes/iwara/ranking.ts
@@ -58,7 +58,7 @@ async function handler(ctx) {
     const items = await cache.tryGet(
         `iwara:ranking:${type}:${sort}:${rating}`,
         async () => {
-            const { page, destory } = await getPuppeteerPage(url, {
+            const { page, destroy } = await getPuppeteerPage(url, {
                 onBeforeLoad: async (page) => {
                     await page.setRequestInterception(true);
                     page.on('request', (request) => {
@@ -83,7 +83,7 @@ async function handler(ctx) {
                     pubDate: parseDate(item.createdAt),
                 }));
             } finally {
-                await destory();
+                await destroy();
             }
         },
         config.cache.routeExpire,

--- a/lib/routes/iwara/subscriptions.ts
+++ b/lib/routes/iwara/subscriptions.ts
@@ -69,7 +69,7 @@ async function handler() {
     const username = config.iwara.username;
     const password = config.iwara.password;
 
-    const { page, destory } = await getPuppeteerPage(rootUrl, {
+    const { page, destroy } = await getPuppeteerPage(rootUrl, {
         gotoConfig: {
             waitUntil: 'domcontentloaded',
         },
@@ -113,7 +113,10 @@ async function handler() {
             async () => {
                 const result = await fetchApi(`${apiqRootUrl}/user/token`, {
                     method: 'POST',
-                    headers: { ...apiHeaders, Authorization: refreshHeaders.authorization },
+                    headers: {
+                        ...apiHeaders,
+                        Authorization: refreshHeaders.authorization,
+                    },
                 });
                 return { authorization: 'Bearer ' + result.accessToken };
             },
@@ -121,7 +124,10 @@ async function handler() {
             false
         );
 
-        const authedHeaders = { ...apiHeaders, Authorization: authHeaders.authorization };
+        const authedHeaders = {
+            ...apiHeaders,
+            Authorization: authHeaders.authorization,
+        };
 
         // fetch subscriptions
         const [videoResponse, imageResponse] = await Promise.all([
@@ -177,7 +183,9 @@ async function handler() {
                     }
 
                     const apiUrl = item.link.replace('www.iwara.tv', 'apiq.iwara.tv');
-                    const response = await fetchApi(apiUrl, { headers: authedHeaders });
+                    const response = await fetchApi(apiUrl, {
+                        headers: authedHeaders,
+                    });
 
                     description = renderSubscriptionImages(response.files ? response.files.filter((f) => f.type === 'image').map((f) => `${imageRootUrl}/image/original/${f.id}/${f.name}`) : [item.imageUrl]);
 
@@ -202,6 +210,6 @@ async function handler() {
             item: items,
         };
     } finally {
-        await destory();
+        await destroy();
     }
 }

--- a/lib/routes/nhentai/util.tsx
+++ b/lib/routes/nhentai/util.tsx
@@ -73,7 +73,7 @@ const fetchPage = async (url: string): Promise<string> => {
     } catch (error: unknown) {
         const status = (error as { status?: number; statusCode?: number }).status ?? (error as { status?: number; statusCode?: number }).statusCode;
         if (status === 403) {
-            const { page, destory } = await getPuppeteerPage(url, {
+            const { page, destroy } = await getPuppeteerPage(url, {
                 onBeforeLoad: async (page) => {
                     const allowedTypes = new Set(['document', 'script', 'xhr', 'fetch']);
                     await page.setRequestInterception(true);
@@ -83,7 +83,7 @@ const fetchPage = async (url: string): Promise<string> => {
                 },
             });
             const content = await page.content();
-            await destory();
+            await destroy();
             return content;
         }
         throw error;

--- a/lib/routes/perplexity/blog.ts
+++ b/lib/routes/perplexity/blog.ts
@@ -38,7 +38,7 @@ async function handler(ctx: Context) {
     const limit = Number.parseInt(ctx.req.query('limit') ?? '20', 10);
     const rootUrl = 'https://www.perplexity.ai/hub';
 
-    const { page, destory, browser } = await getPuppeteerPage(rootUrl, {
+    const { page, destroy, browser } = await getPuppeteerPage(rootUrl, {
         onBeforeLoad: async (page) => {
             await page.setRequestInterception(true);
             page.on('request', (request) => {
@@ -119,7 +119,9 @@ async function handler(ctx: Context) {
                     request.resourceType() === 'document' ? request.continue() : request.abort();
                 });
 
-                await contentPage.goto(item.link!, { waitUntil: 'domcontentloaded' });
+                await contentPage.goto(item.link!, {
+                    waitUntil: 'domcontentloaded',
+                });
 
                 const contentHtml = await contentPage.evaluate(() => document.documentElement.innerHTML);
                 await contentPage.close();
@@ -148,7 +150,7 @@ async function handler(ctx: Context) {
         })
     );
 
-    await destory();
+    await destroy();
 
     return {
         title: 'Perplexity Blog',

--- a/lib/routes/perplexity/changelog.ts
+++ b/lib/routes/perplexity/changelog.ts
@@ -16,7 +16,7 @@ export const handler = async (ctx: Context): Promise<Data> => {
 
     logger.http(`Fetching Perplexity changelog from ${targetUrl}`);
 
-    const { page, destory, browser } = await getPuppeteerPage(targetUrl, {
+    const { page, destroy, browser } = await getPuppeteerPage(targetUrl, {
         onBeforeLoad: async (page) => {
             await page.setRequestInterception(true);
             page.on('request', (request) => {
@@ -131,7 +131,7 @@ export const handler = async (ctx: Context): Promise<Data> => {
     );
 
     // Close the browser session after all requests are done
-    await destory();
+    await destroy();
 
     return {
         title: $('title').text() || 'Perplexity Changelog',

--- a/lib/routes/picnob/utils.ts
+++ b/lib/routes/picnob/utils.ts
@@ -2,7 +2,7 @@ import { getPuppeteerPage } from '@/utils/puppeteer';
 
 const puppeteerGet = async (url) => {
     let data;
-    const { destory } = await getPuppeteerPage(url, {
+    const { destroy } = await getPuppeteerPage(url, {
         onBeforeLoad: async (page) => {
             await page.setRequestInterception(true);
             page.on('request', (request) => {
@@ -13,7 +13,7 @@ const puppeteerGet = async (url) => {
             });
         },
     });
-    await destory();
+    await destroy();
     return data;
 };
 

--- a/lib/routes/picuki/profile.ts
+++ b/lib/routes/picuki/profile.ts
@@ -85,7 +85,7 @@ async function handler(ctx) {
             });
         } catch (error) {
             if (error.status === 403) {
-                const { page, destory } = await getPuppeteerPage(profileUrl, {
+                const { page, destroy } = await getPuppeteerPage(profileUrl, {
                     onBeforeLoad: async (page) => {
                         const expectResourceTypes = new Set(['document', 'script', 'xhr', 'fetch']);
                         await page.setRequestInterception(true);
@@ -96,7 +96,7 @@ async function handler(ctx) {
                 });
                 await page.waitForSelector('.content');
                 response = await page.content();
-                await destory();
+                await destroy();
             } else {
                 throw new NotFoundError(error.message);
             }

--- a/lib/routes/weibo/utils.ts
+++ b/lib/routes/weibo/utils.ts
@@ -80,7 +80,7 @@ const weiboUtils = {
                     logger.info(`Fetching visitor Cookies from ${url}`);
                 }
                 let times = 0;
-                const { page, destory } = await getPuppeteerPage(url, {
+                const { page, destroy } = await getPuppeteerPage(url, {
                     onBeforeLoad: async (page) => {
                         const expectResourceTypes = new Set(['document', 'script', 'xhr', 'fetch']);
                         await page.setUserAgent(weiboUtils.apiHeaders['User-Agent']);
@@ -101,7 +101,7 @@ const weiboUtils = {
                     gotoConfig: { waitUntil: 'networkidle0' },
                 });
                 const cookies: string = await getCookies(page, 'weibo.cn');
-                await destory();
+                await destroy();
                 if (times < 2 || !cookies) {
                     throw new Error(`Unable to fetch visitor cookies. Please set WEIBO_COOKIES. Redirection: ${times}, last URL: ${page.url()}`);
                 }

--- a/lib/routes/xiaohongshu/util.ts
+++ b/lib/routes/xiaohongshu/util.ts
@@ -63,7 +63,7 @@ const getUser = (url, cache) =>
             }
 
             // Use puppeteer
-            const { page, destory } = await getPuppeteerPage(url, {
+            const { page, destroy } = await getPuppeteerPage(url, {
                 onBeforeLoad: async (page) => {
                     await page.setRequestInterception(true);
                     page.on('request', (request) => {
@@ -107,7 +107,7 @@ const getUser = (url, cache) =>
 
                 return { userPageData, notes, collect };
             } finally {
-                await destory();
+                await destroy();
             }
         },
         config.cache.routeExpire,

--- a/lib/utils/puppeteer.mock.test.ts
+++ b/lib/utils/puppeteer.mock.test.ts
@@ -69,7 +69,7 @@ describe('getPuppeteerPage (mocked)', () => {
         expect(endpoint).toContain('stealth=true');
         expect(onBeforeLoad).toHaveBeenCalled();
 
-        await result.destory();
+        await result.destroy();
         expect(browser.close).toHaveBeenCalled();
 
         delete process.env.PUPPETEER_WS_ENDPOINT;

--- a/lib/utils/puppeteer.ts
+++ b/lib/utils/puppeteer.ts
@@ -187,7 +187,7 @@ export const getPuppeteerPage = async (
 
     return {
         page,
-        destory: async () => {
+        destroy: async () => {
             await browser.close();
         },
         browser,

--- a/lib/utils/puppeteer.worker.ts
+++ b/lib/utils/puppeteer.worker.ts
@@ -91,7 +91,7 @@ export const getPuppeteerPage = async (
 
     return {
         page,
-        destory: async () => {
+        destroy: async () => {
             await browser.close();
         },
         browser,


### PR DESCRIPTION
## Example for the Proposed Route(s) / 路由地址示例

```routes
/dailypush
/dailypush/latest
/dailypush/tag/backend
/dailypush/tag/backend/trending
/dailypush/tag/backend/latest
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明
bypass vercel anti bot system using puppeteer