### PR TITLE
feat(route): add perplexity blog

### DIFF
--- a/lib/routes/perplexity/blog.ts
+++ b/lib/routes/perplexity/blog.ts
@@ -136,40 +136,8 @@ async function handler(ctx: Context) {
 
                 $content('script, style, noscript').remove();
 
-                let description: string | undefined;
-                const contentArea = $content('[data-framer-name="Content"]');
-                if (contentArea.length) {
-                    const contentParts: string[] = [];
-                    const seenText = new Set<string>();
-
-                    contentArea.find('h2, h3, h4, h5, h6, p, ul, ol, blockquote, figure, pre').each((_, el) => {
-                        const $el = $content(el);
-                        const text = $el.text().trim();
-                        if (!text || seenText.has(text)) {
-                            return;
-                        }
-
-                        if (text === 'Written by' || text === 'Published on' || text === 'Perplexity Team') {
-                            return;
-                        }
-
-                        if ($el.find('time').length > 0) {
-                            return;
-                        }
-
-                        // Stop before sharing/footer section
-                        if (/^Share this (article|post)$/i.test(text)) {
-                            return false;
-                        }
-
-                        seenText.add(text);
-                        contentParts.push(text);
-                    });
-
-                    if (contentParts.length > 0) {
-                        description = contentParts.join('\n');
-                    }
-                }
+                const contentArea = $content('[data-framer-name="Content"]').first();
+                const description = contentArea.length ? (contentArea.html() ?? undefined) : undefined;
 
                 return {
                     ...item,

--- a/lib/routes/perplexity/blog.ts
+++ b/lib/routes/perplexity/blog.ts
@@ -140,11 +140,12 @@ async function handler(ctx: Context) {
                 const contentArea = $content('[data-framer-name="Content"]');
                 if (contentArea.length) {
                     const contentParts: string[] = [];
+                    const seenText = new Set<string>();
 
                     contentArea.find('h2, h3, h4, h5, h6, p, ul, ol, blockquote, figure, pre').each((_, el) => {
                         const $el = $content(el);
                         const text = $el.text().trim();
-                        if (!text) {
+                        if (!text || seenText.has(text)) {
                             return;
                         }
 
@@ -161,6 +162,7 @@ async function handler(ctx: Context) {
                             return false;
                         }
 
+                        seenText.add(text);
                         contentParts.push(text);
                     });
 

--- a/lib/routes/perplexity/blog.ts
+++ b/lib/routes/perplexity/blog.ts
@@ -1,0 +1,189 @@
+import { load } from 'cheerio';
+import type { Context } from 'hono';
+
+import type { Data, DataItem, Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import { parseDate } from '@/utils/parse-date';
+import { getPuppeteerPage } from '@/utils/puppeteer';
+
+export const route: Route = {
+    path: '/blog',
+    example: '/perplexity/blog',
+    url: 'www.perplexity.ai',
+    categories: ['blog'],
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: true,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.perplexity.ai/hub'],
+            target: '/blog',
+        },
+    ],
+    name: 'Blog',
+    maintainers: ['seeyangzhi'],
+    handler,
+    description: "Perplexity Blog - Explore Perplexity's blog for articles, announcements, product updates, and tips to optimize your experience. Stay informed and make the most of Perplexity.",
+    view: ViewType.Notifications,
+};
+
+async function handler(ctx: Context) {
+    const limit = Number.parseInt(ctx.req.query('limit') ?? '20', 10);
+    const rootUrl = 'https://www.perplexity.ai/hub';
+
+    const { page, destory, browser } = await getPuppeteerPage(rootUrl, {
+        onBeforeLoad: async (page) => {
+            await page.setRequestInterception(true);
+            page.on('request', (request) => {
+                request.resourceType() === 'document' ? request.continue() : request.abort();
+            });
+        },
+    });
+
+    const html = await page.evaluate(() => document.documentElement.innerHTML);
+    const $ = load(html);
+
+    const items: DataItem[] = [];
+
+    const seenLinks = new Set<string>();
+
+    // Step 1: Extract featured article using data-framer-name attribute
+    const featuredCard = $('[data-framer-name="Featured Card"]').first();
+    const featuredHref = featuredCard.find('a[href^="./hub/blog/"]').first().attr('href');
+    const featuredTitle = featuredCard.find('h4').first().text().trim();
+
+    if (featuredHref && featuredTitle) {
+        const link = new URL(featuredHref, rootUrl).href;
+        seenLinks.add(link);
+        items.push({
+            link,
+            title: featuredTitle,
+        });
+    }
+
+    // Step 2: Extract regular articles using data-framer-name="Article Card"
+    for (const element of $('[data-framer-name="Article Card"]').toArray()) {
+        const $card = $(element);
+        const href = $card.attr('href');
+        const title = $card.find('h6').first().text().trim();
+
+        if (!href || !title) {
+            continue;
+        }
+
+        const link = new URL(href, rootUrl).href;
+
+        if (seenLinks.has(link)) {
+            continue;
+        }
+        seenLinks.add(link);
+
+        // First <p> contains the date, subsequent <p> elements are categories
+        const paragraphs = $card.find('p').toArray();
+        const dateText = paragraphs.length > 0 ? $(paragraphs[0]).text().trim() : '';
+        const pubDate = dateText ? parseDate(dateText) : undefined;
+
+        const category = paragraphs
+            .slice(1)
+            .map((p) => $(p).text().trim())
+            .filter(Boolean);
+
+        items.push({
+            link,
+            title,
+            pubDate,
+            category: category.length > 0 ? category : undefined,
+        });
+    }
+
+    // Step 3: Fetch detail pages for items missing pubDate (e.g., featured article)
+    // and extract article content for description
+    const resultItems = await Promise.all(
+        items.slice(0, limit).map(async (item) => {
+            if (!item.link) {
+                return item;
+            }
+
+            return (await cache.tryGet(item.link, async () => {
+                const contentPage = await browser.newPage();
+
+                await contentPage.setRequestInterception(true);
+                contentPage.on('request', (request) => {
+                    request.resourceType() === 'document' ? request.continue() : request.abort();
+                });
+
+                await contentPage.goto(item.link!, { waitUntil: 'domcontentloaded' });
+
+                const contentHtml = await contentPage.evaluate(() => document.documentElement.innerHTML);
+                await contentPage.close();
+
+                const $content = load(contentHtml);
+
+                let pubDate: string | number | Date | undefined = item.pubDate;
+                if (!pubDate) {
+                    const timeEl = $content('time[datetime]').first();
+                    if (timeEl.length) {
+                        pubDate = parseDate(timeEl.attr('datetime')!);
+                    }
+                }
+
+                $content('script, style, noscript').remove();
+
+                let description: string | undefined;
+                const contentArea = $content('[data-framer-name="Content"]');
+                if (contentArea.length) {
+                    const contentParts: string[] = [];
+
+                    contentArea.find('h2, h3, h4, h5, h6, p, ul, ol, blockquote, figure, pre').each((_, el) => {
+                        const $el = $content(el);
+                        const text = $el.text().trim();
+                        if (!text) {
+                            return;
+                        }
+
+                        if (text === 'Written by' || text === 'Published on' || text === 'Perplexity Team') {
+                            return;
+                        }
+
+                        if ($el.find('time').length > 0) {
+                            return;
+                        }
+
+                        // Stop before sharing/footer section
+                        if (/^Share this (article|post)$/i.test(text)) {
+                            return false;
+                        }
+
+                        contentParts.push(text);
+                    });
+
+                    if (contentParts.length > 0) {
+                        description = contentParts.join('\n');
+                    }
+                }
+
+                return {
+                    ...item,
+                    pubDate,
+                    description,
+                } as DataItem;
+            })) as DataItem;
+        })
+    );
+
+    await destory();
+
+    return {
+        title: 'Perplexity Blog',
+        link: rootUrl,
+        item: resultItems,
+        language: 'en',
+    } satisfies Data;
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/perplexity/blog
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
  - [x] Follows Script Standard / 跟随 路由规范
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] Date and time / 日期和时间
  - [x] Parsed / 可以解析
  - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] Puppeteer

## Note / 说明

Add route for Perplexity blog at `/perplexity/blog`, scraping `perplexity.ai/hub` with Puppeteer.

### Implementation details

- **Featured article**: Extracted via `[data-framer-name="Featured Card"]` selector (uses `h4` title)
- **Regular articles**: Extracted via `[data-framer-name="Article Card"]` selector (uses `h6` title)
- **Deduplication**: Framer renders each Article Card twice for responsive layouts (198 elements, 99 unique hrefs verified locally). `seenLinks` Set deduplicates by URL. Example without dedup:
<img width="1495" height="753" alt="Screenshot 2026-03-18 at 4 51 49 PM" src="https://github.com/user-attachments/assets/344e4e96-33e0-4b8b-a4da-76411fd188e4" />

- **Article content**: Scoped to `[data-framer-name="Content"]` container on detail pages to exclude navigation/footer. Plain text extraction.
- **Date extraction**: Uses `<time datetime>` attribute from detail pages for featured articles; list page `<p>` text for regular articles.
- **Request filtering**: Only `document` resource type allowed through Puppeteer to minimize resource usage.