### PR TITLE
fix(route): Fixed an issue where Huxiu subscriptions were being blocked by the WAF

### DIFF
--- a/lib/routes/huxiu/club.ts
+++ b/lib/routes/huxiu/club.ts
@@ -12,7 +12,7 @@ export const route: Route = {
     parameters: { id: '源流 id，可在对应源流页 URL 中找到' },
     features: {
         requireConfig: false,
-        requirePuppeteer: false,
+        requirePuppeteer: true,
         antiCrawler: true,
         supportBT: false,
         supportPodcast: true,

--- a/lib/routes/huxiu/util.ts
+++ b/lib/routes/huxiu/util.ts
@@ -3,6 +3,7 @@ import CryptoJS from 'crypto-js';
 
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import { getPuppeteerPage } from '@/utils/puppeteer';
 
 import { renderDescription } from './templates/description';
 
@@ -164,57 +165,106 @@ const fetchData = async (url) => {
 const buildCategories = (data) => [data.video_article_tag, data.brief_column?.name, data.club_info?.name, ...(data.tags_info?.map((c) => c.name) ?? []), ...(data.relation_info?.channel?.map((c) => c.name) ?? [])].filter(Boolean);
 
 /**
- * Fetches item data.
+ * Fetches item data using puppeteer to bypass WAF protection.
  *
  * @param {Object} item - The item to fetch data for.
  * @returns {Promise<Object>} The fetched item data object.
  */
 const fetchItem = async (item) => {
     let detailResponse: string;
+
+    const { page, destroy } = await getPuppeteerPage(item.link, {
+        onBeforeLoad: async (page) => {
+            // Block unnecessary resources to speed up loading
+            await page.setRequestInterception(true);
+            page.on('request', (request) => {
+                const resourceType = request.resourceType();
+                // Only allow document, script, and xhr requests
+                if (resourceType === 'document' || resourceType === 'script' || resourceType === 'xhr' || resourceType === 'other') {
+                    request.continue();
+                } else {
+                    request.abort();
+                }
+            });
+        },
+    });
+
     try {
-        const response = await got(item.link);
-        detailResponse = response.data;
+        // Wait for the page to load
+        await page.waitForSelector('#__NUXT_DATA__, .detail-content', { timeout: 10000 });
+
+        // Get the rendered HTML content
+        detailResponse = await page.content();
     } catch {
-        // Request failed (e.g., 503, connection terminated), return original item
-        return item;
+        // If timeout, try to get whatever content is available
+        detailResponse = await page.content();
+    } finally {
+        await destroy();
     }
 
     const state = parseInitialState(detailResponse);
     const data = state?.articleDetail?.articleDetail;
 
-    if (!data) {
-        return item;
+    if (data) {
+        const { processed: audio, processedItem: audioItem = {} } = processAudioInfo(data.audio_info);
+
+        if (Object.keys(audioItem).length !== 0) {
+            audioItem.itunes_item_image = data.pic_path ?? data.share_info?.share_img ?? undefined;
+        }
+
+        const { processed: video, processedItem: videoItem = {} } = processVideoInfo(data.video_info);
+
+        const preface = data.content_preface ?? data.preface;
+        const content = data.content;
+
+        return {
+            ...audioItem,
+            ...videoItem,
+            ...item,
+            title: data.title ?? item.title,
+            description: renderDescription({
+                image: { src: data.pic_path },
+                video,
+                audio,
+                preface: preface ? cleanUpHTML(preface) : undefined,
+                summary: data.summary,
+                description: content ? cleanUpHTML(content) : undefined,
+            }),
+            author: data.user_info?.username ?? item.author,
+            category: buildCategories(data),
+            pubDate: parseDate(data.dateline ?? data.publish_time, 'X'),
+            upvotes: Number.parseInt(data.agreenum ?? item.upvotes ?? 0, 10),
+            comments: Number.parseInt(data.commentnum ?? data.total_comment_num ?? item.comments ?? 0, 10),
+        };
     }
 
-    const { processed: audio, processedItem: audioItem = {} } = processAudioInfo(data.audio_info);
+    // Fallback: parse HTML directly using cheerio for brief pages
+    const $ = load(detailResponse);
 
-    if (Object.keys(audioItem).length !== 0) {
-        audioItem.itunes_item_image = data.pic_path ?? data.share_info?.share_img ?? undefined;
+    // Extract pubDate from meta tag
+    const publishedTime = $('meta[property="article:published_time"]').attr('content');
+
+    // Extract description from preface and main content
+    const prefaceHtml = $('.detail-content__preface').html();
+    const mainContentHtml = $('#js-part').html() ?? $('.part').html();
+
+    const descriptionParts: string[] = [];
+    if (prefaceHtml) {
+        descriptionParts.push(prefaceHtml);
+    }
+    if (mainContentHtml) {
+        if (descriptionParts.length > 0) {
+            descriptionParts.push('<br><hr>');
+        }
+        descriptionParts.push(mainContentHtml);
     }
 
-    const { processed: video, processedItem: videoItem = {} } = processVideoInfo(data.video_info);
-
-    const preface = data.content_preface ?? data.preface;
-    const content = data.content;
+    const description = descriptionParts.length > 0 ? descriptionParts.join('') : undefined;
 
     return {
-        ...audioItem,
-        ...videoItem,
         ...item,
-        title: data.title ?? item.title,
-        description: renderDescription({
-            image: { src: data.pic_path },
-            video,
-            audio,
-            preface: preface ? cleanUpHTML(preface) : undefined,
-            summary: data.summary,
-            description: content ? cleanUpHTML(content) : undefined,
-        }),
-        author: data.user_info?.username ?? item.author,
-        category: buildCategories(data),
-        pubDate: parseDate(data.dateline ?? data.publish_time, 'X'),
-        upvotes: Number.parseInt(data.agreenum ?? item.upvotes ?? 0, 10),
-        comments: Number.parseInt(data.commentnum ?? data.total_comment_num ?? item.comments ?? 0, 10),
+        description: description ?? item.description,
+        pubDate: publishedTime ? parseDate(publishedTime) : item.pubDate,
     };
 };
 
@@ -316,18 +366,32 @@ const resolveNuxtData = (arr: unknown[], index: number, visited = new Set<number
  * @returns {Object|undefined} - The parsed initial state object, or undefined if not found.
  */
 const parseInitialState = (data: string) => {
-    const $ = load(data);
+    // Try to extract __NUXT_DATA__ from HTML using multiple methods
+    let nuxtDataScript: string | undefined;
 
-    // Try Nuxt 3 format first (for articles)
-    const nuxtDataScript = $('#__NUXT_DATA__').text();
+    // Method 1: Use regex to find the script tag content directly
+    // Match script tag with id="__NUXT_DATA__" and capture its content
+    const nuxtDataMatch = data.match(/<script[^>]*id="__NUXT_DATA__"[^>]*>\s*(\[[\s\S]*?\])\s*<\/script>/i);
+    if (nuxtDataMatch?.[1]) {
+        nuxtDataScript = nuxtDataMatch[1].trim();
+    }
+
+    // Method 2: Try cheerio if regex failed
+    if (!nuxtDataScript) {
+        const $ = load(data);
+        const scriptEl = $('#__NUXT_DATA__');
+        nuxtDataScript = scriptEl.html() ?? scriptEl.text() ?? undefined;
+    }
+
     if (nuxtDataScript) {
         try {
             const nuxtData = JSON.parse(nuxtDataScript) as unknown[];
 
-            // Find the data object which contains articleDetail
+            // Find the data object which contains articleDetail or briefDetail
             // The structure is: [["ShallowReactive", 1], {data: 2, ...}, ["ShallowReactive", 3], {articleDetail-xxx: 4}, ...]
             for (const item of nuxtData) {
                 if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+                    // Check for articleDetail first
                     const articleDetailKey = Object.keys(item).find((key) => key.startsWith('articleDetail-'));
                     if (articleDetailKey) {
                         const articleDetailIndex = (item as Record<string, number>)[articleDetailKey];
@@ -338,6 +402,40 @@ const parseInitialState = (data: string) => {
                             }
                         }
                     }
+
+                    // Check for briefDetail (used by brief pages like /brief/xxx.html)
+                    const briefDetailKey = Object.keys(item).find((key) => key.startsWith('briefDetail-'));
+                    if (briefDetailKey) {
+                        const briefDetailIndex = (item as Record<string, number>)[briefDetailKey];
+                        if (typeof briefDetailIndex === 'number') {
+                            const briefDetailData = resolveNuxtData(nuxtData, briefDetailIndex) as Record<string, unknown>;
+                            const brief = briefDetailData?.brief as Record<string, unknown> | undefined;
+                            if (brief) {
+                                const publisherList = brief.publisher_list as Array<{ username?: string }> | undefined;
+                                const briefColumn = briefDetailData?.brief_column as Record<string, unknown> | undefined;
+                                const clubInfo = briefDetailData?.club_info as Record<string, unknown> | undefined;
+
+                                return {
+                                    articleDetail: {
+                                        articleDetail: {
+                                            title: brief.title,
+                                            content: brief.content,
+                                            preface: brief.preface,
+                                            dateline: brief.publish_time,
+                                            publish_time: brief.publish_time,
+                                            audio_info: brief.audio_info,
+                                            agreenum: brief.agree_num,
+                                            total_comment_num: brief.total_comment_num,
+                                            user_info: publisherList?.[0] ? { username: publisherList[0].username } : undefined,
+                                            brief_column: briefColumn ? { name: briefColumn.name } : undefined,
+                                            club_info: clubInfo ? { name: clubInfo.name } : undefined,
+                                            share_info: brief.share_info,
+                                        },
+                                    },
+                                };
+                            }
+                        }
+                    }
                 }
             }
         } catch {
@@ -345,7 +443,7 @@ const parseInitialState = (data: string) => {
         }
     }
 
-    // Try window.__INITIAL_STATE__ format (for briefs)
+    // Try window.__INITIAL_STATE__ format (for briefs - legacy)
     const initialStateMatch = data.match(/window\.__INITIAL_STATE__\s*=\s*(\{[\s\S]*?\});?\s*\(function\(\)/);
     if (initialStateMatch?.[1]) {
         try {

--- a/lib/routes/huxiu/util.ts
+++ b/lib/routes/huxiu/util.ts
@@ -2,8 +2,9 @@ import { load } from 'cheerio';
 import CryptoJS from 'crypto-js';
 
 import got from '@/utils/got';
+import logger from '@/utils/logger';
 import { parseDate } from '@/utils/parse-date';
-import { getPuppeteerPage } from '@/utils/puppeteer';
+import puppeteer from '@/utils/puppeteer';
 
 import { renderDescription } from './templates/description';
 
@@ -73,10 +74,12 @@ const cleanUpHTML = (data) => {
  * @returns {Promise<Object>} A promise that resolves to an object containing the fetched data
  *                            to be added into `ctx.state.data`.
  */
-const fetchClubData = async (id: string) => {
+const fetchClubData = async (id: string, requestHeaders = {}) => {
     const currentUrl = new URL(`club/${id}.html`, rootUrl).href;
 
-    const { data: currentResponse } = await got(currentUrl);
+    const { data: currentResponse } = await got(currentUrl, {
+        headers: requestHeaders,
+    });
 
     const $ = load(currentResponse);
 
@@ -165,43 +168,72 @@ const fetchData = async (url) => {
 const buildCategories = (data) => [data.video_article_tag, data.brief_column?.name, data.club_info?.name, ...(data.tags_info?.map((c) => c.name) ?? []), ...(data.relation_info?.channel?.map((c) => c.name) ?? [])].filter(Boolean);
 
 /**
- * Fetches item data using puppeteer to bypass WAF protection.
+ * Solves the WAF once with Puppeteer, fetches all internal detail pages inside the
+ * browser context in small batches, then closes the browser immediately after the
+ * HTML payloads are returned to Node.js.
  *
- * @param {Object} item - The item to fetch data for.
- * @returns {Promise<Object>} The fetched item data object.
+ * @param {string[]} urls - Internal detail URLs to fetch.
+ * @returns {Promise<Map<string, string>>} Map of detail URL to raw HTML.
  */
-const fetchItem = async (item) => {
-    let detailResponse: string;
-
-    const { page, destroy } = await getPuppeteerPage(item.link, {
-        onBeforeLoad: async (page) => {
-            // Block unnecessary resources to speed up loading
-            await page.setRequestInterception(true);
-            page.on('request', (request) => {
-                const resourceType = request.resourceType();
-                // Only allow document, script, and xhr requests
-                if (resourceType === 'document' || resourceType === 'script' || resourceType === 'xhr' || resourceType === 'other') {
-                    request.continue();
-                } else {
-                    request.abort();
-                }
-            });
-        },
-    });
-
-    try {
-        // Wait for the page to load
-        await page.waitForSelector('#__NUXT_DATA__, .detail-content', { timeout: 10000 });
-
-        // Get the rendered HTML content
-        detailResponse = await page.content();
-    } catch {
-        // If timeout, try to get whatever content is available
-        detailResponse = await page.content();
-    } finally {
-        await destroy();
+const fetchDetailPagesInBrowser = async (urls: string[]) => {
+    if (urls.length === 0) {
+        return new Map<string, string>();
     }
 
+    const browser = await puppeteer();
+
+    try {
+        const page = await browser.newPage();
+
+        await page.setRequestInterception(true);
+        page.on('request', (request) => {
+            const resourceType = request.resourceType();
+            if (resourceType === 'document' || resourceType === 'script' || resourceType === 'xhr' || resourceType === 'fetch' || resourceType === 'other') {
+                request.continue();
+            } else {
+                request.abort();
+            }
+        });
+
+        await page.goto(urls[0], {
+            waitUntil: 'domcontentloaded',
+        });
+        await page.waitForSelector('#__NUXT_DATA__, .detail-content', { timeout: 8000 });
+
+        const htmlEntries = await page.evaluate((detailUrls) => {
+            const batchSize = 4;
+            const batches = Array.from({ length: Math.ceil(detailUrls.length / batchSize) }, (_, index) => detailUrls.slice(index * batchSize, (index + 1) * batchSize));
+
+            const fetchBatch = async (index: number): Promise<Array<[string, string]>> => {
+                if (index >= batches.length) {
+                    return [];
+                }
+
+                const currentBatch = await Promise.all(
+                    batches[index].map(async (url) => {
+                        const response = await fetch(url, {
+                            credentials: 'include',
+                        });
+                        return [url, await response.text()] as [string, string];
+                    })
+                );
+
+                return [...currentBatch, ...(await fetchBatch(index + 1))];
+            };
+
+            return fetchBatch(0);
+        }, urls);
+
+        return new Map(htmlEntries);
+    } catch (error) {
+        logger.warn(`[huxiu] failed to fetch details in browser context: ${error instanceof Error ? error.message : String(error)}`);
+        return new Map<string, string>();
+    } finally {
+        await browser.close();
+    }
+};
+
+const fetchItem = (item, detailResponse: string) => {
     const state = parseInitialState(detailResponse);
     const data = state?.articleDetail?.articleDetail;
 
@@ -640,17 +672,31 @@ const processItems = async (items, limit, tryGet) => {
         .filter(Boolean)
         .slice(0, limit);
 
+    const internalItems = processedItems.filter((item) => {
+        const isExternalLink = !new RegExp(domain, 'i').test(new URL(item.link).hostname);
+        const isMoment = item.guid.startsWith('huxiu-moment');
+        return !isExternalLink && !isMoment;
+    });
+
+    const detailResponses = await fetchDetailPagesInBrowser(internalItems.map((item) => item.link));
+
     return await Promise.all(
         processedItems.map((item) =>
-            tryGet(item.guid, async () => {
+            tryGet(item.guid, () => {
                 const isExternalLink = !new RegExp(domain, 'i').test(new URL(item.link).hostname);
                 const isMoment = item.guid.startsWith('huxiu-moment');
 
                 if (isExternalLink || isMoment) {
-                    return item;
+                    return Promise.resolve(item);
                 }
 
-                return await fetchItem(item);
+                const detailResponse = detailResponses.get(item.link);
+
+                if (!detailResponse) {
+                    return Promise.resolve(item);
+                }
+
+                return Promise.resolve(fetchItem(item, detailResponse));
             })
         )
     );


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/huxiu/club/1000                                          
/huxiu/article/429087.html                     
/huxiu/brief/301102.html  
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [x] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明
The Huxiu website has enabled the Alibaba Cloud Shield WAF firewall, causing standard HTTP                               
  requests to be intercepted and redirected to a verification page, which prevents the retrieval of actual __NUXT_DATA__ data.
                                                                             
  This update modifies the `fetchItem` function to render the page using Puppeteer instead of `got`, in order to bypass the WAF
  verification:                                        
                                                                             
  - Use `getPuppeteerPage` to retrieve the full rendered page content          
  - Block non-essential resources (images, CSS, etc.) to speed up loading     
  - Support both `__NUXT_DATA__` and `__INITIAL_STATE__` data formats                     
  - Add fallback HTML parsing for the brief page