### PR TITLE
fix: resolve 7 security vulnerabilities via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,14 @@
             "rss-parser@3.13.0>xml2js": "^0.6.2",
             "safe-buffer": "npm:@nolyfill/safe-buffer@^1",
             "safer-buffer": "npm:@nolyfill/safer-buffer@^1",
-            "side-channel": "npm:@nolyfill/side-channel@^1"
+            "side-channel": "npm:@nolyfill/side-channel@^1",
+            "ws@<1.1.1": ">=1.1.1",
+            "ws@>=0.2.6 <1.1.5": ">=1.1.5",
+            "ws@<1.0.1": ">=1.0.1",
+            "tough-cookie@<4.1.3": ">=4.1.3",
+            "minimatch@>=9.0.0 <9.0.6": ">=9.0.6",
+            "minimatch@>=9.0.0 <9.0.7": ">=9.0.7",
+            "qs@<6.14.1": ">=6.14.1"
         },
         "patchedDependencies": {
             "rss-parser@3.13.0": "patches/rss-parser@3.13.0.patch"


### PR DESCRIPTION
Resolves 7 security vulnerabilities in transitive dependencies:

- ws: patches DoS vulnerabilities (GHSA-6663-c963-2gqg, GHSA-5v72-xg48-5rpm, GHSA-2mhh-w6q8-5hxw)
- tough-cookie: patches prototype pollution (GHSA-72xf-g2v4-qvf3)
- minimatch: patches ReDoS vulnerabilities (GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj)
- qs: patches DoS via memory exhaustion (GHSA-6rw7-vpxm-498p)

Reduces vulnerabilities from 9 to 1 (remaining 1 is in deprecated request package with no patch). Tested via pnpm install.