### PR TITLE
fix(route/landiannews): sanitize rendered titles

### DIFF
--- a/lib/routes/landiannews/utils.ts
+++ b/lib/routes/landiannews/utils.ts
@@ -1,4 +1,4 @@
-import { load } from 'cheerio';
+import sanitizeHtml from 'sanitize-html';
 
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
@@ -6,7 +6,7 @@ import { parseDate } from '@/utils/parse-date';
 
 const rootUrl = 'https://www.landiannews.com/';
 
-const getRenderedText = (html: string) => load(html).text();
+const getRenderedText = (html: string) => sanitizeHtml(html, { allowedTags: [], allowedAttributes: {} });
 
 const getPubDate = (dateGmt?: string, date?: string) => (dateGmt ? parseDate(`${dateGmt}Z`) : date ? parseDate(date) : undefined);
 

--- a/lib/routes/landiannews/utils.ts
+++ b/lib/routes/landiannews/utils.ts
@@ -1,7 +1,14 @@
+import { load } from 'cheerio';
+
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
 
 const rootUrl = 'https://www.landiannews.com/';
+
+const getRenderedText = (html: string) => load(html).text();
+
+const getPubDate = (dateGmt?: string, date?: string) => (dateGmt ? parseDate(`${dateGmt}Z`) : date ? parseDate(date) : undefined);
 
 const fetchTaxonomy = async (slug: string, type: 'categories' | 'tags') => {
     const taxonomyUrl = `${rootUrl}wp-json/wp/v2/${type}?slug=${slug}`;
@@ -22,10 +29,10 @@ async function fetchNewsItems(apiUrl: string) {
     const data = await ofetch(apiUrl);
 
     return data.map((item) => ({
-        title: item.title.rendered,
+        title: getRenderedText(item.title.rendered),
         description: item.content.rendered,
         link: item.link,
-        pubDate: new Date(item.date).toUTCString(),
+        pubDate: getPubDate(item.date_gmt, item.date),
         author: item._embedded.author[0].name,
         category: item._embedded['wp:term'].flat().map((term) => term.name),
     }));


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/landiannews
/landiannews/category/sells
/landiannews/tag/linux-kernel
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Sanitize Landian News rendered post titles before assigning them to RSS item titles, so inline HTML like `<b>` from the WordPress API is not emitted in `<title>`.
Keep article body HTML in `description`, and normalize `pubDate` with RSSHub's `parseDate`, preferring `date_gmt` when available.
