### PR TITLE
fix(route/zsxq): fix topic link precision loss and missing group_id in URL

### DIFF
--- a/lib/routes/zsxq/types.ts
+++ b/lib/routes/zsxq/types.ts
@@ -29,7 +29,7 @@ interface BasicTopic {
     readers_count: number;
     reading_count: number;
     rewards_count: number;
-    topic_id: number;
+    topic_id: number | string;
     type: string;
     user_specific: {
         liked: false;

--- a/lib/routes/zsxq/utils.ts
+++ b/lib/routes/zsxq/utils.ts
@@ -12,8 +12,12 @@ export async function customFetch<T extends BasicResponse<ResponseData>>(path: s
         headers: {
             cookie: `zsxq_access_token=${config.zsxq.accessToken};`,
         },
+        responseType: 'text',
     });
-    const { succeeded, code, resp_data } = response.data as T;
+    // Preserve large integer IDs (topic_id, group_id, user_id etc.) by converting them to strings
+    // before JSON.parse, which would otherwise lose precision on numbers > Number.MAX_SAFE_INTEGER
+    const safeBody = (response.body as string).replaceAll(/("(?:topic_id|group_id|user_id|task_id|image_id|category_id)"\s*:\s*)(\d+)/g, '$1"$2"');
+    const { succeeded, code, resp_data } = JSON.parse(safeBody) as T;
     if (succeeded) {
         return resp_data;
     }
@@ -39,7 +43,7 @@ export function generateTopicDataItem(topics: Topic[]): DataItem[] {
     return topics.map((topic) => {
         let description: string | undefined;
         let title = '';
-        const url = `https://wx.zsxq.com/topic/${topic.topic_id}`;
+        const url = `https://wx.zsxq.com/group/${topic.group.group_id}/topic/${topic.topic_id}`;
         switch (topic.type) {
             case 'talk':
                 title = topic.talk?.text?.split('\n')[0] ?? '文章';


### PR DESCRIPTION
## Problem

The zsxq (知识星球) route generates **broken topic links** due to two issues:

### 1. JavaScript Number precision loss on topic_id

`topic_id` values from the zsxq API are 17+ digit integers (e.g., `12345678901234567`), which exceed `Number.MAX_SAFE_INTEGER` (2^53 - 1 = 9007199254740991, ~16 digits).

When `JSON.parse()` processes these values, precision is silently lost:
- API returns: `"topic_id": 12345678901234567`
- After JSON.parse: `topic_id = 12345678901234568` (last digits corrupted)

This results in links pointing to non-existent topics, returning "没有查看该主题的权限" (no permission to view this topic).

### 2. Missing group_id in topic URL

The current URL template is:
```
https://wx.zsxq.com/topic/{topic_id}
```

But the correct format (which the zsxq web app actually uses) is:
```
https://wx.zsxq.com/group/{group_id}/topic/{topic_id}
```

Without the `group_id` path segment, the link redirects to an error page.

## Fix

### Precision fix
Pre-process the raw JSON response text with a regex to convert large integer ID fields (`topic_id`, `group_id`, `user_id`, etc.) to quoted strings **before** `JSON.parse()`, preserving full precision.

The `responseType` is changed to `'text'` to get the raw body for pre-processing.

### URL fix
Updated the URL template in `generateTopicDataItem` to include `group_id`:

```typescript
const url = `https://wx.zsxq.com/group/${topic.group.group_id}/topic/${topic.topic_id}`;
```

### Type update
Changed `topic_id` in `BasicTopic` from `number` to `number | string` to reflect the pre-processed string value.

## Verification

Tested with a self-hosted RSSHub instance. Before the fix, all generated topic links were broken (wrong topic_id + missing group_id). After the fix, links open correctly in the browser.