### PR TITLE
fix: Update javdb domain in utils.ts

### DIFF
--- a/lib/routes/javdb/utils.ts
+++ b/lib/routes/javdb/utils.ts
@@ -7,7 +7,7 @@ import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 
-const allowDomain = new Set(['javdb.com', 'javdb36.com', 'javdb007.com', 'javdb521.com']);
+const allowDomain = new Set(['javdb.com', 'javdb571.com', 'javdb36.com', 'javdb007.com', 'javdb521.com']);
 
 const ProcessItems = async (ctx, currentUrl, title) => {
     const domain = ctx.req.query('domain') ?? 'javdb.com';


### PR DESCRIPTION
更新一些备用域名

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/javdb
/javdb/actors/R2Vg
/javdb/rankings/censored/daily
/javdb/video_codes/SIVR
/javdb/home/censored/2/1
/javdb/makers/7R
/javdb/search/巨乳/playable/0
/javdb/series/1NW
/javdb/lists/1
/javdb/tags/c2=5&c10=1/censored
```


## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

原来的一些域名无法访问，更新备用域名
Some of the original domain names are inaccessible. Update the backup domain name.