### PR TITLE
feat(route): add Inception Labs blog route

### DIFF
--- a/lib/routes/inceptionlabs/blog.ts
+++ b/lib/routes/inceptionlabs/blog.ts
@@ -1,6 +1,6 @@
 import { load } from 'cheerio';
 
-import type { Route } from '@/types';
+import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
@@ -9,7 +9,7 @@ const ROOT_URL = 'https://www.inceptionlabs.ai';
 
 export const route: Route = {
     path: '/blog',
-    categories: ['technology'],
+    categories: ['programming'],
     example: '/inceptionlabs/blog',
     features: {
         requireConfig: false,
@@ -21,91 +21,76 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['www.inceptionlabs.ai/blog', 'inceptionlabs.ai/blog'],
+            source: ['www.inceptionlabs.ai/blog'],
         },
     ],
     name: 'Blog',
-    maintainers: [],
+    maintainers: ['zdenek-stursa'],
     handler,
     url: 'inceptionlabs.ai/blog',
 };
-
-interface PostMeta {
-    title: string;
-    link: string;
-    category: string;
-    pubDate: string;
-}
 
 async function handler() {
     const response = await ofetch(`${ROOT_URL}/blog`);
     const $ = load(response);
 
-    // Collect blog post cards from listing page.
-    // The page has SSR breakpoint variants (desktop/mobile), so entries appear multiple times.
-    // We deduplicate by link, keeping the first occurrence that has a real title.
-    const seen = new Set<string>();
-    const posts: PostMeta[] = [];
+    // Use [data-framer-name="Desktop"] to target only desktop-variant cards,
+    // avoiding duplicate entries from SSR breakpoint rendering (desktop/mobile).
+    const posts = $('a[href^="./blog/"][data-framer-name="Desktop"]')
+        .toArray()
+        .map((el): DataItem | null => {
+            const $el = $(el);
+            const href = $el.attr('href') ?? '';
 
-    $('a[href^="./blog/"]').each((_, el) => {
-        const href = $(el).attr('href') ?? '';
+            // Skip category filter links and anchor-only links
+            if (href.includes('categories') || href.includes('#')) {
+                return null;
+            }
 
-        // Skip category filter links and anchor links
-        if (href.includes('categories') || href.includes('#')) {
-            return;
-        }
+            // Get title: first h6.framer-text that is not a "Read story" navigation label
+            const title = $el
+                .find('h6.framer-text')
+                .toArray()
+                .map((h6) => $(h6).text().trim())
+                .find((text) => text && text !== 'Read story');
 
-        // Get title: first h6.framer-text that is not a "Read story" navigation label
-        let title = '';
-        $(el)
-            .find('h6.framer-text')
-            .each((_, h6El) => {
-                const text = $(h6El).text().trim();
-                if (!title && text && text !== 'Read story') {
-                    title = text;
-                }
-            });
+            if (!title) {
+                return null;
+            }
 
-        if (!title) {
-            return;
-        }
+            const slug = href.replace('./blog/', '');
+            const link = `${ROOT_URL}/blog/${slug}`;
 
-        const slug = href.replace('./blog/', '');
-        const link = `${ROOT_URL}/blog/${slug}`;
+            // Date/category extraction – two card layouts exist:
+            //   Standard card:  [data-framer-name="Date"][0] = category (teal),
+            //                   [data-framer-name="Date"][1] = plain date text
+            //   Featured card:  [data-framer-name="Date"][0] = date inside <mark>,
+            //                   [data-framer-name="Category"]  = category (teal, separate element)
+            const dateBlocks = $el
+                .find('[data-framer-name="Date"] p.framer-text')
+                .toArray()
+                .map((p) => $(p).text().trim());
 
-        // Deduplicate AFTER confirming the card has a real title,
-        // so that banner anchors (without title) don't block the actual card.
-        if (seen.has(link)) {
-            return;
-        }
-        seen.add(link);
+            // Category: featured cards use data-framer-name="Category"; standard cards use dateBlocks[0]
+            const categoryEl = $el.find('[data-framer-name="Category"]');
+            const category = categoryEl.length > 0 ? categoryEl.first().text().trim() : (dateBlocks[0] ?? '');
 
-        // Date/category extraction – two card layouts exist:
-        //   Standard card:  [data-framer-name="Date"][0] = category (teal),
-        //                   [data-framer-name="Date"][1] = plain date text
-        //   Featured card:  [data-framer-name="Date"][0] = date inside <mark>,
-        //                   [data-framer-name="Category"]  = category (teal, separate element)
-        const dateBlocks: string[] = [];
-        $(el)
-            .find('[data-framer-name="Date"] p.framer-text')
-            .each((_, p) => {
-                dateBlocks.push($(p).text().trim());
-            });
+            // Date: featured cards have a single Date block (the date itself); standard cards have it at index 1
+            const pubDate = dateBlocks.length >= 2 ? dateBlocks[1] : (dateBlocks[0] ?? '');
 
-        // Category: featured cards use data-framer-name="Category"; standard cards use dateBlocks[0]
-        const categoryEl = $(el).find('[data-framer-name="Category"]');
-        const category = categoryEl.length > 0 ? categoryEl.first().text().trim() : (dateBlocks[0] ?? '');
-
-        // Date: featured cards have a single Date block (the date itself); standard cards have it at index 1
-        const pubDate = dateBlocks.length >= 2 ? dateBlocks[1] : (dateBlocks[0] ?? '');
-
-        posts.push({ title, link, category, pubDate });
-    });
+            return {
+                title,
+                link,
+                category: category ? [category] : [],
+                pubDate,
+            };
+        })
+        .filter((post): post is DataItem => post !== null);
 
     const items = await Promise.all(
         posts.map((post) =>
-            cache.tryGet(post.link, async () => {
-                const postHtml = await ofetch(post.link);
+            cache.tryGet(post.link!, async () => {
+                const postHtml = await ofetch(post.link!);
                 const $post = load(postHtml);
 
                 // Full article content
@@ -115,13 +100,11 @@ async function handler() {
                 const author = $post('[data-framer-name="Author"] p.framer-text').first().text().trim();
 
                 return {
-                    title: post.title,
-                    link: post.link,
+                    ...post,
                     description: contentHtml,
                     author,
-                    pubDate: parseDate(post.pubDate),
-                    category: post.category ? [post.category] : [],
-                };
+                    pubDate: parseDate(post.pubDate as string),
+                } as DataItem;
             })
         )
     );

--- a/lib/routes/inceptionlabs/blog.ts
+++ b/lib/routes/inceptionlabs/blog.ts
@@ -1,0 +1,135 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const ROOT_URL = 'https://www.inceptionlabs.ai';
+
+export const route: Route = {
+    path: '/blog',
+    categories: ['technology'],
+    example: '/inceptionlabs/blog',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.inceptionlabs.ai/blog', 'inceptionlabs.ai/blog'],
+        },
+    ],
+    name: 'Blog',
+    maintainers: [],
+    handler,
+    url: 'inceptionlabs.ai/blog',
+};
+
+interface PostMeta {
+    title: string;
+    link: string;
+    category: string;
+    pubDate: string;
+}
+
+async function handler() {
+    const response = await ofetch(`${ROOT_URL}/blog`);
+    const $ = load(response);
+
+    // Collect blog post cards from listing page.
+    // The page has SSR breakpoint variants (desktop/mobile), so entries appear multiple times.
+    // We deduplicate by link, keeping the first occurrence that has a real title.
+    const seen = new Set<string>();
+    const posts: PostMeta[] = [];
+
+    $('a[href^="./blog/"]').each((_, el) => {
+        const href = $(el).attr('href') ?? '';
+
+        // Skip category filter links and anchor links
+        if (href.includes('categories') || href.includes('#')) {
+            return;
+        }
+
+        // Get title: first h6.framer-text that is not a "Read story" navigation label
+        let title = '';
+        $(el)
+            .find('h6.framer-text')
+            .each((_, h6El) => {
+                const text = $(h6El).text().trim();
+                if (!title && text && text !== 'Read story') {
+                    title = text;
+                }
+            });
+
+        if (!title) {
+            return;
+        }
+
+        const slug = href.replace('./blog/', '');
+        const link = `${ROOT_URL}/blog/${slug}`;
+
+        // Deduplicate AFTER confirming the card has a real title,
+        // so that banner anchors (without title) don't block the actual card.
+        if (seen.has(link)) {
+            return;
+        }
+        seen.add(link);
+
+        // Date/category extraction – two card layouts exist:
+        //   Standard card:  [data-framer-name="Date"][0] = category (teal),
+        //                   [data-framer-name="Date"][1] = plain date text
+        //   Featured card:  [data-framer-name="Date"][0] = date inside <mark>,
+        //                   [data-framer-name="Category"]  = category (teal, separate element)
+        const dateBlocks: string[] = [];
+        $(el)
+            .find('[data-framer-name="Date"] p.framer-text')
+            .each((_, p) => {
+                dateBlocks.push($(p).text().trim());
+            });
+
+        // Category: featured cards use data-framer-name="Category"; standard cards use dateBlocks[0]
+        const categoryEl = $(el).find('[data-framer-name="Category"]');
+        const category = categoryEl.length > 0 ? categoryEl.first().text().trim() : (dateBlocks[0] ?? '');
+
+        // Date: featured cards have a single Date block (the date itself); standard cards have it at index 1
+        const pubDate = dateBlocks.length >= 2 ? dateBlocks[1] : (dateBlocks[0] ?? '');
+
+        posts.push({ title, link, category, pubDate });
+    });
+
+    const items = await Promise.all(
+        posts.map((post) =>
+            cache.tryGet(post.link, async () => {
+                const postHtml = await ofetch(post.link);
+                const $post = load(postHtml);
+
+                // Full article content
+                const contentHtml = $post('[data-framer-name="Content"]').first().html() ?? '';
+
+                // Author name from the first [data-framer-name="Author"] RichTextContainer
+                const author = $post('[data-framer-name="Author"] p.framer-text').first().text().trim();
+
+                return {
+                    title: post.title,
+                    link: post.link,
+                    description: contentHtml,
+                    author,
+                    pubDate: parseDate(post.pubDate),
+                    category: post.category ? [post.category] : [],
+                };
+            })
+        )
+    );
+
+    return {
+        title: 'Inception Labs Blog',
+        link: `${ROOT_URL}/blog`,
+        description: 'Latest posts from the Inception Labs blog about diffusion LLMs and AI research',
+        item: items,
+    };
+}

--- a/lib/routes/inceptionlabs/namespace.ts
+++ b/lib/routes/inceptionlabs/namespace.ts
@@ -3,7 +3,7 @@ import type { Namespace } from '@/types';
 export const namespace: Namespace = {
     name: 'Inception Labs',
     url: 'inceptionlabs.ai',
-    categories: ['technology'],
+    categories: ['programming'],
     description: 'Inception Labs - AI research company developing diffusion-based LLMs',
     lang: 'en',
 };

--- a/lib/routes/inceptionlabs/namespace.ts
+++ b/lib/routes/inceptionlabs/namespace.ts
@@ -1,0 +1,9 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Inception Labs',
+    url: 'inceptionlabs.ai',
+    categories: ['technology'],
+    description: 'Inception Labs - AI research company developing diffusion-based LLMs',
+    lang: 'en',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/inceptionlabs/blog
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds RSS feed for **https://www.inceptionlabs.ai/blog/**

Inception Labs is an AI research company building diffusion-based LLMs (dLLMs), known for their Mercury model.

The blog is built with **Framer** and rendered server-side (SSR), so a plain HTTP fetch with a browser User-Agent returns full HTML — no Puppeteer needed.

Two card layouts exist on the listing page:
- **Standard card** – date and category in `[data-framer-name="Date"]` elements
- **Featured card** – date inside `<mark>`, category in `[data-framer-name="Category"]`

Each item includes: title, publication date, author, category, and full article body.