### PR TITLE
feat(route): add /humanlayer/blog route

### DIFF
--- a/lib/routes/humanlayer/blog.ts
+++ b/lib/routes/humanlayer/blog.ts
@@ -1,0 +1,101 @@
+import { load } from 'cheerio';
+
+import type { DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/blog',
+    categories: ['blog'],
+    example: '/humanlayer/blog',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.humanlayer.dev/blog'],
+            target: '/humanlayer/blog',
+        },
+    ],
+    name: 'Blog',
+    maintainers: ['zj1123581321'],
+    handler,
+    url: 'www.humanlayer.dev/blog',
+};
+
+async function handler(ctx) {
+    const baseUrl = 'https://www.humanlayer.dev';
+    const listUrl = `${baseUrl}/blog`;
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 20;
+
+    const response = await ofetch(listUrl);
+    const $ = load(response);
+
+    const list = $('a.block.py-2.group[href^="/blog/"]')
+        .toArray()
+        .filter((el) => {
+            const href = $(el).attr('href')!;
+            return !href.startsWith('/blog/tags/');
+        })
+        .slice(0, limit)
+        .map((el) => {
+            const $el = $(el);
+            const href = $el.attr('href')!;
+            const title = $el.find('h2').text().trim();
+            const metaLine = $el.find('p.text-sm').text().trim();
+            const description = $el.find('p[style]').text().trim();
+
+            // meta format: "Author · Date · Read time · #tag1 #tag2"
+            const parts = metaLine.split('·').map((s) => s.trim());
+            const author = parts[0] || '';
+            const dateStr = parts[1] || '';
+
+            return {
+                title,
+                link: `${baseUrl}${href}`,
+                author,
+                description,
+                pubDate: dateStr ? parseDate(dateStr) : undefined,
+            } as DataItem;
+        });
+
+    const items = (await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link!, async () => {
+                const resp = await ofetch(item.link!);
+                const $detail = load(resp);
+
+                const ogTitle = $detail('meta[property="og:title"]').attr('content');
+                const ogDesc = $detail('meta[property="og:description"]').attr('content');
+                const publishedTime = $detail('meta[property="article:published_time"]').attr('content');
+                const ogAuthor = $detail('meta[property="article:author"]').attr('content');
+                const ogImage = $detail('meta[property="og:image"]').attr('content');
+
+                const content = $detail('div.prose').html();
+
+                return {
+                    ...item,
+                    title: ogTitle || item.title,
+                    description: content || ogDesc || item.description,
+                    pubDate: publishedTime ? parseDate(publishedTime) : item.pubDate,
+                    author: ogAuthor || item.author,
+                    banner: ogImage,
+                } as DataItem;
+            })
+        )
+    )) as DataItem[];
+
+    return {
+        title: 'HumanLayer Blog',
+        link: listUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/humanlayer/namespace.ts
+++ b/lib/routes/humanlayer/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'HumanLayer',
+    url: 'www.humanlayer.dev',
+    lang: 'en',
+};


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/humanlayer/blog
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- **New route**: `/humanlayer/blog` — Scrapes [humanlayer.dev/blog](https://www.humanlayer.dev/blog) for blog posts on AI agents, context engineering, and coding best practices
- Full article content fetched and cached via cheerio + ofetch
- Supports `?limit=` query parameter
- Radar rules included for browser extension detection

via [HAPI](https://hapi.run)

Co-Authored-By: HAPI <noreply@hapi.run>

🤖 Generated with [Claude Code](https://claude.com/claude-code)