### PR TITLE
fix(route): update ncu jwc selector

### DIFF
--- a/lib/routes/ncu/jwc.ts
+++ b/lib/routes/ncu/jwc.ts
@@ -1,9 +1,11 @@
-import { load } from 'cheerio'; // 可以使用类似 jQuery 的 API HTML 解析器
+import { load } from 'cheerio';
 
-import { config } from '@/config';
-import type { Route } from '@/types';
-import got from '@/utils/got'; // 自订的 got
+import type { Data, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
+
+const baseUrl = 'https://jwc.ncu.edu.cn';
 
 export const route: Route = {
     path: '/jwc',
@@ -20,29 +22,23 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['jwc.ncu.edu.cn/', 'jwc.ncu.edu.cn/Notices.jsp'],
+            source: ['jwc.ncu.edu.cn'],
+            target: '/jwc',
         },
     ],
     name: '教务通知',
     maintainers: ['ywh555hhh', 'jixiuweilan'],
     handler,
-    url: 'jwc.ncu.edu.cn/',
+    url: 'jwc.ncu.edu.cn/Notices.jsp',
 };
 
 async function handler() {
-    const baseUrl = 'https://jwc.ncu.edu.cn';
     const targetUrl = `${baseUrl}/Notices.jsp?urltype=tree.TreeTempUrl&wbtreeid=1541`;
 
-    const response = await got(targetUrl, {
-        headers: {
-            'User-Agent': config.trueUA,
-        },
-    });
-    const $ = load(response.body);
+    const response = await ofetch(targetUrl);
+    const $ = load(response);
 
-    const list = $('div.space-y-2 div.group');
-
-    const items = list
+    const list = $('div.space-y-2 div.group')
         .toArray()
         .map((item) => {
             const el = $(item);
@@ -53,26 +49,64 @@ async function handler() {
             const link = rawLink ? new URL(rawLink, baseUrl).href : '';
 
             const dateText = el
-                .find('.font-mono span')
-                .filter((_, e) => {
-                    const cls = $(e).attr('class') || '';
-                    return cls.includes('md:inline') || cls.includes(String.raw`md\:inline`);
-                })
+                .find(String.raw`.font-mono span.md\:inline`)
                 .text()
                 .trim();
 
             return {
                 title,
                 link,
-                pubDate: parseDate(dateText, 'YYYY-MM-DD'),
+                pubDate: dateText ? parseDate(dateText, 'YYYY-MM-DD') : undefined,
             };
         })
         .filter((item) => item.title && item.link);
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const detailResponse = await ofetch(item.link);
+                const $detail = load(detailResponse);
+
+                const contentEl = $detail('.v_news_content');
+
+                contentEl.find('a').each((_, el) => {
+                    const href = $detail(el).attr('href');
+                    if (href && !href.startsWith('http')) {
+                        $detail(el).attr('href', new URL(href, baseUrl).href);
+                    }
+                });
+                contentEl.find('img').each((_, el) => {
+                    const src = $detail(el).attr('src');
+                    if (src && !src.startsWith('http')) {
+                        $detail(el).attr('src', new URL(src, baseUrl).href);
+                    }
+                });
+
+                let description = contentEl.html() || '';
+
+                const attachments = $detail('a[href*="download.jsp"]');
+                if (attachments.length > 0) {
+                    description += '<ul>';
+                    attachments.each((_, el) => {
+                        const href = $detail(el).attr('href');
+                        const text = $detail(el).text().trim();
+                        if (href && text) {
+                            const absoluteHref = href.startsWith('http') ? href : new URL(href, baseUrl).href;
+                            description += `<li><a href="${absoluteHref}">${text}</a></li>`;
+                        }
+                    });
+                    description += '</ul>';
+                }
+
+                return { ...item, description };
+            })
+        )
+    );
 
     return {
         title: '南昌大学教务处 - 通知公告',
         link: targetUrl,
         description: '南昌大学教务处通知公告',
         item: items,
-    };
+    } as Data;
 }


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/ncu/jwc

```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

### 修复说明 / Fix Description

南昌大学教务处官网改版，导致原有的 DOM 选择器失效。本 PR 进行了以下优化：
The official website of Nanchang University Academic Affairs Office has been revised, causing the original DOM selectors to fail. This PR includes the following optimizations:

1. **数据源变更 / Data Source Change**:
将抓取页面从首页改为 `Notices.jsp` 列表页。经测试，首页仅显示 3 条通知且包含非最新的置顶信息，列表页能提供更准确、更完整的最新动态。
Changed the crawling page from the homepage to the `Notices.jsp` list page. Testing showed that the homepage only displays 3 notices and includes non-latest pinned info, while the list page provides more accurate and complete updates.
2. **选择器适配 / Selector Adaptation**:
精准适配了新版 UI 的 `div.group` 结构。
Accurately adapted to the `div.group` structure of the new UI.

### 验证截图 / Verification Screenshot

#### 修改前 / Before

<img width="1830" height="1288" alt="before" src="https://github.com/user-attachments/assets/14968030-a1e4-4597-a1a8-c28420ed7dc7" />

#### 修改后 / After

<img width="1357" height="1361" alt="after" src="https://github.com/user-attachments/assets/4cfbe4f6-7bca-40cc-993f-b8a3cb34f3e1" />
