### PR TITLE
feat(route): yahoo autos tw

### DIFF
--- a/lib/routes/yahoo/news/tw/autos.ts
+++ b/lib/routes/yahoo/news/tw/autos.ts
@@ -1,0 +1,83 @@
+import { load } from 'cheerio';
+
+import { config } from '@/config';
+import type { Route } from '@/types';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+
+const feedUrl = 'https://autos.yahoo.com.tw/rss/car-news';
+const maxRetries = 3;
+
+const parseFeed = (feedContent: string) => {
+    const trimmedFeedContent = feedContent.trim();
+
+    const $feed = load(trimmedFeedContent, { xmlMode: true });
+
+    const hasXmlDeclaration = trimmedFeedContent.startsWith('<?xml');
+    const hasSupportedRoot = trimmedFeedContent.startsWith('<rss') || trimmedFeedContent.startsWith('<feed') || trimmedFeedContent.startsWith('<channel') || hasXmlDeclaration;
+
+    if (!hasSupportedRoot || ($feed('channel').length === 0 && $feed('feed').length === 0)) {
+        throw new Error(`Upstream returned invalid RSS content: ${feedUrl}`);
+    }
+
+    return $feed;
+};
+
+const fetchFeed = async (attempt = 0) => {
+    try {
+        const feedResponse = await got(feedUrl, {
+            headers: {
+                'User-Agent': config.trueUA,
+            },
+        });
+        const feedContent = typeof feedResponse.data === 'string' ? feedResponse.data : String(feedResponse.data);
+        return parseFeed(feedContent);
+    } catch (error) {
+        if (attempt >= maxRetries - 1) {
+            throw error;
+        }
+
+        return fetchFeed(attempt + 1);
+    }
+};
+
+export const route: Route = {
+    path: '/news/tw/autos',
+    categories: ['new-media'],
+    example: '/yahoo/news/tw/autos',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Autos News Taiwan',
+    maintainers: ['ParinLL'],
+    handler: async () => {
+        const $feed = await fetchFeed();
+
+        const items = $feed('item')
+            .toArray()
+            .map((item) => {
+                const $item = $feed(item);
+
+                return {
+                    title: $item.find('title').text(),
+                    link: $item.find('link').text(),
+                    description: $item.find('description').text(),
+                    pubDate: parseDate($item.find('pubDate').text()),
+                };
+            });
+
+        return {
+            title: $feed('channel > title').first().text(),
+            link: $feed('channel > link').first().text(),
+            description: $feed('channel > description').first().text(),
+            item: items,
+            image: $feed('channel > image > url').first().text(),
+        };
+    },
+};


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/yahoo/news/tw/autos
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范] Yes. Uses standard V3 route structure with `export const route`, internal utilities (`got`, `parseDate`), and cheerio for XML parsing.
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? No anti-bot measures needed. The route fetches a public RSS feed directly.
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed: Yes. Uses `parseDate` from `@/utils/parse-date` to parse the `<pubDate>` element from the RSS XML.
    - [x] Correct time zone: Yes. The feed provides RFC 2822 dates with GMT timezone (e.g., `Wed, 25 Feb 2026 09:00:00 GMT`), which `parseDate` handles correctly.
- [ ] New package added / 添加了新的包: No. All dependencies (`cheerio`, `got`, `parseDate`) are already in the project.
- [ ] Puppeteer: Not used. `requirePuppeteer` is set to `false`.

## Note / 说明

- Adds a new route for [Yahoo Autos Taiwan](https://autos.yahoo.com.tw/car-news) (Yahoo 汽車機車).
- Source RSS: https://autos.yahoo.com.tw/rss/car-news
- Parses the RSS XML feed using cheerio in `xmlMode` to extract title, link, description, and pubDate for each item.
- V3 Route structure configured via `export const route` in `lib/routes/yahoo/news/tw/autos.ts`.
