### PR TITLE
fix(route/2048): fix captcha handling and update cookie management

### DIFF
--- a/lib/routes/2048/index.tsx
+++ b/lib/routes/2048/index.tsx
@@ -81,33 +81,12 @@ async function handler(ctx) {
         async () => {
             const captchaPage = await ofetch(redirectResponse.url);
             const $captcha = load(captchaPage);
-
-            const cookieResponse = await ofetch.raw(redirectResponse.url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                    Cookie: `safe18_tok=${$captcha('form#s18f input[name="tok"]').attr('value') || ''}`,
-                },
-                body: new URLSearchParams(
-                    Object.fromEntries(
-                        $captcha('form#s18f input')
-                            .toArray()
-                            .map((el) => [el.attribs.name, el.attribs.value])
-                            .filter(([name, value]) => name !== null && value !== null)
-                    )
-                ).toString(),
-                redirect: 'manual',
-            });
-
-            const safe18Pass = cookieResponse.headers
-                .getSetCookie()
-                ?.find((cookie) => cookie.startsWith('safe18_pass='))
-                ?.split(';')[0]
-                .split('=')[1];
-
+            // Extract the value of safeid from the $captcha HTML content
+            const safeidMatch = $captcha.html()?.match(/var\s+safeid\s*=\s*'([^']+)'/);
+            const safeid = safeidMatch ? safeidMatch[1] : undefined;
             return {
                 url: redirectResponse.url,
-                safe18Pass,
+                safeid,
             };
         },
         86400, // fixed cookie duration: 24 hours
