### PR TITLE
fix(route/showstart): enable `allowEmpty` for all showstart routes

### DIFF
--- a/lib/routes/showstart/artist.ts
+++ b/lib/routes/showstart/artist.ts
@@ -41,5 +41,6 @@ async function handler(ctx: Context): Promise<Data> {
         description: artist.content,
         link: `${HOST}/artist/${artist.id}`,
         item: artist.activityList,
+        allowEmpty: true,
     };
 }

--- a/lib/routes/showstart/brand.ts
+++ b/lib/routes/showstart/brand.ts
@@ -41,5 +41,6 @@ async function handler(ctx: Context): Promise<Data> {
         description: brand.content,
         link: `${HOST}/host/${brand.id}`,
         item: brand.activityList,
+        allowEmpty: true,
     };
 }

--- a/lib/routes/showstart/event.ts
+++ b/lib/routes/showstart/event.ts
@@ -39,7 +39,7 @@ async function handler(ctx: Context): Promise<Data> {
     const tags = [cityName, showName].filter(Boolean).join(' - ');
     return {
         title: `${TITLE} - ${tags}`,
-        link: HOST,
+        link: `${HOST}/event/list?cityCode=${cityCode}${showStyle ? `&showStyle=${showStyle}` : ''}`,
         item: items,
         allowEmpty: true,
     };

--- a/lib/routes/showstart/event.ts
+++ b/lib/routes/showstart/event.ts
@@ -41,5 +41,6 @@ async function handler(ctx: Context): Promise<Data> {
         title: `${TITLE} - ${tags}`,
         link: HOST,
         item: items,
+        allowEmpty: true,
     };
 }

--- a/lib/routes/showstart/search.ts
+++ b/lib/routes/showstart/search.ts
@@ -64,43 +64,49 @@ async function handler(ctx: Context): Promise<Data> {
                 title: `${TITLE} - 搜演出 - ${keyword || '全部'}`,
                 link: HOST,
                 item: await fetchActivityList({ keyword }),
+                allowEmpty: true,
             };
         case 'artist':
             return {
                 title: `${TITLE} - 搜艺人 - ${keyword || '全部'}`,
                 link: HOST,
                 item: await fetchPerformerList({ searchKeyword: keyword }),
+                allowEmpty: true,
             };
         case 'site':
             return {
                 title: `${TITLE} - 搜场地 - ${keyword || '全部'}`,
                 link: HOST,
                 item: await fetchSiteList({ searchKeyword: keyword }),
+                allowEmpty: true,
             };
         case 'brand':
             return {
                 title: `${TITLE} - 搜厂牌 - ${keyword || '全部'}`,
                 link: HOST,
                 item: await fetchBrandList({ searchKeyword: keyword }),
+                allowEmpty: true,
             };
         case 'city':
             return {
                 title: `${TITLE} - 搜城市 - ${keyword || '全部'}`,
                 link: HOST,
                 item: await fetchCityList(keyword),
+                allowEmpty: true,
             };
         case 'style':
             return {
                 title: `${TITLE} - 搜风格 - ${keyword || '全部'}`,
                 link: HOST,
                 item: await fetchStyleList(keyword),
+                allowEmpty: true,
             };
         default:
             return {
                 title: `${TITLE} - 搜演出 - ${type || '全部'}`,
                 link: HOST,
-                allowEmpty: true,
                 item: await fetchActivityList({ keyword: type }),
+                allowEmpty: true,
             };
     }
 }

--- a/lib/routes/showstart/site.ts
+++ b/lib/routes/showstart/site.ts
@@ -39,5 +39,6 @@ async function handler(ctx: Context): Promise<Data> {
         description: siteInfo.address,
         link: HOST,
         item: activityList,
+        allowEmpty: true,
     };
 }

--- a/lib/routes/showstart/site.ts
+++ b/lib/routes/showstart/site.ts
@@ -37,7 +37,7 @@ async function handler(ctx: Context): Promise<Data> {
     return {
         title: `${TITLE} - ${siteInfo.name}`,
         description: siteInfo.address,
-        link: HOST,
+        link: `${HOST}/venue/${siteId}`,
         item: activityList,
         allowEmpty: true,
     };


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/showstart/event/373/0
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
为所有秀动相关路由启用 `allowEmpty`，即便当前无演出也可订阅。