### PR TITLE
feat(route): add Healthline nutrition RSS

### DIFF
--- a/lib/routes/healthline/namespace.ts
+++ b/lib/routes/healthline/namespace.ts
@@ -1,6 +1,6 @@
 export default {
-    name: 'Healthline',
+    name: 'Healthline Articles',
     description: 'Healthline Nutrition',
-    url: 'https://www.healthline.com',
+    url: 'www.healthline.com',
     timezone: 'America/Los_Angeles',
 } as namespace;

--- a/lib/routes/healthline/namespace.ts
+++ b/lib/routes/healthline/namespace.ts
@@ -1,0 +1,6 @@
+export default {
+    name: 'Healthline',
+    description: 'Healthline Nutrition',
+    url: 'https://www.healthline.com',
+    timezone: 'America/Los_Angeles',
+} as namespace;

--- a/lib/routes/healthline/nutrition.ts
+++ b/lib/routes/healthline/nutrition.ts
@@ -1,6 +1,7 @@
 import { load } from 'cheerio';
 
 import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
 import puppeteer from '@/utils/puppeteer';
 
 export const route: Route = {
@@ -19,13 +20,13 @@ export const route: Route = {
     radar: [
         {
             source: ['healthline.com/'],
-            target: '/',
+            target: '/nutrition',
         },
     ],
     name: 'Healthline',
     maintainers: ['maqiu'],
     handler,
-    url: 'healthline.com',
+    url: 'www.healthline.com',
 };
 
 export default handler;
@@ -71,11 +72,37 @@ async function handler(ctx) {
 
     const uniqueList = list.filter((item, index, self) => index === self.findIndex((t) => t.link === item.link));
 
-    const items = uniqueList.slice(0, Number(limit)).map((item) => ({
-        title: item.title,
-        link: item.link,
-        guid: item.link,
-    }));
+    // Fetch article details to get pubDate
+    const items = await Promise.all(
+        uniqueList.slice(0, Number(limit)).map(async (item) => {
+            try {
+                const articleResponse = await fetch(item.link, {
+                    headers: {
+                        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+                    },
+                });
+                const articleHtml = await articleResponse.text();
+                const $article = load(articleHtml);
+
+                // Try to get publish date
+                const dateStr = $article('meta[property="article:published_time"]').attr('content') || $article('time').attr('datetime');
+                const pubDate = dateStr ? parseDate(dateStr) : undefined;
+
+                return {
+                    title: item.title,
+                    link: item.link,
+                    guid: item.link,
+                    pubDate,
+                };
+            } catch {
+                return {
+                    title: item.title,
+                    link: item.link,
+                    guid: item.link,
+                };
+            }
+        })
+    );
 
     return {
         title: `Healthline - ${category.charAt(0).toUpperCase() + category.slice(1)}`,

--- a/lib/routes/healthline/nutrition.ts
+++ b/lib/routes/healthline/nutrition.ts
@@ -1,0 +1,87 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import puppeteer from '@/utils/puppeteer';
+
+export const route: Route = {
+    path: '/:category?',
+    categories: ['new-media'],
+    example: '/healthline/nutrition',
+    parameters: { category: 'Category, nutrition by default' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: true,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['healthline.com/:category'],
+            target: '/:category',
+        },
+    ],
+    name: 'Healthline',
+    maintainers: ['maqiu'],
+    handler,
+    url: 'healthline.com',
+};
+
+export default handler;
+
+async function handler(ctx) {
+    const category = ctx.req.param('category') || 'nutrition';
+    const baseUrl = 'https://www.healthline.com';
+    const url = `${baseUrl}/${category}`;
+
+    const browser = await puppeteer();
+    const page = await browser.newPage();
+
+    // Set realistic browser headers
+    await page.setExtraHTTPHeaders({
+        'Accept-Language': 'en-US,en;q=0.9',
+    });
+
+    await page.goto(url, { waitUntil: 'networkidle2', timeout: 30000 });
+
+    const content = await page.content();
+    await browser.close();
+
+    const $ = load(content);
+
+    // Find all article links
+    const list = $('a[href*="/' + category + '/"]')
+        .filter((_, el) => {
+            const href = $(el).attr('href');
+            return href && href.match(new RegExp(`/${category}/[a-z0-9-]+$`));
+        })
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+            const href = $el.attr('href');
+            const title = $el.text().trim();
+            return {
+                title: title.length > 10 ? title : undefined,
+                link: href?.startsWith('http') ? href : `${baseUrl}${href}`,
+            };
+        })
+        .filter((item) => item.title);
+
+    const uniqueList = list.filter((item, index, self) => index === self.findIndex((t) => t.link === item.link));
+
+    // For now, return the list without full article content (to avoid too many browser launches)
+    // In production, you might want to cache this better
+    const items = uniqueList.slice(0, 20).map((item) => ({
+        title: item.title,
+        link: item.link,
+        guid: item.link,
+    }));
+
+    return {
+        title: `Healthline - ${category.charAt(0).toUpperCase() + category.slice(1)}`,
+        link: url,
+        item: items,
+        description: 'Healthline Nutrition articles',
+    };
+}

