### PR TITLE
feat(route/thinkingmachines): add news route for Thinking Machines Lab

### DIFF
--- a/lib/routes/thinkingmachines/namespace.ts
+++ b/lib/routes/thinkingmachines/namespace.ts
@@ -1,0 +1,6 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Thinking Machines Lab',
+    url: 'thinkingmachines.ai',
+};

--- a/lib/routes/thinkingmachines/news.ts
+++ b/lib/routes/thinkingmachines/news.ts
@@ -49,29 +49,22 @@ async function handler() {
     const fullItems = await Promise.all(
         items.map((item) =>
             cache.tryGet(item.link, async () => {
-                try {
-                    const articleResponse = await ofetch(item.link);
-                    const $article = load(articleResponse);
+                const articleResponse = await ofetch(item.link);
+                const $article = load(articleResponse);
 
-                    // Remove nav, footer, and other non-content elements
-                    $article('nav, footer, header, script, style').remove();
+                // Remove non-content elements
+                $article('nav, footer, header, script, style').remove();
+                // Remove heading block (title, author, pubDate) — these have dedicated fields
+                $article('.post-heading').remove();
 
-                    const description = $article('main').html()?.trim() || $article('article').html()?.trim() || '';
+                const description = $article('main').html()?.trim() || $article('article').html()?.trim() || '';
 
-                    return {
-                        title: item.title,
-                        link: item.link,
-                        pubDate: parseDate(item.dateStr, 'MMM D, YYYY'),
-                        description,
-                    };
-                } catch {
-                    return {
-                        title: item.title,
-                        link: item.link,
-                        pubDate: parseDate(item.dateStr, 'MMM D, YYYY'),
-                        description: '',
-                    };
-                }
+                return {
+                    title: item.title,
+                    link: item.link,
+                    pubDate: parseDate(item.dateStr, 'MMM D, YYYY'),
+                    description,
+                };
             })
         )
     );

--- a/lib/routes/thinkingmachines/news.ts
+++ b/lib/routes/thinkingmachines/news.ts
@@ -1,0 +1,83 @@
+import { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import cache from '@/utils/cache';
+
+export const route: Route = {
+    path: '/news',
+    name: 'News',
+    url: 'thinkingmachines.ai/news',
+    maintainers: ['w3nhao'],
+    example: '/thinkingmachines/news',
+    categories: ['programming'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+    },
+    radar: [
+        {
+            source: ['thinkingmachines.ai/news', 'thinkingmachines.ai/news/'],
+            target: '/news',
+        },
+    ],
+    handler,
+};
+
+async function handler() {
+    const baseUrl = 'https://thinkingmachines.ai';
+    const listUrl = `${baseUrl}/news/`;
+
+    const response = await ofetch(listUrl);
+    const $ = load(response);
+
+    const items = $('main li a')
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+            const title = $el.find('.post-title').text().trim();
+            const dateStr = $el.find('time.desktop-time').text().trim();
+            const href = $el.attr('href') || '';
+            const link = href.startsWith('http') ? href : `${baseUrl}${href}`;
+
+            return { title, dateStr, link };
+        })
+        .filter((item) => item.title && item.link);
+
+    const fullItems = await Promise.all(
+        items.map((item) =>
+            cache.tryGet(item.link, async () => {
+                try {
+                    const articleResponse = await ofetch(item.link);
+                    const $article = load(articleResponse);
+
+                    // Remove nav, footer, and other non-content elements
+                    $article('nav, footer, header, script, style').remove();
+
+                    const description = $article('main').html()?.trim() || $article('article').html()?.trim() || '';
+
+                    return {
+                        title: item.title,
+                        link: item.link,
+                        pubDate: parseDate(item.dateStr, 'MMM D, YYYY'),
+                        description,
+                    };
+                } catch {
+                    return {
+                        title: item.title,
+                        link: item.link,
+                        pubDate: parseDate(item.dateStr, 'MMM D, YYYY'),
+                        description: '',
+                    };
+                }
+            })
+        )
+    );
+
+    return {
+        title: 'Thinking Machines Lab - News',
+        link: listUrl,
+        item: fullItems,
+    };
+}

--- a/lib/routes/thinkingmachines/news.ts
+++ b/lib/routes/thinkingmachines/news.ts
@@ -1,9 +1,9 @@
-import type { Route } from '@/types';
+import { load } from 'cheerio';
 
+import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
-import { load } from 'cheerio';
 
 export const route: Route = {
     path: '/news',

--- a/lib/routes/thinkingmachines/news.ts
+++ b/lib/routes/thinkingmachines/news.ts
@@ -54,10 +54,10 @@ async function handler() {
 
                 // Remove non-content elements
                 $article('nav, footer, header, script, style').remove();
-                // Remove heading block (title, author, pubDate) — these have dedicated fields
-                $article('.post-heading').remove();
+                // Remove heading (title, author, pubDate) and paginator
+                $article('.post-heading, #post-prev-link, #post-next-link').remove();
 
-                const description = $article('main').html()?.trim() || $article('article').html()?.trim() || '';
+                const description = $article('main').html()?.trim() || '';
 
                 return {
                     title: item.title,

--- a/lib/routes/thinkingmachines/news.ts
+++ b/lib/routes/thinkingmachines/news.ts
@@ -1,8 +1,9 @@
-import { Route } from '@/types';
-import ofetch from '@/utils/ofetch';
-import { load } from 'cheerio';
-import { parseDate } from '@/utils/parse-date';
+import type { Route } from '@/types';
+
 import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import { load } from 'cheerio';
 
 export const route: Route = {
     path: '/news',


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A - New route

## Example for the Proposed Route(s) / 路由地址示例

```routes
/thinkingmachines/news
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? (No anti-bot detected)
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析 (using `parseDate` with `MMM D, YYYY` format)
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add RSS feed for [Thinking Machines Lab](https://thinkingmachines.ai/) news page. Founded by Mira Murati (ex-OpenAI CTO), the lab publishes news about their AI research, products (Tinker), and partnerships.

The route scrapes the news listing page using cheerio, extracting article titles, dates, and links from `<time class="desktop-time">` and `<div class="post-title">` elements. Full article content is fetched and cached for each entry.