### PR TITLE
fix(route/zhihu): fix missing images in answers and zhuanlan routes

### DIFF
--- a/lib/routes/zhihu/zhuanlan.ts
+++ b/lib/routes/zhihu/zhuanlan.ts
@@ -4,7 +4,7 @@ import type { Route } from '@/types';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 
-import { getSignedHeader, header } from './utils';
+import { getSignedHeader, header, processImage } from './utils';
 
 export const route: Route = {
     path: '/zhuanlan/:id',
@@ -78,10 +78,8 @@ async function handler(ctx) {
         // 当专栏内文章内容不含任何文字时, 返回空字符, 以免直接报错
         let description = '';
         if (item.content) {
-            const $ = load(item.content);
-            description = $.html();
+            description = processImage(item.content);
         }
-        $('img').css('max-width', '100%');
 
         let title: string;
         let link: string;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fix Zhihu answers and Zhuanlan feeds missing images by processing data-actualsrc/data-original to src.
