### PR TITLE
fix: handle undefined filters and results in digitalpolicyalert/activity-tracker

### DIFF
--- a/lib/routes/digitalpolicyalert/activity-tracker.ts
+++ b/lib/routes/digitalpolicyalert/activity-tracker.ts
@@ -23,7 +23,7 @@ const searchParamsToObject = (searchParams: URLSearchParams): Record<string, str
 };
 
 export const handler = async (ctx: Context): Promise<Data> => {
-    const { filters } = ctx.req.param();
+    const filters = ctx.req.param('filters') ?? '';
     const limit: number = Number.parseInt(ctx.req.query('limit') ?? '30', 10);
     const params: URLSearchParams = createSearchParams(filters, limit);
 
@@ -40,7 +40,7 @@ export const handler = async (ctx: Context): Promise<Data> => {
     const $: CheerioAPI = load(targetResponse);
     const language = $('html').attr('lang') ?? 'en';
 
-    const items: DataItem[] = response.results.slice(0, limit).map((item): DataItem => {
+    const items: DataItem[] = (response.results ?? []).slice(0, limit).map((item): DataItem => {
         const title: string = item.title;
         const description: string | undefined = item.latest_event?.description ?? undefined;
         const pubDate: number | string = item.latest_event?.date;


### PR DESCRIPTION
Fixes #21298

Handle undefined `filters` parameter and `response.results` to prevent "Cannot read properties of undefined (reading slice)" error.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*