### PR TITLE
feat(route/kimi): add blog route

### DIFF
--- a/lib/routes/kimi/blog.ts
+++ b/lib/routes/kimi/blog.ts
@@ -43,7 +43,6 @@ export const route: Route = {
     path: '/blog',
     categories: ['programming'],
     example: '/kimi/blog',
-    parameters: {},
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -54,13 +53,14 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['kimi.com/blog/'],
+            source: ['kimi.com/blog'],
             target: '/kimi/blog',
         },
     ],
-    name: 'Blog',
+    name: 'Kimi Blog',
     maintainers: ['27Aaron'],
-    url: 'kimi.com/blog',
+    url: 'kimi.com',
+    description: 'Kimi AI 官方博客',
     handler: async () => {
         // Step 1: Fetch index page to find the lean.js URL
         const html = await ofetch(`${baseUrl}/blog/`, { responseType: 'text' });

--- a/lib/routes/kimi/blog.ts
+++ b/lib/routes/kimi/blog.ts
@@ -1,0 +1,117 @@
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+interface BlogItem {
+    title: string;
+    link: string;
+    desc?: string;
+    date: string;
+    image: string;
+}
+
+interface BlogData {
+    sections: Array<{
+        items: BlogItem[];
+    }>;
+}
+
+const baseUrl = 'https://www.kimi.com';
+
+const extractBlogData = (jsContent: string): BlogItem[] => {
+    // There are multiple encoded-data attributes; find the one with "sections" (blog listing)
+    const matches = jsContent.matchAll(/"encoded-data":"([A-Za-z0-9+/=]+)"/g);
+    for (const match of matches) {
+        const decoded = Buffer.from(match[1], 'base64').toString();
+        const data = JSON.parse(decoded);
+        if ('sections' in data) {
+            return (data as BlogData).sections.flatMap((section) => section.items);
+        }
+    }
+    throw new Error('Blog data not found in lean.js');
+};
+
+const fetchDescription = (url: string): Promise<string> =>
+    cache.tryGet(url, async () => {
+        const html = await ofetch(url, { responseType: 'text' });
+        const match = html.match(/<meta name="description" content="([^"]+)"/);
+        return match?.[1] ?? '';
+    });
+
+export const route: Route = {
+    path: '/blog',
+    categories: ['programming'],
+    example: '/kimi/blog',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['kimi.com/blog/'],
+            target: '/kimi/blog',
+        },
+    ],
+    name: 'Blog',
+    maintainers: ['27Aaron'],
+    url: 'kimi.com/blog',
+    handler: async () => {
+        // Step 1: Fetch index page to find the lean.js URL
+        const html = await ofetch(`${baseUrl}/blog/`, { responseType: 'text' });
+
+        // Step 2: Extract the index.md lean.js URL
+        const jsMatch = html.match(/(?:src|href)="([^"]*?index\.md\.[^.]+\.lean\.js)"/);
+        if (!jsMatch) {
+            throw new Error('index.md lean.js not found');
+        }
+
+        let jsUrl = jsMatch[1];
+        if (jsUrl.startsWith('//')) {
+            jsUrl = `https:${jsUrl}`;
+        } else if (jsUrl.startsWith('/')) {
+            jsUrl = `${baseUrl}${jsUrl}`;
+        }
+
+        // Step 3: Fetch lean.js and extract blog data
+        const jsContent = await ofetch(jsUrl, { responseType: 'text' });
+        const items = extractBlogData(jsContent);
+
+        // Step 4: Fetch descriptions for internal blog posts and map to RSS items
+        const result = await Promise.all(
+            items.map(async (item) => {
+                const isInternal = item.link.startsWith('/');
+                const link = isInternal ? `${baseUrl}${item.link}` : item.link;
+
+                let description = '';
+                if (isInternal) {
+                    const metaDesc = await fetchDescription(link);
+                    if (metaDesc) {
+                        description = metaDesc;
+                    }
+                }
+                if (!description && item.desc) {
+                    description = item.desc;
+                }
+
+                return {
+                    title: item.title,
+                    link,
+                    pubDate: parseDate(item.date, 'YYYY/MM/DD'),
+                    description,
+                };
+            })
+        );
+
+        return {
+            title: 'Kimi Blog',
+            link: `${baseUrl}/blog/`,
+            item: result,
+        };
+    },
+};

--- a/lib/routes/kimi/namespace.ts
+++ b/lib/routes/kimi/namespace.ts
@@ -3,4 +3,6 @@ import type { Namespace } from '@/types';
 export const namespace: Namespace = {
     name: 'Kimi',
     url: 'kimi.com',
+    description: 'Kimi AI Official Blog',
+    lang: 'en',
 };

--- a/lib/routes/kimi/namespace.ts
+++ b/lib/routes/kimi/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Kimi',
+    url: 'kimi.com',
+};


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/kimi/blog
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Kimi Blog (https://www.kimi.com/blog/) 是 VitePress 静态站点，博客列表数据以 base64 编码 JSON 嵌入在编译后的 lean.js 文件中。通过提取 lean.js 中的编码数据获取文章列表，并获取内部博客详情页的 meta description 作为摘要