### PR TITLE
fix(abc,afr): fix broken routes for abc.net.au and afr.com

### DIFF
--- a/lib/routes/abc/index.ts
+++ b/lib/routes/abc/index.ts
@@ -43,7 +43,7 @@ async function handler(ctx) {
     let currentUrl: string;
     let documentId;
 
-    if (Number.isNaN(category)) {
+    if (Number.isNaN(Number(category))) {
         currentUrl = new URL(category, rootUrl).href;
     } else {
         documentId = category;

--- a/lib/routes/afr/latest.ts
+++ b/lib/routes/afr/latest.ts
@@ -40,7 +40,7 @@ async function handler(ctx: Context) {
             variables: {
                 brand: 'afr',
                 first: limit,
-                render: 'web',
+                render: 'WEB',
                 types: ['article', 'bespoke', 'featureArticle', 'liveArticle', 'video'],
                 after: '',
             },

--- a/lib/routes/afr/utils.ts
+++ b/lib/routes/afr/utils.ts
@@ -6,7 +6,13 @@ export const getItem = async (item) => {
     const response = await ofetch(item.link);
     const $ = cheerio.load(response);
 
-    const reduxState = JSON.parse($('script#__REDUX_STATE__').text().replaceAll(':undefined', ':null').match('__REDUX_STATE__=(.*);')?.[1] || '{}');
+    const reduxState = JSON.parse(
+        $('script#__REDUX_STATE__').text()
+            .replaceAll(':undefined', ':null')
+            .replace(/new\s+Set\s*\(\[([^\[\]]*)\]\)/g, 'null')
+            .replace(/new\s+Map\s*\(\[(?:[^\[\]]|\[(?:[^\[\]])*\])*\]\)/g, 'null')
+            .match('__REDUX_STATE__=(.*);')?.[1] || '{}'
+    );
 
     const content = reduxState.page.content;
     const asset = content.asset;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Fixes broken routes for `www.abc.net.au` and `www.afr.com`.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/abc/wa
/abc/news/justin
/afr/latest
/afr/navigation/markets
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

### `abc` — `lib/routes/abc/index.ts`

`Number.isNaN(category)` always returns `false` for any string value, so string-based route slugs like `wa`, `news/justin`, `news/topic/computer-science` were incorrectly entering the numeric `documentId` branch and requesting non-existent URLs like `news/feed/wa/rss.xml` (404).

**Fix:** `Number.isNaN(category)` → `Number.isNaN(Number(category))`

### `afr/latest` — `lib/routes/afr/latest.ts`

The `assetsConnectionByCriteria` GraphQL endpoint now requires the `render` variable to be the enum value `"WEB"` (uppercase). The previous value `"web"` caused a 400 Bad Request.

**Fix:** `render: 'web'` → `render: 'WEB'`

### `afr/utils` — `lib/routes/afr/utils.ts`

The AFR article page's `__REDUX_STATE__` now contains JavaScript-only literals (`new Map(...)`, `new Set(...)`) which are not valid JSON. `JSON.parse()` was throwing `SyntaxError: Unexpected token`.

**Fix:** Added two regex replacement passes before `JSON.parse()` to replace `new Set([...])` and `new Map([...])` with `null`.
