### PR TITLE
fix(yomiuri): fix broken routes for www.yomiuri.co.jp

### DIFF
--- a/lib/routes/yomiuri/news.ts
+++ b/lib/routes/yomiuri/news.ts
@@ -58,6 +58,7 @@ async function handler(ctx) {
     const $ = load(data);
 
     let list;
+    const rootUrl = 'https://www.yomiuri.co.jp';
     if (category === 'news') {
         list = $('.news-top-latest__list .news-top-latest__list-item__inner')
             .toArray()
@@ -66,24 +67,22 @@ async function handler(ctx) {
                 const a = item.find('h3 a');
                 return {
                     title: a.text(),
-                    link: a.attr('href'),
+                    link: new URL(a.attr('href'), rootUrl).href,
                     pubDate: timezone(parseDate(item.find('time').attr('datetime')), +9),
                     locked: item.find('.icon-locked').length,
                 };
             });
     } else {
-        $('.p-category-reading-recommend').remove();
-        list = $('.layout-contents__main .c-list-title')
+        list = $('.p-category-organization .list .item')
             .toArray()
             .map((item) => {
                 item = $(item);
-                const a = item.find('h3 a');
-                const parent = item.parent();
+                const a = item.find('h3.title a');
                 return {
                     title: a.text(),
-                    link: a.attr('href'),
-                    pubDate: timezone(parseDate(parent.find('time').attr('datetime')), +9),
-                    locked: parent.find('.c-list-member-only').length,
+                    link: new URL(a.attr('href'), rootUrl).href,
+                    pubDate: timezone(parseDate(item.find('.info time').attr('datetime')), +9),
+                    locked: item.find('.c-list-member-only').length,
                 };
             });
     }
@@ -108,7 +107,7 @@ async function handler(ctx) {
                 item.pubDate = parseDate($('meta[property="article:published_time"]').attr('content')); // 2023-05-17T22:33:00+09:00
                 item.updated = parseDate($('meta[property="article:modified_time"]').attr('content'));
 
-                const tag = $('.p-header-category-breadcrumbs li a').last().text();
+                const tag = $('.p-header-category__breadcrumbs li a').last().text();
                 item.category = tag;
                 item.title = `[${tag}] ${item.title}`;
                 return item;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Fixes broken routes for `www.yomiuri.co.jp`.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/yomiuri/news
/yomiuri/national
/yomiuri/politics
/yomiuri/economy
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Three issues fixed in `lib/routes/yomiuri/news.ts`:

### 1. Relative URLs (`/yomiuri/news` and all category routes)

`h3 a` elements return relative hrefs like `/national/20260421-xxx/`. The code passed these directly to `got(item.link)`, which does not resolve relative URLs and throws an exception.

**Fix:** Wrap with `new URL(a.attr('href'), rootUrl).href` to produce absolute URLs for both the item link and the `got()` call.

### 2. Category-page article selector (all routes except `/yomiuri/news`)

The previous selector `.layout-contents__main .c-list-title` no longer matches article entries — `.c-list-title` is now used for a notice sidebar, not articles. Article cards are now rendered inside `.p-category-organization .list .item` with the structure:

```html
<div class="item">
  <h3 class="title"><a href="/national/...">title</a></h3>
  <div class="info"><time datetime="2026-04-21T22:29">...</time></div>
</div>
```

**Fix:** Changed selector to `.p-category-organization .list .item` and updated child selectors accordingly (`h3.title a`, `.info time`).

### 3. Breadcrumb selector for article detail pages

The breadcrumb class was renamed from `p-header-category-breadcrumbs` to `p-header-category__breadcrumbs` (BEM double-underscore convention). This caused category tags to be empty strings, resulting in titles like `[] Article title`.

**Fix:** Updated selector from `.p-header-category-breadcrumbs li a` to `.p-header-category__breadcrumbs li a`.
