### PR TITLE
fix: claude code changelog query

### DIFF
--- a/lib/routes/claude/code-changelog.ts
+++ b/lib/routes/claude/code-changelog.ts
@@ -14,29 +14,27 @@ const handler = async (ctx: Context): Promise<Data> => {
     const response = await ofetch(targetUrl);
     const $: CheerioAPI = load(response);
 
-    const items: DataItem[] = $('div.markdown-heading')
+    const items: DataItem[] = $('div.update-container')
         .slice(0, limit)
         .toArray()
         .map((el): DataItem => {
-            const $heading = $(el);
-            const version = $heading.find('h2.heading-element').text().trim();
+            const $entry = $(el);
+            const version = $entry.find('[data-component-part="update-label"]').first().text().trim();
             if (!version) {
                 return null as unknown as DataItem;
             }
 
-            const descriptionParts: string[] = [];
-            $heading.nextUntil('div.markdown-heading').each((_, sibling) => {
-                descriptionParts.push($(sibling).prop('outerHTML') ?? '');
-            });
-            const description = descriptionParts.join('');
+            const dateText = $entry.find('[data-component-part="update-description"]').first().text().trim();
+            const description = $entry.find('[data-component-part="update-content"]').first().html() ?? '';
 
-            const anchor = $heading.find('a.anchor').attr('href') ?? `#${version.replaceAll('.', '')}`;
-            const link = `${targetUrl}${anchor}`;
+            const anchor = $entry.attr('id') ?? version.replaceAll('.', '-');
+            const link = `${targetUrl}#${anchor}`;
 
             return {
                 title: version,
                 description,
                 link,
+                pubDate: dateText ? new Date(dateText).toUTCString() : undefined,
                 guid: `claude-code-${version}`,
                 id: `claude-code-${version}`,
             };

--- a/lib/routes/claude/code-changelog.ts
+++ b/lib/routes/claude/code-changelog.ts
@@ -4,6 +4,7 @@ import type { Context } from 'hono';
 
 import type { Data, DataItem, Route } from '@/types';
 import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
 
 const handler = async (ctx: Context): Promise<Data> => {
     const limit = Number.parseInt(ctx.req.query('limit') ?? '25', 10);
@@ -34,7 +35,7 @@ const handler = async (ctx: Context): Promise<Data> => {
                 title: version,
                 description,
                 link,
-                pubDate: dateText ? new Date(dateText).toUTCString() : undefined,
+                pubDate: dateText ? parseDate(dateText) : undefined,
                 guid: `claude-code-${version}`,
                 id: `claude-code-${version}`,
             };

--- a/lib/routes/claude/code-changelog.ts
+++ b/lib/routes/claude/code-changelog.ts
@@ -20,13 +20,13 @@ const handler = async (ctx: Context): Promise<Data> => {
         .toArray()
         .map((el): DataItem => {
             const $entry = $(el);
-            const version = $entry.find('[data-component-part="update-label"]').first().text().trim();
+            const version = $entry.find('[data-component-part="update-label"]').text().trim();
             if (!version) {
                 return null as unknown as DataItem;
             }
 
-            const dateText = $entry.find('[data-component-part="update-description"]').first().text().trim();
-            const description = $entry.find('[data-component-part="update-content"]').first().html() ?? '';
+            const dateText = $entry.find('[data-component-part="update-description"]').text().trim();
+            const description = $entry.find('[data-component-part="update-content"]').html() ?? '';
 
             const anchor = $entry.attr('id') ?? version.replaceAll('.', '-');
             const link = `${targetUrl}#${anchor}`;


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Fixing parsing claude code changelog route entries

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/claude/code/changelog
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
