### PR TITLE
feat(route/twitter): support parsing tweet threads from web-api response

### DIFF
--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -311,7 +311,7 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
             const itemTweets = content?.items
                 ?.map((i) => i?.item?.itemContent?.tweet_results?.result)
                 .filter(Boolean);
-	
+
             if (itemTweets?.length > 0) {
                 logger.debug('Found a tweet thread');
                 for (let t of itemTweets) {
@@ -368,7 +368,7 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
                         t.legacy.entities.urls = tmp.entity_set.urls;
                         t.legacy.entities.user_mentions = tmp.entity_set.user_mentions;
                         t.legacy.full_text = tmp.text;
-                        logger.debug(`t.legacy.full_text: ${t.legacy.full_text.slice(0,100)}`);
+                        logger.debug(`t.legacy.full_text: ${t.legacy.full_text.slice(0, 100)}`);
                     }
                 }
                 const legacy = tweet.legacy;

--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -296,6 +296,7 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
     }
     for (const entry of filteredEntries) {
         if (entry.entryId) {
+            logger.debug(`entry.entryId: ${entry.entryId}`);
             const content = entry.content || entry.item;
             const tweetCandidates: any[] = [];
 
@@ -307,14 +308,12 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
                 tweetCandidates.push(tweet);
             }
 
-            logger.debug(`entry.entryId: ${entry.entryId}`)
-
             const itemTweets = content?.items
                 ?.map((i) => i?.item?.itemContent?.tweet_results?.result)
                 .filter(Boolean);
 	
             if (itemTweets?.length > 0) {
-                logger.debug("Found a tweet thread")
+                logger.debug('Found a tweet thread');
                 for (let t of itemTweets) {
                     if (t?.tweet) {
                         t = t.tweet;
@@ -326,7 +325,7 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
             }
 
             if (tweetCandidates.length === 0) {
-                logger.debug(`Cannot find any item for the entry: ${entry}`)
+                logger.debug(`Cannot find any item for the entry: ${entry}`);
             }
 
             for (const tweet of tweetCandidates) {
@@ -369,7 +368,7 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
                         t.legacy.entities.urls = tmp.entity_set.urls;
                         t.legacy.entities.user_mentions = tmp.entity_set.user_mentions;
                         t.legacy.full_text = tmp.text;
-                        logger.debug(`t.legacy.full_text: ${t.legacy.full_text.substring(0,100)}`)
+                        logger.debug(`t.legacy.full_text: ${t.legacy.full_text.slice(0,100)}`);
                     }
                 }
                 const legacy = tweet.legacy;


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/twitter/user/_RSSHub
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Some tweets from user timeline are not being parsed as they are grouped in a thread like in the example below

<img width="600" height="656" alt="image" src="https://github.com/user-attachments/assets/10223356-9712-4551-9ad5-046dd2fd8449" />

I added the entryId "profile-conversation-" of these tweet to the filter and modified the code to handle these missing tweets

<img width="2558" height="386" alt="image" src="https://github.com/user-attachments/assets/714bd367-667f-4d66-a9e8-029f343032c2" />