### PR TITLE
feat(route): add 国际能源网 (in-en.com) news route

### DIFF
--- a/lib/routes/in-en/index.ts
+++ b/lib/routes/in-en/index.ts
@@ -1,0 +1,143 @@
+import { load } from 'cheerio';
+import type { DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+// 各子站配置：name=频道中文名，newsPath=新闻列表路径
+const CATEGORIES: Record<string, { name: string; newsPath: string }> = {
+    solar: { name: '光伏太阳能', newsPath: '/news/' },
+    wind: { name: '风电', newsPath: '/windnews/' },
+    chuneng: { name: '储能', newsPath: '/news/' },
+    h2: { name: '氢能', newsPath: '/news/' },
+    chd: { name: '充换电', newsPath: '/news/' },
+    newenergy: { name: '新能源', newsPath: '/news/' },
+    power: { name: '电力', newsPath: '/news/' },
+    huanbao: { name: '环保', newsPath: '/news/' },
+};
+
+/**
+ * 将列表页的相对时间文本（"X分钟前"、"X小时前"、"X天前"、"YYYY-MM-DD"）
+ * 转换为 Date 对象（UTC+8 本地时）
+ */
+function parseRelTime(text: string): Date | undefined {
+    if (!text) {
+        return undefined;
+    }
+    const m = text.match(/^(\d+)(分钟|小时|天)前$/);
+    if (m) {
+        const n = Number.parseInt(m[1], 10);
+        const now = Date.now();
+        const offsets: Record<string, number> = {
+            分钟: 60_000,
+            小时: 3_600_000,
+            天: 86_400_000,
+        };
+        return new Date(now - n * offsets[m[2]]);
+    }
+    return parseDate(text) ?? undefined;
+}
+
+export const route: Route = {
+    path: '/news/:type',
+    categories: ['traditional-media'],
+    example: '/in-en/news/solar',
+    parameters: {
+        type: '频道类型，见下表',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '新闻',
+    maintainers: [],
+    description: `| 频道 | type 参数 |
+| --- | --- |
+| 光伏太阳能 | solar |
+| 风电 | wind |
+| 储能 | chuneng |
+| 氢能 | h2 |
+| 充换电 | chd |
+| 新能源综合 | newenergy |
+| 电力 | power |
+| 环保 | huanbao |`,
+
+    async handler(ctx) {
+        const type = ctx.req.param('type') ?? 'solar';
+        const cat = CATEGORIES[type];
+        if (!cat) {
+            throw new Error(`未知的频道类型: ${type}，可选值: ${Object.keys(CATEGORIES).join(', ')}`);
+        }
+
+        const baseUrl = `https://${type}.in-en.com`;
+        const listUrl = `${baseUrl}${cat.newsPath}`;
+
+        const html = await ofetch(listUrl);
+        const $ = load(html);
+
+        const list: DataItem[] = $('ul.infoList > li')
+            .toArray()
+            .map((el) => {
+                const $el = $(el);
+                const $a = $el.find('.listTxt h5 a');
+                const link = $a.attr('href') ?? '';
+
+                // 优先用 title 属性（完整标题），否则取文本并去掉「原创」标签
+                const titleAttr = $a.attr('title')?.trim() ?? '';
+                const titleText = $a.clone().children('span.OrigSign').remove().end().text().trim();
+                const title = titleAttr || titleText;
+
+                const pubDateRaw = $el.find('.listTxt .prompt i').first().text().trim();
+                const author = $el.find('.listTxt .prompt span em.ly').first().text().trim();
+
+                return {
+                    title,
+                    link,
+                    author: author || undefined,
+                    pubDate: timezone(parseRelTime(pubDateRaw), +8),
+                } as DataItem;
+            })
+            .filter((item) => Boolean(item.title && item.link));
+
+        // 并发抓取详情页正文（带缓存）
+        const items = await Promise.all(
+            list.map((item) =>
+                cache.tryGet(item.link!, async () => {
+                    try {
+                        const detail = await ofetch(item.link!);
+                        const $d = load(detail);
+
+                        // 正文
+                        item.description = $d('.article-body').first().html() ?? '';
+
+                        // 详情页有精确到日的发布时间，覆盖列表页的相对时间
+                        const dateText = $d('.article-meta .date').first().text().replace('日期：', '').trim();
+                        if (dateText) {
+                            item.pubDate = timezone(parseDate(dateText), +8);
+                        }
+
+                        // 详情页来源可能比列表页更完整
+                        const detailAuthor = $d('.article-meta .source a').first().text().trim();
+                        if (detailAuthor) {
+                            item.author = detailAuthor;
+                        }
+                    } catch {
+                        // 详情页抓取失败时保留列表页数据
+                    }
+                    return item;
+                })
+            )
+        );
+
+        return {
+            title: `国际能源网 · ${cat.name}`,
+            link: listUrl,
+            item: items as DataItem[],
+        };
+    },
+};

--- a/lib/routes/in-en/index.ts
+++ b/lib/routes/in-en/index.ts
@@ -3,18 +3,17 @@ import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
-import timezone from '@/utils/timezone';
 
 // Subdomain config: name = channel display name, newsPath = news list path
 const CATEGORIES: Record<string, { name: string; newsPath: string }> = {
     solar: { name: '光伏太阳能', newsPath: '/news/' },
     wind: { name: '风电', newsPath: '/windnews/' },
     chuneng: { name: '储能', newsPath: '/news/' },
-    h2: { name: '氢能', newsPath: '/news/' },
-    chd: { name: '充换电', newsPath: '/news/' },
+    h2: { name: '氢能', newsPath: '/hydrogen/' },
+    chd: { name: '充换电', newsPath: '/ChargingStation/' },
     newenergy: { name: '新能源', newsPath: '/news/' },
     power: { name: '电力', newsPath: '/news/' },
-    huanbao: { name: '环保', newsPath: '/news/' },
+    huanbao: { name: '环保', newsPath: '/policy/' },
 };
 
 /**
@@ -117,13 +116,9 @@ export const route: Route = {
 
                         item.description = $d('.article-body').first().html() ?? '';
 
-                        // Detail page has an exact date (YYYY-MM-DD); override relative list-page time
-                        const dateText = $d('.article-meta .date').first().text().replace('日期：', '').trim();
-                        if (dateText) {
-                            item.pubDate = timezone(parseDate(dateText), +8);
-                        }
-
                         // Detail page source may be more complete than the list snippet
+                        // Note: detail page only provides date-level precision (YYYY-MM-DD),
+                        // so we keep the more precise relative timestamp from the list page.
                         const detailAuthor = $d('.article-meta .source a').first().text().trim();
                         if (detailAuthor) {
                             item.author = detailAuthor;

--- a/lib/routes/in-en/index.ts
+++ b/lib/routes/in-en/index.ts
@@ -1,4 +1,6 @@
 import { load } from 'cheerio';
+
+import { config } from '@/config';
 import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
@@ -16,6 +18,8 @@ const CATEGORIES: Record<string, { name: string; newsPath: string }> = {
     huanbao: { name: '环保', newsPath: '/policy/' },
 };
 
+const headers = { 'User-Agent': config.trueUA };
+
 /**
  * Parse Chinese relative time strings ("X分钟前", "X小时前", "X天前") or
  * absolute date strings ("YYYY-MM-DD") into a Date object.
@@ -30,7 +34,7 @@ function parseRelTime(text: string): Date | undefined {
         const n = Number.parseInt(m[1], 10);
         const now = Date.now();
         const offsets: Record<string, number> = {
-            分钟: 60_000,
+            分钟: 60000,
             小时: 3_600_000,
             天: 86_400_000,
         };
@@ -78,7 +82,7 @@ export const route: Route = {
         const baseUrl = `https://${type}.in-en.com`;
         const listUrl = `${baseUrl}${cat.newsPath}`;
 
-        const html = await ofetch(listUrl);
+        const html = await ofetch(listUrl, { headers });
         const $ = load(html);
 
         const list: DataItem[] = $('ul.infoList > li')
@@ -96,10 +100,18 @@ export const route: Route = {
                 const pubDateRaw = $el.find('.listTxt .prompt i').first().text().trim();
                 const author = $el.find('.listTxt .prompt span em.ly').first().text().trim();
 
+                // Extract article keyword tags into the category field
+                const category = $el
+                    .find('.listTxt .prompt span em a')
+                    .toArray()
+                    .map((a) => $(a).text().trim())
+                    .filter(Boolean);
+
                 return {
                     title,
                     link,
                     author: author || undefined,
+                    category: category.length > 0 ? category : undefined,
                     // parseRelTime returns an absolute UTC Date; no extra timezone shift needed
                     pubDate: parseRelTime(pubDateRaw),
                 } as DataItem;
@@ -111,7 +123,7 @@ export const route: Route = {
             list.map((item) =>
                 cache.tryGet(item.link!, async () => {
                     try {
-                        const detail = await ofetch(item.link!);
+                        const detail = await ofetch(item.link!, { headers });
                         const $d = load(detail);
 
                         item.description = $d('.article-body').first().html() ?? '';

--- a/lib/routes/in-en/index.ts
+++ b/lib/routes/in-en/index.ts
@@ -70,7 +70,14 @@ export const route: Route = {
                 const title = titleAttr || titleText;
 
                 const pubDateRaw = $el.find('.listTxt .prompt i').text().trim();
-                const author = $el.find('.listTxt .prompt > span').first().text().replace('来源：', '').trim();
+                const author = $el
+                    .find('.listTxt .prompt > span')
+                    .first()
+                    .contents()
+                    .filter((_, n) => n.type === 'text')
+                    .text()
+                    .replace('来源：', '')
+                    .trim();
 
                 const category = $el
                     .find('.listTxt .prompt span em a')
@@ -83,7 +90,30 @@ export const route: Route = {
                     link,
                     author: author || undefined,
                     category,
-                    pubDate: parseDate(pubDateRaw),
+                    pubDate: (() => {
+                        if (!pubDateRaw) {
+                            return undefined;
+                        }
+                        if (pubDateRaw.includes('刚刚')) {
+                            return new Date();
+                        }
+                        const minutesMatch = pubDateRaw.match(/(\d+)分钟前/);
+                        if (minutesMatch) {
+                            return new Date(Date.now() - Number(minutesMatch[1]) * 60_000);
+                        }
+                        const hoursMatch = pubDateRaw.match(/(\d+)小时前/);
+                        if (hoursMatch) {
+                            return new Date(Date.now() - Number(hoursMatch[1]) * 3_600_000);
+                        }
+                        if (pubDateRaw.startsWith('今天')) {
+                            return parseDate(new Date().toDateString() + ' ' + pubDateRaw.replace('今天', '').trim());
+                        }
+                        if (pubDateRaw.startsWith('昨天')) {
+                            const d = new Date(Date.now() - 86_400_000);
+                            return parseDate(d.toDateString() + ' ' + pubDateRaw.replace('昨天', '').trim());
+                        }
+                        return parseDate(pubDateRaw);
+                    })(),
                 } as DataItem;
             })
             .filter((item) => Boolean(item.title && item.link));

--- a/lib/routes/in-en/index.ts
+++ b/lib/routes/in-en/index.ts
@@ -1,6 +1,5 @@
 import { load } from 'cheerio';
 
-import { config } from '@/config';
 import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
@@ -17,32 +16,6 @@ const CATEGORIES: Record<string, { name: string; newsPath: string }> = {
     power: { name: '电力', newsPath: '/news/' },
     huanbao: { name: '环保', newsPath: '/policy/' },
 };
-
-const headers = { 'User-Agent': config.trueUA };
-
-/**
- * Parse Chinese relative time strings ("X分钟前", "X小时前", "X天前") or
- * absolute date strings ("YYYY-MM-DD") into a Date object.
- * Returns undefined when input is empty.
- */
-function parseRelTime(text: string): Date | undefined {
-    if (!text) {
-        return undefined;
-    }
-    const m = text.match(/^(\d+)(分钟|小时|天)前$/);
-    if (m) {
-        const n = Number.parseInt(m[1], 10);
-        const now = Date.now();
-        const offsets: Record<string, number> = {
-            分钟: 60000,
-            小时: 3_600_000,
-            天: 86_400_000,
-        };
-        // Returns an absolute UTC timestamp; no further timezone shift needed.
-        return new Date(now - n * offsets[m[2]]);
-    }
-    return parseDate(text) ?? undefined;
-}
 
 export const route: Route = {
     path: '/news/:type',
@@ -82,7 +55,7 @@ export const route: Route = {
         const baseUrl = `https://${type}.in-en.com`;
         const listUrl = `${baseUrl}${cat.newsPath}`;
 
-        const html = await ofetch(listUrl, { headers });
+        const html = await ofetch(listUrl);
         const $ = load(html);
 
         const list: DataItem[] = $('ul.infoList > li')
@@ -92,15 +65,13 @@ export const route: Route = {
                 const $a = $el.find('.listTxt h5 a');
                 const link = $a.attr('href') ?? '';
 
-                // Prefer title attribute (full title); fall back to text with OrigSign badge removed
                 const titleAttr = $a.attr('title')?.trim() ?? '';
-                const titleText = $a.clone().children('span.OrigSign').remove().end().text().trim();
+                const titleText = $a.contents().filter((_, n) => n.type === 'text').text().trim();
                 const title = titleAttr || titleText;
 
-                const pubDateRaw = $el.find('.listTxt .prompt i').first().text().trim();
-                const author = $el.find('.listTxt .prompt span em.ly').first().text().trim();
+                const pubDateRaw = $el.find('.listTxt .prompt i').text().trim();
+                const author = $el.find('.listTxt .prompt > span').first().text().replace('来源：', '').trim();
 
-                // Extract article keyword tags into the category field
                 const category = $el
                     .find('.listTxt .prompt span em a')
                     .toArray()
@@ -111,33 +82,25 @@ export const route: Route = {
                     title,
                     link,
                     author: author || undefined,
-                    category: category.length > 0 ? category : undefined,
-                    // parseRelTime returns an absolute UTC Date; no extra timezone shift needed
-                    pubDate: parseRelTime(pubDateRaw),
+                    category,
+                    pubDate: parseDate(pubDateRaw),
                 } as DataItem;
             })
             .filter((item) => Boolean(item.title && item.link));
 
-        // Fetch full article body concurrently with caching
         const items = await Promise.all(
             list.map((item) =>
                 cache.tryGet(item.link!, async () => {
-                    try {
-                        const detail = await ofetch(item.link!, { headers });
-                        const $d = load(detail);
+                    const detail = await ofetch(item.link!);
+                    const $d = load(detail);
 
-                        item.description = $d('.article-body').first().html() ?? '';
+                    item.description = $d('#article').html() ?? '';
 
-                        // Detail page source may be more complete than the list snippet
-                        // Note: detail page only provides date-level precision (YYYY-MM-DD),
-                        // so we keep the more precise relative timestamp from the list page.
-                        const detailAuthor = $d('.article-meta .source a').first().text().trim();
-                        if (detailAuthor) {
-                            item.author = detailAuthor;
-                        }
-                    } catch {
-                        // Keep list-page data if detail fetch fails
+                    const detailAuthor = $d('p.source a').text().trim();
+                    if (detailAuthor) {
+                        item.author = detailAuthor;
                     }
+
                     return item;
                 })
             )

--- a/lib/routes/in-en/index.ts
+++ b/lib/routes/in-en/index.ts
@@ -5,7 +5,7 @@ import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 import timezone from '@/utils/timezone';
 
-// 各子站配置：name=频道中文名，newsPath=新闻列表路径
+// Subdomain config: name = channel display name, newsPath = news list path
 const CATEGORIES: Record<string, { name: string; newsPath: string }> = {
     solar: { name: '光伏太阳能', newsPath: '/news/' },
     wind: { name: '风电', newsPath: '/windnews/' },
@@ -18,8 +18,9 @@ const CATEGORIES: Record<string, { name: string; newsPath: string }> = {
 };
 
 /**
- * 将列表页的相对时间文本（"X分钟前"、"X小时前"、"X天前"、"YYYY-MM-DD"）
- * 转换为 Date 对象（UTC+8 本地时）
+ * Parse Chinese relative time strings ("X分钟前", "X小时前", "X天前") or
+ * absolute date strings ("YYYY-MM-DD") into a Date object.
+ * Returns undefined when input is empty.
  */
 function parseRelTime(text: string): Date | undefined {
     if (!text) {
@@ -34,6 +35,7 @@ function parseRelTime(text: string): Date | undefined {
             小时: 3_600_000,
             天: 86_400_000,
         };
+        // Returns an absolute UTC timestamp; no further timezone shift needed.
         return new Date(now - n * offsets[m[2]]);
     }
     return parseDate(text) ?? undefined;
@@ -44,7 +46,7 @@ export const route: Route = {
     categories: ['traditional-media'],
     example: '/in-en/news/solar',
     parameters: {
-        type: '频道类型，见下表',
+        type: 'Channel type, see table below',
     },
     features: {
         requireConfig: false,
@@ -55,7 +57,7 @@ export const route: Route = {
         supportScihub: false,
     },
     name: '新闻',
-    maintainers: [],
+    maintainers: ['Harviewang'],
     description: `| 频道 | type 参数 |
 | --- | --- |
 | 光伏太阳能 | solar |
@@ -71,7 +73,7 @@ export const route: Route = {
         const type = ctx.req.param('type') ?? 'solar';
         const cat = CATEGORIES[type];
         if (!cat) {
-            throw new Error(`未知的频道类型: ${type}，可选值: ${Object.keys(CATEGORIES).join(', ')}`);
+            throw new Error(`Unknown channel type: ${type}. Valid values: ${Object.keys(CATEGORIES).join(', ')}`);
         }
 
         const baseUrl = `https://${type}.in-en.com`;
@@ -87,7 +89,7 @@ export const route: Route = {
                 const $a = $el.find('.listTxt h5 a');
                 const link = $a.attr('href') ?? '';
 
-                // 优先用 title 属性（完整标题），否则取文本并去掉「原创」标签
+                // Prefer title attribute (full title); fall back to text with OrigSign badge removed
                 const titleAttr = $a.attr('title')?.trim() ?? '';
                 const titleText = $a.clone().children('span.OrigSign').remove().end().text().trim();
                 const title = titleAttr || titleText;
@@ -99,12 +101,13 @@ export const route: Route = {
                     title,
                     link,
                     author: author || undefined,
-                    pubDate: timezone(parseRelTime(pubDateRaw), +8),
+                    // parseRelTime returns an absolute UTC Date; no extra timezone shift needed
+                    pubDate: parseRelTime(pubDateRaw),
                 } as DataItem;
             })
             .filter((item) => Boolean(item.title && item.link));
 
-        // 并发抓取详情页正文（带缓存）
+        // Fetch full article body concurrently with caching
         const items = await Promise.all(
             list.map((item) =>
                 cache.tryGet(item.link!, async () => {
@@ -112,22 +115,21 @@ export const route: Route = {
                         const detail = await ofetch(item.link!);
                         const $d = load(detail);
 
-                        // 正文
                         item.description = $d('.article-body').first().html() ?? '';
 
-                        // 详情页有精确到日的发布时间，覆盖列表页的相对时间
+                        // Detail page has an exact date (YYYY-MM-DD); override relative list-page time
                         const dateText = $d('.article-meta .date').first().text().replace('日期：', '').trim();
                         if (dateText) {
                             item.pubDate = timezone(parseDate(dateText), +8);
                         }
 
-                        // 详情页来源可能比列表页更完整
+                        // Detail page source may be more complete than the list snippet
                         const detailAuthor = $d('.article-meta .source a').first().text().trim();
                         if (detailAuthor) {
                             item.author = detailAuthor;
                         }
                     } catch {
-                        // 详情页抓取失败时保留列表页数据
+                        // Keep list-page data if detail fetch fails
                     }
                     return item;
                 })

--- a/lib/routes/in-en/index.ts
+++ b/lib/routes/in-en/index.ts
@@ -19,7 +19,7 @@ const CATEGORIES: Record<string, { name: string; newsPath: string }> = {
 
 export const route: Route = {
     path: '/news/:type',
-    categories: ['traditional-media'],
+    categories: ['new-media'],
     example: '/in-en/news/solar',
     parameters: {
         type: 'Channel type, see table below',
@@ -46,7 +46,7 @@ export const route: Route = {
 | 环保 | huanbao |`,
 
     async handler(ctx) {
-        const type = ctx.req.param('type') ?? 'solar';
+        const type = ctx.req.param('type')!;
         const cat = CATEGORIES[type];
         if (!cat) {
             throw new Error(`Unknown channel type: ${type}. Valid values: ${Object.keys(CATEGORIES).join(', ')}`);

--- a/lib/routes/in-en/index.ts
+++ b/lib/routes/in-en/index.ts
@@ -3,7 +3,7 @@ import { load } from 'cheerio';
 import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
-import { parseDate } from '@/utils/parse-date';
+import { parseRelativeDate } from '@/utils/parse-date';
 
 // Subdomain config: name = channel display name, newsPath = news list path
 const CATEGORIES: Record<string, { name: string; newsPath: string }> = {
@@ -58,29 +58,23 @@ export const route: Route = {
         const html = await ofetch(listUrl);
         const $ = load(html);
 
+        // Each `ul.infoList > li` carries a single `.prompt` block with this fixed shape:
+        //   <i>{relative or absolute date}</i>
+        //   <span>来源：{author or <em class="ly">{author}</em>}</span>
+        //   <span><em>{<a>{category}</a>}+</em></span>
+        // See https://solar.in-en.com/news/ for live samples.
         const list: DataItem[] = $('ul.infoList > li')
             .toArray()
             .map((el) => {
                 const $el = $(el);
                 const $a = $el.find('.listTxt h5 a');
                 const link = $a.attr('href') ?? '';
+                const title = $a.attr('title')?.trim() || $a.text().trim();
 
-                const titleAttr = $a.attr('title')?.trim() ?? '';
-                const titleText = $a.contents().filter((_, n) => n.type === 'text').text().trim();
-                const title = titleAttr || titleText;
-
-                const pubDateRaw = $el.find('.listTxt .prompt i').text().trim();
-                const author = $el
-                    .find('.listTxt .prompt > span')
-                    .first()
-                    .contents()
-                    .filter((_, n) => n.type === 'text')
-                    .text()
-                    .replace('来源：', '')
-                    .trim();
-
+                const pubDateRaw = $el.find('.listTxt .prompt > i').text().trim();
+                const author = $el.find('.listTxt .prompt > span').first().text().replace('来源：', '').trim();
                 const category = $el
-                    .find('.listTxt .prompt span em a')
+                    .find('.listTxt .prompt > span:not(:first-of-type) em a')
                     .toArray()
                     .map((a) => $(a).text().trim())
                     .filter(Boolean);
@@ -88,32 +82,9 @@ export const route: Route = {
                 return {
                     title,
                     link,
-                    author: author || undefined,
+                    author,
                     category,
-                    pubDate: (() => {
-                        if (!pubDateRaw) {
-                            return undefined;
-                        }
-                        if (pubDateRaw.includes('刚刚')) {
-                            return new Date();
-                        }
-                        const minutesMatch = pubDateRaw.match(/(\d+)分钟前/);
-                        if (minutesMatch) {
-                            return new Date(Date.now() - Number(minutesMatch[1]) * 60_000);
-                        }
-                        const hoursMatch = pubDateRaw.match(/(\d+)小时前/);
-                        if (hoursMatch) {
-                            return new Date(Date.now() - Number(hoursMatch[1]) * 3_600_000);
-                        }
-                        if (pubDateRaw.startsWith('今天')) {
-                            return parseDate(new Date().toDateString() + ' ' + pubDateRaw.replace('今天', '').trim());
-                        }
-                        if (pubDateRaw.startsWith('昨天')) {
-                            const d = new Date(Date.now() - 86_400_000);
-                            return parseDate(d.toDateString() + ' ' + pubDateRaw.replace('昨天', '').trim());
-                        }
-                        return parseDate(pubDateRaw);
-                    })(),
+                    pubDate: pubDateRaw ? parseRelativeDate(pubDateRaw) : undefined,
                 } as DataItem;
             })
             .filter((item) => Boolean(item.title && item.link));
@@ -124,7 +95,7 @@ export const route: Route = {
                     const detail = await ofetch(item.link!);
                     const $d = load(detail);
 
-                    item.description = $d('#article').html() ?? '';
+                    item.description = $d('#article').html() ?? undefined;
 
                     const detailAuthor = $d('p.source a').text().trim();
                     if (detailAuthor) {

--- a/lib/routes/in-en/namespace.ts
+++ b/lib/routes/in-en/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '国际能源网',
+    url: 'www.in-en.com',
+    lang: 'zh-CN',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/in-en/news/solar
/in-en/news/wind
/in-en/news/chuneng
/in-en/news/h2
/in-en/news/chd
/in-en/news/newenergy
/in-en/news/power
/in-en/news/huanbao
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add RSS route for **国际能源网** (in-en.com), a major Chinese energy news portal covering solar, wind, energy storage, hydrogen, EV charging, and more.

Supported channels via `/in-en/news/:type`:

| type | Channel | Subdomain |
| --- | --- | --- |
| solar | 光伏太阳能 | solar.in-en.com |
| wind | 风电 | wind.in-en.com |
| chuneng | 储能 | chuneng.in-en.com |
| h2 | 氢能 | h2.in-en.com |
| chd | 充换电 | chd.in-en.com |
| newenergy | 新能源综合 | newenergy.in-en.com |
| power | 电力 | power.in-en.com |
| huanbao | 环保 | huanbao.in-en.com |

Implementation notes:
- Parses article list from `ul.infoList > li` on each subdomain's news page
- Fetches full article body from detail page (`.article-body`) via `cache.tryGet`
- Handles Chinese relative timestamps (`X分钟前` / `X小时前` / `X天前`)
- Wind subdomain uses `/windnews/` path instead of `/news/`