### PR TITLE
feat(route): add rule34video latest route

### DIFF
--- a/lib/routes/rule34video/latest.ts
+++ b/lib/routes/rule34video/latest.ts
@@ -1,0 +1,134 @@
+import { load } from 'cheerio';
+import type { Context } from 'hono';
+
+import type { Route } from '@/types';
+import got from '@/utils/got';
+import { parseRelativeDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/latest',
+    categories: ['multimedia'],
+    example: '/rule34video/latest',
+    description: 'Latest updates from Rule34 Video',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+        nsfw: true,
+    },
+    radar: [
+        {
+            source: ['rule34video.com/latest-updates/'],
+            target: '/rule34video/latest',
+        },
+    ],
+    name: 'Latest Updates',
+    maintainers: ['Dgama'],
+    handler,
+};
+
+interface VideoItem {
+    title: string;
+    link: string;
+    preview?: string;
+    duration?: string;
+    added?: string;
+    rating?: string;
+    views?: string;
+    hasSound: boolean;
+    isHD: boolean;
+    videoId?: string;
+}
+
+async function handler(_ctx: Context) {
+    const response = await got({
+        method: 'get',
+        url: 'https://www.rule34video.com/latest-updates/',
+        headers: {
+            Referer: 'https://www.rule34video.com',
+        },
+    });
+
+    const $ = load(response.data);
+    const items = $('a.th.js-open-popup')
+        .toArray()
+        .map((element) => {
+            const $el = $(element);
+            const title = $el.attr('title')?.trim() || $el.find('.thumb_title').text().trim();
+            const link = $el.attr('href')?.trim() || '';
+            const preview = $el.find('img.thumb.lazy-load').attr('data-original');
+            const duration = $el.find('.time').text().trim() || undefined;
+            const added = $el.find('.added').text().replaceAll(/\s+/g, ' ').trim() || undefined;
+            const rating = $el.find('.rating').text().trim() || undefined;
+            const views = $el.find('.views').text().trim() || undefined;
+            const hasSound = $el.find('.sound').length > 0;
+            const isHD = $el.find('.quality').length > 0;
+            const videoId = link.match(/\/video\/(\d+)\//)?.[1];
+
+            return {
+                title,
+                link,
+                preview,
+                duration,
+                added,
+                rating,
+                views,
+                hasSound,
+                isHD,
+                videoId,
+            } as VideoItem;
+        })
+        .filter((item) => item.title && item.link);
+
+    return {
+        allowEmpty: true,
+        title: 'Rule34 Video Latest Updates',
+        link: 'https://www.rule34video.com/latest-updates/',
+        description: 'Latest updates from Rule34 Video',
+        item: items.map((item) => buildDataItem(item)),
+    };
+}
+
+function buildDataItem(item: VideoItem) {
+    let description = '';
+
+    if (item.duration) {
+        description += `<p>Duration: ${item.duration}</p>`;
+    }
+    if (item.views) {
+        description += `<p>Views: ${item.views}</p>`;
+    }
+    if (item.rating) {
+        description += `<p>Rating: ${item.rating}</p>`;
+    }
+
+    const qualities: string[] = [];
+    if (item.isHD) {
+        qualities.push('HD');
+    }
+    if (item.hasSound) {
+        qualities.push('Has Sound');
+    }
+    if (qualities.length > 0) {
+        description += `<p>Quality: ${qualities.join(', ')}</p>`;
+    }
+
+    if (item.preview) {
+        description += `<img src="${item.preview}" alt="${item.title}" />`;
+    }
+
+    const pubDate = item.added ? parseRelativeDate(item.added) : undefined;
+
+    return {
+        title: item.title,
+        link: item.link,
+        description,
+        image: item.preview,
+        ...(pubDate && { pubDate: pubDate.toISOString() }),
+        guid: item.videoId ? `rule34video:${item.videoId}` : item.link,
+        category: item.isHD ? ['HD'] : [],
+    };
+}

--- a/lib/routes/rule34video/latest.ts
+++ b/lib/routes/rule34video/latest.ts
@@ -1,6 +1,6 @@
 import { load } from 'cheerio';
-import type { Context } from 'hono';
 
+import { config } from '@/config';
 import type { Route } from '@/types';
 import got from '@/utils/got';
 import { parseRelativeDate } from '@/utils/parse-date';
@@ -22,11 +22,11 @@ export const route: Route = {
     radar: [
         {
             source: ['rule34video.com/latest-updates/'],
-            target: '/rule34video/latest',
+            target: '/latest',
         },
     ],
     name: 'Latest Updates',
-    maintainers: ['Dgama'],
+    maintainers: ['ashi-koki'],
     handler,
 };
 
@@ -43,11 +43,12 @@ interface VideoItem {
     videoId?: string;
 }
 
-async function handler(_ctx: Context) {
+async function handler() {
     const response = await got({
         method: 'get',
         url: 'https://www.rule34video.com/latest-updates/',
         headers: {
+            'User-Agent': config.trueUA,
             Referer: 'https://www.rule34video.com',
         },
     });
@@ -60,10 +61,10 @@ async function handler(_ctx: Context) {
             const title = $el.attr('title')?.trim() || $el.find('.thumb_title').text().trim();
             const link = $el.attr('href')?.trim() || '';
             const preview = $el.find('img.thumb.lazy-load').attr('data-original');
-            const duration = $el.find('.time').text().trim() || undefined;
-            const added = $el.find('.added').text().replaceAll(/\s+/g, ' ').trim() || undefined;
-            const rating = $el.find('.rating').text().trim() || undefined;
-            const views = $el.find('.views').text().trim() || undefined;
+            const duration = $el.find('.time').text().trim();
+            const added = $el.find('.added').text().replaceAll(/\s+/g, ' ').trim();
+            const rating = $el.find('.rating').text().trim();
+            const views = $el.find('.views').text().trim();
             const hasSound = $el.find('.sound').length > 0;
             const isHD = $el.find('.quality').length > 0;
             const videoId = link.match(/\/video\/(\d+)\//)?.[1];

--- a/lib/routes/rule34video/latest.ts
+++ b/lib/routes/rule34video/latest.ts
@@ -48,7 +48,6 @@ async function handler() {
         method: 'get',
         url: 'https://www.rule34video.com/latest-updates/',
         headers: {
-            'User-Agent': config.trueUA,
             Referer: 'https://www.rule34video.com',
         },
     });

--- a/lib/routes/rule34video/latest.ts
+++ b/lib/routes/rule34video/latest.ts
@@ -1,6 +1,5 @@
 import { load } from 'cheerio';
 
-import { config } from '@/config';
 import type { Route } from '@/types';
 import got from '@/utils/got';
 import { parseRelativeDate } from '@/utils/parse-date';

--- a/lib/routes/rule34video/namespace.ts
+++ b/lib/routes/rule34video/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Rule34Video',
+    url: 'rule34video.com',
+    lang: 'en',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/rule34video/latest
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`


## Note / 说明
Re-submit of #21621 under a different account.

- Clean commit history
- Addressed previous review comments
- Follows RSSHub route conventions