### PR TITLE
feat(cursor): support localized blog and changelog routes

### DIFF
--- a/lib/routes/cursor/blog.ts
+++ b/lib/routes/cursor/blog.ts
@@ -7,18 +7,16 @@ import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
 export const handler = async (ctx: Context): Promise<Data> => {
-    const { topic } = ctx.req.param();
+    const { topic, locale } = ctx.req.param();
     const limit: number = Number.parseInt(ctx.req.query('limit') ?? '10', 10);
 
     const baseUrl = 'https://cursor.com';
-    const path = topic ? `/blog/topic/${topic}` : '/blog';
+    const normalizedTopic = topic === 'all' ? undefined : topic;
+    const localeSegment = locale ? `/${locale}` : '';
+    const path = normalizedTopic ? `${localeSegment}/blog/topic/${normalizedTopic}` : `${localeSegment}/blog`;
     const targetUrl = new URL(path, baseUrl).href;
 
-    const html = await ofetch(targetUrl, {
-        headers: {
-            cookie: 'NEXT_LOCALE=en',
-        },
-    });
+    const html = await ofetch(targetUrl);
     const $ = load(html);
 
     const main = $('#main').last(); // there are two main tags before hydration
@@ -56,13 +54,14 @@ export const handler = async (ctx: Context): Promise<Data> => {
 };
 
 export const route: Route = {
-    path: '/blog/:topic?',
+    path: '/blog/:topic?/:locale?',
     name: 'Blog',
     url: 'cursor.com',
     maintainers: ['johan456789'],
     example: '/cursor/blog',
     parameters: {
-        topic: 'Optional topic: product | research | company | news',
+        locale: 'Locale appended to the route path, e.g. `ja`',
+        topic: 'Topic: all | product | research | company | news',
     },
     description: undefined,
     categories: ['blog'],
@@ -77,8 +76,20 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['cursor.com/blog', 'cursor.com/blog/topic/:topic'],
+            source: ['cursor.com/blog'],
+            target: '/blog',
+        },
+        {
+            source: ['cursor.com/blog/topic/:topic'],
             target: '/blog/:topic',
+        },
+        {
+            source: ['cursor.com/:locale/blog'],
+            target: '/blog/all/:locale',
+        },
+        {
+            source: ['cursor.com/:locale/blog/topic/:topic'],
+            target: '/blog/:topic/:locale',
         },
     ],
     view: ViewType.Articles,

--- a/lib/routes/cursor/changelog.ts
+++ b/lib/routes/cursor/changelog.ts
@@ -9,16 +9,14 @@ import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
 export const handler = async (ctx: Context): Promise<Data> => {
+    const locale = ctx.req.param('locale');
     const limit: number = Number.parseInt(ctx.req.query('limit') ?? '100', 10);
 
     const baseUrl = 'https://cursor.com';
-    const targetUrl: string = new URL('changelog', baseUrl).href;
+    const localeSegment = locale ? `/${locale}` : '';
+    const targetUrl: string = new URL(`${localeSegment}/changelog`, baseUrl).href;
 
-    const response = await ofetch(targetUrl, {
-        headers: {
-            cookie: 'NEXT_LOCALE=en',
-        },
-    });
+    const response = await ofetch(targetUrl);
     const $: CheerioAPI = load(response);
     const language = ($('html').attr('lang') ?? 'en') as Language;
 
@@ -75,13 +73,15 @@ export const handler = async (ctx: Context): Promise<Data> => {
 };
 
 export const route: Route = {
-    path: '/changelog',
+    path: '/changelog/:locale?',
     name: 'Changelog',
     url: 'cursor.com',
     maintainers: ['p3psi-boo', 'nczitzk'],
     handler,
     example: '/cursor/changelog',
-    parameters: undefined,
+    parameters: {
+        locale: 'Locale appended to the route path, e.g. `ja`',
+    },
     description: undefined,
     categories: ['program-update'],
     features: {
@@ -97,6 +97,10 @@ export const route: Route = {
         {
             source: ['cursor.com/changelog'],
             target: '/changelog',
+        },
+        {
+            source: ['cursor.com/:locale/changelog'],
+            target: '/changelog/:locale',
         },
     ],
     view: ViewType.Articles,


### PR DESCRIPTION
<!--
If you have difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/cursor/blog
/cursor/blog/research
/cursor/changelog
/cursor/blog/all/cn
/cursor/blog/research/cn
/cursor/changelog/cn
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Support localized `Cursor` blog and changelog

adds optional `locale` path support for existing `Cursor` routes, so localized pages like `https://cursor.com/cn/blog` and `https://cursor.com/ja/changelog` can be fetched through RSSHub. Existing English routes remainunchanged.