### PR TITLE
fix(github): update topics route selector to fix empty route

### DIFF
--- a/lib/routes/github/topic.ts
+++ b/lib/routes/github/topic.ts
@@ -46,7 +46,7 @@ async function handler(ctx) {
         title: $('title').text(),
         description: $('.markdown-body').text().trim(),
         link: url,
-        item: $('article.my-4')
+        item: $('article.border')
             .toArray()
             .map((item) => {
                 item = $(item);


### PR DESCRIPTION
修复 GitHub Topics 路由报 "Error: this route is empty" 的问题。

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
github/topics/framework
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
GitHub 更新了 Topics 页面的底层 DOM 结构，去掉了原本列表项中的 .my-4 class，导致原本的 Cheerio 选择器 $('article.my-4') 抓取结果为空。
本地测试已将选择器修改为更具通用性的 $('article.border')（或者 $('article')），修改后已能正常输出 XML 数据，修复了该路由。