### PR TITLE
feat(route/nfl): add NFL team news route

### DIFF
--- a/lib/routes/nfl/namespace.ts
+++ b/lib/routes/nfl/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'NFL',
+    url: 'nfl.com',
+    lang: 'en',
+};

--- a/lib/routes/nfl/news.ts
+++ b/lib/routes/nfl/news.ts
@@ -170,15 +170,17 @@ async function handler(ctx) {
                         const content = $article(selector);
                         if (content.length) {
                             content.find('script, style, [data-ad], .ad, .social-share, .related-content').remove();
-                            // Fix lazy-loaded images: real URLs live in data-src/data-srcset, src is a placeholder GIF
+                            // Fix lazy-loaded images: real URLs live in data-src/data-srcset, src is a placeholder GIF.
+                            // Also strip the Cloudinary "/t_lazy/" transformation which returns a blurred placeholder.
+                            const unlazy = (url: string) => url.replaceAll('/t_lazy/', '/');
                             content.find('img[data-src]').each((_, img) => {
                                 const $img = $article(img);
-                                $img.attr('src', $img.attr('data-src')!);
+                                $img.attr('src', unlazy($img.attr('data-src')!));
                                 $img.removeAttr('data-src');
                             });
                             content.find('source[data-srcset]').each((_, src) => {
                                 const $src = $article(src);
-                                $src.attr('srcset', $src.attr('data-srcset')!);
+                                $src.attr('srcset', unlazy($src.attr('data-srcset')!));
                                 $src.removeAttr('data-srcset');
                             });
                             const html = content

--- a/lib/routes/nfl/news.ts
+++ b/lib/routes/nfl/news.ts
@@ -149,6 +149,7 @@ async function handler(ctx) {
 
                 // Fix lazy-loaded images within the article body
                 const content = $article('.nfl-c-article__body');
+                content.find('.nfl-c-article__divider').remove();
                 content.find('img[data-src]').each((_, img) => {
                     const $img = $article(img);
                     $img.attr('src', unlazy($img.attr('data-src')!));

--- a/lib/routes/nfl/news.ts
+++ b/lib/routes/nfl/news.ts
@@ -134,8 +134,9 @@ async function handler(ctx) {
         }
     });
 
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')!, 10) : 20;
     const items = await Promise.all(
-        list.map((item) =>
+        list.slice(0, limit).map((item) =>
             cache.tryGet(item.link, async () => {
                 const articleResponse = await ofetch(item.link);
                 const $article = load(articleResponse);

--- a/lib/routes/nfl/news.ts
+++ b/lib/routes/nfl/news.ts
@@ -1,0 +1,197 @@
+import { load } from 'cheerio';
+
+import type { DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const teamDomains: Record<string, string> = {
+    '49ers': 'www.49ers.com',
+    bears: 'www.chicagobears.com',
+    bengals: 'www.bengals.com',
+    bills: 'www.buffalobills.com',
+    broncos: 'www.denverbroncos.com',
+    browns: 'www.clevelandbrowns.com',
+    buccaneers: 'www.buccaneers.com',
+    cardinals: 'www.azcardinals.com',
+    chargers: 'www.chargers.com',
+    chiefs: 'www.chiefs.com',
+    colts: 'www.colts.com',
+    commanders: 'www.commanders.com',
+    cowboys: 'www.dallascowboys.com',
+    dolphins: 'www.miamidolphins.com',
+    eagles: 'www.philadelphiaeagles.com',
+    falcons: 'www.atlantafalcons.com',
+    giants: 'www.giants.com',
+    jaguars: 'www.jaguars.com',
+    jets: 'www.newyorkjets.com',
+    lions: 'www.detroitlions.com',
+    packers: 'www.packers.com',
+    panthers: 'www.panthers.com',
+    patriots: 'www.patriots.com',
+    raiders: 'www.raiders.com',
+    rams: 'www.therams.com',
+    ravens: 'www.baltimoreravens.com',
+    saints: 'www.neworleanssaints.com',
+    seahawks: 'www.seahawks.com',
+    steelers: 'www.steelers.com',
+    texans: 'www.houstontexans.com',
+    titans: 'www.tennesseetitans.com',
+    vikings: 'www.vikings.com',
+};
+
+export const route: Route = {
+    path: '/news/:team',
+    categories: ['traditional-media'],
+    example: '/nfl/news/seahawks',
+    parameters: { team: 'Team name as used in the route key, see table below' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: Object.entries(teamDomains).map(([team, domain]) => ({
+        source: [`${domain}/news/*`],
+        target: `/news/${team}`,
+    })),
+    name: 'Team News',
+    maintainers: ['nickyfoto'],
+    description: `Fetches news from official NFL team websites.
+
+| Team | Key | Domain |
+|------|-----|--------|
+| Arizona Cardinals | cardinals | azcardinals.com |
+| Atlanta Falcons | falcons | atlantafalcons.com |
+| Baltimore Ravens | ravens | baltimoreravens.com |
+| Buffalo Bills | bills | buffalobills.com |
+| Carolina Panthers | panthers | panthers.com |
+| Chicago Bears | bears | chicagobears.com |
+| Cincinnati Bengals | bengals | bengals.com |
+| Cleveland Browns | browns | clevelandbrowns.com |
+| Dallas Cowboys | cowboys | dallascowboys.com |
+| Denver Broncos | broncos | denverbroncos.com |
+| Detroit Lions | lions | detroitlions.com |
+| Green Bay Packers | packers | packers.com |
+| Houston Texans | texans | houstontexans.com |
+| Indianapolis Colts | colts | colts.com |
+| Jacksonville Jaguars | jaguars | jaguars.com |
+| Kansas City Chiefs | chiefs | chiefs.com |
+| Las Vegas Raiders | raiders | raiders.com |
+| Los Angeles Chargers | chargers | chargers.com |
+| Los Angeles Rams | rams | therams.com |
+| Miami Dolphins | dolphins | miamidolphins.com |
+| Minnesota Vikings | vikings | vikings.com |
+| New England Patriots | patriots | patriots.com |
+| New Orleans Saints | saints | neworleanssaints.com |
+| New York Giants | giants | giants.com |
+| New York Jets | jets | newyorkjets.com |
+| Philadelphia Eagles | eagles | philadelphiaeagles.com |
+| Pittsburgh Steelers | steelers | steelers.com |
+| San Francisco 49ers | 49ers | 49ers.com |
+| Seattle Seahawks | seahawks | seahawks.com |
+| Tampa Bay Buccaneers | buccaneers | buccaneers.com |
+| Tennessee Titans | titans | tennesseetitans.com |
+| Washington Commanders | commanders | commanders.com |`,
+    handler,
+};
+
+async function handler(ctx) {
+    const team = ctx.req.param('team');
+    const domain = teamDomains[team];
+    if (!domain) {
+        throw new Error(`Unknown NFL team: ${team}. Valid teams: ${Object.keys(teamDomains).join(', ')}`);
+    }
+
+    const baseUrl = `https://${domain}`;
+    const listingUrl = `${baseUrl}/news/`;
+
+    const response = await ofetch(listingUrl);
+    const $ = load(response);
+
+    const seen = new Set<string>();
+    const list: Array<{ title: string; link: string }> = [];
+
+    $('a[href^="/news/"]').each((_, el) => {
+        const $el = $(el);
+        const href = $el.attr('href');
+        // Only match article links: /news/{single-slug} (no extra path segments or trailing slash)
+        if (!href || !/^\/news\/[^/]+$/.test(href) || seen.has(href)) {
+            return;
+        }
+        seen.add(href);
+        const title = $el.text().trim() || $el.find('img').attr('alt') || '';
+        if (title) {
+            list.push({
+                title,
+                link: `${baseUrl}${href}`,
+            });
+        }
+    });
+
+    const items = (
+        await Promise.all(
+            list.map((item) =>
+                cache.tryGet(item.link, async () => {
+                    let articleResponse;
+                    try {
+                        articleResponse = await ofetch(item.link);
+                    } catch {
+                        return null;
+                    }
+                    const $article = load(articleResponse);
+
+                    let jsonLd: Record<string, any> | null = null;
+                    $article('script[type="application/ld+json"]').each((_, el) => {
+                        try {
+                            const data = JSON.parse($article(el).text());
+                            const candidate = Array.isArray(data) ? data.find((d) => d['@type'] === 'NewsArticle') : data;
+                            if (candidate?.['@type'] === 'NewsArticle') {
+                                jsonLd = candidate;
+                            }
+                        } catch {
+                            // skip malformed JSON-LD
+                        }
+                    });
+
+                    const result: DataItem = {
+                        title: jsonLd?.headline || item.title,
+                        link: item.link,
+                        pubDate: jsonLd?.datePublished ? parseDate(jsonLd.datePublished) : undefined,
+                        author: jsonLd?.author?.name || (Array.isArray(jsonLd?.author) ? jsonLd.author[0]?.name : undefined),
+                        image: jsonLd?.image?.url || (Array.isArray(jsonLd?.image) ? jsonLd.image[0]?.url : undefined),
+                    };
+
+                    // Try to extract article body HTML
+                    const contentSelectors = ['article .nfl-c-body-part', '.article-body', 'article [data-module="content"]', 'article'];
+                    for (const selector of contentSelectors) {
+                        const content = $article(selector);
+                        if (content.length) {
+                            content.find('script, style, [data-ad], .ad, .social-share, .related-content').remove();
+                            const html = content.html();
+                            if (html) {
+                                result.description = html;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!result.description && jsonLd?.description) {
+                        result.description = jsonLd.description;
+                    }
+
+                    return result;
+                })
+            )
+        )
+    ).filter(Boolean) as DataItem[];
+
+    return {
+        title: $('title').text() || `${team.charAt(0).toUpperCase() + team.slice(1)} News`,
+        link: listingUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/nfl/news.ts
+++ b/lib/routes/nfl/news.ts
@@ -149,7 +149,7 @@ async function handler(ctx) {
 
                 // Fix lazy-loaded images within the article body
                 const content = $article('.nfl-c-article__body');
-                content.find('.nfl-c-article__divider').remove();
+                content.find('.nfl-c-article__divider, .nfl-c-photo-album').remove();
                 content.find('img[data-src]').each((_, img) => {
                     const $img = $article(img);
                     $img.attr('src', unlazy($img.attr('data-src')!));

--- a/lib/routes/nfl/news.ts
+++ b/lib/routes/nfl/news.ts
@@ -170,7 +170,11 @@ async function handler(ctx) {
                         const content = $article(selector);
                         if (content.length) {
                             content.find('script, style, [data-ad], .ad, .social-share, .related-content').remove();
-                            const html = content.html();
+                            const html = content
+                                .toArray()
+                                .map((el) => $article(el).html())
+                                .filter(Boolean)
+                                .join('');
                             if (html) {
                                 result.description = html;
                                 break;

--- a/lib/routes/nfl/news.ts
+++ b/lib/routes/nfl/news.ts
@@ -1,9 +1,12 @@
 import { load } from 'cheerio';
 
-import type { DataItem, Route } from '@/types';
+import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
+
+// Strip the Cloudinary `/t_lazy/` transformation which returns a blurred placeholder
+const unlazy = (url: string) => url.replaceAll('/t_lazy/', '/');
 
 const teamDomains: Record<string, string> = {
     '49ers': 'www.49ers.com',
@@ -131,84 +134,46 @@ async function handler(ctx) {
         }
     });
 
-    const items = (
-        await Promise.all(
-            list.map((item) =>
-                cache.tryGet(item.link, async () => {
-                    let articleResponse;
-                    try {
-                        articleResponse = await ofetch(item.link);
-                    } catch {
-                        return null;
-                    }
-                    const $article = load(articleResponse);
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const articleResponse = await ofetch(item.link);
+                const $article = load(articleResponse);
 
-                    let jsonLd: Record<string, any> | null = null;
-                    $article('script[type="application/ld+json"]').each((_, el) => {
-                        try {
-                            const data = JSON.parse($article(el).text());
-                            const candidate = Array.isArray(data) ? data.find((d) => d['@type'] === 'NewsArticle') : data;
-                            if (candidate?.['@type'] === 'NewsArticle') {
-                                jsonLd = candidate;
-                            }
-                        } catch {
-                            // skip malformed JSON-LD
-                        }
-                    });
+                let jsonLd: Record<string, any> = {};
+                try {
+                    jsonLd = JSON.parse($article('script[type="application/ld+json"]').first().text());
+                } catch {
+                    // no JSON-LD or malformed
+                }
 
-                    const result: DataItem = {
-                        title: jsonLd?.headline || item.title,
-                        link: item.link,
-                        pubDate: jsonLd?.datePublished ? parseDate(jsonLd.datePublished) : undefined,
-                        author: jsonLd?.author?.name || (Array.isArray(jsonLd?.author) ? jsonLd.author[0]?.name : undefined),
-                        image: jsonLd?.image?.url || (Array.isArray(jsonLd?.image) ? jsonLd.image[0]?.url : undefined),
-                    };
+                // Fix lazy-loaded images within the article body
+                const content = $article('.nfl-c-article__body');
+                content.find('img[data-src]').each((_, img) => {
+                    const $img = $article(img);
+                    $img.attr('src', unlazy($img.attr('data-src')!));
+                    $img.removeAttr('data-src');
+                });
+                content.find('source[data-srcset]').each((_, src) => {
+                    const $src = $article(src);
+                    $src.attr('srcset', unlazy($src.attr('data-srcset')!));
+                    $src.removeAttr('data-srcset');
+                });
 
-                    // Try to extract article body HTML
-                    const contentSelectors = ['article .nfl-c-body-part', '.article-body', 'article [data-module="content"]', 'article'];
-                    for (const selector of contentSelectors) {
-                        const content = $article(selector);
-                        if (content.length) {
-                            content.find('script, style, [data-ad], .ad, .social-share, .related-content').remove();
-                            // Fix lazy-loaded images: real URLs live in data-src/data-srcset, src is a placeholder GIF.
-                            // Also strip the Cloudinary "/t_lazy/" transformation which returns a blurred placeholder.
-                            const unlazy = (url: string) => url.replaceAll('/t_lazy/', '/');
-                            content.find('img[data-src]').each((_, img) => {
-                                const $img = $article(img);
-                                $img.attr('src', unlazy($img.attr('data-src')!));
-                                $img.removeAttr('data-src');
-                            });
-                            content.find('source[data-srcset]').each((_, src) => {
-                                const $src = $article(src);
-                                $src.attr('srcset', unlazy($src.attr('data-srcset')!));
-                                $src.removeAttr('data-srcset');
-                            });
-                            const html = content
-                                .toArray()
-                                .map((el) => $article(el).html())
-                                .filter(Boolean)
-                                .join('');
-                            if (html) {
-                                result.description = html;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!result.description && jsonLd?.description) {
-                        result.description = jsonLd.description;
-                    }
-
-                    return result;
-                })
-            )
+                return {
+                    title: jsonLd.headline || item.title,
+                    link: item.link,
+                    pubDate: jsonLd.datePublished ? parseDate(jsonLd.datePublished) : undefined,
+                    author: jsonLd.author?.name,
+                    description: content.html() || jsonLd.description,
+                };
+            })
         )
-    ).filter(Boolean) as DataItem[];
+    );
 
     return {
         title: $('title').text() || `${team.charAt(0).toUpperCase() + team.slice(1)} News`,
         link: listingUrl,
-        language: 'en',
         item: items,
     };
 }

--- a/lib/routes/nfl/news.ts
+++ b/lib/routes/nfl/news.ts
@@ -170,6 +170,17 @@ async function handler(ctx) {
                         const content = $article(selector);
                         if (content.length) {
                             content.find('script, style, [data-ad], .ad, .social-share, .related-content').remove();
+                            // Fix lazy-loaded images: real URLs live in data-src/data-srcset, src is a placeholder GIF
+                            content.find('img[data-src]').each((_, img) => {
+                                const $img = $article(img);
+                                $img.attr('src', $img.attr('data-src')!);
+                                $img.removeAttr('data-src');
+                            });
+                            content.find('source[data-srcset]').each((_, src) => {
+                                const $src = $article(src);
+                                $src.attr('srcset', $src.attr('data-srcset')!);
+                                $src.removeAttr('data-srcset');
+                            });
                             const html = content
                                 .toArray()
                                 .map((el) => $article(el).html())


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/nfl/news/seahawks
/nfl/news/49ers
/nfl/news/bears
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add RSS feed support for all 32 NFL team news pages. Each team has its own official website (e.g., seahawks.com, chicagobears.com, 49ers.com) but they all share the same NFL infrastructure. The route scrapes team news listing pages and extracts article metadata from JSON-LD structured data (`NewsArticle`) on individual article pages. Includes radar rules for all 32 team domains.