### PR TITLE
feat(route): add /anthropic/blog and fix /anthropic/research

### DIFF
--- a/lib/routes/anthropic/blog.ts
+++ b/lib/routes/anthropic/blog.ts
@@ -1,0 +1,77 @@
+import { load } from 'cheerio';
+import pMap from 'p-map';
+
+import type { DataItem, Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/blog',
+    categories: ['blog'],
+    view: ViewType.Articles,
+    example: '/anthropic/blog',
+    parameters: {},
+    radar: [
+        {
+            source: ['claude.com/blog'],
+        },
+    ],
+    name: 'Claude Blog',
+    maintainers: ['zlx'],
+    handler,
+    url: 'claude.com/blog',
+};
+
+async function handler(ctx) {
+    const baseUrl = 'https://claude.com';
+    const listUrl = `${baseUrl}/blog`;
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 15;
+
+    const response = await ofetch(listUrl);
+    const $ = load(response);
+
+    const list: DataItem[] = $('.blog_cms_item.w-dyn-item')
+        .toArray()
+        .slice(0, limit)
+        .map((el) => {
+            const $el = $(el);
+            const title = $el.find('[fs-list-field="heading"]').text().trim();
+            const href = $el.find('a.clickable_link').attr('href') ?? '';
+            const dateText = $el.find('[fs-list-field="date"]').text().trim();
+            const category = $el.find('[fs-list-field="category"]').text().trim();
+
+            return {
+                title,
+                link: href.startsWith('http') ? href : `${baseUrl}${href}`,
+                pubDate: dateText ? parseDate(dateText) : undefined,
+                category: category ? [category] : [],
+            };
+        })
+        .filter((item) => item.title && item.link);
+
+    const items = await pMap(
+        list,
+        (item) =>
+            cache.tryGet(item.link!, async () => {
+                const res = await ofetch(item.link!);
+                const $article = load(res);
+
+                const description = $article('.blog_post_content_wrap .u-rich-text-blog').html();
+
+                return {
+                    ...item,
+                    description: description || '',
+                };
+            }),
+        { concurrency: 5 }
+    );
+
+    return {
+        title: 'Claude Blog',
+        link: listUrl,
+        description: 'Product news and best practices for teams building with Claude.',
+        item: items,
+    };
+}

--- a/lib/routes/anthropic/research.ts
+++ b/lib/routes/anthropic/research.ts
@@ -1,7 +1,7 @@
 import { load } from 'cheerio';
 import pMap from 'p-map';
 
-import type { Route } from '@/types';
+import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
@@ -17,87 +17,74 @@ export const route: Route = {
         },
     ],
     name: 'Research',
-    maintainers: ['ttttmr'],
+    maintainers: ['ttttmr', 'zlx'],
     handler,
     url: 'www.anthropic.com/research',
 };
 
