### PR TITLE
fix(route/zsxq): fix topic link precision loss and missing group_id in URL

### DIFF
--- a/lib/routes/zsxq/types.ts
+++ b/lib/routes/zsxq/types.ts
@@ -29,7 +29,7 @@ interface BasicTopic {
     readers_count: number;
     reading_count: number;
     rewards_count: number;
-    topic_id: number;
+    topic_id: number | string;
     type: string;
     user_specific: {
         liked: false;

--- a/lib/routes/zsxq/types.ts
+++ b/lib/routes/zsxq/types.ts
@@ -11,7 +11,7 @@ interface BasicTopic {
     create_time: string;
     digested: boolean;
     group: {
-        group_id: number;
+        group_id: number | string;
         name: string;
         type: string;
         background_url: string;
@@ -22,7 +22,7 @@ interface BasicTopic {
             avatar_url: string;
             name: string;
             number: number;
-            user_id: number;
+            user_id: number | string;
         };
     }>;
     likes_count: number;

--- a/lib/routes/zsxq/utils.ts
+++ b/lib/routes/zsxq/utils.ts
@@ -12,8 +12,12 @@ export async function customFetch<T extends BasicResponse<ResponseData>>(path: s
         headers: {
             cookie: `zsxq_access_token=${config.zsxq.accessToken};`,
         },
+        responseType: 'text',
     });
-    const { succeeded, code, resp_data } = response.data as T;
+    // Preserve large integer IDs (topic_id, group_id, user_id etc.) by converting them to strings
+    // before JSON.parse, which would otherwise lose precision on numbers > Number.MAX_SAFE_INTEGER
+    const safeBody = (response.body as string).replaceAll(/("(?:topic_id|group_id|user_id|task_id|image_id|category_id)"\s*:\s*)(\d+)/g, '$1"$2"');
+    const { succeeded, code, resp_data } = JSON.parse(safeBody) as T;
     if (succeeded) {
         return resp_data;
     }
@@ -39,7 +43,7 @@ export function generateTopicDataItem(topics: Topic[]): DataItem[] {
     return topics.map((topic) => {
         let description: string | undefined;
         let title = '';
-        const url = `https://wx.zsxq.com/topic/${topic.topic_id}`;
+        const url = `https://wx.zsxq.com/group/${topic.group.group_id}/topic/${topic.topic_id}`;
         switch (topic.type) {
             case 'talk':
                 title = topic.talk?.text?.split('\n')[0] ?? '文章';


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A - bug discovered during self-hosted usage

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zsxq/group/88855458825252
/zsxq/group/88855458825252/digests
```

## Description

The zsxq (知识星球) route generates **broken topic links** due to two issues:

### 1. JavaScript Number precision loss on topic_id

`topic_id` values from the zsxq API are 17+ digit integers, which exceed `Number.MAX_SAFE_INTEGER` (2^53 - 1). When `JSON.parse()` processes these values, precision is silently lost (e.g., last digits get corrupted), resulting in links pointing to non-existent topics.

### 2. Missing group_id in topic URL

The current URL template is `https://wx.zsxq.com/topic/{topic_id}`, but the correct format is `https://wx.zsxq.com/group/{group_id}/topic/{topic_id}`. Without the `group_id` path segment, the link redirects to an error page.

## Fix

1. **Precision fix**: Changed `responseType` to `'text'` and pre-process raw JSON to convert large integer ID fields to strings before `JSON.parse()`.
2. **URL fix**: Updated URL template to include `group_id`.
3. **Type fix**: Updated `topic_id`, `group_id`, `user_id` types from `number` to `number | string`.

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] Bug fix for existing route / 现有路由的 Bug 修复
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) - Parsed (no change)