### PR TITLE
fix(xiaomiyoupin): 修复众筹路由 API 失效问题

### DIFF
--- a/lib/routes/xiaomiyoupin/crowdfunding.ts
+++ b/lib/routes/xiaomiyoupin/crowdfunding.ts
@@ -1,9 +1,10 @@
 import type { Route } from '@/types';
 import got from '@/utils/got';
 
-import { renderGoods } from './templates/goods';
+import { renderCrowdfunding } from './templates/crowdfunding';
 
 const base_url = 'https://m.xiaomiyoupin.com';
+
 export const route: Route = {
     path: '/crowdfunding',
     categories: ['shopping'],
@@ -29,39 +30,30 @@ export const route: Route = {
 };
 
 async function handler() {
-    const resp = await got('https://home.mi.com/lasagne/page/5');
-    const site_url = resp.data.redirect.location;
+    // 使用 homepage/main/v1005 API，不需要 sign，长期稳定
+    const resp = await got('https://m.xiaomiyoupin.com/homepage/main/v1005');
 
-    const urlParams = new URLSearchParams(site_url);
-    const pageid = urlParams.get('pageid');
-    const sign = urlParams.get('sign');
+    const floors = resp.data.data.homepage.floors;
+    const crowdFloor = floors.find((floor) => floor.module_key === 'crowd_funding');
 
-    // 1. fetchPageData
-    const pageData = await got(`${base_url}/mtop/navi/venue/page?page_id=${pageid}&pdl=jianyu&sign=${sign}`);
-    const crowd_funding_floor = pageData.data.data.floors.find((floor) => floor.module_key === 'crowding');
-    const query_list = crowd_funding_floor.query_list;
+    if (!crowdFloor || !crowdFloor.data.items) {
+        throw new Error('未找到众筹数据');
+    }
 
-    // 2. fetchFloorDetailData
-    const floor_detail_data = await got.post(`${base_url}/mtop/navi/venue/batch?page_id=${pageid}&pdl=jianyu&sign=${sign}`, {
-        json: {
-            query_list,
-        },
-    });
-
-    const goodsList = floor_detail_data.data.data.result_list[0].list;
-    const items = goodsList.map((e) => {
-        const goods = e.value.goods;
+    const goodsList = crowdFloor.data.items.map((e) => e.item);
+    const items = goodsList.map((goods) => {
         return {
             title: goods.name,
             guid: `xiaomiyoupin:${goods.gid}`,
-            description: renderGoods(goods),
+            description: renderCrowdfunding(goods),
             link: goods.jump_url,
-            pubDate: new Date(goods.fist_release_time * 1000).toUTCString(),
+            pubDate: goods.start ? new Date(goods.start * 1000).toUTCString() : undefined,
         };
     });
+
     return {
         title: '小米有品众筹',
-        link: site_url,
+        link: `${base_url}/w/crowdfundV3`,
         description: '小米有品众筹',
         item: items,
     };

--- a/lib/routes/xiaomiyoupin/templates/crowdfunding.tsx
+++ b/lib/routes/xiaomiyoupin/templates/crowdfunding.tsx
@@ -1,0 +1,102 @@
+import { raw } from 'hono/html';
+import { renderToString } from 'hono/jsx/dom/server';
+
+type CrowdfundingGoods = {
+    gid?: number;
+    name?: string;
+    summary?: string;
+    short_summary?: string;
+    market_price?: number;
+    price_min?: number;
+    pic_url?: string;
+    img_square?: string;
+    imgs?: { img800?: string };
+    jump_url?: string;
+    start?: number;
+    end?: number;
+    target_count?: number;
+    saled_count?: number;
+    progress?: number;
+    is_stock?: boolean;
+};
+
+const formatPrice = (cent: number | undefined) => (cent ? (cent / 100).toFixed(2) : '-');
+const formatDate = (ts: number | undefined) => (ts ? new Date(ts * 1000).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' }) : '-');
+
+const CrowdfundingCard = (goods: CrowdfundingGoods) => {
+    const imageUrl = goods.pic_url || goods.imgs?.img800 || goods.img_square;
+    const salePrice = formatPrice(goods.price_min);
+    const marketPrice = formatPrice(goods.market_price);
+    const discount = goods.market_price && goods.price_min ? Math.round((1 - goods.price_min / goods.market_price) * 100) : 0;
+
+    return (
+        <div>
+            <figure>
+                <img src={imageUrl} alt={goods.name} loading="lazy" style="display:block; width:100%; border-radius:8px;" />
+            </figure>
+            <div style="padding: 8px 0;">
+                <h3 style="margin:4px 0;">{raw(goods.name ?? '')}</h3>
+                <p style="color:#666; margin:4px 0;">{raw(goods.summary ?? goods.short_summary ?? '')}</p>
+                <table style="width:100%; border-collapse:collapse; font-size:14px; margin-top:8px;">
+                    <tr>
+                        <td style="padding:4px 8px; border:1px solid #eee; width:100px;">
+                            <strong>众筹价</strong>
+                        </td>
+                        <td style="padding:4px 8px; border:1px solid #eee; color:#ff6700; font-weight:bold; font-size:16px;">¥{salePrice}</td>
+                    </tr>
+                    {goods.market_price && goods.market_price !== goods.price_min ? (
+                        <tr>
+                            <td style="padding:4px 8px; border:1px solid #eee;">
+                                <strong>市场价</strong>
+                            </td>
+                            <td style="padding:4px 8px; border:1px solid #eee;">
+                                <span style="text-decoration:line-through; color:#999;">¥{marketPrice}</span>
+                                {discount > 0 ? <span style="color:#ff6700; margin-left:8px; font-size:12px;">省{discount}%</span> : null}
+                            </td>
+                        </tr>
+                    ) : null}
+                    <tr>
+                        <td style="padding:4px 8px; border:1px solid #eee;">
+                            <strong>众筹进度</strong>
+                        </td>
+                        <td style="padding:4px 8px; border:1px solid #eee;">
+                            <div style="background:#f0f0f0; border-radius:4px; overflow:hidden; height:22px; position:relative;">
+                                <div
+                                    style={`width:${Math.min(goods.progress ?? 0, 100)}%; background:linear-gradient(90deg,#ff6700,#ff9800); height:100%; line-height:22px; text-align:center; color:white; font-size:12px; font-weight:bold;`}
+                                >
+                                    {goods.progress}%
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    {goods.saled_count ? (
+                        <tr>
+                            <td style="padding:4px 8px; border:1px solid #eee;">
+                                <strong>支持人数</strong>
+                            </td>
+                            <td style="padding:4px 8px; border:1px solid #eee;">{goods.saled_count} 人</td>
+                        </tr>
+                    ) : null}
+                    {goods.target_count ? (
+                        <tr>
+                            <td style="padding:4px 8px; border:1px solid #eee;">
+                                <strong>目标人数</strong>
+                            </td>
+                            <td style="padding:4px 8px; border:1px solid #eee;">{goods.target_count} 人</td>
+                        </tr>
+                    ) : null}
+                    <tr>
+                        <td style="padding:4px 8px; border:1px solid #eee;">
+                            <strong>起止时间</strong>
+                        </td>
+                        <td style="padding:4px 8px; border:1px solid #eee; font-size:12px;">
+                            {formatDate(goods.start)} ~ {formatDate(goods.end)}
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    );
+};
+
+export const renderCrowdfunding = (goods: CrowdfundingGoods): string => renderToString(<CrowdfundingCard {...goods} />);


### PR DESCRIPTION
## 问题描述
原 `/xiaomiyoupin/crowdfunding` 路由无法获取数据，因为：
1. 依赖 `https://home.mi.com/lasagne/page/5` 获取重定向 URL（pageid 和 sign）✅ 还能工作
2. 用 pageid/sign 调用 `/mtop/navi/venue/page` 获取 floors ❌ **floors 返回空数组 `[]`**
3. 从 floors 中找 `module_key === 'crowding'` 的 query_list ❌ **找不到，整个流程挂掉**

## 解决方案
改用 `https://m.xiaomiyoupin.com/homepage/main/v1005` API：
- ✅ 不需要 sign，长期稳定
- ✅ 直接返回众筹商品数据
- ✅ 结构清晰，易于维护

## 变更内容
- 修改 `crowdfunding.ts`：简化请求逻辑，直接使用 homepage/main/v1005 API
- 新增 `templates/crowdfunding.tsx`：展示更丰富的众筹信息（进度条、支持人数、起止时间等）

## 自测结果
```
✅ 获取到 3 个众筹商品

1. 米家吸油烟机3C
   价格: ¥999.00 | 进度: 63% | 支持: 19人 | 目标: 30人

2. 领普智能屏显开关
   价格: ¥49.00 | 进度: 407% | 支持: 28104人 | 目标: 5000人

3. 3D包裹透气缓震鞋
   价格: ¥199.00 | 进度: 71% | 支持: 1917人 | 目标: 2700人
```

## 注意事项
- 新 API 只返回 3 个众筹商品（官方推荐位），但质量较高
- 部分字段在新 API 中不可用：已筹金额、众筹期次、评论数