-async function handler() {
-    const link = 'https://www.anthropic.com/research';
+async function handler(ctx) {
+    const baseUrl = 'https://www.anthropic.com';
+    const link = `${baseUrl}/research`;
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 15;
+
     const response = await ofetch(link);
     const $ = load(response);
 
-    // self.__next_f.push
-    const regexp = /self\.__next_f\.push\((.+)\)/;
-    const textList: string[] = [];
-    for (const e of $('script').toArray()) {
-        const $e = $(e);
-        const text = $e.text();
-        const match = regexp.exec(text);
-        if (match) {
-            let data;
-            try {
-                data = JSON.parse(match[1]);
-                if (Array.isArray(data) && data.length === 2 && data[0] === 1) {
-                    textList.push(data[1]);
-                }
-            } catch {
-                // ignore
-            }
+    const seen = new Set<string>();
+    const list: DataItem[] = [];
+
+    // Featured items and publication list items share the same link pattern
+    $('a[href^="/research/"]').each((_, el) => {
+        const $el = $(el);
+        const href = $el.attr('href') ?? '';
+
+        // Skip non-article links
+        if (!href || href === '/research' || href.includes('/team/') || href.endsWith('#')) {
+            return;
         }
-    }
 
-    const partRegex = /^([0-9a-zA-Z]+):([0-9a-zA-Z]+)?(\[.*)$/;
-    const fd = textList
-        .join('')
-        .split('\n')
-        .map((d) => {
-            const matchPart = partRegex.exec(d);
-            if (matchPart) {
-                return {
-                    id: matchPart[1],
-                    tag: matchPart[2],
-                    data: JSON.parse(matchPart[3]),
-                };
-            }
-            return {
-                id: '',
-                tag: '',
-                data: d,
-            };
-        });
+        const fullLink = `${baseUrl}${href}`;
+        if (seen.has(fullLink)) {
+            return;
+        }
 
-    const sections = fd.flatMap((d) => (Array.isArray(d.data) ? d.data : [])).flatMap((item) => item?.page?.sections ?? []);
-    const tabPages = sections.flatMap((section) => section?.tabPages ?? []).filter((tabPage) => tabPage?.label === 'Overview');
-    const publicationSections = tabPages.flatMap((tabPage) => tabPage.sections).filter((section) => section?.title === 'Publications');
-    const posts = publicationSections
-        .flatMap((section) => section?.posts ?? [])
-        .map((post) => ({
-            title: post.title,
-            link: `https://www.anthropic.com/research/${post.slug.current}`,
-            pubDate: parseDate(post.publishedOn),
-        }));
+        const title = $el.find('h2, h4, [class*="__title"]').first().text().trim();
+        const dateText = $el.find('time').text().trim();
+        const category = $el.find('span').first().text().trim();
+
+        if (title) {
+            seen.add(fullLink);
+            list.push({
+                title,
+                link: fullLink,
+                pubDate: dateText ? parseDate(dateText) : undefined,
+                category: category ? [category] : [],
+            });
+        }
+    });
 
     const items = await pMap(
-        posts,
+        list.slice(0, limit),
         (item) =>
-            cache.tryGet(item.link, async () => {
-                const response = await ofetch(item.link);
+            cache.tryGet(item.link!, async () => {
+                const response = await ofetch(item.link!);
                 const $ = load(response);
 
-                const content = $('div[class*="PostDetail_post-detail__"]');
+                const content = $('article');
                 content.find('img').each((_, e) => {
                     const $e = $(e);
                     $e.removeAttr('style srcset');
                     const src = $e.attr('src');
-                    const params = new URLSearchParams(src);
-                    const newSrc = params.get('/_next/image?url');
-                    if (newSrc) {
-                        $e.attr('src', newSrc);
+                    if (src) {
+                        const params = new URLSearchParams(src);
+                        const newSrc = params.get('/_next/image?url');
+                        if (newSrc) {
+                            $e.attr('src', newSrc);
+                        }
                     }
                 });
 
-                item.description = content.html();
+                item.description = content.html() ?? undefined;
 
                 return item;
             }),


### PR DESCRIPTION
## Summary
- **New route**: `/anthropic/blog` — Scrapes [claude.com/blog](https://claude.com/blog) for product news and best practices, with full article content
- **Fix route**: `/anthropic/research` — Rewrites the broken handler that relied on Next.js RSC data extraction (`self.__next_f.push`), now uses standard HTML parsing after the site redesign

## Checklist
- [x] New route `/anthropic/blog` follows existing conventions (cheerio + ofetch + cache)
- [x] Fixed `/anthropic/research` handles both featured items and publication list
- [x] Both routes support `?limit=` query parameter
- [x] Full article content fetched and cached for both routes
- [x] Tested locally with `pnpm dev`

## Test plan
- [ ] Visit `http://localhost:1200/anthropic/blog` — should return 15 articles with full content
- [ ] Visit `http://localhost:1200/anthropic/research` — should return 14+ articles with full content
- [ ] Verify RSS feed renders correctly in a feed reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)

via [HAPI](https://hapi.run)