### PR TITLE
fix(route/iwara): use puppeteer to fix subscriptions route

### DIFF
--- a/lib/routes/iwara/subscriptions.ts
+++ b/lib/routes/iwara/subscriptions.ts
@@ -1,17 +1,28 @@
 import MarkdownIt from 'markdown-it';
+import pMap from 'p-map';
 
 import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
-import ofetch from '@/utils/ofetch';
+import { getPuppeteerPage } from '@/utils/puppeteer';
 import { parseDate } from '@/utils/parse-date';
 
+import { apiqRootUrl, imageRootUrl, rootUrl } from './utils';
 import { renderSubscriptionImages } from './templates/subscriptions';
 
 const md = MarkdownIt({
     html: true,
 });
+
+const apiHeaders = {
+    'Content-Type': 'application/json',
+    'X-Site': 'www.iwara.tv',
+    Origin: rootUrl,
+    Referer: `${rootUrl}/`,
+    Accept: 'application/json',
+    'User-Agent': config.trueUA,
+};
 
 export const route: Route = {
     path: '/subscriptions',
@@ -29,7 +40,7 @@ export const route: Route = {
                 description: '',
             },
         ],
-        requirePuppeteer: false,
+        requirePuppeteer: true,
         antiCrawler: false,
         supportBT: false,
         supportPodcast: false,
@@ -55,104 +66,124 @@ async function handler() {
         throw new ConfigNotFoundError('Iwara subscription RSS is disabled due to the lack of <a href="https://docs.rsshub.app/deploy/config#route-specific-configurations">relevant config</a>');
     }
 
-    const rootUrl = 'https://www.iwara.tv';
     const username = config.iwara.username;
     const password = config.iwara.password;
 
