### PR TITLE
feat(routes/cognition): add category support to cognition blog route

### DIFF
--- a/lib/routes/cognition/blog.ts
+++ b/lib/routes/cognition/blog.ts
@@ -1,6 +1,6 @@
 import { load } from 'cheerio';
 
-import type { Data, DataItem, Route } from '@/types';
+import type { DataItem, Route } from '@/types';
 import { ViewType } from '@/types';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
@@ -29,6 +29,9 @@ export const route: Route = {
     ],
     view: ViewType.Articles,
     handler,
+    parameters: {
+        category: 'Category name, e.g., Research, Tutorials',
+    },
 };
 
 const splitAuthors = (text: string | undefined): DataItem['author'] => {

--- a/lib/routes/cognition/blog.ts
+++ b/lib/routes/cognition/blog.ts
@@ -6,10 +6,10 @@ import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
-    path: '/blog',
+    path: '/blog/:category?',
     name: 'Blog',
     url: 'cognition.ai/blog',
-    maintainers: ['Loongphy'],
+    maintainers: ['Loongphy', 'ttttmr'],
     example: '/cognition/blog',
     categories: ['programming'],
     features: {
@@ -23,8 +23,8 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['cognition.ai/blog/1'],
-            target: '/blog',
+            source: ['cognition.ai/blog/1', 'cognition.ai/blog/:category/1'],
+            target: '/blog/:category?',
         },
     ],
     view: ViewType.Articles,
@@ -50,9 +50,10 @@ const splitAuthors = (text: string | undefined): DataItem['author'] => {
     }));
 };
 
-export async function handler(): Promise<Data> {
+export async function handler(ctx) {
     const baseUrl = 'https://cognition.ai';
-    const listPath = '/blog/1';
+    const { category } = ctx.req.param();
+    const listPath = category ? `/blog/${category}/1` : '/blog/1';
     const targetUrl = new URL(listPath, baseUrl).href;
     const html = await ofetch(targetUrl);
     const $ = load(html);


### PR DESCRIPTION
- Add optional category parameter to blog route path
- Update radar configuration to support category routes
- Add new maintainer ttttmr
- Modify handler to handle category parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/cognition/blog
/cognition/blog/Research
/cognition/blog/Tutorials
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Support selecting categories to subscribe to blogs