@@ -117,7 +96,7 @@ async function handler(ctx) {
 
     const response = await ofetch.raw(currentUrl, {
         headers: {
-            cookie: `safe18_pass=${redirected.safe18Pass}`,
+            cookie: `_safe=${redirected.safeid}`,
         },
     });
 
@@ -147,7 +126,7 @@ async function handler(ctx) {
             cache.tryGet(item.guid, async () => {
                 const detailResponse = await ofetch(item.link, {
                     headers: {
-                        cookie: `safe18_pass=${redirected.safe18Pass}`,
+                        cookie: `_safe=${redirected.safeid}`,
                     },
                 });
 
@@ -167,24 +146,31 @@ async function handler(ctx) {
                 item.author = content('.fl.black').first().text();
                 item.pubDate = timezone(parseDate(content('span.fl.gray').first().attr('title')), +8);
 
-                const downloadLink = content('#read_tpc').first().find('a').last();
+                const readTpc = content('#read_tpc').first();
                 const copyLink = content('#copytext')?.first()?.text();
-                if (new URL(downloadLink.text()).hostname === 'bt.azvmw.com') {
-                    const torrentResponse = await ofetch(downloadLink.text());
+                const readTpcHtml = readTpc.html() ?? '';
 
-                    const torrent = load(torrentResponse);
+                // Extract enclosure: rmdown.com (fetch page for magnet) | magnet from 哈希校验 | copyLink
+                const rmdownLink = readTpc.find('a[href*="rmdown.com/link.php"]').first().attr('href');
+                const enclosureHref = rmdownLink?.startsWith('http') ? rmdownLink : rmdownLink ? `https://www.rmdown.com/${rmdownLink}` : null;
 
-                    item.enclosure_type = 'application/x-bittorrent';
-                    const ahref = torrent('.uk-button').last().attr('href');
-                    item.enclosure_url = ahref?.startsWith('http') ? ahref : `https://bt.azvmw.com/${ahref}`;
-
-                    const magnet = torrent('.uk-button').first().attr('href');
-
-                    downloadLink.replaceWith(renderToString(<DownloadLinks magnet={magnet} torrent={item.enclosure_url} />));
-                } else if (copyLink?.startsWith('magnet')) {
-                    // copy link
-                    item.enclosure_url = copyLink;
-                    item.enclosure_type = 'x-scheme-handler/magnet';
+                if (enclosureHref) {
+                    const rmdownPage = await cache.tryGet(`2048:rmdown:${enclosureHref}`, () => ofetch(enclosureHref));
+                    const btihMatch = rmdownPage.match(/Code:\s*([a-fA-F0-9]{40})/);
+                    const magnetUrl = btihMatch ? `magnet:?xt=urn:btih:${btihMatch[1]}` : null;
+                    if (magnetUrl) {
+                        item.enclosure_url = magnetUrl;
+                        item.enclosure_type = 'x-scheme-handler/magnet';
+                    }
+                }
+                if (!item.enclosure_url) {
+                    const hashMatch = readTpcHtml.match(/哈希校验[^;]*;\s*([a-fA-F0-9]{40})\s*[;；]/);
+                    const magnetFromHash = hashMatch ? `magnet:?xt=urn:btih:${hashMatch[1]}` : null;
+                    const magnetLink = readTpcHtml.match(/magnet:\?xt=urn:btih:[^\s"'<>]+/)?.[0] ?? magnetFromHash ?? copyLink;
+                    if (magnetLink?.startsWith('magnet')) {
+                        item.enclosure_url = magnetLink;
+                        item.enclosure_type = 'x-scheme-handler/magnet';
+                    }
                 }
 
                 const desp = content('#read_tpc').first();
@@ -206,9 +192,3 @@ async function handler(ctx) {
         item: items,
     };
 }
-
-const DownloadLinks = ({ magnet, torrent }: { magnet?: string; torrent?: string }) => (
-    <>
-        <a href={magnet}>磁力連結</a> | <a href={torrent}>下載檔案</a>
-    </>
-);

--- a/lib/routes/2048/index.tsx
+++ b/lib/routes/2048/index.tsx
@@ -1,5 +1,4 @@
 import { load } from 'cheerio';
-import { renderToString } from 'hono/jsx/dom/server';
 
 import type { Route } from '@/types';
 import cache from '@/utils/cache';

--- a/lib/routes/2048/index.tsx
+++ b/lib/routes/2048/index.tsx
@@ -148,6 +148,7 @@ async function handler(ctx) {
                 const readTpc = content('#read_tpc').first();
                 const copyLink = content('#copytext')?.first()?.text();
                 const readTpcHtml = readTpc.html() ?? '';
+                const magnetText = readTpc.find('.magnet-text').first().text().trim();
 
                 // Extract enclosure: rmdown.com (fetch page for magnet) | magnet from 哈希校验 | copyLink
                 const rmdownLink = readTpc.find('a[href*="rmdown.com/link.php"]').first().attr('href');
@@ -165,20 +166,19 @@ async function handler(ctx) {
                 if (!item.enclosure_url) {
                     const hashMatch = readTpcHtml.match(/哈希校验[^;]*;\s*([a-fA-F0-9]{40})\s*[;；]/);
                     const magnetFromHash = hashMatch ? `magnet:?xt=urn:btih:${hashMatch[1]}` : null;
-                    const magnetLink = readTpcHtml.match(/magnet:\?xt=urn:btih:[^\s"'<>]+/)?.[0] ?? magnetFromHash ?? copyLink;
+                    const magnetFromText = magnetText.match(/magnet:\?xt=urn:btih:[^\s"'<>]+/)?.[0];
+                    const magnetLink = magnetFromText ?? readTpcHtml.match(/magnet:\?xt=urn:btih:[^\s"'<>]+/)?.[0] ?? magnetFromHash ?? copyLink;
                     if (magnetLink?.startsWith('magnet')) {
                         item.enclosure_url = magnetLink;
                         item.enclosure_type = 'x-scheme-handler/magnet';
                     }
                 }
 
-                const desp = content('#read_tpc').first();
-
                 content('.showhide img').each(function () {
-                    desp.append(`<br><img style="max-width: 100%;" src="${content(this).attr('src')}">`);
+                    readTpc.append(`<br><img style="max-width: 100%;" src="${content(this).attr('src')}">`);
                 });
 
-                item.description = desp.html();
+                item.description = readTpc.html();
 
                 return item;
             })


### PR DESCRIPTION
- Removed outdated cookie handling logic and replaced it with safeid extraction from the captcha HTML.
- Updated the response structure to use safeid instead of safe18Pass for cookie management.
- Enhanced enclosure extraction logic to support new sources。

<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/2048/2
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
