### PR TITLE
fix(nytimes): only initialize Puppeteer when lang === 'en'

### DIFF
--- a/lib/routes/nytimes/index.ts
+++ b/lib/routes/nytimes/index.ts
@@ -81,8 +81,11 @@ async function handler(ctx) {
         // Do nothing
     }
 
-    const browser = await puppeteer();
     const feed = await parser.parseURL(rssUrl);
+
+    // Puppeteer is only needed for lang === 'en' to fetch www.nytimes.com article pages
+    const browser = lang === 'en' ? await puppeteer() : null;
+
     const items = await Promise.all(
         feed.items.splice(0, 10).map(async (item) => {
             let link = item.link;
@@ -154,7 +157,9 @@ async function handler(ctx) {
         })
     );
 
-    await browser.close();
+    if (browser) {
+        await browser.close();
+    }
 
     return {
         title,


### PR DESCRIPTION
## Involved Issue

Fixes broken `/nytimes/dual`, `/nytimes/`, `/nytimes/traditionalchinese` routes.

## Example for the Proposed Route(s)

```routes
/nytimes/dual
/nytimes/traditionalchinese
```

## New RSS Route Checklist

- [ ] New Route
- [ ] Anti-bot or rate limit
- [x] Date and time
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added
- [ ] `Puppeteer`

## Note

### Root Cause

`puppeteer()` was called unconditionally at the top of `handler()` in `lib/routes/nytimes/index.ts`:

```ts
const browser = await puppeteer(); // called for ALL modes
```

However, the Puppeteer browser is only used inside the `lang === 'en'` branch, when the route needs to fetch English article pages from `www.nytimes.com`. For all other modes (`dual`, default Chinese, `traditionalchinese`), only `got()` is used to fetch from `cn.nytimes.com`.

This mismatch is also reflected in the route metadata which correctly sets `requirePuppeteer: false`.

Docker images and many self-hosted RSSHub deployments do not bundle Chromium, so calling `puppeteer()` unconditionally caused an immediate crash:

```
Error: Could not find Chrome (ver. 136.0.7103.49)
```

### Fix

Initialize `browser` only when `lang === 'en'`, and guard `browser.close()` with a null check:

```ts
const browser = lang === 'en' ? await puppeteer() : null;
// ...
if (browser) {
    await browser.close();
}
```

### Verification

Tested against a local Docker deployment (without Chromium):

| Route | Before | After |
|-------|--------|-------|
| `/nytimes/dual` | 503 (Chrome not found) | ✅ 200, 10 items |
| `/nytimes/traditionalchinese` | 503 (Chrome not found) | ✅ 200, 10 items |
