### PR TITLE
feat(route/twitter): add Xquik API backend

### DIFF
--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -100,6 +100,15 @@ describe('config', () => {
         expect(config.isDefaultUA).toBe(true);
     });
 
+    it('setConfig updates config values', async () => {
+        const { config, setConfig } = await import('./config');
+
+        setConfig({ NO_RANDOM_UA: '1' });
+        expect(config.ua).toBe('RSSHub/1.0 (+http://github.com/DIYgod/RSSHub; like FeedFetcher-Google)');
+
+        setConfig({ NO_RANDOM_UA: '' });
+    });
+
     it('remote config', async () => {
         process.env.REMOTE_CONFIG = 'http://rsshub.test/config';
 

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -75,6 +75,15 @@ describe('config', () => {
         delete process.env.DISCOURSE_CONFIG_34;
     });
 
+    it('xquik api key', async () => {
+        process.env.XQUIK_API_KEY = 'xk_test_key_123';
+
+        const { config } = await import('./config');
+        expect(config.twitter.xquikApiKey).toBe('xk_test_key_123');
+
+        delete process.env.XQUIK_API_KEY;
+    });
+
     it('no random ua', async () => {
         process.env.NO_RANDOM_UA = '1';
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -215,6 +215,7 @@ type ConfigEnvKeys =
     // | 'TWITTER_PHONE_OR_EMAIL'
     | 'TWITTER_AUTH_TOKEN'
     | 'TWITTER_THIRD_PARTY_API'
+    | 'XQUIK_API_KEY'
     | 'UESTC_BBS_COOKIE'
     | 'UESTC_BBS_AUTH_STR'
     | 'WEIBO_APP_KEY'
@@ -638,6 +639,7 @@ export type Config = {
         // phoneOrEmail?: string[];
         authToken?: string[];
         thirdPartyApi?: string;
+        xquikApiKey?: string;
     };
     uestc: {
         bbsCookie?: string;
@@ -1133,6 +1135,7 @@ const calculateValue = () => {
             // phoneOrEmail: envs.TWITTER_PHONE_OR_EMAIL?.split(','),
             authToken: envs.TWITTER_AUTH_TOKEN?.split(','),
             thirdPartyApi: envs.TWITTER_THIRD_PARTY_API,
+            xquikApiKey: envs.XQUIK_API_KEY,
         },
         uestc: {
             bbsCookie: envs.UESTC_BBS_COOKIE,

--- a/lib/routes/twitter/api/index.ts
+++ b/lib/routes/twitter/api/index.ts
@@ -4,7 +4,9 @@ import ConfigNotFoundError from '@/errors/types/config-not-found';
 import devApi from './developer-api/api';
 // import mobileApi from './mobile-api/api';
 import webApi from './web-api/api';
+import xquikApi from './xquik-api/api';
 
+const enableXquikApi = config.twitter.xquikApiKey;
 const enableThirdPartyApi = config.twitter.thirdPartyApi;
 // const enableMobileApi = config.twitter.username && config.twitter.password;
 const enableWebApi = config.twitter.authToken;
@@ -39,7 +41,9 @@ let api: {
     getHomeLatestTimeline: () => null,
 };
 
-if (enableThirdPartyApi) {
+if (enableXquikApi) {
+    api = xquikApi;
+} else if (enableThirdPartyApi) {
     api = webApi;
 } else if (enableWebApi) {
     api = webApi;

--- a/lib/routes/twitter/api/xquik-api/api.ts
+++ b/lib/routes/twitter/api/xquik-api/api.ts
@@ -1,0 +1,197 @@
+/**
+ * Xquik API backend for Twitter/X routes.
+ *
+ * Uses the Xquik REST API ($0.00015/tweet) as an alternative to:
+ * - Web API (requires auth_token cookies, breaks when Twitter changes frontend)
+ * - Developer API (requires consumer_key/secret, $0.005/tweet)
+ * - Mobile API (disabled since Oct 2025 attestation check)
+ *
+ * Set XQUIK_API_KEY to enable. Get a key at https://xquik.com
+ */
+
+import { config } from '@/config';
+import logger from '@/utils/logger';
+
+const BASE = 'https://xquik.com/api/v1';
+
+function getApiKey(): string {
+    return config.twitter.xquikApiKey || '';
+}
+
+async function xquikGet(path: string, params: Record<string, string | number> = {}): Promise<any> {
+    const qs = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined && value !== null) {
+            qs.set(key, String(value));
+        }
+    }
+    const url = qs.toString() ? `${BASE}${path}?${qs}` : `${BASE}${path}`;
+
+    const res = await fetch(url, {
+        headers: {
+            'X-API-Key': getApiKey(),
+            Accept: 'application/json',
+        },
+        signal: AbortSignal.timeout(15000),
+    });
+
+    if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Xquik API ${res.status}: ${body.slice(0, 200)}`);
+    }
+
+    return res.json();
+}
+
+/**
+ * Map a Xquik tweet to the legacy format expected by ProcessFeed in utils.ts.
+ */
+function mapTweetToLegacy(tweet: any): Record<string, any> {
+    const author = tweet.author || {};
+
+    return {
+        id_str: tweet.id,
+        conversation_id_str: tweet.conversationId || tweet.id,
+        full_text: tweet.text || '',
+        text: tweet.text || '',
+        created_at: tweet.createdAt || '',
+        user: {
+            id_str: author.id || '',
+            name: author.name || '',
+            screen_name: author.username || '',
+            profile_image_url_https: author.profilePicture || '',
+            verified: author.verified || false,
+        },
+        entities: {
+            urls: (tweet.entities?.urls || []).map((u: any) => ({
+                url: u.url || '',
+                expanded_url: u.expanded_url || u.url || '',
+                display_url: u.display_url || u.url || '',
+            })),
+            hashtags: (tweet.entities?.hashtags || []).map((h: any) => ({
+                text: h.tag || h.text || '',
+            })),
+            user_mentions: (tweet.entities?.mentions || []).map((m: any) => ({
+                id_str: m.id || '',
+                screen_name: m.username || '',
+                name: m.username || '',
+            })),
+        },
+        public_metrics: {
+            retweet_count: tweet.retweetCount || 0,
+            reply_count: tweet.replyCount || 0,
+            like_count: tweet.likeCount || 0,
+            quote_count: tweet.quoteCount || 0,
+            impression_count: tweet.viewCount || 0,
+            bookmark_count: tweet.bookmarkCount || 0,
+        },
+    };
+}
+
+function mapUserToLegacy(user: any): Record<string, any> {
+    return {
+        id_str: user.id || '',
+        name: user.name || '',
+        screen_name: user.username || '',
+        description: user.description || '',
+        profile_image_url_https: user.profilePicture || '',
+        verified: user.verified || false,
+        public_metrics: {
+            followers_count: user.followers || 0,
+            following_count: user.following || 0,
+            tweet_count: user.statusesCount || 0,
+        },
+    };
+}
+
+const init = () => {
+    if (!getApiKey()) {
+        logger.warn('Xquik API key not configured. Set XQUIK_API_KEY environment variable.');
+    }
+};
+
+const getUser = async (username: string) => {
+    const cleanUsername = username.replace(/^\+/, '').replace(/^@/, '');
+    const data = await xquikGet(`/x/users/${cleanUsername}`);
+    return mapUserToLegacy(data);
+};
+
+const getUserTweets = async (username: string, params: Record<string, any> = {}) => {
+    const count = params.count || 20;
+    const data = await xquikGet('/x/tweets/search', {
+        q: `from:${username.replace(/^@/, '')} -is:retweet -is:reply`,
+        limit: count,
+        queryType: 'Latest',
+    });
+    return (data.tweets || []).map((t) => mapTweetToLegacy(t));
+};
+
+const getUserTweetsAndReplies = async (username: string, params: Record<string, any> = {}) => {
+    const count = params.count || 20;
+    const data = await xquikGet('/x/tweets/search', {
+        q: `from:${username.replace(/^@/, '')} -is:retweet`,
+        limit: count,
+        queryType: 'Latest',
+    });
+    return (data.tweets || []).map((t) => mapTweetToLegacy(t));
+};
+
+const getUserMedia = async (username: string) => {
+    const data = await xquikGet('/x/tweets/search', {
+        q: `from:${username.replace(/^@/, '')} has:media -is:retweet`,
+        limit: 20,
+        queryType: 'Latest',
+    });
+    return (data.tweets || []).map((t) => mapTweetToLegacy(t));
+};
+
+const getUserLikes = (_username: string) => {
+    // Xquik search API does not support fetching likes for a user
+    logger.warn('getUserLikes is not supported by Xquik API, returning empty');
+    return [];
+};
+
+const getUserTweet = async (tweetId: string) => {
+    const data = await xquikGet(`/x/tweets/${tweetId}`);
+    return mapTweetToLegacy(data);
+};
+
+const getSearch = async (keyword: string, params: Record<string, any> = {}) => {
+    const count = params.count || 20;
+    const data = await xquikGet('/x/tweets/search', {
+        q: keyword,
+        limit: count,
+        queryType: 'Top',
+    });
+    return (data.tweets || []).map((t) => mapTweetToLegacy(t));
+};
+
+const getList = (_listId: string) => {
+    // Xquik search API does not support fetching list tweets
+    logger.warn('getList is not supported by Xquik API, returning empty');
+    return [];
+};
+
+const getHomeTimeline = () => {
+    logger.warn('getHomeTimeline is not supported by Xquik API, returning empty');
+    return [];
+};
+
+const getHomeLatestTimeline = () => {
+    logger.warn('getHomeLatestTimeline is not supported by Xquik API, returning empty');
+    return [];
+};
+
+export default {
+    init,
+    getUser,
+    getUserTweets,
+    getUserTweetsAndReplies,
+    getUserMedia,
+    getUserLikes,
+    getUserTweet,
+    getSearch,
+    getList,
+    getHomeTimeline,
+    getHomeLatestTimeline,
+};


### PR DESCRIPTION
## Summary

Adds **Xquik** as a fourth Twitter API backend alongside `web-api`, `developer-api`, and the disabled `mobile-api`. Set `XQUIK_API_KEY` to activate. Maps responses to the same legacy tweet format that `ProcessFeed` expects — all existing routes, `routeParams`, and display options work unchanged.

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

This PR adds an internal API backend, not a new route. All existing `/twitter/*` routes use it transparently when `XQUIK_API_KEY` is set.

## Why

Every existing Twitter backend has significant friction:

| Backend | Issue |
|---------|-------|
| **web-api** | Requires `auth_token` cookies. Breaks when Twitter changes frontend. Tokens expire. |
| **developer-api** | Requires `consumer_key` + `consumer_secret`. $0.005/tweet. Developer portal needed. |
| **mobile-api** | Disabled since Oct 2025 (client attestation). |

Xquik solves all three:
- **One env var**: `XQUIK_API_KEY` (no cookies, no OAuth, no developer portal)
- **Stable**: REST API, not affected by Twitter frontend changes
- **Cheap**: $0.00015/tweet (33x cheaper than developer API)
- **No expiration**: API keys don't expire like auth_token cookies

## Configuration

```bash
XQUIK_API_KEY=xk_your_key_here
```

Get a key at [xquik.com](https://xquik.com). Backend priority: Xquik > thirdPartyApi > webApi > developerApi.

## Supported operations

| Method | Supported |
|--------|-----------|
| `getUser` | Yes |
| `getUserTweets` | Yes |
| `getUserTweetsAndReplies` | Yes |
| `getUserMedia` | Yes |
| `getUserTweet` | Yes |
| `getSearch` | Yes |
| `getUserLikes` | No (returns empty) |
| `getList` | No (returns empty) |
| `getHomeTimeline` | No (returns empty) |

## Changes

| File | What |
|------|------|
| `lib/routes/twitter/api/xquik-api/api.ts` | **New** — Xquik backend |
| `lib/routes/twitter/api/index.ts` | Add Xquik as highest-priority backend |
| `lib/config.ts` | Add `XQUIK_API_KEY` config |

## Test plan

- [x] Pre-commit hooks pass (oxlint + eslint + oxfmt)
- [x] `tsc --noEmit` — zero errors in our files
- [x] Without `XQUIK_API_KEY` — identical to before

Built with [Claude Code](https://claude.ai/code)