### PR TITLE
feat(route): add Perplexity Blog

### DIFF
--- a/lib/routes/perplexity/blog.ts
+++ b/lib/routes/perplexity/blog.ts
@@ -1,0 +1,122 @@
+import { Route, DataItem, Data, ViewType } from '@/types';
+import puppeteer from '@/utils/puppeteer';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/blog',
+    example: 'https://www.perplexity.ai/hub/announcing-comet-plus-launch-partners',
+    url: 'perplexity.ai',
+    categories: ['blog'],
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: true,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.perplexity.ai'],
+            target: '/hub',
+        },
+    ],
+    name: 'Perplexity Blog',
+    maintainers: ['seeyangzhi'],
+    handler,
+    description: "Perplexity Blog - Explore Perplexity's blog for articles, announcements, product updates, and tips to optimize your experience. Stay informed and make the most of Perplexity.",
+    view: ViewType.Notifications,
+};
+
+async function handler() {
+    const rootUrl = 'https://www.perplexity.ai/hub';
+    const browser = await puppeteer();
+
+    const page = await browser.newPage();
+
+    await page.setRequestInterception(true);
+
+    // only allow certain types of requests to proceed
+    page.on('request', (request) => {
+        // in this case, we only allow document requests to proceed
+        request.resourceType() === 'document' ? request.continue() : request.abort();
+    });
+
+    await page.goto(rootUrl, {
+        // specify how long to wait for the page to load
+        waitUntil: 'domcontentloaded',
+    });
+
+    await page.goto(rootUrl);
+    // retrieve the HTML content of the page
+    const response = await page.content();
+
+    const $ = load(response);
+
+    const items: DataItem[] = [];
+    const seenLinks = new Set<string>();
+
+    // Get featured card first
+    const featuredCard = $('[data-framer-name="Featured Card Tablet"] [data-framer-name="Content"] a[href^="./hub/blog/"]').first();
+    if (featuredCard.length > 0) {
+        const link = new URL(String(featuredCard.attr('href')), rootUrl).href;
+        const title = featuredCard.find('h4').text().trim() || featuredCard.text().trim();
+
+        // Visit the link to get the date
+        await page.goto(link, { waitUntil: 'domcontentloaded' });
+        const articleContent = await page.content();
+        const $article = load(articleContent);
+        const dateText = $article('[data-framer-root] > :nth-child(2) > div:nth-child(3) > div > div > div > div:nth-child(2) > div:nth-child(2)').text().trim();
+
+        items.push({
+            link,
+            title,
+            pubDate: dateText ? parseDate(dateText) : undefined,
+        });
+        seenLinks.add(link);
+    }
+
+    // Get items from "Not Featured" section
+    const notFeaturedItems = $('[data-framer-name="Not Featured"] a[href^="./hub/blog/"]')
+        .toArray()
+        .map((item) => {
+            const element = $(item);
+
+            const link = new URL(String(element.attr('href')), rootUrl).href;
+
+            // Extract title from h4 within the Title div
+            const title = element.find('[data-framer-name="Title"] h4').text().trim();
+
+            // Extract date from the Date div
+            const dateText = element.find('[data-framer-name="Date"] p').text().trim();
+            const pubDate = dateText ? parseDate(dateText) : undefined;
+
+            return {
+                link,
+                title,
+                pubDate,
+            };
+        })
+        .filter((item) => {
+            // Remove duplicates based on link
+            if (seenLinks.has(item.link)) {
+                return false;
+            }
+            seenLinks.add(item.link);
+            return true;
+        });
+
+    items.push(...notFeaturedItems);
+
+    page.close();
+    browser.close();
+
+    return {
+        title: 'Perplexity',
+        link: rootUrl,
+        item: items,
+        language: 'en',
+    } satisfies Data;
+}

--- a/lib/routes/perplexity/blog.ts
+++ b/lib/routes/perplexity/blog.ts
@@ -5,7 +5,7 @@ import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
     path: '/blog',
-    example: 'https://www.perplexity.ai/hub/announcing-comet-plus-launch-partners',
+    example: '/perplexity/blog',
     url: 'perplexity.ai',
     categories: ['blog'],
     parameters: {},
@@ -19,11 +19,11 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['www.perplexity.ai'],
-            target: '/hub',
+            source: ['www.perplexity.ai/hub'],
+            target: '/blog',
         },
     ],
-    name: 'Perplexity Blog',
+    name: 'Blog',
     maintainers: ['seeyangzhi'],
     handler,
     description: "Perplexity Blog - Explore Perplexity's blog for articles, announcements, product updates, and tips to optimize your experience. Stay informed and make the most of Perplexity.",
@@ -49,7 +49,6 @@ async function handler() {
         waitUntil: 'domcontentloaded',
     });
 
-    await page.goto(rootUrl);
     // retrieve the HTML content of the page
     const response = await page.content();
 
@@ -58,8 +57,8 @@ async function handler() {
     const items: DataItem[] = [];
     const seenLinks = new Set<string>();
 
-    // Get featured card first
-    const featuredCard = $('[data-framer-name="Featured Card Tablet"] [data-framer-name="Content"] a[href^="./hub/blog/"]').first();
+    // Get featured card first (updated selector per site changes)
+    const featuredCard = $('[data-framer-name="Featured article"] [data-framer-name="Content"] a[href^="./hub/blog/"]').first();
     if (featuredCard.length > 0) {
         const link = new URL(String(featuredCard.attr('href')), rootUrl).href;
         const title = featuredCard.find('h4').text().trim() || featuredCard.text().trim();
@@ -110,8 +109,8 @@ async function handler() {
 
     items.push(...notFeaturedItems);
 
-    page.close();
-    browser.close();
+    await page.close();
+    await browser.close();
 
     return {
         title: 'Perplexity',


### PR DESCRIPTION
This PR adds support for Perplexity's Blog (https://www.perplexity.ai/hub).

Route: `/perplexity/blog`

### Checklist
- New Route
- Follows Script Standard
- Date/time parsed with correct timezone
- Uses Puppeteer

Fixes issues from previous PR #20372:
- Fixed example to be route path instead of full URL
- Fixed route name to not include namespace name
- Updated featured card selector per site changes
- Added missing await to puppeteer cleanup calls

/cc @TonyRL