-    // get refresh token
-    const refreshHeaders = await cache.tryGet(
-        'iwara:token',
-        async () => {
-            const loginResponse = await ofetch('https://api.iwara.tv/user/login', {
-                method: 'post',
-                headers: {
-                    referer: 'https://www.iwara.tv/',
-                    'user-agent': config.trueUA,
+    const { page, destory } = await getPuppeteerPage(rootUrl, {
+        gotoConfig: {
+            waitUntil: 'domcontentloaded',
+        },
+    });
+
+    try {
+        const fetchApi = async (url: string, options: any) =>
+            page.evaluate(
+                async (args) => {
+                    const res = await fetch(args.url, {
+                        method: args.options.method || 'GET',
+                        headers: args.options.headers,
+                        body: args.options.body ? JSON.stringify(args.options.body) : undefined,
+                    });
+                    if (!res.ok) {
+                        throw new Error(`HTTP error! status: ${res.status}`);
+                    }
+                    return res.json();
                 },
-                body: {
-                    email: username,
-                    password,
-                },
-            });
+                { url, options }
+            );
+
+        // login and get refresh token
+        const refreshHeaders = await cache.tryGet(
+            'iwara:token',
+            async () => {
+                const result = await fetchApi(`${apiqRootUrl}/user/login`, {
+                    method: 'POST',
+                    headers: apiHeaders,
+                    body: { email: username, password },
+                });
+                return { authorization: 'Bearer ' + result.token };
+            },
+            30 * 24 * 60 * 60,
+            false
+        );
+
+        // get access token
+        const authHeaders = await cache.tryGet(
+            'iwara:authToken',
+            async () => {
+                const result = await fetchApi(`${apiqRootUrl}/user/token`, {
+                    method: 'POST',
+                    headers: { ...apiHeaders, Authorization: refreshHeaders.authorization },
+                });
+                return { authorization: 'Bearer ' + result.accessToken };
+            },
+            60 * 60,
+            false
+        );
+
+        const authedHeaders = { ...apiHeaders, Authorization: authHeaders.authorization };
+
+        // fetch subscriptions
+        const [videoResponse, imageResponse] = await Promise.all([
+            fetchApi(`${apiqRootUrl}/videos?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
+            fetchApi(`${apiqRootUrl}/images?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
+        ]);
+
+        const videoList = videoResponse.results.map((item) => {
+            const imageUrl = item.file ? `${imageRootUrl}/image/original/${item.file.id}/thumbnail-${item.thumbnail.toString().padStart(2, '0')}.jpg` : '';
+
             return {
-                authorization: 'Bearer ' + loginResponse.token,
+                title: item.title,
+                author: item.user.name,
+                link: `${rootUrl}/video/${item.id}`,
+                category: ['Video', ...(item.tags ? item.tags.map((i) => i.id) : [])],
+                imageUrl,
+                pubDate: parseDate(item.createdAt),
+                private: item.private,
             };
-        },
-        30 * 24 * 60 * 60,
-        false
-    );
+        });
 
-    // get subscription list
-    const videoSubUrl = 'https://api.iwara.tv/videos?rating=all&page=0&limit=24&subscribed=true';
-    const imageSubUrl = 'https://api.iwara.tv/images?rating=all&page=0&limit=24&subscribed=true';
-
-    // get access token
-    const authHeaders = await cache.tryGet(
-        'iwara:authToken',
-        async () => {
-            const accessResponse = await ofetch('https://api.iwara.tv/user/token', {
-                method: 'post',
-                headers: {
-                    ...refreshHeaders,
-                    referer: 'https://www.iwara.tv/',
-                    'user-agent': config.trueUA,
-                },
-            });
+        const imageList = imageResponse.results.map((item) => {
+            const imageUrl = item.thumbnail ? `${imageRootUrl}/image/original/${item.thumbnail.id}/${item.thumbnail.name}` : '';
             return {
-                authorization: 'Bearer ' + accessResponse.accessToken,
+                title: item.title,
+                author: item.user.name,
+                link: `${rootUrl}/image/${item.id}`,
+                category: ['Image', ...(item.tags ? item.tags.map((i) => i.id) : [])],
+                imageUrl,
+                pubDate: parseDate(item.createdAt),
             };
-        },
-        60 * 60,
-        false
-    );
+        });
 
-    const videoResponse = await ofetch(videoSubUrl, {
-        headers: authHeaders,
-    });
+        // fulltext
+        const list = [...videoList, ...imageList];
+        // Execute fetches with limited concurrency
+        const items = await pMap(
+            list,
+            (item) =>
+                cache.tryGet(item.link, async () => {
+                    let description = renderSubscriptionImages([item.imageUrl]);
 
-    const imageResponse = await ofetch(imageSubUrl, {
-        headers: {
-            ...authHeaders,
-            'user-agent': config.trueUA,
-        },
-    });
+                    if (item.private === true) {
+                        description += 'private';
+                        return {
+                            title: item.title,
+                            author: item.author,
+                            link: item.link,
+                            category: item.category,
+                            pubDate: item.pubDate,
+                            description,
+                        };
+                    }
 
-    const videoList = videoResponse.results.map((item) => {
-        const imgPath = 'https://i.iwara.tv/image/original/';
-        const imageUrl = item.file ? `${imgPath}${item.file.id}/thumbnail-${item.thumbnail.toString().padStart(2, '0')}.jpg` : '';
+                    const apiUrl = item.link.replace('www.iwara.tv', 'apiq.iwara.tv');
+                    const response = await fetchApi(apiUrl, { headers: authedHeaders });
 
-        return {
-            title: item.title,
-            author: item.user.name,
-            link: `${rootUrl}/video/${item.id}`,
-            category: ['Video', ...(item.tags ? item.tags.map((i) => i.id) : [])],
-            imageUrl,
-            pubDate: parseDate(item.createdAt),
-            private: item.private,
-        };
-    });
+                    description = renderSubscriptionImages(response.files ? response.files.filter((f) => f.type === 'image').map((f) => `${imageRootUrl}/image/original/${f.id}/${f.name}`) : [item.imageUrl]);
 
-    const imageList = imageResponse.results.map((item) => {
-        const imageUrl = item.thumbnail ? `https://i.iwara.tv/image/original/${item.thumbnail.id}/${item.thumbnail.name}` : '';
-        return {
-            title: item.title,
-            author: item.user.name,
-            link: `${rootUrl}/image/${item.id}`,
-            category: ['Image', ...(item.tags ? item.tags.map((i) => i.id) : [])],
-            imageUrl,
-            pubDate: parseDate(item.createdAt),
-        };
-    });
+                    const body = response.body ? md.render(response.body) : '';
+                    description += body;
 
-    // fulltext
-    const list = [...videoList, ...imageList];
-    const items = await Promise.all(
-        list.map((item) =>
-            cache.tryGet(item.link, async () => {
-                let description = renderSubscriptionImages([item.imageUrl]);
-
-                if (item.private === true) {
-                    description += 'private';
                     return {
                         title: item.title,
                         author: item.author,
@@ -161,35 +192,16 @@ async function handler() {
                         pubDate: item.pubDate,
                         description,
                     };
-                }
-                const link = item.link.replace('www.iwara.tv', 'api.iwara.tv');
-                const response = await ofetch(link, {
-                    headers: {
-                        ...authHeaders,
-                        'user-agent': config.trueUA,
-                    },
-                });
+                }),
+            { concurrency: 5 }
+        );
 
-                description = renderSubscriptionImages(response.files ? response.files.filter((f) => f.type === 'image')?.map((f) => `https://i.iwara.tv/image/original/${f.id}/${f.name}`) : [item.imageUrl]);
-
-                const body = response.body ? md.render(response.body) : '';
-                description += body;
-
-                return {
-                    title: item.title,
-                    author: item.author,
-                    link: item.link,
-                    category: item.category,
-                    pubDate: item.pubDate,
-                    description,
-                };
-            })
-        )
-    );
-
-    return {
-        title: 'Iwara Subscription',
-        link: rootUrl,
-        item: items,
-    };
+        return {
+            title: 'Iwara Subscription',
+            link: rootUrl,
+            item: items,
+        };
+    } finally {
+        await destory();
+    }
 }

--- a/lib/routes/iwara/subscriptions.ts
+++ b/lib/routes/iwara/subscriptions.ts
@@ -76,7 +76,7 @@ async function handler() {
     });
 
     try {
-        const fetchApi = async (url: string, options: any) =>
+        const fetchApi = (url: string, options: any) =>
             page.evaluate(
                 async (args) => {
                     const res = await fetch(args.url, {

--- a/lib/routes/iwara/subscriptions.ts
+++ b/lib/routes/iwara/subscriptions.ts
@@ -5,11 +5,11 @@ import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
-import { getPuppeteerPage } from '@/utils/puppeteer';
 import { parseDate } from '@/utils/parse-date';
+import { getPuppeteerPage } from '@/utils/puppeteer';
 
-import { apiqRootUrl, imageRootUrl, rootUrl } from './utils';
 import { renderSubscriptionImages } from './templates/subscriptions';
+import { apiqRootUrl, imageRootUrl, rootUrl } from './utils';
 
 const md = MarkdownIt({
     html: true,


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #21491

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/iwara/subscriptions
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

Fixes `iwara/subscriptions` route by switching from `ofetch` to Puppeteer to bypass recent anti-crawler mechanisms.