### PR TITLE
feat(route/zhipuai): add research route

### DIFF
--- a/lib/routes/zhipuai/namespace.ts
+++ b/lib/routes/zhipuai/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Zhipu AI',
+    url: 'zhipuai.cn',
+};

--- a/lib/routes/zhipuai/namespace.ts
+++ b/lib/routes/zhipuai/namespace.ts
@@ -3,4 +3,6 @@ import type { Namespace } from '@/types';
 export const namespace: Namespace = {
     name: 'Zhipu AI',
     url: 'zhipuai.cn',
+    description: '智谱AI研究文章，支持中英文切换和标签筛选',
+    lang: 'zh-CN',
 };

--- a/lib/routes/zhipuai/research.ts
+++ b/lib/routes/zhipuai/research.ts
@@ -87,7 +87,8 @@ export const route: Route = {
     ],
     name: 'Research',
     maintainers: ['27Aaron'],
-    url: 'zhipuai.cn/zh/research',
+    url: 'zhipuai.cn',
+    description: '智谱AI研究文章，支持中英文切换和标签筛选',
     handler: async (ctx) => {
         const language = ctx.req.param('language') ?? 'zh';
         const validLanguages = ['zh', 'en'];

--- a/lib/routes/zhipuai/research.ts
+++ b/lib/routes/zhipuai/research.ts
@@ -1,0 +1,135 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const tagMap: Record<string, string> = {
+    basemodel: '基座模型',
+    multimodal: '多模态',
+    reasoning: '推理模型',
+    agent: 'Agent',
+    codemodel: '代码模型',
+};
+
+export const route: Route = {
+    path: '/research/:language?/:tag?',
+    categories: ['programming'],
+    example: '/zhipuai/research',
+    parameters: {
+        language: {
+            description: 'Language',
+            options: [
+                { value: 'zh', label: '中文' },
+                { value: 'en', label: 'English' },
+            ],
+            default: 'zh',
+        },
+        tag: {
+            description: 'Filter by tag',
+            options: [
+                { value: 'basemodel', label: '基座模型' },
+                { value: 'multimodal', label: '多模态' },
+                { value: 'reasoning', label: '推理模型' },
+                { value: 'agent', label: 'Agent' },
+                { value: 'codemodel', label: '代码模型' },
+            ],
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['zhipuai.cn/zh/research', 'zhipuai.cn/en/research'],
+            target: '/zhipuai/research',
+        },
+    ],
+    name: 'Research',
+    maintainers: ['27Aaron'],
+    url: 'zhipuai.cn/zh/research',
+    handler: async (ctx) => {
+        const language = ctx.req.param('language') ?? 'zh';
+        const validLanguages = ['zh', 'en'];
+        const lang = validLanguages.includes(language) ? language : 'zh';
+        const locale = lang === 'zh' ? 'zh' : 'en';
+
+        const tag = ctx.req.param('tag');
+        const filterTag = tag && tag in tagMap ? tagMap[tag] : undefined;
+
+        // Fetch SSR page - article data is embedded in Next.js RSC payload
+        const html = await ofetch(`https://www.zhipuai.cn/${locale}/research`, { responseType: 'text' });
+
+        // Extract blogsItems from RSC payload using bracket counting
+        const extractArticles = (html: string): Array<Record<string, unknown>> => {
+            let startIdx = html.indexOf('blogsItems\\\":[');
+            let offset = 'blogsItems\\\":'.length;
+            if (startIdx === -1) {
+                startIdx = html.indexOf('blogsItems":[');
+                offset = 'blogsItems":'.length;
+            }
+            if (startIdx === -1) {
+                throw new Error('blogsItems not found in page');
+            }
+
+            const arrStart = startIdx + offset;
+            let depth = 0;
+            let arrEnd = arrStart;
+            for (let i = arrStart; i < html.length; i++) {
+                const c = html[i];
+                if (c === '[') {
+                    depth++;
+                } else if (c === ']') {
+                    depth--;
+                    if (depth === 0) {
+                        arrEnd = i + 1;
+                        break;
+                    }
+                }
+            }
+
+            const raw = html.slice(arrStart, arrEnd).replaceAll('\\"', '"').replaceAll('\\n', '\n').replaceAll('\\\\', '\\');
+            return JSON.parse(raw);
+        };
+
+        const items = extractArticles(html);
+
+        const filtered = filterTag ? items.filter((item) => (item.tag_zh as string[])?.includes(filterTag)) : items;
+
+        const titleKey = lang === 'zh' ? 'title_zh' : 'title_en';
+        const resumeKey = lang === 'zh' ? 'resume_zh' : 'resume_en';
+        const thumbnailKey = lang === 'zh' ? 'thumbnail_zh' : 'thumbnail_en';
+        const tagKey = lang === 'zh' ? 'tag_zh' : 'tag_en';
+
+        const result = filtered.map((item) => {
+            const thumbnail = item[thumbnailKey] as string | undefined;
+            const resume = item[resumeKey] as string | undefined;
+            const coverHtml = thumbnail ? `<img src="${thumbnail}">` : '';
+            const $ = load(`<div>${coverHtml}<p>${resume ?? ''}</p></div>`);
+            $('div').find('script').remove();
+
+            return {
+                title: item[titleKey] as string,
+                link: `https://www.zhipuai.cn/${locale}/research/${item.id}`,
+                pubDate: parseDate(item.createAt as string),
+                author: '智谱AI',
+                category: item[tagKey] as string[],
+                description: $('div').html() ?? '',
+            };
+        });
+
+        const titlePrefix = lang === 'zh' ? '智谱AI 研究' : 'Zhipu AI Research';
+        const titleSuffix = filterTag ? ` - ${filterTag}` : '';
+
+        return {
+            title: `${titlePrefix}${titleSuffix}`,
+            link: `https://www.zhipuai.cn/${locale}/research`,
+            item: result,
+        };
+    },
+};

--- a/lib/routes/zhipuai/research.ts
+++ b/lib/routes/zhipuai/research.ts
@@ -67,8 +67,8 @@ export const route: Route = {
 
         // Extract blogsItems from RSC payload using bracket counting
         const extractArticles = (html: string): Array<Record<string, unknown>> => {
-            let startIdx = html.indexOf('blogsItems\\\":[');
-            let offset = 'blogsItems\\\":'.length;
+            let startIdx = html.indexOf(String.raw`blogsItems\":[`);
+            let offset = String.raw`blogsItems\":`.length;
             if (startIdx === -1) {
                 startIdx = html.indexOf('blogsItems":[');
                 offset = 'blogsItems":'.length;
@@ -93,7 +93,11 @@ export const route: Route = {
                 }
             }
 
-            const raw = html.slice(arrStart, arrEnd).replaceAll('\\"', '"').replaceAll('\\n', '\n').replaceAll('\\\\', '\\');
+            const raw = html
+                .slice(arrStart, arrEnd)
+                .replaceAll(String.raw`\"`, '"')
+                .replaceAll(String.raw`\n`, '\n')
+                .replaceAll(String.raw`\\`, '\\');
             return JSON.parse(raw);
         };
 

--- a/lib/routes/zhipuai/research.ts
+++ b/lib/routes/zhipuai/research.ts
@@ -12,6 +12,41 @@ const tagMap: Record<string, string> = {
     codemodel: '代码模型',
 };
 
+const extractArticles = (html: string): Array<Record<string, unknown>> => {
+    let startIdx = html.indexOf(String.raw`blogsItems\":[`);
+    let offset = String.raw`blogsItems\":`.length;
+    if (startIdx === -1) {
+        startIdx = html.indexOf('blogsItems":[');
+        offset = 'blogsItems":'.length;
+    }
+    if (startIdx === -1) {
+        throw new Error('blogsItems not found in page');
+    }
+
+    const arrStart = startIdx + offset;
+    let depth = 0;
+    let arrEnd = arrStart;
+    for (let i = arrStart; i < html.length; i++) {
+        const c = html[i];
+        if (c === '[') {
+            depth++;
+        } else if (c === ']') {
+            depth--;
+            if (depth === 0) {
+                arrEnd = i + 1;
+                break;
+            }
+        }
+    }
+
+    const raw = html
+        .slice(arrStart, arrEnd)
+        .replaceAll(String.raw`\"`, '"')
+        .replaceAll(String.raw`\n`, '\n')
+        .replaceAll(String.raw`\\`, '\\');
+    return JSON.parse(raw);
+};
+
 export const route: Route = {
     path: '/research/:language?/:tag?',
     categories: ['programming'],
@@ -64,42 +99,6 @@ export const route: Route = {
 
         // Fetch SSR page - article data is embedded in Next.js RSC payload
         const html = await ofetch(`https://www.zhipuai.cn/${locale}/research`, { responseType: 'text' });
-
-        // Extract blogsItems from RSC payload using bracket counting
-        const extractArticles = (html: string): Array<Record<string, unknown>> => {
-            let startIdx = html.indexOf(String.raw`blogsItems\":[`);
-            let offset = String.raw`blogsItems\":`.length;
-            if (startIdx === -1) {
-                startIdx = html.indexOf('blogsItems":[');
-                offset = 'blogsItems":'.length;
-            }
-            if (startIdx === -1) {
-                throw new Error('blogsItems not found in page');
-            }
-
-            const arrStart = startIdx + offset;
-            let depth = 0;
-            let arrEnd = arrStart;
-            for (let i = arrStart; i < html.length; i++) {
-                const c = html[i];
-                if (c === '[') {
-                    depth++;
-                } else if (c === ']') {
-                    depth--;
-                    if (depth === 0) {
-                        arrEnd = i + 1;
-                        break;
-                    }
-                }
-            }
-
-            const raw = html
-                .slice(arrStart, arrEnd)
-                .replaceAll(String.raw`\"`, '"')
-                .replaceAll(String.raw`\n`, '\n')
-                .replaceAll(String.raw`\\`, '\\');
-            return JSON.parse(raw);
-        };
 
         const items = extractArticles(html);
 


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/zhipuai/research
/zhipuai/research/en
/zhipuai/research/zh/agent
/zhipuai/research/zh/multimodal
/zhipuai/research/zh/basemodel
/zhipuai/research/zh/codemodel
/zhipuai/research/zh/reasoning
/zhipuai/research/en/agent
/zhipuai/research/en/multimodal
/zhipuai/research/en/basemodel
/zhipuai/research/en/codemodel
/zhipuai/research/en/reasoning
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
新增智谱 AI (Zhipu AI) Research 路由。
数据从 `zhipuai.cn` 的 Next.js SSR HTML RSC payload 中提取，无需 Puppeteer。支持中英文（`zh`/`en`）和按标签过滤（`basemodel`/`multimodal`/`reasoning`/`agent`/`codemodel`）。
> **备注**：`reasoning`（推理模型）和 `codemodel`（代码模型）目前暂无对应文章，等智谱发布相关内容后自动生效。