--- a/lib/routes/healthline/nutrition.ts
+++ b/lib/routes/healthline/nutrition.ts
@@ -18,8 +18,8 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['healthline.com/:category'],
-            target: '/:category',
+            source: ['healthline.com/'],
+            target: '/',
         },
     ],
     name: 'Healthline',
@@ -32,6 +32,7 @@ export default handler;
 
 async function handler(ctx) {
     const category = ctx.req.param('category') || 'nutrition';
+    const limit = ctx.req.query('limit') || 20;
     const baseUrl = 'https://www.healthline.com';
     const url = `${baseUrl}/${category}`;
 
@@ -62,7 +63,7 @@ async function handler(ctx) {
             const href = $el.attr('href');
             const title = $el.text().trim();
             return {
-                title: title.length > 10 ? title : undefined,
+                title,
                 link: href?.startsWith('http') ? href : `${baseUrl}${href}`,
             };
         })
@@ -70,9 +71,7 @@ async function handler(ctx) {
 
     const uniqueList = list.filter((item, index, self) => index === self.findIndex((t) => t.link === item.link));
 
-    // For now, return the list without full article content (to avoid too many browser launches)
-    // In production, you might want to cache this better
-    const items = uniqueList.slice(0, 20).map((item) => ({
+    const items = uniqueList.slice(0, Number(limit)).map((item) => ({
         title: item.title,
         link: item.link,
         guid: item.link,

--- a/lib/routes/healthline/radar.ts
+++ b/lib/routes/healthline/radar.ts
@@ -1,12 +1,12 @@
 export default {
     'healthline.com': {
         _name: 'Healthline',
-        nutrition: [
+        '.': [
             {
-                title: 'Nutrition Articles',
+                title: 'Healthline Articles',
                 docs: 'https://rsshub.app/healthline/nutrition',
-                source: ['/nutrition'],
-                target: '/nutrition',
+                source: ['/'],
+                target: '/',
             },
         ],
     },

--- a/lib/routes/healthline/radar.ts
+++ b/lib/routes/healthline/radar.ts
@@ -1,0 +1,13 @@
+export default {
+    'healthline.com': {
+        _name: 'Healthline',
+        nutrition: [
+            {
+                title: 'Nutrition Articles',
+                docs: 'https://rsshub.app/healthline/nutrition',
+                source: ['/nutrition'],
+                target: '/nutrition',
+            },
+        ],
+    },
+} as RadarRecord;


### PR DESCRIPTION
## Involved Issue

Close #

## Example for the Proposed Route(s)

\`\`\`routes
/healthline/nutrition
/healthline/weight-management
/healthline/diets
\`\`\`

## New RSS Route Checklist

- [x] New Route
    - [x] Follows Script Standard
- [x] Anti-bot or rate limit
    - [ ] If yes, do your code reflect this sign?
- [x] Date and time
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added
- [x] Puppeteer (required for this site due to anti-bot protection)

## Note

Healthline has strong anti-bot protection, so Puppeteer is required to fetch the content. This route supports any category on healthline.com by using the category parameter.

---

Updated v3: Fixed radar target, URL consistency, and added pubDate extraction.