### PR TITLE
fix: parse VXNA entry date

### DIFF
--- a/lib/routes/v2ex/xna.ts
+++ b/lib/routes/v2ex/xna.ts
@@ -3,6 +3,7 @@ import { load } from 'cheerio';
 import type { Route } from '@/types';
 import { ViewType } from '@/types';
 import got from '@/utils/got';
+import { parseRelativeDate } from '@/utils/parse-date';
 
 export const route: Route = {
     path: '/xna',
@@ -39,12 +40,14 @@ async function handler(ctx) {
         .map((dom) => {
             const link = $(dom).find('.xna-entry-title > a');
             const author = $(dom).find('.xna-source-author > a').text();
+            const dateText = $(dom).find('.xna-entry-date').text().trim();
 
             return {
                 title: $(link).text(),
                 link: $(link).attr('href'),
                 description: $(link).text(),
                 author,
+                pubDate: dateText ? parseRelativeDate(dateText) : undefined,
             };
         });
 


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/v2ex/xna
```

## Note / 说明
原来没有解析 `xna-entry-date` 中的日期。