### PR TITLE
feat(weibo): apply description render params to comments

### DIFF
--- a/lib/routes/weibo/namespace.ts
+++ b/lib/routes/weibo/namespace.ts
@@ -31,8 +31,8 @@ export const namespace: Namespace = {
 | displayVideo               | 是否直接显示微博视频和 Live Photo，只在博主或个人时间线 RSS 中有效 | 0/1/true/false | true                                |
 | displayArticle             | 是否直接显示微博文章，只在博主或个人时间线 RSS 中有效              | 0/1/true/false | false                               |
 | displayComments            | 是否直接显示热门评论，只在博主或个人时间线 RSS 中有效              | 0/1/true/false | false                               |
-| showEmojiInDescription     | 是否展示正文中的微博表情，关闭则替换为 \`[表情名]\`                  | 0/1/true/false | true                                |
-| showLinkIconInDescription  | 是否展示正文中的链接图标                                           | 0/1/true/false | true                                |
+| showEmojiInDescription     | 是否展示正文和评论中的微博表情，关闭则替换为 \`[表情名]\`            | 0/1/true/false | true                                |
+| showLinkIconInDescription  | 是否展示正文和评论中的链接图标                                     | 0/1/true/false | true                                |
 | preferMobileLink           | 是否使用移动版链接（默认使用 PC 版）                               | 0/1/true/false | false                               |
 | showRetweeted              | 是否显示转发的微博                                                 | 0/1/true/false | true                               |
 | showBloggerIcons           | 是否显示评论中博主的标志，只在显示热门评论时有效                                           | 0/1/true/false | false                               |

--- a/lib/routes/weibo/utils.ts
+++ b/lib/routes/weibo/utils.ts
@@ -17,6 +17,25 @@ class RenewWeiboCookiesError extends Error {
     }
 }
 
+const getDescriptionRenderParams = (routeParams, params = {}) => ({
+    showEmojiInDescription: fallback(params.showEmojiInDescription, queryToInteger(routeParams.showEmojiInDescription), false),
+    showLinkIconInDescription: fallback(params.showLinkIconInDescription, queryToInteger(routeParams.showLinkIconInDescription), true),
+});
+
+const formatDescriptionText = (html, { showEmojiInDescription, showLinkIconInDescription }) => {
+    let formattedHtml = html;
+
+    if (!showEmojiInDescription) {
+        formattedHtml = formattedHtml.replaceAll(/<span class=["']?url-icon["']?><img\s[^>]*?alt=["']?([^>]+?)["']?\s[^>]*?\/><\/span>/g, '$1');
+    }
+
+    if (!showLinkIconInDescription) {
+        formattedHtml = formattedHtml.replaceAll(/(<a\s[^>]*>)<span class=["']?url-icon["']?><img\s[^>]*><\/span>[^<>]*?<span class=["']?surl-text["']?>([^<>]*?)<\/span><\/a>/g, '$1$2</a>');
+    }
+
+    return formattedHtml;
+};
+
 const weiboUtils = {
     apiHeaders: {
         'MWeibo-Pwa': 1,
@@ -135,6 +154,7 @@ const weiboUtils = {
 
         // undefined and strings like "1" is also safely parsed, so no if branch is needed
         const routeParams = querystring.parse(ctx.req.param('routeParams'));
+        const descriptionRenderParams = getDescriptionRenderParams(routeParams, params);
 
         const mergedParams = {
             readable: fallback(params.readable, queryToBoolean(routeParams.readable), false),
@@ -151,8 +171,8 @@ const weiboUtils = {
             widthOfPics: fallback(params.widthOfPics, queryToInteger(routeParams.widthOfPics), -1),
             heightOfPics: fallback(params.heightOfPics, queryToInteger(routeParams.heightOfPics), -1),
             sizeOfAuthorAvatar: fallback(params.sizeOfAuthorAvatar, queryToInteger(routeParams.sizeOfAuthorAvatar), 48),
-            showEmojiInDescription: fallback(params.showEmojiInDescription, queryToInteger(routeParams.showEmojiInDescription), false),
-            showLinkIconInDescription: fallback(params.showLinkIconInDescription, queryToInteger(routeParams.showLinkIconInDescription), true),
+            showEmojiInDescription: descriptionRenderParams.showEmojiInDescription,
+            showLinkIconInDescription: descriptionRenderParams.showLinkIconInDescription,
             preferMobileLink: fallback(params.preferMobileLink, queryToBoolean(routeParams.preferMobileLink), false),
         };
 
@@ -173,22 +193,13 @@ const weiboUtils = {
             widthOfPics,
             heightOfPics,
             sizeOfAuthorAvatar,
-            showEmojiInDescription,
-            showLinkIconInDescription,
             preferMobileLink,
         } = params;
 
         let retweeted = '';
         // 长文章的处理
         let htmlNewLineUnreplaced = (status.longText && status.longText.longTextContent) || status.text || '';
-        // 表情图标转换为文字
-        if (!showEmojiInDescription) {
-            htmlNewLineUnreplaced = htmlNewLineUnreplaced.replaceAll(/<span class=["']?url-icon["']?><img\s[^>]*?alt=["']?([^>]+?)["']?\s[^>]*?\/><\/span>/g, '$1');
-        }
-        // 去掉链接的图标，保留 a 标签链接
-        if (!showLinkIconInDescription) {
-            htmlNewLineUnreplaced = htmlNewLineUnreplaced.replaceAll(/(<a\s[^>]*>)<span class=["']?url-icon["']?><img\s[^>]*><\/span>[^<>]*?<span class=["']?surl-text["']?>([^<>]*?)<\/span><\/a>/g, '$1$2</a>');
-        }
+        htmlNewLineUnreplaced = formatDescriptionText(htmlNewLineUnreplaced, descriptionRenderParams);
 
         // 提取 话题作为 category
         const category: string[] = htmlNewLineUnreplaced.match(/<span class=["']?surl-text["']?>#([^<>]*?)#<\/span>/g)?.map((e) => e?.match(/#([^#]+)#/)?.[1]);
@@ -519,6 +530,9 @@ const weiboUtils = {
         return itemDesc;
     },
     formatComments: async (ctx, itemDesc, status, showBloggerIcons) => {
+        const routeParams = querystring.parse(ctx.req.param('routeParams'));
+        const descriptionRenderParams = getDescriptionRenderParams(routeParams);
+
         if (status && status.comments_count && status.id && status.mid) {
             const id = status.id;
             const mid = status.mid;
@@ -542,7 +556,8 @@ const weiboUtils = {
                     if (showBloggerIcons === '1' && comment.blogger_icons) {
                         name += comment.blogger_icons[0].name;
                     }
-                    itemDesc += `<a href="https://weibo.com/${comment.user.id}" target="_blank">${name}</a>: ${comment.text}`;
+                    const commentText = formatDescriptionText(comment.text, descriptionRenderParams);
+                    itemDesc += `<a href="https://weibo.com/${comment.user.id}" target="_blank">${name}</a>: ${commentText}`;
                     // 带有图片的评论直接输出图片
                     if ('pic' in comment) {
                         itemDesc += `<br><img src="${comment.pic.url}">`;
@@ -552,7 +567,8 @@ const weiboUtils = {
                         for (const com of comment.comments) {
                             // 评论的带有图片的评论直接输出图片
                             const pattern = /<a\s+href="https:\/\/weibo\.cn\/sinaurl\?u=([^"]+)"[^>]*><span class='url-icon'><img[^>]*><\/span><span class="surl-text">(查看图片|评论配图|查看动图)<\/span><\/a>/g;
-                            const matches = com.text.match(pattern);
+                            let replyText = com.text;
+                            const matches = replyText.match(pattern);
                             if (matches) {
                                 for (const match of matches) {
                                     const hrefMatch = match.match(/href="https:\/\/weibo\.cn\/sinaurl\?u=([^"]+)"/);
@@ -561,16 +577,17 @@ const weiboUtils = {
                                         const imgSrc = decodeURIComponent(hrefMatch[1]);
                                         const imgTag = `<img src="${imgSrc}" style="width: 1rem; height: 1rem;">`;
                                         // 用替换后的 img 标签替换原来的 <a> 标签部分
-                                        com.text = com.text.replaceAll(match, imgTag);
+                                        replyText = replyText.replaceAll(match, imgTag);
                                     }
                                 }
                             }
+                            replyText = formatDescriptionText(replyText, descriptionRenderParams);
                             itemDesc += '<div style="font-size: 0.9em">';
                             let name = com.user.screen_name;
                             if (showBloggerIcons === '1' && com.blogger_icons) {
                                 name += com.blogger_icons[0].name;
                             }
-                            itemDesc += `<a href="https://weibo.com/${com.user.id}" target="_blank">${name}</a>: ${com.text}`;
+                            itemDesc += `<a href="https://weibo.com/${com.user.id}" target="_blank">${name}</a>: ${replyText}`;
                             itemDesc += '</div>';
                         }
                         itemDesc += '</blockquote>';


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/weibo/user/3306934123/readable=1&displayComments=1&showEmojiInDescription=0&showLinkIconInDescription=0
/weibo/timeline/0/readable=1&displayComments=1&showEmojiInDescription=0&showLinkIconInDescription=0
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

This PR fixes Weibo comment rendering so `showEmojiInDescription` and `showLinkIconInDescription` also apply to hot comments and nested replies, instead of only applying to the main post body.

It reuses the existing description text formatting logic for comments and updates the route documentation accordingly.

No new route or package is introduced.