### PR TITLE
feat(route/rumble): add channel feed

### DIFF
--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -31,7 +31,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['rumble.com/c/:channel'],
+            source: ['rumble.com/c/:channel', 'rumble.com/c/:channel/videos'],
             target: '/c/:channel',
         },
     ],
@@ -205,8 +205,9 @@ async function handler(ctx) {
     const channel = ctx.req.param('channel');
     const includeEmbed = !ctx.req.param('embed');
     const channelUrl = new URL(`/c/${encodeURIComponent(channel)}`, rootUrl).href;
+    const videosUrl = `${channelUrl}/videos`;
 
-    const response = await ofetch(channelUrl, {
+    const response = await ofetch(videosUrl, {
         retryStatusCodes: [403],
     });
 
@@ -230,7 +231,7 @@ async function handler(ctx) {
 
     return {
         title: `Rumble - ${title}`,
-        link: channelUrl,
+        link: videosUrl,
         item: items.filter((item): item is DataItem => Boolean(item && item.link)),
     };
 }

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -49,14 +49,14 @@ function parseChannelTitle($: ReturnType<typeof load>): string {
     return title || 'Rumble';
 }
 
-function parseDescription($: ReturnType<typeof load>): string | undefined {
+function parseDescription($: ReturnType<typeof load>, fallback: string | undefined): string | undefined {
     const paragraphs = $('div[data-js="media_long_description_container"] > p.media-description')
         .toArray()
         .map((element) => $.html(element))
         .filter(Boolean)
         .join('');
 
-    return paragraphs || $('meta[name="description"]').attr('content')?.trim() || undefined;
+    return paragraphs || $('meta[name="description"]').attr('content')?.trim() || fallback || undefined;
 }
 
 function parseStructuredVideoObject($: ReturnType<typeof load>) {
@@ -73,10 +73,14 @@ function parseStructuredVideoObject($: ReturnType<typeof load>) {
             for (const entry of entries) {
                 if (entry?.['@type'] === 'VideoObject') {
                     return entry as {
+                        description?: string;
                         embedUrl?: string;
+                        genre?: string | string[];
+                        keywords?: string | string[];
                         author?: {
                             name?: string;
                         };
+                        thumbnailUrl?: string | string[];
                     };
                 }
             }
@@ -84,6 +88,34 @@ function parseStructuredVideoObject($: ReturnType<typeof load>) {
             continue;
         }
     }
+}
+
+function parseImage($: ReturnType<typeof load>, videoObject: ReturnType<typeof parseStructuredVideoObject>) {
+    const thumbnailUrl = Array.isArray(videoObject?.thumbnailUrl) ? videoObject.thumbnailUrl[0] : videoObject?.thumbnailUrl;
+    const image = thumbnailUrl || $('meta[property="og:image"]').attr('content')?.trim();
+
+    return image ? new URL(image, rootUrl).href : undefined;
+}
+
+async function mapLimit<T, R>(values: T[], limit: number, mapper: (value: T, index: number) => Promise<R>) {
+    const results = Array.from({ length: values.length }) as R[];
+    let nextIndex = 0;
+
+    const worker = async (): Promise<void> => {
+        const currentIndex = nextIndex;
+        nextIndex += 1;
+
+        if (currentIndex >= values.length) {
+            return;
+        }
+
+        results[currentIndex] = await mapper(values[currentIndex], currentIndex);
+        await worker();
+    };
+
+    await Promise.all(Array.from({ length: Math.min(limit, values.length) }, () => worker()));
+
+    return results;
 }
 
 function renderDescription(image: string | undefined, description: string | undefined, embedUrl: string | undefined, includeEmbed: boolean): string | undefined {
@@ -113,13 +145,13 @@ function fetchVideoDetails(link: string) {
 
         const $ = load(response);
         const videoObject = parseStructuredVideoObject($);
-        const category = $('.media-by--category a').first().text().trim();
+        const image = parseImage($, videoObject);
 
         return {
             author: videoObject?.author?.name || $('.channel-header--title').first().text().trim() || undefined,
-            category: category || undefined,
-            description: parseDescription($),
+            description: parseDescription($, videoObject?.description?.trim()),
             embedUrl: videoObject?.embedUrl,
+            image,
         };
     });
 }
@@ -141,10 +173,11 @@ async function parseItemFromVideoElement($: ReturnType<typeof load>, videoElemen
 
     const $img = $video.find('img.thumbnail__image, .thumbnail__thumb img').first();
     const imageRaw = $img.attr('src') || $img.attr('data-src');
-    const image = imageRaw ? new URL(imageRaw, rootUrl).href : undefined;
+    const listImage = imageRaw ? new URL(imageRaw, rootUrl).href : undefined;
     const pubDateRaw = $video.find('time.videostream__time[datetime], time[datetime]').first().attr('datetime')?.trim();
     const pubDate = pubDateRaw ? parseDate(pubDateRaw) : undefined;
     const details = await fetchVideoDetails(url.href);
+    const image = listImage || details.image;
 
     const media = image
         ? {
@@ -163,7 +196,7 @@ async function parseItemFromVideoElement($: ReturnType<typeof load>, videoElemen
     return {
         title,
         author: details.author,
-        category: details.category ? [details.category] : undefined,
+        image,
         link: url.href,
         description,
         itunes_item_image: image,
@@ -189,19 +222,18 @@ async function handler(ctx) {
     const title = parseChannelTitle($);
 
     const uniqueIds = new Set<string>();
-    const items = await Promise.all(
-        $('.channel-listing__container .videostream[data-video-id], .videostream.thumbnail__grid--item[data-video-id]')
-            .toArray()
-            .map((element) => {
-                const videoId = $(element).attr('data-video-id')?.trim();
-                if (!videoId || uniqueIds.has(videoId)) {
-                    return null;
-                }
+    const videoElements = $('.channel-listing__container .videostream[data-video-id], .videostream.thumbnail__grid--item[data-video-id]')
+        .toArray()
+        .filter((element) => {
+            const videoId = $(element).attr('data-video-id')?.trim();
+            if (!videoId || uniqueIds.has(videoId)) {
+                return false;
+            }
 
-                uniqueIds.add(videoId);
-                return parseItemFromVideoElement($, element, includeEmbed);
-            })
-    );
+            uniqueIds.add(videoId);
+            return true;
+        });
+    const items = await mapLimit(videoElements, 5, (element) => parseItemFromVideoElement($, element, includeEmbed));
 
     return {
         title: `Rumble - ${title}`,

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -11,7 +11,7 @@ import { parseDate } from '@/utils/parse-date';
 const rootUrl = 'https://rumble.com';
 
 export const route: Route = {
-    path: ['/c/:channel', '/c/:channel/embed'],
+    path: '/c/:channel/:embed?',
     categories: ['social-media'],
     view: ViewType.Videos,
     name: 'Channel',
@@ -19,8 +19,9 @@ export const route: Route = {
     example: '/rumble/c/Timcast',
     parameters: {
         channel: 'Channel slug from `https://rumble.com/c/<channel>`',
+        embed: 'Default to embed the video, set to any value to disable embedding',
     },
-    description: 'Append `/embed` to include the Rumble player iframe in each item description.',
+    description: 'Fetches full Rumble video descriptions and embeds the player by default.',
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -173,7 +174,7 @@ async function parseItemFromVideoElement($: ReturnType<typeof load>, videoElemen
 
 async function handler(ctx) {
     const channel = ctx.req.param('channel');
-    const includeEmbed = ctx.req.path.endsWith('/embed');
+    const includeEmbed = !ctx.req.param('embed');
     const channelUrl = new URL(`/c/${encodeURIComponent(channel)}`, rootUrl).href;
 
     const response = await ofetch(channelUrl, {

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -1,7 +1,6 @@
 import { load } from 'cheerio';
 import type { Element } from 'domhandler';
 
-import { config } from '@/config';
 import type { DataItem, Route } from '@/types';
 import { ViewType } from '@/types';
 import cache from '@/utils/cache';
@@ -137,9 +136,6 @@ function renderDescription(image: string | undefined, description: string | unde
 function fetchVideoDetails(link: string) {
     return cache.tryGet(link, async () => {
         const response = await ofetch(link, {
-            headers: {
-                'user-agent': config.trueUA,
-            },
             retryStatusCodes: [403],
         });
 
@@ -211,9 +207,6 @@ async function handler(ctx) {
     const channelUrl = new URL(`/c/${encodeURIComponent(channel)}`, rootUrl).href;
 
     const response = await ofetch(channelUrl, {
-        headers: {
-            'user-agent': config.trueUA,
-        },
         retryStatusCodes: [403],
     });
 

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -15,7 +15,7 @@ export const route: Route = {
     view: ViewType.Videos,
     name: 'Channel',
     maintainers: ['luckycold'],
-    example: '/rumble/c/Timcast',
+    example: '/rumble/c/MikhailaPeterson',
     parameters: {
         channel: 'Channel slug from `https://rumble.com/c/<channel>`',
         embed: 'Default to embed the video, set to any value to disable embedding',

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -1,5 +1,6 @@
 import { load } from 'cheerio';
 import type { Element } from 'domhandler';
+import pMap from 'p-map';
 
 import type { DataItem, Route } from '@/types';
 import { ViewType } from '@/types';
@@ -8,10 +9,18 @@ import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
 const rootUrl = 'https://rumble.com';
+type RumbleVideoObject = {
+    author?: {
+        name?: string;
+    };
+    description?: string;
+    embedUrl?: string;
+    thumbnailUrl?: string;
+};
 
 export const route: Route = {
     path: '/c/:channel/:embed?',
-    categories: ['social-media'],
+    categories: ['multimedia'],
     view: ViewType.Videos,
     name: 'Channel',
     maintainers: ['luckycold'],
@@ -39,13 +48,7 @@ export const route: Route = {
 };
 
 function parseChannelTitle($: ReturnType<typeof load>): string {
-    const h1 = $('h1').first().text().trim();
-    if (h1) {
-        return h1;
-    }
-
-    const title = $('title').first().text().trim();
-    return title || 'Rumble';
+    return $('title').first().text().trim() || 'Rumble';
 }
 
 function parseDescription($: ReturnType<typeof load>, fallback: string | undefined): string | undefined {
@@ -58,124 +61,45 @@ function parseDescription($: ReturnType<typeof load>, fallback: string | undefin
     return paragraphs || $('meta[name="description"]').attr('content')?.trim() || fallback || undefined;
 }
 
-function parseStructuredVideoObject($: ReturnType<typeof load>) {
-    for (const element of $('script[type="application/ld+json"]').toArray()) {
-        const content = $(element).text().trim();
-        if (!content) {
-            continue;
-        }
+function parseStructuredVideoObject($: ReturnType<typeof load>): RumbleVideoObject | undefined {
+    const content = $('script[type="application/ld+json"]').text().trim();
+    if (!content) {
+        return;
+    }
 
-        try {
-            const parsed = JSON.parse(content);
-            const entries = Array.isArray(parsed) ? parsed : [parsed];
-
-            for (const entry of entries) {
-                if (entry?.['@type'] === 'VideoObject') {
-                    return entry as {
-                        description?: string;
-                        embedUrl?: string;
-                        genre?: string | string[];
-                        keywords?: string | string[];
-                        author?: {
-                            name?: string;
-                        };
-                        thumbnailUrl?: string | string[];
-                    };
-                }
-            }
-        } catch {
-            continue;
-        }
+    try {
+        const parsed = JSON.parse(content);
+        const type = parsed?.['@type'];
+        return type === 'VideoObject' || (Array.isArray(type) && type.includes('VideoObject')) ? (parsed as RumbleVideoObject) : undefined;
+    } catch {
+        return;
     }
 }
 
-function parseImage($: ReturnType<typeof load>, videoObject: ReturnType<typeof parseStructuredVideoObject>) {
-    const thumbnailUrl = Array.isArray(videoObject?.thumbnailUrl) ? videoObject.thumbnailUrl[0] : videoObject?.thumbnailUrl;
-    const image = thumbnailUrl || $('meta[property="og:image"]').attr('content')?.trim();
+function parseImage($: ReturnType<typeof load>, videoObject: RumbleVideoObject | undefined) {
+    const image = videoObject?.thumbnailUrl || $('meta[property="og:image"]').attr('content')?.trim();
 
     return image ? new URL(image, rootUrl).href : undefined;
 }
 
-async function mapLimit<T, R>(values: T[], limit: number, mapper: (value: T, index: number) => Promise<R>) {
-    const results = Array.from({ length: values.length }) as R[];
-    let nextIndex = 0;
-
-    const worker = async (): Promise<void> => {
-        const currentIndex = nextIndex;
-        nextIndex += 1;
-
-        if (currentIndex >= values.length) {
-            return;
-        }
-
-        results[currentIndex] = await mapper(values[currentIndex], currentIndex);
-        await worker();
-    };
-
-    await Promise.all(Array.from({ length: Math.min(limit, values.length) }, () => worker()));
-
-    return results;
-}
-
 function renderDescription(image: string | undefined, description: string | undefined, embedUrl: string | undefined, includeEmbed: boolean): string | undefined {
-    const parts: string[] = [];
+    let descriptionHtml = '';
 
     if (includeEmbed && embedUrl) {
-        parts.push(`<iframe src="${embedUrl}" width="640" height="360" frameborder="0" allowfullscreen></iframe>`);
+        descriptionHtml += `<iframe src="${embedUrl}" width="640" height="360" frameborder="0" allowfullscreen></iframe>`;
     } else if (image) {
-        parts.push(`<p><img src="${image}"></p>`);
+        descriptionHtml += `<p><img src="${image}"></p>`;
     }
 
     if (description) {
-        parts.push(description);
+        descriptionHtml += description;
     }
 
-    return parts.join('');
+    return descriptionHtml || undefined;
 }
 
-function fetchVideoDetails(link: string) {
-    return cache.tryGet(link, async () => {
-        const response = await ofetch(link, {
-            retryStatusCodes: [403],
-        });
-
-        const $ = load(response);
-        const videoObject = parseStructuredVideoObject($);
-        const image = parseImage($, videoObject);
-
-        return {
-            author: videoObject?.author?.name || $('.channel-header--title').first().text().trim() || undefined,
-            description: parseDescription($, videoObject?.description?.trim()),
-            embedUrl: videoObject?.embedUrl,
-            image,
-        };
-    });
-}
-
-async function parseItemFromVideoElement($: ReturnType<typeof load>, videoElement: Element, includeEmbed: boolean): Promise<DataItem | null> {
-    const $video = $(videoElement);
-    const $link = $video.find('.title__link[href], .videostream__link[href]').first();
-    const href = $link.attr('href')?.trim();
-    if (!href) {
-        return null;
-    }
-
-    const url = new URL(href, rootUrl);
-    url.search = '';
-    url.hash = '';
-
-    const $title = $video.find('.thumbnail__title').first();
-    const title = $title.attr('title')?.trim() || $title.text().trim() || url.pathname;
-
-    const $img = $video.find('img.thumbnail__image, .thumbnail__thumb img').first();
-    const imageRaw = $img.attr('src') || $img.attr('data-src');
-    const listImage = imageRaw ? new URL(imageRaw, rootUrl).href : undefined;
-    const pubDateRaw = $video.find('time.videostream__time[datetime], time[datetime]').first().attr('datetime')?.trim();
-    const pubDate = pubDateRaw ? parseDate(pubDateRaw) : undefined;
-    const details = await fetchVideoDetails(url.href);
-    const image = listImage || details.image;
-
-    const media = image
+function getMedia(image: string | undefined): DataItem['media'] {
+    return image
         ? {
               thumbnail: {
                   url: image,
@@ -186,17 +110,27 @@ async function parseItemFromVideoElement($: ReturnType<typeof load>, videoElemen
               },
           }
         : undefined;
+}
 
-    const description = renderDescription(image, details.description, details.embedUrl, includeEmbed);
+async function buildItem(link: string, title: string, listImage: string | undefined, pubDate: Date | undefined, includeEmbed: boolean): Promise<DataItem> {
+    const response = await ofetch(link, {
+        retryStatusCodes: [403],
+    });
+
+    const $ = load(response);
+    const videoObject = parseStructuredVideoObject($);
+    const image = listImage || parseImage($, videoObject);
+    const description = renderDescription(image, parseDescription($, videoObject?.description?.trim()), videoObject?.embedUrl, includeEmbed);
+    const author = videoObject?.author?.name;
 
     return {
         title,
-        author: details.author,
+        author,
         image,
-        link: url.href,
+        link,
         description,
         itunes_item_image: image,
-        media,
+        media: getMedia(image),
         pubDate,
     };
 }
@@ -215,19 +149,33 @@ async function handler(ctx) {
 
     const title = parseChannelTitle($);
 
-    const uniqueIds = new Set<string>();
-    const videoElements = $('.channel-listing__container .videostream[data-video-id], .videostream.thumbnail__grid--item[data-video-id]')
-        .toArray()
-        .filter((element) => {
-            const videoId = $(element).attr('data-video-id')?.trim();
-            if (!videoId || uniqueIds.has(videoId)) {
-                return false;
+    const videoElements = $('.videostream.thumbnail__grid--item[data-video-id]').toArray();
+    const items = await pMap(
+        videoElements,
+        (element: Element) => {
+            const $video = $(element);
+            const href = $video.find('.videostream__link[href]').attr('href')?.trim();
+            if (!href) {
+                return null;
             }
 
-            uniqueIds.add(videoId);
-            return true;
-        });
-    const items = await mapLimit(videoElements, 5, (element) => parseItemFromVideoElement($, element, includeEmbed));
+            const url = new URL(href, rootUrl);
+            url.search = '';
+
+            const title = $video.find('.thumbnail__title').text().trim();
+            if (!title) {
+                return null;
+            }
+
+            const imageRaw = $video.find('img.thumbnail__image').attr('src');
+            const listImage = imageRaw ? new URL(imageRaw, rootUrl).href : undefined;
+            const pubDateRaw = $video.find('time.videostream__time[datetime]').attr('datetime')?.trim();
+            const pubDate = pubDateRaw ? parseDate(pubDateRaw) : undefined;
+
+            return cache.tryGet(`${url.href}:${includeEmbed ? 'embed' : 'noembed'}`, () => buildItem(url.href, title, listImage, pubDate, includeEmbed));
+        },
+        { concurrency: 5 }
+    );
 
     return {
         title: `Rumble - ${title}`,

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -1,0 +1,128 @@
+import { load } from 'cheerio';
+import type { Element } from 'domhandler';
+
+import { config } from '@/config';
+import type { DataItem, Route } from '@/types';
+import { ViewType } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const rootUrl = 'https://rumble.com';
+
+export const route: Route = {
+    path: '/c/:channel',
+    categories: ['social-media'],
+    view: ViewType.Videos,
+    name: 'Channel',
+    maintainers: ['luckycold'],
+    example: '/rumble/c/Timcast',
+    parameters: {
+        channel: 'Channel slug from `https://rumble.com/c/<channel>`',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['rumble.com/c/:channel'],
+            target: '/c/:channel',
+        },
+    ],
+    handler,
+};
+
+function parseChannelTitle($: ReturnType<typeof load>): string {
+    const h1 = $('h1').first().text().trim();
+    if (h1) {
+        return h1;
+    }
+
+    const title = $('title').first().text().trim();
+    return title || 'Rumble';
+}
+
+function parseItemFromVideoElement($: ReturnType<typeof load>, videoElement: Element): DataItem | null {
+    const $video = $(videoElement);
+    const $link = $video.find('.title__link[href], .videostream__link[href]').first();
+    const href = $link.attr('href')?.trim();
+    if (!href) {
+        return null;
+    }
+
+    const url = new URL(href, rootUrl);
+    url.search = '';
+    url.hash = '';
+
+    const $title = $video.find('.thumbnail__title').first();
+    const title = $title.attr('title')?.trim() || $title.text().trim() || url.pathname;
+
+    const $img = $video.find('img.thumbnail__image, .thumbnail__thumb img').first();
+    const imageRaw = $img.attr('src') || $img.attr('data-src');
+    const image = imageRaw ? new URL(imageRaw, rootUrl).href : undefined;
+    const pubDateRaw = $video.find('time.videostream__time[datetime], time[datetime]').first().attr('datetime')?.trim();
+    const pubDate = pubDateRaw ? parseDate(pubDateRaw) : undefined;
+
+    const media = image
+        ? {
+              thumbnail: {
+                  url: image,
+              },
+              content: {
+                  url: image,
+                  medium: 'image',
+              },
+          }
+        : undefined;
+
+    const description = image ? `<p><img src="${image}"></p>` : undefined;
+
+    return {
+        title,
+        link: url.href,
+        description,
+        itunes_item_image: image,
+        media,
+        pubDate,
+    };
+}
+
+async function handler(ctx) {
+    const channel = ctx.req.param('channel');
+    const channelUrl = new URL(`/c/${encodeURIComponent(channel)}`, rootUrl).href;
+
+    const response = await ofetch(channelUrl, {
+        headers: {
+            'user-agent': config.trueUA,
+        },
+        retryStatusCodes: [403],
+    });
+
+    const $ = load(response);
+
+    const title = parseChannelTitle($);
+
+    const uniqueIds = new Set<string>();
+    const items = $('.channel-listing__container .videostream[data-video-id], .videostream.thumbnail__grid--item[data-video-id]')
+        .toArray()
+        .map((element) => {
+            const videoId = $(element).attr('data-video-id')?.trim();
+            if (!videoId || uniqueIds.has(videoId)) {
+                return null;
+            }
+
+            uniqueIds.add(videoId);
+            return parseItemFromVideoElement($, element);
+        })
+        .filter((item): item is DataItem => Boolean(item && item.link));
+
+    return {
+        title: `Rumble - ${title}`,
+        link: channelUrl,
+        item: items,
+    };
+}

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -4,13 +4,14 @@ import type { Element } from 'domhandler';
 import { config } from '@/config';
 import type { DataItem, Route } from '@/types';
 import { ViewType } from '@/types';
+import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
 const rootUrl = 'https://rumble.com';
 
 export const route: Route = {
-    path: '/c/:channel',
+    path: ['/c/:channel', '/c/:channel/embed'],
     categories: ['social-media'],
     view: ViewType.Videos,
     name: 'Channel',
@@ -19,6 +20,7 @@ export const route: Route = {
     parameters: {
         channel: 'Channel slug from `https://rumble.com/c/<channel>`',
     },
+    description: 'Append `/embed` to include the Rumble player iframe in each item description.',
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -46,7 +48,82 @@ function parseChannelTitle($: ReturnType<typeof load>): string {
     return title || 'Rumble';
 }
 
-function parseItemFromVideoElement($: ReturnType<typeof load>, videoElement: Element): DataItem | null {
+function parseDescription($: ReturnType<typeof load>): string | undefined {
+    const paragraphs = $('div[data-js="media_long_description_container"] > p.media-description')
+        .toArray()
+        .map((element) => $.html(element))
+        .filter(Boolean)
+        .join('');
+
+    return paragraphs || $('meta[name="description"]').attr('content')?.trim() || undefined;
+}
+
+function parseStructuredVideoObject($: ReturnType<typeof load>) {
+    for (const element of $('script[type="application/ld+json"]').toArray()) {
+        const content = $(element).text().trim();
+        if (!content) {
+            continue;
+        }
+
+        try {
+            const parsed = JSON.parse(content);
+            const entries = Array.isArray(parsed) ? parsed : [parsed];
+
+            for (const entry of entries) {
+                if (entry?.['@type'] === 'VideoObject') {
+                    return entry as {
+                        embedUrl?: string;
+                        author?: {
+                            name?: string;
+                        };
+                    };
+                }
+            }
+        } catch {
+            continue;
+        }
+    }
+}
+
+function renderDescription(image: string | undefined, description: string | undefined, embedUrl: string | undefined, includeEmbed: boolean): string | undefined {
+    const parts: string[] = [];
+
+    if (includeEmbed && embedUrl) {
+        parts.push(`<iframe src="${embedUrl}" width="640" height="360" frameborder="0" allowfullscreen></iframe>`);
+    } else if (image) {
+        parts.push(`<p><img src="${image}"></p>`);
+    }
+
+    if (description) {
+        parts.push(description);
+    }
+
+    return parts.join('');
+}
+
+function fetchVideoDetails(link: string) {
+    return cache.tryGet(link, async () => {
+        const response = await ofetch(link, {
+            headers: {
+                'user-agent': config.trueUA,
+            },
+            retryStatusCodes: [403],
+        });
+
+        const $ = load(response);
+        const videoObject = parseStructuredVideoObject($);
+        const category = $('.media-by--category a').first().text().trim();
+
+        return {
+            author: videoObject?.author?.name || $('.channel-header--title').first().text().trim() || undefined,
+            category: category || undefined,
+            description: parseDescription($),
+            embedUrl: videoObject?.embedUrl,
+        };
+    });
+}
+
+async function parseItemFromVideoElement($: ReturnType<typeof load>, videoElement: Element, includeEmbed: boolean): Promise<DataItem | null> {
     const $video = $(videoElement);
     const $link = $video.find('.title__link[href], .videostream__link[href]').first();
     const href = $link.attr('href')?.trim();
@@ -66,6 +143,7 @@ function parseItemFromVideoElement($: ReturnType<typeof load>, videoElement: Ele
     const image = imageRaw ? new URL(imageRaw, rootUrl).href : undefined;
     const pubDateRaw = $video.find('time.videostream__time[datetime], time[datetime]').first().attr('datetime')?.trim();
     const pubDate = pubDateRaw ? parseDate(pubDateRaw) : undefined;
+    const details = await fetchVideoDetails(url.href);
 
     const media = image
         ? {
@@ -79,10 +157,12 @@ function parseItemFromVideoElement($: ReturnType<typeof load>, videoElement: Ele
           }
         : undefined;
 
-    const description = image ? `<p><img src="${image}"></p>` : undefined;
+    const description = renderDescription(image, details.description, details.embedUrl, includeEmbed);
 
     return {
         title,
+        author: details.author,
+        category: details.category ? [details.category] : undefined,
         link: url.href,
         description,
         itunes_item_image: image,
@@ -93,6 +173,7 @@ function parseItemFromVideoElement($: ReturnType<typeof load>, videoElement: Ele
 
 async function handler(ctx) {
     const channel = ctx.req.param('channel');
+    const includeEmbed = ctx.req.path.endsWith('/embed');
     const channelUrl = new URL(`/c/${encodeURIComponent(channel)}`, rootUrl).href;
 
     const response = await ofetch(channelUrl, {
@@ -107,22 +188,23 @@ async function handler(ctx) {
     const title = parseChannelTitle($);
 
     const uniqueIds = new Set<string>();
-    const items = $('.channel-listing__container .videostream[data-video-id], .videostream.thumbnail__grid--item[data-video-id]')
-        .toArray()
-        .map((element) => {
-            const videoId = $(element).attr('data-video-id')?.trim();
-            if (!videoId || uniqueIds.has(videoId)) {
-                return null;
-            }
+    const items = await Promise.all(
+        $('.channel-listing__container .videostream[data-video-id], .videostream.thumbnail__grid--item[data-video-id]')
+            .toArray()
+            .map((element) => {
+                const videoId = $(element).attr('data-video-id')?.trim();
+                if (!videoId || uniqueIds.has(videoId)) {
+                    return null;
+                }
 
-            uniqueIds.add(videoId);
-            return parseItemFromVideoElement($, element);
-        })
-        .filter((item): item is DataItem => Boolean(item && item.link));
+                uniqueIds.add(videoId);
+                return parseItemFromVideoElement($, element, includeEmbed);
+            })
+    );
 
     return {
         title: `Rumble - ${title}`,
         link: channelUrl,
-        item: items,
+        item: items.filter((item): item is DataItem => Boolean(item && item.link)),
     };
 }

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -1,7 +1,7 @@
 import { load } from 'cheerio';
-import type { Element } from 'domhandler';
 import pMap from 'p-map';
 
+import { config } from '@/config';
 import type { DataItem, Route } from '@/types';
 import { ViewType } from '@/types';
 import cache from '@/utils/cache';
@@ -16,6 +16,14 @@ type RumbleVideoObject = {
     description?: string;
     embedUrl?: string;
     thumbnailUrl?: string;
+};
+type RumbleListVideo = {
+    relative_url?: string;
+    tags?: string[];
+    thumb?: string;
+    title?: string;
+    upload_date?: string;
+    url?: string;
 };
 
 export const route: Route = {
@@ -67,13 +75,19 @@ function parseStructuredVideoObject($: ReturnType<typeof load>): RumbleVideoObje
         return;
     }
 
-    try {
-        const parsed = JSON.parse(content);
-        const type = parsed?.['@type'];
-        return type === 'VideoObject' || (Array.isArray(type) && type.includes('VideoObject')) ? (parsed as RumbleVideoObject) : undefined;
-    } catch {
-        return;
+    const parsed = JSON.parse(content);
+    const type = parsed?.['@type'];
+    return type === 'VideoObject' ? (parsed as RumbleVideoObject) : undefined;
+}
+
+function parseListVideos($: ReturnType<typeof load>): RumbleListVideo[] {
+    const content = $('rum-videos-grid script[type="application/json"]').text().trim();
+    if (!content) {
+        return [];
     }
+
+    const parsed = JSON.parse(content);
+    return Array.isArray(parsed?.items) ? parsed.items : [];
 }
 
 function parseImage($: ReturnType<typeof load>, videoObject: RumbleVideoObject | undefined) {
@@ -112,8 +126,11 @@ function getMedia(image: string | undefined): DataItem['media'] {
         : undefined;
 }
 
-async function buildItem(link: string, title: string, listImage: string | undefined, pubDate: Date | undefined, includeEmbed: boolean): Promise<DataItem> {
+async function buildItem(link: string, title: string, listImage: string | undefined, pubDate: Date | undefined, includeEmbed: boolean, category: string[] | undefined): Promise<DataItem> {
     const response = await ofetch(link, {
+        headers: {
+            'user-agent': config.trueUA,
+        },
         retryStatusCodes: [403],
     });
 
@@ -129,6 +146,7 @@ async function buildItem(link: string, title: string, listImage: string | undefi
         image,
         link,
         description,
+        category,
         itunes_item_image: image,
         media: getMedia(image),
         pubDate,
@@ -142,6 +160,9 @@ async function handler(ctx) {
     const videosUrl = `${channelUrl}/videos`;
 
     const response = await ofetch(videosUrl, {
+        headers: {
+            'user-agent': config.trueUA,
+        },
         retryStatusCodes: [403],
     });
 
@@ -149,30 +170,30 @@ async function handler(ctx) {
 
     const title = parseChannelTitle($);
 
-    const videoElements = $('.videostream.thumbnail__grid--item[data-video-id]').toArray();
+    const videos = parseListVideos($);
     const items = await pMap(
-        videoElements,
-        (element: Element) => {
-            const $video = $(element);
-            const href = $video.find('.videostream__link[href]').attr('href')?.trim();
-            if (!href) {
+        videos,
+        (video) => {
+            const videoUrl = video.url || video.relative_url;
+            if (!videoUrl) {
                 return null;
             }
 
-            const url = new URL(href, rootUrl);
+            const url = new URL(videoUrl, rootUrl);
             url.search = '';
 
-            const title = $video.find('.thumbnail__title').text().trim();
+            const title = video.title;
             if (!title) {
                 return null;
             }
 
-            const imageRaw = $video.find('img.thumbnail__image').attr('src');
+            const imageRaw = video.thumb;
             const listImage = imageRaw ? new URL(imageRaw, rootUrl).href : undefined;
-            const pubDateRaw = $video.find('time.videostream__time[datetime]').attr('datetime')?.trim();
+            const pubDateRaw = video.upload_date;
             const pubDate = pubDateRaw ? parseDate(pubDateRaw) : undefined;
+            const category = video.tags?.length ? video.tags : undefined;
 
-            return cache.tryGet(`${url.href}:${includeEmbed ? 'embed' : 'noembed'}`, () => buildItem(url.href, title, listImage, pubDate, includeEmbed));
+            return cache.tryGet(`${url.href}:${includeEmbed ? 'embed' : 'noembed'}`, () => buildItem(url.href, title, listImage, pubDate, includeEmbed, category));
         },
         { concurrency: 5 }
     );

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -1,4 +1,4 @@
-import { load } from 'cheerio';
+import { type CheerioAPI, load } from 'cheerio';
 import pMap from 'p-map';
 
 import type { DataItem, Route } from '@/types';
@@ -50,7 +50,7 @@ export const route: Route = {
     handler,
 };
 
-function parseDescription($: ReturnType<typeof load>, fallback: string | undefined): string | undefined {
+function parseDescription($: CheerioAPI, fallback: string | undefined): string | undefined {
     const paragraphs = $('div[data-js="media_long_description_container"] > p.media-description')
         .toArray()
         .map((element) => $.html(element))
@@ -60,7 +60,7 @@ function parseDescription($: ReturnType<typeof load>, fallback: string | undefin
     return paragraphs || $('meta[name="description"]').attr('content') || fallback || undefined;
 }
 
-function parseStructuredVideoObject($: ReturnType<typeof load>): RumbleVideoObject | undefined {
+function parseStructuredVideoObject($: CheerioAPI): RumbleVideoObject | undefined {
     const elements = $('script[type="application/ld+json"]').toArray();
 
     for (const element of elements) {
@@ -76,7 +76,7 @@ function parseStructuredVideoObject($: ReturnType<typeof load>): RumbleVideoObje
     }
 }
 
-function parseListVideos($: ReturnType<typeof load>): RumbleListVideo[] {
+function parseListVideos($: CheerioAPI): RumbleListVideo[] {
     const content = $('rum-videos-grid script[type="application/json"]').text();
     if (!content) {
         return [];
@@ -90,7 +90,7 @@ function parseListVideos($: ReturnType<typeof load>): RumbleListVideo[] {
     }
 }
 
-function parseImage($: ReturnType<typeof load>, videoObject: RumbleVideoObject | undefined) {
+function parseImage($: CheerioAPI, videoObject: RumbleVideoObject | undefined) {
     const image = videoObject?.thumbnailUrl || $('meta[property="og:image"]').attr('content');
 
     return image || undefined;

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -30,9 +30,9 @@ export const route: Route = {
     example: '/rumble/c/MikhailaPeterson',
     parameters: {
         channel: 'Channel slug from `https://rumble.com/c/<channel>`',
-        embed: 'Default to not embed the video, set to any value to enable embedding',
+        embed: 'Default to embed the video, set to any value to disable embedding',
     },
-    description: 'Fetches full Rumble video descriptions without embedding the player by default.',
+    description: 'Fetches full Rumble video descriptions and embeds the player by default.',
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -159,7 +159,7 @@ async function buildItem(link: string, title: string, listImage: string, pubDate
 
 async function handler(ctx) {
     const channel = ctx.req.param('channel');
-    const includeEmbed = Boolean(ctx.req.param('embed'));
+    const includeEmbed = !ctx.req.param('embed');
     const channelUrl = new URL(`/c/${encodeURIComponent(channel)}`, rootUrl).href;
     const videosUrl = `${channelUrl}/videos`;
 

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -30,9 +30,9 @@ export const route: Route = {
     example: '/rumble/c/MikhailaPeterson',
     parameters: {
         channel: 'Channel slug from `https://rumble.com/c/<channel>`',
-        embed: 'Default to embed the video, set to any value to disable embedding',
+        embed: 'Default to not embed the video, set to any value to enable embedding',
     },
-    description: 'Fetches full Rumble video descriptions and embeds the player by default.',
+    description: 'Fetches full Rumble video descriptions without embedding the player by default.',
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -159,7 +159,7 @@ async function buildItem(link: string, title: string, listImage: string, pubDate
 
 async function handler(ctx) {
     const channel = ctx.req.param('channel');
-    const includeEmbed = !ctx.req.param('embed');
+    const includeEmbed = Boolean(ctx.req.param('embed'));
     const channelUrl = new URL(`/c/${encodeURIComponent(channel)}`, rootUrl).href;
     const videosUrl = `${channelUrl}/videos`;
 

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -30,9 +30,9 @@ export const route: Route = {
     example: '/rumble/c/MikhailaPeterson',
     parameters: {
         channel: 'Channel slug from `https://rumble.com/c/<channel>`',
-        embed: 'Default to embed the video, set to any value to disable embedding',
+        embed: 'Default to not embed the video, set to `embed` to enable embedding',
     },
-    description: 'Fetches full Rumble video descriptions and embeds the player by default.',
+    description: 'Fetches full Rumble video descriptions without embedding the player by default.',
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -159,7 +159,7 @@ async function buildItem(link: string, title: string, listImage: string, pubDate
 
 async function handler(ctx) {
     const channel = ctx.req.param('channel');
-    const includeEmbed = !ctx.req.param('embed');
+    const includeEmbed = ctx.req.param('embed') === 'embed';
     const channelUrl = new URL(`/c/${encodeURIComponent(channel)}`, rootUrl).href;
     const videosUrl = `${channelUrl}/videos`;
 

--- a/lib/routes/rumble/channel.ts
+++ b/lib/routes/rumble/channel.ts
@@ -1,7 +1,6 @@
 import { load } from 'cheerio';
 import pMap from 'p-map';
 
-import { config } from '@/config';
 import type { DataItem, Route } from '@/types';
 import { ViewType } from '@/types';
 import cache from '@/utils/cache';
@@ -10,19 +9,15 @@ import { parseDate } from '@/utils/parse-date';
 
 const rootUrl = 'https://rumble.com';
 type RumbleVideoObject = {
-    author?: {
-        name?: string;
-    };
     description?: string;
     embedUrl?: string;
     thumbnailUrl?: string;
 };
 type RumbleListVideo = {
-    relative_url?: string;
-    tags?: string[];
-    thumb?: string;
-    title?: string;
-    upload_date?: string;
+    relative_url: string;
+    thumb: string;
+    title: string;
+    upload_date: string;
     url?: string;
 };
 
@@ -55,10 +50,6 @@ export const route: Route = {
     handler,
 };
 
-function parseChannelTitle($: ReturnType<typeof load>): string {
-    return $('title').first().text().trim() || 'Rumble';
-}
-
 function parseDescription($: ReturnType<typeof load>, fallback: string | undefined): string | undefined {
     const paragraphs = $('div[data-js="media_long_description_container"] > p.media-description')
         .toArray()
@@ -66,34 +57,43 @@ function parseDescription($: ReturnType<typeof load>, fallback: string | undefin
         .filter(Boolean)
         .join('');
 
-    return paragraphs || $('meta[name="description"]').attr('content')?.trim() || fallback || undefined;
+    return paragraphs || $('meta[name="description"]').attr('content') || fallback || undefined;
 }
 
 function parseStructuredVideoObject($: ReturnType<typeof load>): RumbleVideoObject | undefined {
-    const content = $('script[type="application/ld+json"]').text().trim();
-    if (!content) {
-        return;
-    }
+    const elements = $('script[type="application/ld+json"]').toArray();
 
-    const parsed = JSON.parse(content);
-    const type = parsed?.['@type'];
-    return type === 'VideoObject' ? (parsed as RumbleVideoObject) : undefined;
+    for (const element of elements) {
+        try {
+            const parsed = JSON.parse($(element).text());
+            const videoObject = Array.isArray(parsed) ? parsed.find((item) => item?.['@type'] === 'VideoObject') : parsed;
+            if (videoObject?.['@type'] === 'VideoObject') {
+                return videoObject as RumbleVideoObject;
+            }
+        } catch {
+            continue;
+        }
+    }
 }
 
 function parseListVideos($: ReturnType<typeof load>): RumbleListVideo[] {
-    const content = $('rum-videos-grid script[type="application/json"]').text().trim();
+    const content = $('rum-videos-grid script[type="application/json"]').text();
     if (!content) {
         return [];
     }
 
-    const parsed = JSON.parse(content);
-    return Array.isArray(parsed?.items) ? parsed.items : [];
+    try {
+        const parsed = JSON.parse(content);
+        return parsed.items;
+    } catch {
+        return [];
+    }
 }
 
 function parseImage($: ReturnType<typeof load>, videoObject: RumbleVideoObject | undefined) {
-    const image = videoObject?.thumbnailUrl || $('meta[property="og:image"]').attr('content')?.trim();
+    const image = videoObject?.thumbnailUrl || $('meta[property="og:image"]').attr('content');
 
-    return image ? new URL(image, rootUrl).href : undefined;
+    return image || undefined;
 }
 
 function renderDescription(image: string | undefined, description: string | undefined, embedUrl: string | undefined, includeEmbed: boolean): string | undefined {
@@ -126,27 +126,31 @@ function getMedia(image: string | undefined): DataItem['media'] {
         : undefined;
 }
 
-async function buildItem(link: string, title: string, listImage: string | undefined, pubDate: Date | undefined, includeEmbed: boolean, category: string[] | undefined): Promise<DataItem> {
-    const response = await ofetch(link, {
+async function buildItem(link: string, title: string, listImage: string, pubDate: Date, includeEmbed: boolean): Promise<DataItem> {
+    const initialResponse = await ofetch.raw<string>(link, {
+        ignoreResponseError: true,
+    });
+    const cookies = (initialResponse.headers.getSetCookie?.() || []).map((cookie) => cookie.split(';', 1)[0]).join('; ');
+    if (!cookies) {
+        throw new Error(`Failed to get Rumble page cookie from ${link}`);
+    }
+
+    const response = await ofetch<string>(link, {
         headers: {
-            'user-agent': config.trueUA,
+            Cookie: cookies,
         },
-        retryStatusCodes: [403],
     });
 
     const $ = load(response);
     const videoObject = parseStructuredVideoObject($);
     const image = listImage || parseImage($, videoObject);
-    const description = renderDescription(image, parseDescription($, videoObject?.description?.trim()), videoObject?.embedUrl, includeEmbed);
-    const author = videoObject?.author?.name;
+    const description = renderDescription(image, parseDescription($, videoObject?.description), videoObject?.embedUrl, includeEmbed);
 
     return {
         title,
-        author,
         image,
         link,
         description,
-        category,
         itunes_item_image: image,
         media: getMedia(image),
         pubDate,
@@ -159,41 +163,21 @@ async function handler(ctx) {
     const channelUrl = new URL(`/c/${encodeURIComponent(channel)}`, rootUrl).href;
     const videosUrl = `${channelUrl}/videos`;
 
-    const response = await ofetch(videosUrl, {
-        headers: {
-            'user-agent': config.trueUA,
-        },
-        retryStatusCodes: [403],
-    });
+    const response = await ofetch(videosUrl);
 
     const $ = load(response);
 
-    const title = parseChannelTitle($);
+    const title = $('title').first().text() || 'Rumble';
 
     const videos = parseListVideos($);
     const items = await pMap(
         videos,
         (video) => {
-            const videoUrl = video.url || video.relative_url;
-            if (!videoUrl) {
-                return null;
-            }
+            const link = new URL(video.url || video.relative_url, rootUrl).href;
+            const listImage = new URL(video.thumb, rootUrl).href;
+            const pubDate = parseDate(video.upload_date);
 
-            const url = new URL(videoUrl, rootUrl);
-            url.search = '';
-
-            const title = video.title;
-            if (!title) {
-                return null;
-            }
-
-            const imageRaw = video.thumb;
-            const listImage = imageRaw ? new URL(imageRaw, rootUrl).href : undefined;
-            const pubDateRaw = video.upload_date;
-            const pubDate = pubDateRaw ? parseDate(pubDateRaw) : undefined;
-            const category = video.tags?.length ? video.tags : undefined;
-
-            return cache.tryGet(`${url.href}:${includeEmbed ? 'embed' : 'noembed'}`, () => buildItem(url.href, title, listImage, pubDate, includeEmbed, category));
+            return cache.tryGet(`${link}:${includeEmbed ? 'embed' : 'noembed'}`, () => buildItem(link, video.title, listImage, pubDate, includeEmbed));
         },
         { concurrency: 5 }
     );
@@ -201,6 +185,6 @@ async function handler(ctx) {
     return {
         title: `Rumble - ${title}`,
         link: videosUrl,
-        item: items.filter((item): item is DataItem => Boolean(item && item.link)),
+        item: items,
     };
 }

--- a/lib/routes/rumble/namespace.ts
+++ b/lib/routes/rumble/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Rumble',
+    url: 'rumble.com',
+    lang: 'en',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

No issue involved. This was just something I wanted and thought others might like too.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/rumble/c/MikhailaPeterson
/rumble/c/MikhailaPeterson/noembed
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This adds a Rumble route that keeps the channel listing on server-rendered markup while using structured detail-page data for fallback descriptions and thumbnails. It also adds standard `image` output and limits detail-page fetch concurrency to reduce anti-bot risk.