### PR TITLE
fix(route/zhihu): auto-fetch `__zse_ck` when absent from `ZHIHU_COOKIES`

### DIFF
--- a/lib/routes/zhihu/utils.ts
+++ b/lib/routes/zhihu/utils.ts
@@ -72,8 +72,24 @@ export const getSignedHeader = async (url: string, apiPath: string) => {
         const xzse93 = '101_3_3.0';
         const f = `${xzse93}+${apiPath}+${dc0}`;
         const xzse96 = '2.0_' + g_encrypt(md5(f));
+
+        // If __zse_ck is absent from ZHIHU_COOKIES, fetch it automatically from
+        // Zhihu's public static JS. The value is site-wide (not user-specific)
+        // and requires no login, but it expires and must be kept up to date.
+        let cookieStr = config.zhihu.cookies;
+        if (!getCookieValueByKey('__zse_ck')) {
+            const zseCk = await cache.tryGet('zhihu:zse_ck', async () => {
+                const response = await ofetch.raw('https://static.zhihu.com/zse-ck/v3.js');
+                const script = await response._data.text();
+                return script.match(/__g\.ck\|\|"([\w+/=\\]*?)",_=/)?.[1] || '';
+            });
+            if (zseCk) {
+                cookieStr = `${cookieStr}; __zse_ck=${zseCk}`;
+            }
+        }
+
         return {
-            cookie: config.zhihu.cookies,
+            cookie: cookieStr,
             'x-zse-96': xzse96,
             'x-app-za': 'OS=Web',
             'x-zse-93': xzse93,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] \`Puppeteer\`

## Note / 说明

When `ZHIHU_COOKIES` is configured, the `if` branch in `getSignedHeader` sends the full cookie string as-is, including a potentially stale `__zse_ck`. This token is embedded in Zhihu's static JS (`static.zhihu.com/zse-ck/v3.js`) and rotates periodically. When it expires, routes that scrape HTML pages (e.g. `/zhihu/posts/people/:id`) return 403, while API-only routes (e.g. `/zhihu/people/answers/:id`) are unaffected because they only rely on the dynamically computed `x-zse-96` header.

This PR adds a fallback: if `__zse_ck` is absent from `ZHIHU_COOKIES`, fetch it automatically from Zhihu's public static JS. The value is site-wide (not user-specific) and requires no login. Users can now omit `__zse_ck` from `ZHIHU_COOKIES` and it will be fetched and cached automatically. Existing configs that include `__zse_ck` are unchanged.