### PR TITLE
fix(route/apple/podcast): adapt to new serialized-server-data structure

### DIFF
--- a/lib/routes/apple/podcast.ts
+++ b/lib/routes/apple/podcast.ts
@@ -43,8 +43,9 @@ async function handler(ctx) {
 
     const $ = load(response);
 
-    const serializedServerData = JSON.parse($('#serialized-server-data').text());
-    const header = serializedServerData[0].data.shelves.find((item) => item.contentType === 'showHeaderRegular').items[0];
+    const rawServerData = JSON.parse($('#serialized-server-data').text());
+    const serverData = (Array.isArray(rawServerData) ? rawServerData : rawServerData.data)[0].data;
+    const header = serverData.shelves.find((item) => item.contentType === 'showHeaderRegular').items[0];
 
     const bearerToken = await cache.tryGet(
         'apple:podcast:bearer',
@@ -93,7 +94,7 @@ async function handler(ctx) {
         };
     });
 
-    const channel = episodeReponse.data.find((d) => d.type === 'podcast-episodes').relationships.channel.data.find((d) => d.type === 'podcast-channels')?.attributes;
+    const channel = episodeReponse.data.find((d) => d.type === 'podcast-episodes')?.relationships?.channel?.data?.find((d) => d.type === 'podcast-channels')?.attributes;
 
     return {
         title: channel?.name ?? header.title,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #20095

## Summary

Apple Podcasts recently changed the `#serialized-server-data` element from a direct array format to an object wrapper `{ data: [...], userTokenHash: '' }`.

This broke the `/apple/podcast/:id/:region?` route with:
```
TypeError: Cannot read properties of undefined (reading 'data')
```

### Changes

1. **Handle both old and new data formats** — Use `Array.isArray()` to detect whether `serialized-server-data` is the old array format or the new object wrapper, then access `.data` accordingly. This maintains backward compatibility.

2. **Add defensive optional chaining on channel access** — The `channel` relationship chain (`episodeReponse.data.find(...).relationships.channel.data.find(...)`) can crash when episodes lack channel relationship data. Added `?.` at each level to gracefully fall back to header data.

### Context

- yt-dlp encountered the same structural change in Feb 2026 and [fixed it](https://github.com/yt-dlp/yt-dlp/issues/15926)

## Example for the Proposed Route(s) / 路由地址示例

```routes
/apple/podcast/id1559695855/us
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由

- [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)

- [ ] Anti-bot or rate limit / 反爬/频率限制

- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?

- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)

- [x] Fully documented the new route / 完整描述了新的路由

Made with [Cursor](https://cursor.com)