### PR TITLE
fix(route): update zxcs domain to zxcs.click

### DIFF
--- a/lib/routes/zxcs/namespace.ts
+++ b/lib/routes/zxcs/namespace.ts
@@ -2,6 +2,6 @@ import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
     name: '知轩藏书',
-    url: 'zxcs.info',
+    url: 'zxcs.click',
     lang: 'zh-CN',
 };

--- a/lib/routes/zxcs/novel.ts
+++ b/lib/routes/zxcs/novel.ts
@@ -24,7 +24,7 @@ const types = {
 export const route: Route = {
     path: '/novel/:type',
     name: '小说列表',
-    url: 'zxcs.info',
+    url: 'zxcs.click',
     maintainers: ['liaochuan'],
     example: '/zxcs/novel/jinqigengxin',
     parameters: { type: '小说类型, 可在对应类型页 URL 中找到' },
@@ -42,7 +42,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['zxcs.info/:type'],
+            source: ['zxcs.click/:type'],
             target: '/novel/:type',
         },
     ],
@@ -52,7 +52,7 @@ export const route: Route = {
 async function handler(ctx) {
     const { type } = ctx.req.param();
 
-    const baseUrl = 'https://www.zxcs.info';
+    const baseUrl = 'https://www.zxcs.click';
     const link = `${baseUrl}/${type}`;
     const response = await ofetch(link);
     const $ = load(response);


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zxcs/novel/jinqigengxin
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows Script Standard / 跟随路由规范
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] Date and time / 日期和时间
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Update the 知轩藏书 route from `zxcs.info` to `zxcs.click`.
Verified locally with `/zxcs/novel/jinqigengxin`.