### PR TITLE
feat(route/youtube): Allow configuring custom embed url

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -236,6 +236,7 @@ type ConfigEnvKeys =
     | 'YOUTUBE_CLIENT_ID'
     | 'YOUTUBE_CLIENT_SECRET'
     | 'YOUTUBE_REFRESH_TOKEN'
+    | 'YOUTUBE_VIDEO_EMBED_URL'
     | 'ZHIHU_COOKIES'
     | 'ZODGAME_COOKIE'
     | 'ZSXQ_ACCESS_TOKEN'
@@ -675,6 +676,7 @@ export type Config = {
         clientId?: string;
         clientSecret?: string;
         refreshToken?: string;
+        videoEmbedUrl?: string;
     };
     zhihu: {
         cookies?: string;
@@ -1164,6 +1166,7 @@ const calculateValue = () => {
             clientId: envs.YOUTUBE_CLIENT_ID,
             clientSecret: envs.YOUTUBE_CLIENT_SECRET,
             refreshToken: envs.YOUTUBE_REFRESH_TOKEN,
+            videoEmbedUrl: envs.YOUTUBE_VIDEO_EMBED_URL || 'https://www.youtube-nocookie.com/embed/',
         },
         zhihu: {
             cookies: envs.ZHIHU_COOKIES,

--- a/lib/routes/youtube/utils.tsx
+++ b/lib/routes/youtube/utils.tsx
@@ -68,7 +68,16 @@ export const renderDescription = (embed, videoId, img, description) =>
     renderToString(
         <>
             {embed ? (
-                <iframe id="ytplayer" type="text/html" width="640" height="360" src={`https://www.youtube-nocookie.com/embed/${videoId}`} frameborder="0" allowfullscreen referrerpolicy="strict-origin-when-cross-origin" />
+                <iframe
+                    id="ytplayer"
+                    type="text/html"
+                    width="640"
+                    height="360"
+                    src={(config.youtube?.videoEmbedUrl || 'https://www.youtube-nocookie.com/embed/') + videoId}
+                    frameborder="0"
+                    allowfullscreen
+                    referrerpolicy="strict-origin-when-cross-origin"
+                />
             ) : (
                 <img src={img?.url ?? ''} />
             )}


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/youtube/user/@JFlaMusic
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds a configuration to customize the embed url that is used for YouTube videos. The video ID will be appended to this value (and defaults to the original `https://www.youtube-nocookie.com/embed/`). This allows to have the embed point to the original YouTube embed with `https://www.youtube.com/embed/`, or could point to an invidious instance.

I'm not sure where the documentation for the server settings is located. If this change is welcome, I can happily contribute adding a description to this setting if told where.
