### PR TITLE
fix(route): remove elements for screen readers

### DIFF
--- a/lib/routes/google/jules.ts
+++ b/lib/routes/google/jules.ts
@@ -46,6 +46,7 @@ async function handler() {
             // Full HTML for the item content
             article.find('h2').first().remove(); // remove title
             article.find('b').first().remove(); // remove date
+            article.find('.sr-only').remove(); // remove sr-only elements
 
             return {
                 title,


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Elements for screen reader only (.sr-only) are incorrectly shown.

<img width="150" alt="image" src="https://github.com/user-attachments/assets/f69a9dcb-dd03-4a16-af1f-b4b6e6a1088b" />


## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/google/jules/changelog
```

## Note / 说明

They are removed instead of hidden because RSS readers might override the style. Also the element just repeats the header, which is redundant.