### PR TITLE
feat(route): add aschmelyun.com blog route

### DIFF
--- a/lib/routes/aschmelyun/blog.ts
+++ b/lib/routes/aschmelyun/blog.ts
@@ -1,0 +1,48 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    name: 'Blog',
+    categories: ['blog'],
+    maintainers: ['raxod502'],
+    path: '/blog',
+    example: '/aschmelyun/blog',
+    handler,
+    radar: [
+        {
+            source: ['aschmelyun.com'],
+            target: '/blog',
+        },
+    ],
+};
+
+async function handler() {
+    const response = await ofetch('https://aschmelyun.com/blog/');
+    const $ = load(response);
+
+    const items = $('div.rounded-lg')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const a = item.find('a.text-xl').first();
+            return {
+                title: a.text(),
+                link: new URL(a.attr('href'), 'https://aschmelyun.com/blog/').href,
+                pubDate: parseDate(item.find('span.text-sm').text()),
+                category: item
+                    .find('a.rounded-full')
+                    .toArray()
+                    .map((cat) => $(cat).text().trim()),
+                description: item.find('p').first().text(),
+            };
+        });
+
+    return {
+        title: 'Andrew Schmelyun Blog',
+        link: 'https://aschmelyun.com/',
+        item: items,
+    };
+}

--- a/lib/routes/aschmelyun/namespace.ts
+++ b/lib/routes/aschmelyun/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Andrew Schmelyun',
+    url: 'aschmelyun.com',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

n/a

## Example for the Proposed Route(s) / 路由地址示例

```routes
/aschmelyun/blog
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

The HTML layout of the blog is tidy and clean, but extremely hostile to structured parsing. I did my best to pick reasonably reliable selectors, but there's only so much I could do. The author of the blog actually maintains an RSS library for PHP, so I find it amusing there's no RSS feed :P
