### PR TITLE
feat(route/qwen): add research route

### DIFF
--- a/lib/routes/qwen/namespace.ts
+++ b/lib/routes/qwen/namespace.ts
@@ -3,4 +3,6 @@ import type { Namespace } from '@/types';
 export const namespace: Namespace = {
     name: 'Qwen',
     url: 'qwen.ai',
+    description: '通义千问研究文章，支持中英文切换和标签筛选',
+    lang: 'zh-CN',
 };

--- a/lib/routes/qwen/namespace.ts
+++ b/lib/routes/qwen/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Qwen',
+    url: 'qwen.ai',
+};

--- a/lib/routes/qwen/research.ts
+++ b/lib/routes/qwen/research.ts
@@ -72,7 +72,8 @@ export const route: Route = {
     ],
     name: 'Research',
     maintainers: ['27Aaron'],
-    url: 'qwen.ai/research',
+    url: 'qwen.ai',
+    description: '通义千问研究文章，支持中英文切换和标签筛选',
     handler: async (ctx) => {
         const language = ctx.req.param('language') ?? 'en';
         const validLanguages = ['en', 'zh-cn'];

--- a/lib/routes/qwen/research.ts
+++ b/lib/routes/qwen/research.ts
@@ -1,0 +1,129 @@
+import MarkdownIt from 'markdown-it';
+
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const md = new MarkdownIt({
+    html: true,
+    breaks: true,
+});
+
+interface ResearchArticle {
+    id: string;
+    title: string;
+    date: string;
+    description?: string;
+    introduction: string;
+    tags: string[];
+    cover?: string;
+    cover_small?: string;
+    authors?: string[];
+    author?: string;
+    tokenLinks?: string;
+}
+
+const extractExternalLinks = (tokens: Array<Record<string, string>>): Array<{ href: string; label: string }> => {
+    const links: Array<{ href: string; label: string }> = [];
+    for (const token of tokens) {
+        if (token.type === 'hugoButton' && token.href && token.label) {
+            links.push({ href: token.href, label: token.label });
+        }
+    }
+    return links;
+};
+
+export const route: Route = {
+    path: '/research/:language?/:tag?',
+    categories: ['programming'],
+    example: '/qwen/research',
+    parameters: {
+        language: {
+            description: 'Language',
+            options: [
+                { value: 'en', label: 'English' },
+                { value: 'zh-cn', label: '中文' },
+            ],
+            default: 'en',
+        },
+        tag: {
+            description: 'Filter by tag',
+            options: [
+                { value: 'Research', label: 'Research' },
+                { value: 'Open-Source', label: 'Open Source' },
+                { value: 'Release', label: 'Release' },
+            ],
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['qwen.ai/research'],
+            target: '/qwen/research',
+        },
+    ],
+    name: 'Research',
+    maintainers: ['27Aaron'],
+    url: 'qwen.ai/research',
+    handler: async (ctx) => {
+        const language = ctx.req.param('language') ?? 'en';
+        const validLanguages = ['en', 'zh-cn'];
+        const lang = validLanguages.includes(language) ? language : 'en';
+        const tag = ctx.req.param('tag');
+        const validTags = ['Research', 'Open-Source', 'Release'];
+        const filterTag = tag && validTags.includes(tag as string) ? tag : undefined;
+
+        const list: ResearchArticle[] = await ofetch('https://qwen.ai/api/page_config', {
+            params: { code: 'research.research-list', language: lang },
+        });
+
+        const filtered = filterTag ? list.filter((item) => item.tags?.includes(filterTag)) : list;
+
+        const items = await Promise.all(
+            filtered.map((item) =>
+                cache.tryGet(`qwen:research:${lang}:${item.id}`, async () => {
+                    let content = item.introduction || item.description || '';
+
+                    if (item.tokenLinks) {
+                        try {
+                            const tokens: Array<Record<string, string>> = await ofetch(item.tokenLinks);
+                            const links = extractExternalLinks(tokens);
+                            if (links.length) {
+                                content += '\n\n' + links.map((l) => `[${l.label}](${l.href})`).join(' | ');
+                            }
+                        } catch {
+                            /* ignore */
+                        }
+                    }
+
+                    const coverHtml = item.cover ? `<img src="${item.cover}">` : '';
+                    return {
+                        title: item.title,
+                        link: `https://qwen.ai/blog?id=${item.id}`,
+                        pubDate: parseDate(item.date),
+                        author: item.authors?.join(', ') ?? item.author,
+                        category: item.tags,
+                        description: `${coverHtml}${md.render(content)}`,
+                    };
+                })
+            )
+        );
+
+        const titlePrefix = lang === 'zh-cn' ? 'Qwen 研究' : 'Qwen Research';
+        const titleSuffix = filterTag ? ` - ${filterTag}` : '';
+
+        return {
+            title: `${titlePrefix}${titleSuffix}`,
+            link: 'https://qwen.ai/research',
+            item: items,
+        };
+    },
+};


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/qwen/research
/qwen/research/zh-cn
/qwen/research/en/Research
/qwen/research/en/Open-Source
/qwen/research/en/Release
/qwen/research/zh-cn/Research
/qwen/research/zh-cn/Open-Source
/qwen/research/zh-cn/Release
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
新增 Qwen Research 路由，通过 `qwen.ai` 官方 JSON API 获取研究文章列表。
支持中英文（`en` / `zh-cn`）和按标签过滤（`Research`、`Open-Source`、`Release`）。
每篇文章包含标题、封面图、introduction 渲染为 HTML、以及从 tokenLinks 提取的 Paper/GitHub 等外部链接。
数据源：`https://qwen.ai/api/page_config?code=research.research-list`
