### PR TITLE
fix(zhihu): use v4 API for daily route

### DIFF
--- a/lib/routes/zhihu/daily.ts
+++ b/lib/routes/zhihu/daily.ts
@@ -1,5 +1,3 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
@@ -13,7 +11,7 @@ export const route: Route = {
     features: {
         requireConfig: false,
         requirePuppeteer: false,
-        antiCrawler: true,
+        antiCrawler: false,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
@@ -30,34 +28,27 @@ export const route: Route = {
 };
 
 async function handler() {
-    const response = await ofetch('https://daily.zhihu.com/');
-
-    const $ = load(response);
+    // The v7 /stories/latest requires login; use v4 which is publicly accessible
+    const listResponse = await ofetch('https://daily.zhihu.com/api/4/stories/latest');
+    const stories = listResponse.stories ?? [];
 
     const items = await Promise.all(
-        $('.box')
-            .toArray()
-            .map(async (item) => {
-                item = $(item);
-                const linkElem = item.find('.link-button');
-                const storyUrl = 'https://daily.zhihu.com/api/7' + linkElem.attr('href');
+        stories.map(async (story: { id: number; title: string; image?: string }) => {
+            const storyUrl = `https://daily.zhihu.com/api/4/story/${story.id}`;
 
-                // Fetch full story content
-                const storyJson = await cache.tryGet(storyUrl, async () => {
-                    const response = await ofetch(storyUrl);
-                    return response;
-                });
+            const storyJson = await cache.tryGet(storyUrl, async () => {
+                const response = await ofetch(storyUrl);
+                return response;
+            });
 
-                const storyTitle = storyJson.title;
-                const storyContent = storyJson.body;
-
-                return {
-                    title: storyTitle,
-                    description: storyContent,
-                    link: storyJson.url,
-                    pubDate: parseDate(storyJson.publish_time, 'X'),
-                };
-            })
+            return {
+                title: storyJson.title ?? story.title,
+                description: storyJson.body ?? '',
+                link: storyJson.share_url ?? `https://daily.zhihu.com/story/${story.id}`,
+                pubDate: parseDate(storyJson.publish_time, 'X'),
+                image: storyJson.image ?? story.image,
+            };
+        })
     );
 
     return {


### PR DESCRIPTION
## Fix: 知乎日报路由修复

### 问题

知乎日报 (`/zhihu/daily`) 路由已损坏，返回 503。

原因有两点：
1. `daily.zhihu.com` 首页已改版，变为纯下载引导页，不再包含 `.box` 文章列表元素，HTML 解析逻辑完全失效
2. `/api/7/stories/latest` 现在需要登录（返回 401 "您需要登录才能调用该接口"）

### 修复

切换到公开可访问的 v4 API：
- 使用 `GET /api/4/stories/latest` 获取当日故事列表（无需登录）
- 使用 `GET /api/4/story/:id` 获取正文内容（同样无需登录）

同时将 `antiCrawler` 改为 `false`，因为 v4 API 完全公开。

### 验证

```
curl https://daily.zhihu.com/api/4/stories/latest  # 200 ✅
curl https://daily.zhihu.com/api/4/story/9787903   # 200 ✅
```

本地测试 `/zhihu/daily` 可正常返回 RSS feed，包含当日文章标题和正文。