### PR TITLE
fix(route/huxiu): restore article content fetching and unify metadata building

### DIFF
--- a/lib/routes/huxiu/channel.ts
+++ b/lib/routes/huxiu/channel.ts
@@ -2,7 +2,15 @@ import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 
-import { apiArticleRootUrl, fetchData, processItems, rootUrl } from './util';
+import { apiArticleRootUrl, processItems, rootUrl } from './util';
+
+const prefixHuxiu = (value?: string) => {
+    if (!value) {
+        return;
+    }
+
+    return value.startsWith('虎嗅资讯-') ? value : `虎嗅资讯-${value}`;
+};
 
 export const route: Route = {
     path: ['/article', '/channel/:id?'],
@@ -55,8 +63,17 @@ async function handler(ctx) {
     });
 
     const items = await processItems(response.data?.dataList ?? response.data.datalist, limit, cache.tryGet);
-
-    const data = await fetchData(currentUrl);
+    const rawTitle = response.data?.share_info?.share_title ?? response.data?.name ?? '全部';
+    const data = {
+        title: prefixHuxiu(rawTitle) ?? rawTitle,
+        link: currentUrl,
+        description: prefixHuxiu(response.data?.share_info?.share_desc || rawTitle),
+        icon: response.data?.share_info?.share_img,
+        logo: response.data?.share_info?.share_img,
+        subtitle: rawTitle,
+        allowEmpty: true,
+        itunes_category: 'News',
+    };
 
     return {
         item: items,

--- a/lib/routes/huxiu/channel.ts
+++ b/lib/routes/huxiu/channel.ts
@@ -2,15 +2,7 @@ import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 
-import { apiArticleRootUrl, processItems, rootUrl } from './util';
-
-const prefixHuxiu = (value?: string) => {
-    if (!value) {
-        return;
-    }
-
-    return value.startsWith('虎嗅资讯-') ? value : `虎嗅资讯-${value}`;
-};
+import { apiArticleRootUrl, buildFeedMetadata, buildHuxiuRouteTitlePrefix, processItems, rootUrl } from './util';
 
 export const route: Route = {
     path: ['/article', '/channel/:id?'],
@@ -64,16 +56,16 @@ async function handler(ctx) {
 
     const items = await processItems(response.data?.dataList ?? response.data.datalist, limit, cache.tryGet);
     const rawTitle = response.data?.share_info?.share_title ?? response.data?.name ?? '全部';
-    const data = {
-        title: prefixHuxiu(rawTitle) ?? rawTitle,
+
+    const data = buildFeedMetadata({
+        title: rawTitle,
         link: currentUrl,
-        description: prefixHuxiu(response.data?.share_info?.share_desc || rawTitle),
-        icon: response.data?.share_info?.share_img,
-        logo: response.data?.share_info?.share_img,
+        description: response.data?.share_info?.share_desc || rawTitle,
+        image: response.data?.share_info?.share_img,
         subtitle: rawTitle,
-        allowEmpty: true,
-        itunes_category: 'News',
-    };
+        titlePrefix: buildHuxiuRouteTitlePrefix(route.name),
+        descriptionPrefix: buildHuxiuRouteTitlePrefix(route.name),
+    });
 
     return {
         item: items,

--- a/lib/routes/huxiu/club.ts
+++ b/lib/routes/huxiu/club.ts
@@ -2,7 +2,7 @@ import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 
-import { apiClubRootUrl, fetchClubData, processItems } from './util';
+import { apiClubRootUrl, buildHuxiuRouteTitlePrefix, fetchApiRouteData, processItems, rootUrl } from './util';
 
 export const route: Route = {
     path: '/club/:id',
@@ -28,8 +28,30 @@ async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 20;
 
     const apiUrl = new URL('v1/club/briefList', apiClubRootUrl).href;
+    const currentUrl = new URL(`club/${id}.html`, rootUrl).href;
 
-    const data = await fetchClubData(id);
+    const data = await fetchApiRouteData<{
+        name: string;
+        format_desc?: string;
+        icon_path?: string;
+        share_info?: {
+            share_desc?: string;
+            share_img?: string;
+        };
+    }>({
+        currentUrl,
+        apiUrl: new URL('v1/club/detail', apiClubRootUrl).href,
+        form: {
+            platform: 'www',
+            club_id: id,
+        },
+        mapData: (data) => ({
+            title: data.name,
+            description: data.format_desc ?? data.share_info?.share_desc,
+            image: data.icon_path ?? data.share_info?.share_img,
+            titlePrefix: buildHuxiuRouteTitlePrefix(route.name),
+        }),
+    });
 
     const { data: response } = await got.post(apiUrl, {
         form: {

--- a/lib/routes/huxiu/collection.ts
+++ b/lib/routes/huxiu/collection.ts
@@ -2,7 +2,7 @@ import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 
-import { apiArticleRootUrl, fetchData, processItems, rootUrl } from './util';
+import { apiArticleRootUrl, buildHuxiuRouteTitlePrefix, fetchApiRouteData, processItems, rootUrl } from './util';
 
 export const route: Route = {
     path: '/collection/:id',
@@ -29,7 +29,6 @@ async function handler(ctx) {
 
     const apiUrl = new URL('web/collection/articleList', apiArticleRootUrl).href;
     const currentUrl = new URL(`collection/${id}.html`, rootUrl).href;
-
     const { data: response } = await got.post(apiUrl, {
         form: {
             platform: 'www',
@@ -39,7 +38,25 @@ async function handler(ctx) {
 
     const items = await processItems(response.data.datalist, limit, cache.tryGet);
 
-    const data = await fetchData(currentUrl);
+    const data = await fetchApiRouteData<{
+        name: string;
+        summary?: string;
+        icon?: string;
+        head_img?: string;
+    }>({
+        currentUrl,
+        apiUrl: new URL('web/collection/detail', apiArticleRootUrl).href,
+        form: {
+            platform: 'www',
+            collection_id: id,
+        },
+        mapData: (data) => ({
+            title: data.name,
+            description: data.summary,
+            image: data.head_img || (data.icon ? new URL(data.icon, rootUrl).href : undefined),
+            titlePrefix: buildHuxiuRouteTitlePrefix(route.name),
+        }),
+    });
 
     return {
         item: items,

--- a/lib/routes/huxiu/member.ts
+++ b/lib/routes/huxiu/member.ts
@@ -2,7 +2,7 @@ import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 
-import { apiMemberRootUrl, fetchData, processItems, rootUrl } from './util';
+import { apiMemberRootUrl, buildHuxiuRouteTitlePrefix, fetchMemberData, processItems } from './util';
 
 export const route: Route = {
     path: ['/author/:id/:type?', '/member/:id/:type?'],
@@ -30,8 +30,6 @@ async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 10;
 
     const apiUrl = new URL(`web/${type}/${type}List`, apiMemberRootUrl).href;
-    const currentUrl = new URL(`member/${id}${type === 'article' ? '' : `/${type}`}.html`, rootUrl).href;
-
     const { data: response } = await got.post(apiUrl, {
         form: {
             platform: 'www',
@@ -41,7 +39,7 @@ async function handler(ctx) {
 
     const items = await processItems(response.data.datalist, limit, cache.tryGet);
 
-    const data = await fetchData(currentUrl);
+    const data = await fetchMemberData(id, type, response.data.datalist ?? [], buildHuxiuRouteTitlePrefix(route.name));
 
     return {
         item: items,

--- a/lib/routes/huxiu/moment.ts
+++ b/lib/routes/huxiu/moment.ts
@@ -2,7 +2,7 @@ import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 
-import { apiMomentRootUrl, fetchData, processItems, rootUrl } from './util';
+import { apiMomentRootUrl, buildFeedMetadata, buildHuxiuRouteTitlePrefix, processItems, rootUrl } from './util';
 
 export const route: Route = {
     path: '/moment',
@@ -42,7 +42,13 @@ async function handler(ctx) {
 
     const items = await processItems(response.data.moment_list.datalist, limit, cache.tryGet);
 
-    const data = await fetchData(currentUrl);
+    const data = buildFeedMetadata({
+        title: '24 小时',
+        link: currentUrl,
+        description: '虎嗅 24 小时',
+        subtitle: '24 小时',
+        titlePrefix: buildHuxiuRouteTitlePrefix(route.name),
+    });
 
     return {
         item: items,

--- a/lib/routes/huxiu/search.ts
+++ b/lib/routes/huxiu/search.ts
@@ -2,7 +2,7 @@ import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 
-import { apiSearchRootUrl, fetchData, generateSignature, processItems, rootUrl } from './util';
+import { apiSearchRootUrl, buildFeedMetadata, buildHuxiuRouteTitlePrefix, generateSignature, processItems, rootUrl, siteTitle } from './util';
 
 export const route: Route = {
     path: '/search/:keyword',
@@ -31,6 +31,7 @@ export const route: Route = {
 async function handler(ctx) {
     const keyword = ctx.req.param('keyword');
     const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 20;
+    const baseTitle = siteTitle;
 
     const apiUrl = new URL('api/article', apiSearchRootUrl).href;
     const currentUrl = rootUrl;
@@ -49,8 +50,13 @@ async function handler(ctx) {
 
     const items = await processItems(response.data.datalist, limit, cache.tryGet);
 
-    const data = await fetchData(currentUrl);
-    data.title = `${keyword}-搜索结果-${data.title}`;
+    const data = buildFeedMetadata({
+        title: `搜索结果-${keyword}`,
+        link: currentUrl,
+        description: baseTitle,
+        subtitle: baseTitle,
+        titlePrefix: buildHuxiuRouteTitlePrefix(route.name),
+    });
 
     ctx.set('json', response.data.datalist);
 

--- a/lib/routes/huxiu/tag.ts
+++ b/lib/routes/huxiu/tag.ts
@@ -2,7 +2,7 @@ import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 
-import { apiArticleRootUrl, fetchData, processItems, rootUrl } from './util';
+import { apiArticleRootUrl, buildHuxiuRouteTitlePrefix, fetchApiRouteData, processItems, rootUrl } from './util';
 
 export const route: Route = {
     path: '/tag/:id',
@@ -29,7 +29,6 @@ async function handler(ctx) {
 
     const apiUrl = new URL('/v3/tag/articleList', apiArticleRootUrl).href;
     const currentUrl = new URL(`tag/${id}.html`, rootUrl).href;
-
     const { data: response } = await got.post(apiUrl, {
         form: {
             platform: 'www',
@@ -39,7 +38,28 @@ async function handler(ctx) {
 
     const items = await processItems(response.data.datalist, limit, cache.tryGet);
 
-    const data = await fetchData(currentUrl);
+    const data = await fetchApiRouteData<{
+        tag_name: string;
+        summary?: string;
+        pic_path?: string;
+        share_info?: {
+            share_img?: string;
+            share_desc?: string;
+        };
+    }>({
+        currentUrl,
+        apiUrl: new URL('v3/tag/detail', apiArticleRootUrl).href,
+        form: {
+            platform: 'www',
+            tag_id: id,
+        },
+        mapData: (data) => ({
+            title: data.tag_name,
+            description: data.summary ?? data.share_info?.share_desc,
+            image: data.pic_path ?? data.share_info?.share_img,
+            titlePrefix: buildHuxiuRouteTitlePrefix(route.name),
+        }),
+    });
 
     return {
         item: items,

--- a/lib/routes/huxiu/util.ts
+++ b/lib/routes/huxiu/util.ts
@@ -14,6 +14,7 @@ const apiClubRootUrl = `https://api-ms-web-club.${domain}`;
 const apiMemberRootUrl = `https://api-account.${domain}`;
 const apiMomentRootUrl = `https://moment-api.${domain}`;
 const apiSearchRootUrl = `https://search-api.${domain}`;
+const siteTitle = '虎嗅';
 
 /**
  * Cleans up HTML data by removing specific elements and attributes.
@@ -65,97 +66,100 @@ const cleanUpHTML = (data) => {
     return $.html();
 };
 
-/**
- * Fetches club data for the specified ID.
- *
- * @param {string} id - The ID of the club to fetch data from.
- * @returns {Promise<Object>} A promise that resolves to an object containing the fetched data
- *                            to be added into `ctx.state.data`.
- */
-const fetchClubData = async (id: string) => {
-    const currentUrl = new URL(`club/${id}.html`, rootUrl).href;
-
-    const { data: currentResponse } = await got(currentUrl);
-
-    const $ = load(currentResponse);
-
-    const title = $('title').text();
-    const icon = new URL($('link[rel="apple-touch-icon"]').prop('href') ?? '', rootUrl).href;
-    const author = $('meta[name="author"]').prop('content');
-
-    // Parse club data from __NUXT_DATA__
-    let clubData: Record<string, unknown> | undefined;
-
-    const nuxtDataScript = $('#__NUXT_DATA__').text();
-    if (nuxtDataScript) {
-        try {
-            const nuxtData = JSON.parse(nuxtDataScript) as unknown[];
-
-            // Find the fetchData object which contains club info
-            for (const item of nuxtData) {
-                if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
-                    const keys = Object.keys(item);
-                    if (keys.includes('fetchData')) {
-                        const fetchDataIndex = (item as Record<string, number>).fetchData;
-                        if (typeof fetchDataIndex === 'number') {
-                            clubData = resolveNuxtData(nuxtData, fetchDataIndex) as Record<string, unknown>;
-                            break;
-                        }
-                    }
-                }
-            }
-        } catch {
-            // Failed to parse Nuxt data
-        }
+const normalizeText = (value?: string) => {
+    if (!value) {
+        return;
     }
 
-    return {
-        title,
-        link: currentUrl,
-        description: String(clubData?.format_desc ?? $('meta[name="description"]').prop('content') ?? ''),
-        language: $('html').prop('lang'),
-        image: clubData?.icon_path ? String(clubData.icon_path).split(/\?/)[0] : undefined,
-        icon,
-        logo: icon,
-        subtitle: String(clubData?.name ?? title.split(/-/)[0]),
-        author,
-        itunes_author: author,
-        itunes_category: 'News',
-        allowEmpty: true,
-    };
+    return load(value).text().trim() || undefined;
 };
 
-/**
- * Fetch data from the specified URL.
- *
- * @param {string} url - The URL to fetch data from.
- * @returns {Promise<Object>} A promise that resolves to an object containing the fetched data
- *                            to be added into `ctx.state.data`.
- */
-const fetchData = async (url) => {
-    const { data: response } = await got(url);
+const buildRouteData = ({ title, link, description, image, icon, subtitle, author }: { title: string; link: string; description?: string; image?: string; icon?: string; subtitle?: string; author?: string }) => ({
+    title,
+    link,
+    description,
+    language: 'zh-CN' as const,
+    image,
+    icon,
+    logo: icon,
+    subtitle: subtitle ?? title,
+    author,
+    itunes_author: author,
+    itunes_category: 'News',
+    allowEmpty: true,
+});
 
-    const $ = load(response);
-    const iconHref = $('link[rel="apple-touch-icon"]').prop('href');
-    const title = $('title').text();
-    const description = $('div.tag-content').text() || $('span.author-intro').text() || $('p.collection__intro').text() || $('meta[name="description"]').prop('content');
-    const author = $('meta[name="author"]').prop('content');
+const prefixValue = (value?: string, prefix?: string) => {
+    if (!value || !prefix) {
+        return value;
+    }
 
-    const icon = iconHref ? new URL(iconHref, rootUrl).href : undefined;
+    return value.startsWith(prefix) ? value : `${prefix}${value}`;
+};
 
-    return {
-        title,
-        link: url,
-        description,
-        language: $('html').prop('lang'),
-        icon,
-        logo: icon,
-        subtitle: title.split(/-/)[0],
+const buildHuxiuRouteTitlePrefix = (routeName: string) => `${siteTitle}${routeName}-`;
+
+const buildFeedMetadata = ({
+    title,
+    link,
+    description,
+    image,
+    subtitle,
+    author,
+    titlePrefix,
+    descriptionPrefix,
+}: {
+    title: string;
+    link: string;
+    description?: string;
+    image?: string;
+    subtitle?: string;
+    author?: string;
+    titlePrefix?: string;
+    descriptionPrefix?: string;
+}) => {
+    const baseTitle = title;
+    const baseDescription = normalizeText(description) ?? description ?? subtitle ?? title;
+    const resolvedTitle = prefixValue(baseTitle, titlePrefix) ?? baseTitle;
+    const resolvedDescription = prefixValue(baseDescription, descriptionPrefix) ?? baseDescription;
+    const resolvedSubtitle = subtitle ?? baseTitle;
+
+    return buildRouteData({
+        title: resolvedTitle,
+        link,
+        description: resolvedDescription,
+        image,
+        icon: image,
+        subtitle: resolvedSubtitle,
         author,
-        itunes_author: author,
-        itunes_category: 'News',
-        allowEmpty: true,
+    });
+};
+
+const fetchApiRouteData = async <T>({
+    currentUrl,
+    apiUrl,
+    form,
+    mapData,
+}: {
+    currentUrl: string;
+    apiUrl: string;
+    form: Record<string, string | number>;
+    mapData: (data: T) => {
+        title: string;
+        description?: string;
+        image?: string;
+        subtitle?: string;
+        author?: string;
+        titlePrefix?: string;
+        descriptionPrefix?: string;
     };
+}) => {
+    const { data: response } = await got.post(apiUrl, { form });
+
+    return buildFeedMetadata({
+        link: currentUrl,
+        ...mapData(response.data as T),
+    });
 };
 
 /**
@@ -171,6 +175,11 @@ const extractArticleId = (link: string) => {
     return pathname.match(/^\/article\/(\d+)\.html$/)?.[1];
 };
 
+const extractBriefId = (link: string) => {
+    const pathname = new URL(link).pathname;
+    return pathname.match(/^\/brief\/(\d+)\.html$/)?.[1];
+};
+
 const fetchArticleDetail = async (aid: string) => {
     const apiUrl = new URL('web/article/detail', apiArticleRootUrl).href;
     const { data: response } = await got.post(apiUrl, {
@@ -183,6 +192,58 @@ const fetchArticleDetail = async (aid: string) => {
     return response.data;
 };
 
+const fetchBriefDetail = async (briefId: string) => {
+    const apiUrl = new URL('v1/brief/detail', apiClubRootUrl).href;
+    const { data: response } = await got.post(apiUrl, {
+        form: {
+            platform: 'www',
+            brief_id: briefId,
+        },
+    });
+
+    return response.data;
+};
+
+const buildBriefCategories = (data) => [data.brief_column?.name, data.club_info?.name, ...(data.brief?.tags_info?.map((c) => c.name) ?? [])].filter(Boolean);
+
+const buildBriefAuthor = (data) =>
+    data.brief?.publisher_list
+        ?.map((publisher) => publisher.username)
+        .filter(Boolean)
+        .join(', ') || data.brief_column?.name;
+
+const fetchMemberData = async (id: string, type: string, items, titlePrefix?: string) => {
+    const currentUrl = new URL(`member/${id}${type === 'article' ? '' : `/${type}`}.html`, rootUrl).href;
+    const firstArticleId = items.find((item) => item.aid)?.aid;
+
+    if (firstArticleId) {
+        try {
+            const detail = await fetchArticleDetail(firstArticleId);
+            const username = detail.user_info?.username ?? detail.author;
+            const description = detail.user_info?.yijuhua ?? `${username ?? `用户 ${id}`}的${type === 'moment' ? '24 小时' : '文章'}`;
+            const image = detail.user_info?.avatar?.split(/\?/)[0];
+
+            return buildFeedMetadata({
+                title: username ?? `用户 ${id}`,
+                link: currentUrl,
+                description,
+                image,
+                author: username,
+                titlePrefix,
+            });
+        } catch {
+            // Fall back to generic member metadata when article detail is unavailable.
+        }
+    }
+
+    return buildFeedMetadata({
+        title: `用户 ${id}`,
+        link: currentUrl,
+        description: `用户 ${id} 的${type === 'moment' ? '24 小时' : '文章'}`,
+        titlePrefix,
+    });
+};
+
 /**
  * Fetches item data.
  *
@@ -191,14 +252,15 @@ const fetchArticleDetail = async (aid: string) => {
  */
 const fetchItem = async (item) => {
     const articleId = extractArticleId(item.link);
+    const briefId = extractBriefId(item.link);
 
-    if (!articleId) {
+    if (!articleId && !briefId) {
         return item;
     }
 
     let data;
     try {
-        data = await fetchArticleDetail(articleId);
+        data = articleId ? await fetchArticleDetail(articleId) : await fetchBriefDetail(briefId!);
     } catch {
         return item;
     }
@@ -207,7 +269,32 @@ const fetchItem = async (item) => {
         return item;
     }
 
-    const { processed: audio, processedItem: audioItem = {} } = processAudioInfo(data.audio_info);
+    if (briefId) {
+        const { brief, brief_column: briefColumn, club_info: clubInfo } = data;
+        const briefAudioInfo = processAudioInfo(brief.audio_info);
+        const audio = briefAudioInfo.processed;
+        const audioItem: Record<string, unknown> = briefAudioInfo.processedItem ?? {};
+        const body = [brief.preface, brief.content, brief.peroration].filter(Boolean).join('');
+
+        return {
+            ...audioItem,
+            ...item,
+            title: brief.title ?? item.title,
+            description: renderDescription({
+                audio,
+                description: body ? cleanUpHTML(body) : undefined,
+            }),
+            author: buildBriefAuthor(data) ?? item.author,
+            category: buildBriefCategories({ brief, brief_column: briefColumn, club_info: clubInfo }),
+            pubDate: parseDate(brief.publish_time, 'X'),
+            upvotes: Number.parseInt(brief.agree_num ?? item.upvotes ?? 0, 10),
+            comments: Number.parseInt(brief.total_comment_num ?? brief.comment_num ?? item.comments ?? 0, 10),
+        };
+    }
+
+    const articleAudioInfo = processAudioInfo(data.audio_info);
+    const audio = articleAudioInfo.processed;
+    const audioItem: Record<string, unknown> = articleAudioInfo.processedItem ?? {};
 
     if (Object.keys(audioItem).length !== 0) {
         audioItem.itunes_item_image = data.pic_path ?? data.share_info?.share_img ?? undefined;
@@ -272,60 +359,6 @@ const generateSignature = () => {
         timestamp,
         signature: CryptoJS.SHA1(r[0] + r[1] + r[2]).toString(),
     };
-};
-
-/**
- * Resolves Nuxt 3 data array references recursively.
- * Nuxt 3 uses a special array format where numbers are references to other array indices.
- *
- * @param {unknown[]} arr - The Nuxt data array.
- * @param {number} index - The index to resolve.
- * @param {Set<number>} visited - Set of visited indices to prevent infinite loops.
- * @returns {unknown} - The resolved value.
- */
-const resolveNuxtData = (arr: unknown[], index: number, visited = new Set<number>()): unknown => {
-    if (visited.has(index)) {
-        return arr[index];
-    }
-    visited.add(index);
-
-    const item = arr[index];
-
-    // Handle ShallowReactive wrapper: ["ShallowReactive", refIndex]
-    if (Array.isArray(item) && item[0] === 'ShallowReactive' && typeof item[1] === 'number') {
-        return resolveNuxtData(arr, item[1], visited);
-    }
-
-    // Handle Reactive wrapper: ["Reactive", refIndex]
-    if (Array.isArray(item) && item[0] === 'Reactive' && typeof item[1] === 'number') {
-        return resolveNuxtData(arr, item[1], visited);
-    }
-
-    // Handle Set wrapper: ["Set"]
-    if (Array.isArray(item) && item[0] === 'Set') {
-        return new Set();
-    }
-
-    // Handle object - resolve all numeric references in values
-    if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
-        const resolved: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(item)) {
-            resolved[key] = typeof value === 'number' ? resolveNuxtData(arr, value, new Set(visited)) : value;
-        }
-        return resolved;
-    }
-
-    // Handle arrays that are not special wrappers
-    if (Array.isArray(item)) {
-        return item.map((value, i) => {
-            if (typeof value === 'number' && value !== i) {
-                return resolveNuxtData(arr, value, new Set(visited));
-            }
-            return value;
-        });
-    }
-
-    return item;
 };
 
 const audioQualities = ['', 'low'];
@@ -441,7 +474,9 @@ const mapItem = (item) => {
         return '';
     }
 
-    const { processed: audio, processedItem: audioItem = {} } = processAudioInfo(item.audio_info);
+    const mappedAudioInfo = processAudioInfo(item.audio_info);
+    const audio = mappedAudioInfo.processed;
+    const audioItem: Record<string, unknown> = mappedAudioInfo.processedItem ?? {};
 
     if (Object.keys(audioItem).length !== 0) {
         audioItem.itunes_item_image = item.pic_path ?? item.share_info?.share_img ?? undefined;
@@ -542,4 +577,18 @@ const processVideoInfo = (info) => {
     };
 };
 
-export { apiArticleRootUrl, apiClubRootUrl, apiMemberRootUrl, apiMomentRootUrl, apiSearchRootUrl, fetchClubData, fetchData, generateSignature, processItems, rootUrl };
+export {
+    apiArticleRootUrl,
+    apiClubRootUrl,
+    apiMemberRootUrl,
+    apiMomentRootUrl,
+    apiSearchRootUrl,
+    buildFeedMetadata,
+    buildHuxiuRouteTitlePrefix,
+    fetchApiRouteData,
+    fetchMemberData,
+    generateSignature,
+    processItems,
+    rootUrl,
+    siteTitle,
+};

--- a/lib/routes/huxiu/util.ts
+++ b/lib/routes/huxiu/util.ts
@@ -136,18 +136,21 @@ const fetchData = async (url) => {
     const { data: response } = await got(url);
 
     const $ = load(response);
-
-    const icon = new URL($('link[rel="apple-touch-icon"]').prop('href'), rootUrl).href;
+    const iconHref = $('link[rel="apple-touch-icon"]').prop('href');
+    const title = $('title').text();
+    const description = $('div.tag-content').text() || $('span.author-intro').text() || $('p.collection__intro').text() || $('meta[name="description"]').prop('content');
     const author = $('meta[name="author"]').prop('content');
 
+    const icon = iconHref ? new URL(iconHref, rootUrl).href : undefined;
+
     return {
-        title: $('title').text(),
+        title,
         link: url,
-        description: $('div.tag-content').text() || $('span.author-intro').text() || $('p.collection__intro').text() || $('meta[name="description"]').prop('content'),
+        description,
         language: $('html').prop('lang'),
         icon,
         logo: icon,
-        subtitle: $('title').text().split(/-/)[0],
+        subtitle: title.split(/-/)[0],
         author,
         itunes_author: author,
         itunes_category: 'News',
@@ -188,29 +191,16 @@ const fetchArticleDetail = async (aid: string) => {
  */
 const fetchItem = async (item) => {
     const articleId = extractArticleId(item.link);
-    let data;
-    let state;
 
-    if (articleId) {
-        try {
-            data = await fetchArticleDetail(articleId);
-        } catch {
-            // Fall back to HTML parsing when the article detail API is unavailable.
-        }
+    if (!articleId) {
+        return item;
     }
 
-    if (!data) {
-        let detailResponse: string;
-        try {
-            const response = await got(item.link);
-            detailResponse = response.data;
-        } catch {
-            // Request failed (e.g., 503, connection terminated), return original item
-            return item;
-        }
-
-        state = parseInitialState(detailResponse);
-        data = state?.articleDetail?.articleDetail;
+    let data;
+    try {
+        data = await fetchArticleDetail(articleId);
+    } catch {
+        return item;
     }
 
     if (!data) {
@@ -336,86 +326,6 @@ const resolveNuxtData = (arr: unknown[], index: number, visited = new Set<number
     }
 
     return item;
-};
-
-/**
- * Parses the initial state from the provided data.
- * Supports both Nuxt 3 (__NUXT_DATA__) format for articles and
- * window.__INITIAL_STATE__ format for briefs.
- *
- * @param {string} data - The data to parse the initial state from.
- * @returns {Object|undefined} - The parsed initial state object, or undefined if not found.
- */
-const parseInitialState = (data: string) => {
-    const $ = load(data);
-
-    // Try Nuxt 3 format first (for articles)
-    const nuxtDataScript = $('#__NUXT_DATA__').text();
-    if (nuxtDataScript) {
-        try {
-            const nuxtData = JSON.parse(nuxtDataScript) as unknown[];
-
-            // Find the data object which contains articleDetail
-            // The structure is: [["ShallowReactive", 1], {data: 2, ...}, ["ShallowReactive", 3], {articleDetail-xxx: 4}, ...]
-            for (const item of nuxtData) {
-                if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
-                    const articleDetailKey = Object.keys(item).find((key) => key.startsWith('articleDetail-'));
-                    if (articleDetailKey) {
-                        const articleDetailIndex = (item as Record<string, number>)[articleDetailKey];
-                        if (typeof articleDetailIndex === 'number') {
-                            const articleData = resolveNuxtData(nuxtData, articleDetailIndex) as Record<string, unknown>;
-                            if (articleData?.articleDetail) {
-                                return { articleDetail: articleData };
-                            }
-                        }
-                    }
-                }
-            }
-        } catch {
-            // Failed to parse Nuxt data
-        }
-    }
-
-    // Try window.__INITIAL_STATE__ format (for briefs)
-    const initialStateMatch = data.match(/window\.__INITIAL_STATE__\s*=\s*(\{[\s\S]*?\});?\s*\(function\(\)/);
-    if (initialStateMatch?.[1]) {
-        try {
-            const initialState = JSON.parse(initialStateMatch[1]) as Record<string, unknown>;
-            const briefStoreModule = initialState.briefStoreModule as Record<string, unknown> | undefined;
-            const briefDetail = briefStoreModule?.brief_detail as Record<string, unknown> | undefined;
-            const brief = briefDetail?.brief as Record<string, unknown> | undefined;
-
-            if (brief) {
-                // Transform brief data to match the articleDetail structure expected by fetchItem
-                const publisherList = brief.publisher_list as Array<{ username?: string }> | undefined;
-                const briefColumn = briefDetail?.brief_column as Record<string, unknown> | undefined;
-                const clubInfo = briefDetail?.club_info as Record<string, unknown> | undefined;
-
-                return {
-                    articleDetail: {
-                        articleDetail: {
-                            title: brief.title,
-                            content: brief.content,
-                            preface: brief.preface,
-                            dateline: brief.publish_time,
-                            publish_time: brief.publish_time,
-                            audio_info: brief.audio_info,
-                            agreenum: brief.agree_num,
-                            total_comment_num: brief.total_comment_num,
-                            user_info: publisherList?.[0] ? { username: publisherList[0].username } : undefined,
-                            brief_column: briefColumn ? { name: briefColumn.name } : undefined,
-                            club_info: clubInfo ? { name: clubInfo.name } : undefined,
-                            share_info: brief.share_info,
-                        },
-                    },
-                };
-            }
-        } catch {
-            // Failed to parse initial state
-        }
-    }
-
-    return;
 };
 
 const audioQualities = ['', 'low'];

--- a/lib/routes/huxiu/util.ts
+++ b/lib/routes/huxiu/util.ts
@@ -163,6 +163,23 @@ const fetchData = async (url) => {
  */
 const buildCategories = (data) => [data.video_article_tag, data.brief_column?.name, data.club_info?.name, ...(data.tags_info?.map((c) => c.name) ?? []), ...(data.relation_info?.channel?.map((c) => c.name) ?? [])].filter(Boolean);
 
+const extractArticleId = (link: string) => {
+    const pathname = new URL(link).pathname;
+    return pathname.match(/^\/article\/(\d+)\.html$/)?.[1];
+};
+
+const fetchArticleDetail = async (aid: string) => {
+    const apiUrl = new URL('web/article/detail', apiArticleRootUrl).href;
+    const { data: response } = await got.post(apiUrl, {
+        form: {
+            platform: 'www',
+            aid,
+        },
+    });
+
+    return response.data;
+};
+
 /**
  * Fetches item data.
  *
@@ -170,17 +187,31 @@ const buildCategories = (data) => [data.video_article_tag, data.brief_column?.na
  * @returns {Promise<Object>} The fetched item data object.
  */
 const fetchItem = async (item) => {
-    let detailResponse: string;
-    try {
-        const response = await got(item.link);
-        detailResponse = response.data;
-    } catch {
-        // Request failed (e.g., 503, connection terminated), return original item
-        return item;
+    const articleId = extractArticleId(item.link);
+    let data;
+    let state;
+
+    if (articleId) {
+        try {
+            data = await fetchArticleDetail(articleId);
+        } catch {
+            // Fall back to HTML parsing when the article detail API is unavailable.
+        }
     }
 
-    const state = parseInitialState(detailResponse);
-    const data = state?.articleDetail?.articleDetail;
+    if (!data) {
+        let detailResponse: string;
+        try {
+            const response = await got(item.link);
+            detailResponse = response.data;
+        } catch {
+            // Request failed (e.g., 503, connection terminated), return original item
+            return item;
+        }
+
+        state = parseInitialState(detailResponse);
+        data = state?.articleDetail?.articleDetail;
+    }
 
     if (!data) {
         return item;


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #21706

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/huxiu/article
/huxiu/club/1161
/huxiu/collection/212
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/huxiu/article
/huxiu/club/1161
/huxiu/collection/212
/huxiu/member/2313050
/huxiu/moment
/huxiu/search/生活
/huxiu/tag/291
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
This PR fixes the broken full-text fetching for Huxiu article content and refactors metadata handling across Huxiu routes.
It replaces fragile page-based metadata fetching with route-specific API-backed metadata retrieval where needed, and consolidates the title-building logic so Huxiu routes follow a consistent channel title convention. As part of the cleanup, obsolete compatibility code and unused legacy helpers were removed to keep the route logic smaller and easier to maintain.
