### PR TITLE
fix(ofetch): use late-binding fetch in ofetch to ensure request-rewri…

### DIFF
--- a/lib/utils/ofetch.ts
+++ b/lib/utils/ofetch.ts
@@ -13,7 +13,7 @@ declare module 'ofetch' {
 
 config.enableRemoteDebugging && process.env.NODE_ENV === 'dev' && register();
 
-const rofetch = createFetch().create({
+const rofetch = createFetch({ fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) }).create({
     retryStatusCodes: [400, 408, 409, 425, 429, 500, 502, 503, 504],
     retry: config.requestRetry,
     retryDelay: 1000,


### PR DESCRIPTION
…ter intercepts bundled builds

<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/isct/news/ja
/dongqiudi/result/50001755
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

#21505 changed the execution order of `lib/app.ts` which makes request-rewritter being skipped again.
<details>
<summary>Screenshot</summary>
<img width="328" height="163" alt="image" src="https://github.com/user-attachments/assets/05daef03-7177-4d16-8c41-ca531aa71d45" />

Missing debug log `Outgoing request: GET`

</details>
