### PR TITLE
chore(deps): bump @jocmp/mercury-parser from 3.0.6 to 3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "@bbob/preset-html5": "4.3.1",
         "@hono/node-server": "1.19.11",
         "@hono/zod-openapi": "1.2.3",
-        "@jocmp/mercury-parser": "3.0.6",
+        "@jocmp/mercury-parser": "3.0.7",
         "@notionhq/client": "5.14.0",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/exporter-prometheus": "0.213.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
         specifier: 1.2.3
         version: 1.2.3(hono@4.12.8)(zod@4.3.6)
       '@jocmp/mercury-parser':
-        specifier: 3.0.6
-        version: 3.0.6
+        specifier: 3.0.7
+        version: 3.0.7
       '@notionhq/client':
         specifier: 5.14.0
         version: 5.14.0
@@ -1301,8 +1301,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@jocmp/mercury-parser@3.0.6':
-    resolution: {integrity: sha512-MKVZvpFboVNfKYGOlpl7SIn+9VnJ9jXIjSC2QYAsvksXsp5CM91IZdtKCSBOMogPdXQx0o34JiPclU5TI2SRjQ==}
+  '@jocmp/mercury-parser@3.0.7':
+    resolution: {integrity: sha512-DnZqzYrLFaOc6SPiCKQ1GuaqN1ZPi72JbheKmE4XDwRBr4eFF7FzMlv3eujO1+huBtnIyKYi4zOCMSYmMFAc1A==}
     engines: {node: '>=22'}
     hasBin: true
     bundledDependencies:
@@ -3467,9 +3467,8 @@ packages:
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
-  ellipsize@0.7.0:
-    resolution: {integrity: sha512-zxc0AigE4HMvuiqEk7//BjwCSFBXseJCuGNxfjo6wz1BoCSrJDj8tYnIgn/Z7lQ2T89ZypvGyJvPCCVf9uErBA==}
-    engines: {node: ^20.19.0 || >= 22.12.0}
+  ellipsize@0.6.0:
+    resolution: {integrity: sha512-oest45O39yGzIKJj3gJv/Gt6jtYN6PHw/IbCXHPEd2KwC0dgxKqXOhTU0EGwRXWhGKoBJk7eJQkb3sp8W0px2g==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -6828,13 +6827,13 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@jocmp/mercury-parser@3.0.6':
+  '@jocmp/mercury-parser@3.0.7':
     dependencies:
       '@babel/runtime-corejs2': 7.29.2
       cheerio: 1.2.0
       dayjs: 1.11.20
       difflib: https://codeload.github.com/postlight/difflib.js/tar.gz/32e8e38c7fcd935241b9baab71bb432fd9b166ed
-      ellipsize: 0.7.0
+      ellipsize: 0.6.0
       iconv-lite: 0.7.2
       postman-request: 2.88.1-postman.48
       string-direction: 0.1.2
@@ -8847,7 +8846,7 @@ snapshots:
 
   electron-to-chromium@1.5.313: {}
 
-  ellipsize@0.7.0: {}
+  ellipsize@0.6.0: {}
 
   emoji-regex@10.6.0: {}
 


### PR DESCRIPTION
v3.0.6 introduced a bug via the ellipsize dependency. That version switched to pure ESM which broke the mercury.js require call. This downgrades the ellipsize dependency for now.

<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #21493

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

v3.0.6 introduced a bug via the ellipsize dependency. That version switched to pure ESM which broke the mercury.js require call. This downgrades the ellipsize dependency for now.