### PR TITLE
style: remove unnecessary `|| undefined` in openai route

### DIFF
--- a/lib/routes/openai/common.tsx
+++ b/lib/routes/openai/common.tsx
@@ -39,7 +39,7 @@ export const fetchArticleDetails = async (url: string) => {
         // Categories can be found on https://openai.com/news/ and https://openai.com/research/index/
         categories,
         image: $('meta[property="og:image"]').attr('content'),
-        author: authors.join(', ') || undefined,
+        author: authors.join(', '),
         link: normalizedUrl,
     };
 };


### PR DESCRIPTION
## Summary
- Remove unnecessary `|| undefined` after `authors.join(', ')` in `lib/routes/openai/common.tsx`
- `Array.join()` returns a string, so the `|| undefined` coercion is not needed

Follow-up from #21309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)