### PR TITLE
fix(telegram): preserve access auth params in media links

### DIFF
--- a/lib/routes/telegram/tglib/channel.test.ts
+++ b/lib/routes/telegram/tglib/channel.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { Api } from 'telegram';
+import { describe, expect, it } from 'vitest';
 
 import { getMediaLink, getMessageMediaUrl, withSearchParams } from './channel';
 
@@ -7,15 +7,11 @@ describe('telegram tglib channel', () => {
     it('preserves access auth params in telegram media urls', () => {
         expect(getMessageMediaUrl('https://rsshub.app/telegram/channel/test?key=secret', 'test', 123)).toBe('https://rsshub.app/telegram/media/test/123?key=secret');
         expect(getMessageMediaUrl('https://rsshub.app/telegram/channel/test?code=signed', 'test', 123)).toBe('https://rsshub.app/telegram/media/test/123?code=signed');
-        expect(getMessageMediaUrl('https://rsshub.app/telegram/channel/test?key=secret&code=signed', 'test', 123)).toBe(
-            'https://rsshub.app/telegram/media/test/123?key=secret&code=signed'
-        );
+        expect(getMessageMediaUrl('https://rsshub.app/telegram/channel/test?key=secret&code=signed', 'test', 123)).toBe('https://rsshub.app/telegram/media/test/123?key=secret&code=signed');
     });
 
     it('appends thumb without dropping existing query params', () => {
-        expect(withSearchParams('https://rsshub.app/telegram/media/test/123?key=secret', { thumb: '' })).toBe(
-            'https://rsshub.app/telegram/media/test/123?key=secret&thumb='
-        );
+        expect(withSearchParams('https://rsshub.app/telegram/media/test/123?key=secret', { thumb: '' })).toBe('https://rsshub.app/telegram/media/test/123?key=secret&thumb=');
     });
 
     it('renders video poster urls with preserved auth params', () => {

--- a/lib/routes/telegram/tglib/channel.test.ts
+++ b/lib/routes/telegram/tglib/channel.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { Api } from 'telegram';
+
+import { getMediaLink, getMessageMediaUrl, withSearchParams } from './channel';
+
+describe('telegram tglib channel', () => {
+    it('preserves access auth params in telegram media urls', () => {
+        expect(getMessageMediaUrl('https://rsshub.app/telegram/channel/test?key=secret', 'test', 123)).toBe('https://rsshub.app/telegram/media/test/123?key=secret');
+        expect(getMessageMediaUrl('https://rsshub.app/telegram/channel/test?code=signed', 'test', 123)).toBe('https://rsshub.app/telegram/media/test/123?code=signed');
+        expect(getMessageMediaUrl('https://rsshub.app/telegram/channel/test?key=secret&code=signed', 'test', 123)).toBe(
+            'https://rsshub.app/telegram/media/test/123?key=secret&code=signed'
+        );
+    });
+
+    it('appends thumb without dropping existing query params', () => {
+        expect(withSearchParams('https://rsshub.app/telegram/media/test/123?key=secret', { thumb: '' })).toBe(
+            'https://rsshub.app/telegram/media/test/123?key=secret&thumb='
+        );
+    });
+
+    it('renders video poster urls with preserved auth params', () => {
+        const media = new Api.MessageMediaDocument({
+            document: new Api.Document({
+                id: 1,
+                accessHash: 1,
+                fileReference: Buffer.alloc(0),
+                date: 0,
+                mimeType: 'video/mp4',
+                size: 1,
+                dcId: 1,
+                attributes: [new Api.DocumentAttributeVideo({ w: 1280, h: 720, duration: 1 })],
+            }),
+        });
+
+        expect(getMediaLink('https://rsshub.app/telegram/media/test/123?key=secret', media)).toContain('poster="https://rsshub.app/telegram/media/test/123?key=secret&thumb="');
+    });
+});

--- a/lib/routes/telegram/tglib/channel.ts
+++ b/lib/routes/telegram/tglib/channel.ts
@@ -35,6 +35,26 @@ export async function getPollResults(client, message, m: Api.MessageMediaPoll) {
     return txt;
 }
 
+export function withSearchParams(src: string, params: Record<string, string>) {
+    const url = new URL(src);
+    for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value);
+    }
+    return url.toString();
+}
+
+export function getMessageMediaUrl(requestUrl: string, username: string, messageId: number) {
+    const request = new URL(requestUrl);
+    const url = new URL(`/telegram/media/${username}/${messageId}`, request.origin);
+    for (const key of ['key', 'code']) {
+        const value = request.searchParams.get(key);
+        if (value) {
+            url.searchParams.set(key, value);
+        }
+    }
+    return url.toString();
+}
+
 export function getMediaLink(src: string, m: Api.TypeMessageMedia) {
     const doc = getDocument(m);
     const mime = doc ? doc.mimeType : '';
@@ -44,7 +64,7 @@ export function getMediaLink(src: string, m: Api.TypeMessageMedia) {
     }
     if (doc && mime.startsWith('video/')) {
         const vid = (doc.attributes.find((t) => t instanceof Api.DocumentAttributeVideo) ?? { w: 1080, h: 720 }) as { w: number; h: number };
-        return `<video controls preload="metadata" poster="${src}?thumb" width="${vid.w / 2}" height="${vid.h / 2}"><source src="${src}" type="${mime}"></video>`;
+        return `<video controls preload="metadata" poster="${withSearchParams(src, { thumb: '' })}" width="${vid.w / 2}" height="${vid.h / 2}"><source src="${src}" type="${mime}"></video>`;
     }
     if (doc && mime.startsWith('audio/')) {
         return `<div>${getAudioTitle(m)}</div><div><audio src="${src}"></audio></div>`;
@@ -56,7 +76,7 @@ export function getMediaLink(src: string, m: Api.TypeMessageMedia) {
             linkText = ''; // remove filename, it's only an animated sticker
         }
         if ((doc.thumbs?.length ?? 0) > 0) {
-            linkText = `<div><img src="${src}?thumb" alt=""/></div><div>${linkText}</div>`;
+            linkText = `<div><img src="${withSearchParams(src, { thumb: '' })}" alt=""/></div><div>${linkText}</div>`;
         }
         return `<a href="${src}" target="_blank">${linkText}</a>`;
     }
@@ -155,7 +175,7 @@ export default async function handler(ctx: Context) {
             }
             // messages that have no text are shown as if they're one post
             // because in TG only 1 attachment per message is possible
-            const src = `${new URL(ctx.req.url).origin}/telegram/media/${username}/${message.id}`;
+            const src = getMessageMediaUrl(ctx.req.url, username, message.id);
             attachments.push(getMediaLink(src, media));
         }
         if (message.replyMarkup instanceof Api.ReplyInlineMarkup) {


### PR DESCRIPTION
## Involved Issue

Close #21473

## Example for the Proposed Route(s)

```routes
/telegram/channel/VisualNovelChannel
```

## New RSS Route Checklist

- [ ] New Route
- [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit
- [ ] If yes, does your code reflect this sign?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
- [x] Parsed
- [x] Correct time zone
- [ ] New package added
- [ ] `Puppeteer`

## Note

Fix `/telegram/channel/:username` media URLs when `ACCESS_KEY` is enabled.

When both `HOTLINK_TEMPLATE` and `ACCESS_KEY` are enabled, generated `/telegram/media/...` URLs did not preserve the request `key` or `code` query params. As a result, rewritten media links lost authentication and images could not be loaded correctly.

This PR:
- preserves `key` and `code` when generating `/telegram/media/...` URLs
- appends `thumb` with `URLSearchParams` so existing auth params are preserved
- adds regression tests for authenticated media URLs and thumbnail URLs

## Test

```bash
npm run vitest -- lib/routes/telegram/tglib/channel.test.ts
```
