### PR TITLE
fix(zhihu): use v4 API for daily route

### DIFF
--- a/lib/routes/zhihu/daily.ts
+++ b/lib/routes/zhihu/daily.ts
@@ -2,6 +2,7 @@ import { load } from 'cheerio';
 
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
+import logger from '@/utils/logger';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
@@ -13,7 +14,7 @@ export const route: Route = {
     features: {
         requireConfig: false,
         requirePuppeteer: false,
-        antiCrawler: true,
+        antiCrawler: false,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
@@ -34,31 +35,35 @@ async function handler() {
 
     const $ = load(response);
 
-    const items = await Promise.all(
-        $('.box')
-            .toArray()
-            .map(async (item) => {
-                item = $(item);
-                const linkElem = item.find('.link-button');
-                const storyUrl = 'https://daily.zhihu.com/api/7' + linkElem.attr('href');
+    const items = (
+        await Promise.all(
+            $('.box')
+                .toArray()
+                .map(async (item) => {
+                    item = $(item);
+                    const linkElem = item.find('.link-button');
+                    const storyUrl = 'https://daily.zhihu.com/api/4' + linkElem.attr('href');
 
-                // Fetch full story content
-                const storyJson = await cache.tryGet(storyUrl, async () => {
-                    const response = await ofetch(storyUrl);
-                    return response;
-                });
+                    try {
+                        const storyJson = await cache.tryGet(storyUrl, async () => {
+                            const response = await ofetch(storyUrl);
+                            return response;
+                        });
 
-                const storyTitle = storyJson.title;
-                const storyContent = storyJson.body;
-
-                return {
-                    title: storyTitle,
-                    description: storyContent,
-                    link: storyJson.url,
-                    pubDate: parseDate(storyJson.publish_time, 'X'),
-                };
-            })
-    );
+                        return {
+                            title: storyJson.title,
+                            description: storyJson.body,
+                            link: storyJson.url,
+                            image: storyJson.image,
+                            pubDate: storyJson.publish_time ? parseDate(storyJson.publish_time, 'X') : undefined,
+                        };
+                    } catch (error) {
+                        logger.debug(`Failed to fetch story detail: ${storyUrl} - ${error}`);
+                        return null;
+                    }
+                })
+        )
+    ).filter(Boolean);
 
     return {
         title: '知乎日报',


### PR DESCRIPTION
## Involved Issue

Close #

## Example for the Proposed Route(s)

```routes
/zhihu/daily
```

## New RSS Route Checklist

- [ ] New Route
- [x] Bug fix

### Problem

The `/zhihu/daily` route uses v7 API (`/api/7/story/:id`) to fetch story details, which no longer returns `publish_time`, causing `pubDate` to be `Invalid Date` for all items.

Additionally, some stories on the homepage may return HTTP 500 from the story detail API, which causes `Promise.all` to reject and the entire route to return 503.

### Fix

- Keep HTML scraping of `daily.zhihu.com` homepage for story list (30 items via `.box` elements)
- Switch story detail API from v7 to v4 (`/api/4/story/:id`), which returns `publish_time` as a Unix timestamp
- Add try-catch around individual story fetches so a single failed story does not crash the entire route
- Add `image` field from story detail response

### Verified locally

Compiled, restarted, and tested: 29 items returned with valid pubDate (1 story skipped due to server-side HTTP 500 on story/9787342).