### PR TITLE
feat(route):add xtu routes

### DIFF
--- a/lib/routes/xtu/cyxy.ts
+++ b/lib/routes/xtu/cyxy.ts
@@ -1,0 +1,140 @@
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+import { Route } from '@/types';
+
+const rootUrl = 'https://cyxy.xtu.edu.cn/';
+const host = 'cyxy.xtu.edu.cn';
+
+const handler: Route['handler'] = async (ctx) => {
+    const type = ctx.req.param('type') ?? 'dxscxcyxljhxm';
+    const typeDict = {
+        dxscxcyxljhxm: ['大学生创新创业训练计划', 'scsj/dxscxcyxljhxm.htm'],
+        scjs: ['双创竞赛', 'scsj/scjs/zggjdxscxds1.htm'],
+    };
+
+    if (!typeDict[type]) {
+        throw new Error(`Invalid type: ${type}`);
+    }
+
+    const listUrl = `${rootUrl}${typeDict[type][1]}`;
+
+    const response = await ofetch(listUrl);
+    const $ = load(response);
+
+    const list = $('.common-list li')
+        .toArray()
+        .map((item) => {
+            const $item = $(item);
+            const $a = $item.find('a').first();
+
+            let title = $a.attr('title') || $item.find('h2.ellipsis').text() || $a.text() || '';
+            let link = $a.attr('href') || '';
+
+            // 处理相对路径
+            if (link && !link.startsWith('http')) {
+                if (link.startsWith('../')) {
+                    link = rootUrl + link.replace('../', '');
+                } else if (link.startsWith('./')) {
+                    link = rootUrl + link.replace('./', '');
+                } else if (link.startsWith('/')) {
+                    link = rootUrl.slice(0, -1) + link;
+                } else {
+                    link = rootUrl + link;
+                }
+            }
+
+            // 从 date 结构中提取日期 (格式: <h3>10</h3><p>2026.02</p>)
+            const $dateH3 = $item.find('.date h3');
+            const $dateP = $item.find('.date p');
+            let pubDate: Date | undefined;
+            if ($dateH3.length && $dateP.length) {
+                const day = $dateH3.text().trim();
+                const yearMonth = $dateP.text().trim().replace('.', '-');
+                const dateText = `${yearMonth}-${day}`;
+                pubDate = timezone(parseDate(dateText), +8);
+            }
+
+            return {
+                title: title.trim(),
+                link: link.trim(),
+                pubDate,
+            };
+        })
+        .filter((item) => item.title && item.link);
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const newItem = {
+                    ...item,
+                    description: '',
+                };
+
+                try {
+                    const linkHost = new URL(item.link).hostname;
+                    if (host === linkHost) {
+                        const response = await ofetch(item.link);
+                        const $ = load(response);
+
+                        // 尝试多种可能的内容选择器
+                        const contentSelectors = ['.v_news_content', '.content-detail', '.article-content', '.wp_articlecontent', '#main-content', '.content', '.news-content', '.infodetail'];
+
+                        for (const selector of contentSelectors) {
+                            const content = $(selector).html();
+                            if (content) {
+                                newItem.description = content;
+                                break;
+                            }
+                        }
+
+                        // 如果没找到内容，返回链接提示
+                        if (!newItem.description) {
+                            newItem.description = `<p>请访问原网页查看内容：<a href="${item.link}">${item.title}</a></p>`;
+                        }
+                    } else {
+                        // 外部链接
+                        newItem.description = `<p>外部链接：<a href="${item.link}">${item.title}</a></p>`;
+                    }
+                } catch {
+                    newItem.description = `<p>获取内容失败，请访问原网页：<a href="${item.link}">${item.title}</a></p>`;
+                }
+
+                return newItem;
+            })
+        )
+    );
+
+    return {
+        title: `湘潭大学创新创业学院 - ${typeDict[type][0]}`,
+        link: listUrl,
+        item: items,
+    };
+};
+
+export const route: Route = {
+    name: '创新创业学院',
+    path: '/cyxy/:type?',
+    example: '/xtu/cyxy/dxscxcyxljhxm',
+    url: 'cyxy.xtu.edu.cn',
+    handler,
+    categories: ['university'],
+    maintainers: ['zzy00747'],
+    parameters: {
+        type: '栏目类型，见下表，默认为大创项目',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    description: `| 栏目 | 参数 | 说明 |
+| ---- | ---- | ---- |
+| 大创项目 | dxscxcyxljhxm | 大学生创新创业训练计划项目 |
+| 双创竞赛 | scjs | 双创竞赛（互联网+、挑战杯等） |`,
+};

--- a/lib/routes/xtu/jwc.ts
+++ b/lib/routes/xtu/jwc.ts
@@ -1,0 +1,129 @@
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+import { Route } from '@/types';
+
+const rootUrl = 'https://jwc.xtu.edu.cn/';
+const host = 'jwc.xtu.edu.cn';
+
+const handler: Route['handler'] = async (ctx) => {
+    const type = ctx.req.param('type') ?? 'tzgg';
+    const listUrl = type === 'xkjs' ? `${rootUrl}xkjs/tzgg.htm` : `${rootUrl}tzgg.htm`;
+
+    const response = await ofetch(listUrl);
+    const $ = load(response);
+
+    const list = $('.col-md-9 li')
+        .toArray()
+        .filter((item) => {
+            const $item = $(item);
+            // 只保留包含 span 日期和 a 链接的列表项
+            return $item.find('span').length > 0 && $item.find('a').length > 0;
+        })
+        .map((item) => {
+            const $item = $(item);
+            const $a = $item.find('a');
+            const $span = $item.find('span');
+
+            let title = $a.attr('title') || $a.text() || '';
+            let link = $a.attr('href') || '';
+
+            // 处理相对路径
+            if (link && !link.startsWith('http')) {
+                if (link.startsWith('../')) {
+                    link = rootUrl + link.replace('../', '');
+                } else if (link.startsWith('./')) {
+                    link = rootUrl + link.replace('./', '');
+                } else if (link.startsWith('/')) {
+                    link = rootUrl.slice(0, -1) + link;
+                } else {
+                    link = rootUrl + link;
+                }
+            }
+
+            const dateText = $span.text().trim();
+            const pubDate = dateText ? timezone(parseDate(dateText), +8) : undefined;
+
+            return {
+                title: title.trim(),
+                link: link.trim(),
+                pubDate,
+            };
+        })
+        .filter((item) => item.title && item.link);
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const newItem = {
+                    ...item,
+                    description: '',
+                };
+
+                try {
+                    const linkHost = new URL(item.link).hostname;
+                    if (host === linkHost) {
+                        const response = await ofetch(item.link);
+                        const $ = load(response);
+
+                        // 尝试多种可能的内容选择器
+                        const contentSelectors = ['.v_news_content', '.content-detail', '.article-content', '.wp_articlecontent', '#main-content', '.content'];
+
+                        for (const selector of contentSelectors) {
+                            const content = $(selector).html();
+                            if (content) {
+                                newItem.description = content;
+                                break;
+                            }
+                        }
+
+                        // 如果没找到内容，返回链接提示
+                        if (!newItem.description) {
+                            newItem.description = `<p>请访问原网页查看内容：<a href="${item.link}">${item.title}</a></p>`;
+                        }
+                    } else {
+                        // 外部链接
+                        newItem.description = `<p>外部链接：<a href="${item.link}">${item.title}</a></p>`;
+                    }
+                } catch {
+                    newItem.description = `<p>获取内容失败，请访问原网页：<a href="${item.link}">${item.title}</a></p>`;
+                }
+
+                return newItem;
+            })
+        )
+    );
+
+    return {
+        title: type === 'xkjs' ? '湘潭大学教务处 - 学科竞赛通知公告' : '湘潭大学教务处 - 通知公告',
+        link: listUrl,
+        item: items,
+    };
+};
+
+export const route: Route = {
+    name: '教务处通知公告',
+    path: '/jwc/:type?',
+    example: '/xtu/jwc/tzgg',
+    url: 'jwc.xtu.edu.cn',
+    handler,
+    categories: ['university'],
+    maintainers: ['zzy00747'],
+    parameters: {
+        type: '通知类型，见下表，默认为首页通知公告',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    description: `| 类型 | 参数 | 说明 |
+| ---- | ---- | ---- |
+| 通知公告 | tzgg | 首页综合通知公告 |
+| 学科竞赛 | xkjs | 学科竞赛相关通知公告 |`,
+};

--- a/lib/routes/xtu/jwxy.ts
+++ b/lib/routes/xtu/jwxy.ts
@@ -1,0 +1,133 @@
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+import { Route } from '@/types';
+
+const rootUrl = 'https://jwxy.xtu.edu.cn/';
+const host = 'jwxy.xtu.edu.cn';
+
+const handler: Route['handler'] = async (ctx) => {
+    const type = ctx.req.param('type') ?? 'tzgg';
+    const typeDict = {
+        tzgg: ['通知公告', 'tzgg.htm'],
+        xwdt: ['新闻动态', 'xwdt.htm'],
+    };
+
+    if (!typeDict[type]) {
+        throw new Error(`Invalid type: ${type}`);
+    }
+
+    const listUrl = `${rootUrl}${typeDict[type][1]}`;
+
+    const response = await ofetch(listUrl);
+    const $ = load(response);
+
+    const list = $('.common-list li')
+        .toArray()
+        .map((item) => {
+            const $item = $(item);
+            const $a = $item.find('a').first();
+            const $span = $item.find('span').first();
+
+            let title = $a.attr('title') || $item.find('p.ellipsis').text() || $a.text() || '';
+            let link = $a.attr('href') || '';
+
+            // 处理相对路径
+            if (link && !link.startsWith('http')) {
+                if (link.startsWith('../')) {
+                    link = rootUrl + link.replace('../', '');
+                } else if (link.startsWith('./')) {
+                    link = rootUrl + link.replace('./', '');
+                } else if (link.startsWith('/')) {
+                    link = rootUrl.slice(0, -1) + link;
+                } else {
+                    link = rootUrl + link;
+                }
+            }
+
+            const dateText = $span.text().trim();
+            const pubDate = dateText ? timezone(parseDate(dateText), +8) : undefined;
+
+            return {
+                title: title.trim(),
+                link: link.trim(),
+                pubDate,
+            };
+        })
+        .filter((item) => item.title && item.link);
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const newItem = {
+                    ...item,
+                    description: '',
+                };
+
+                try {
+                    const linkHost = new URL(item.link).hostname;
+                    if (host === linkHost) {
+                        const response = await ofetch(item.link);
+                        const $ = load(response);
+
+                        // 尝试多种可能的内容选择器
+                        const contentSelectors = ['.v_news_content', '.content-detail', '.article-content', '.wp_articlecontent', '#main-content', '.content', '.news-content'];
+
+                        for (const selector of contentSelectors) {
+                            const content = $(selector).html();
+                            if (content) {
+                                newItem.description = content;
+                                break;
+                            }
+                        }
+
+                        // 如果没找到内容，返回链接提示
+                        if (!newItem.description) {
+                            newItem.description = `<p>请访问原网页查看内容：<a href="${item.link}">${item.title}</a></p>`;
+                        }
+                    } else {
+                        // 外部链接
+                        newItem.description = `<p>外部链接：<a href="${item.link}">${item.title}</a></p>`;
+                    }
+                } catch {
+                    newItem.description = `<p>获取内容失败，请访问原网页：<a href="${item.link}">${item.title}</a></p>`;
+                }
+
+                return newItem;
+            })
+        )
+    );
+
+    return {
+        title: `湘潭大学计算机学院 - ${typeDict[type][0]}`,
+        link: listUrl,
+        item: items,
+    };
+};
+
+export const route: Route = {
+    name: '计算机学院',
+    path: '/jwxy/:type?',
+    example: '/xtu/jwxy/tzgg',
+    url: 'jwxy.xtu.edu.cn',
+    handler,
+    categories: ['university'],
+    maintainers: ['zzy00747'],
+    parameters: {
+        type: '栏目类型，见下表，默认为通知公告',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    description: `| 栏目 | 参数 | 说明 |
+| ---- | ---- | ---- |
+| 通知公告 | tzgg | 学院通知公告 |
+| 新闻动态 | xwdt | 学院新闻动态 |`,
+};

--- a/lib/routes/xtu/namespace.ts
+++ b/lib/routes/xtu/namespace.ts
@@ -1,0 +1,21 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '湘潭大学',
+    url: 'xtu.edu.cn',
+    description: `
+:::tip
+湘潭大学 RSS 订阅源包含以下学院和部门：
+
+-   计算机学院：通知公告、新闻动态
+-   创新创业学院：大创项目、双创竞赛
+-   网络与信息中心：新闻动态、通知公告
+-   团委：通知公告、校内新闻
+-   学校官网：通知公告、湘大新闻
+-   教务处：竞赛通知、网站首页通告
+:::
+`,
+    zh: {
+        name: '湘潭大学',
+    },
+};

--- a/lib/routes/xtu/nic.ts
+++ b/lib/routes/xtu/nic.ts
@@ -1,0 +1,133 @@
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+import { Route } from '@/types';
+
+const rootUrl = 'https://nic.xtu.edu.cn/';
+const host = 'nic.xtu.edu.cn';
+
+const handler: Route['handler'] = async (ctx) => {
+    const type = ctx.req.param('type') ?? 'dt';
+    const typeDict = {
+        dt: ['新闻动态', 'index/dt.htm'],
+        tzgg: ['通知公告', 'wldt/tzgg.htm'],
+    };
+
+    if (!typeDict[type]) {
+        throw new Error(`Invalid type: ${type}`);
+    }
+
+    const listUrl = `${rootUrl}${typeDict[type][1]}`;
+
+    const response = await ofetch(listUrl);
+    const $ = load(response);
+
+    const list = $('.detail-main-list-ul li')
+        .toArray()
+        .map((item) => {
+            const $item = $(item);
+            const $a = $item.find('a').first();
+            const $span = $item.find('span').last();
+
+            let title = $a.attr('title') || $a.text() || '';
+            let link = $a.attr('href') || '';
+
+            // 处理相对路径
+            if (link && !link.startsWith('http')) {
+                if (link.startsWith('../')) {
+                    link = rootUrl + link.replace('../', '');
+                } else if (link.startsWith('./')) {
+                    link = rootUrl + link.replace('./', '');
+                } else if (link.startsWith('/')) {
+                    link = rootUrl.slice(0, -1) + link;
+                } else {
+                    link = rootUrl + link;
+                }
+            }
+
+            const dateText = $span.text().trim();
+            const pubDate = dateText ? timezone(parseDate(dateText), +8) : undefined;
+
+            return {
+                title: title.trim(),
+                link: link.trim(),
+                pubDate,
+            };
+        })
+        .filter((item) => item.title && item.link);
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const newItem = {
+                    ...item,
+                    description: '',
+                };
+
+                try {
+                    const linkHost = new URL(item.link).hostname;
+                    if (host === linkHost) {
+                        const response = await ofetch(item.link);
+                        const $ = load(response);
+
+                        // 尝试多种可能的内容选择器
+                        const contentSelectors = ['.v_news_content', '.content-detail', '.article-content', '.wp_articlecontent', '#main-content', '.content', '.news-content'];
+
+                        for (const selector of contentSelectors) {
+                            const content = $(selector).html();
+                            if (content) {
+                                newItem.description = content;
+                                break;
+                            }
+                        }
+
+                        // 如果没找到内容，返回链接提示
+                        if (!newItem.description) {
+                            newItem.description = `<p>请访问原网页查看内容：<a href="${item.link}">${item.title}</a></p>`;
+                        }
+                    } else {
+                        // 外部链接
+                        newItem.description = `<p>外部链接：<a href="${item.link}">${item.title}</a></p>`;
+                    }
+                } catch {
+                    newItem.description = `<p>获取内容失败，请访问原网页：<a href="${item.link}">${item.title}</a></p>`;
+                }
+
+                return newItem;
+            })
+        )
+    );
+
+    return {
+        title: `湘潭大学网络与信息中心 - ${typeDict[type][0]}`,
+        link: listUrl,
+        item: items,
+    };
+};
+
+export const route: Route = {
+    name: '网络与信息中心',
+    path: '/nic/:type?',
+    example: '/xtu/nic/dt',
+    url: 'nic.xtu.edu.cn',
+    handler,
+    categories: ['university'],
+    maintainers: ['zzy00747'],
+    parameters: {
+        type: '栏目类型，见下表，默认为新闻动态',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    description: `| 栏目 | 参数 | 说明 |
+| ---- | ---- | ---- |
+| 新闻动态 | dt | 中心新闻动态 |
+| 通知公告 | tzgg | 网络动态通知公告 |`,
+};

--- a/lib/routes/xtu/tw.ts
+++ b/lib/routes/xtu/tw.ts
@@ -1,0 +1,153 @@
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+import { Route } from '@/types';
+
+const rootUrl = 'https://tw.xtu.edu.cn/';
+const host = 'tw.xtu.edu.cn';
+
+const handler: Route['handler'] = async (ctx) => {
+    const type = ctx.req.param('type') ?? 'tzgg';
+    const typeDict = {
+        tzgg: ['通知公告', 'tzgg.htm'],
+        xnxw: ['校内新闻', 'xnxw.htm'],
+    };
+
+    if (!typeDict[type]) {
+        throw new Error(`Invalid type: ${type}`);
+    }
+
+    const listUrl = `${rootUrl}${typeDict[type][1]}`;
+
+    const response = await ofetch(listUrl);
+    const $ = load(response);
+
+    // 根据类型选择不同的选择器
+    const listSelector = type === 'xnxw' ? '.pt-tx' : '.text-list2 li, .text-list li';
+
+    const list = $(listSelector)
+        .toArray()
+        .map((item) => {
+            const $item = $(item);
+            // xnxw 页面结构不同：li > a > div.pt-tx > h3 + p + span
+            const $a = type === 'xnxw' ? $item.closest('a') : $item.find('a').first();
+
+            let title = $a.attr('title') || $item.find('h2, h3').text() || $a.text() || '';
+            let link = $a.attr('href') || '';
+
+            // 处理相对路径
+            if (link && !link.startsWith('http')) {
+                if (link.startsWith('../')) {
+                    link = rootUrl + link.replace('../', '');
+                } else if (link.startsWith('./')) {
+                    link = rootUrl + link.replace('./', '');
+                } else if (link.startsWith('/')) {
+                    link = rootUrl.slice(0, -1) + link;
+                } else {
+                    link = rootUrl + link;
+                }
+            }
+
+            let pubDate: Date | undefined;
+
+            if (type === 'xnxw') {
+                // xnxw 页面：日期在 span 中，格式 2026-04-21
+                const dateText = $item.find('span').last().text().trim();
+                if (dateText) {
+                    pubDate = timezone(parseDate(dateText), +8);
+                }
+            } else {
+                // tzgg 页面：从 date2 结构中提取日期
+                const $dateP = $item.find('.date2 p');
+                const $dateSpan = $item.find('.date2 span');
+                if ($dateP.length && $dateSpan.length) {
+                    const day = $dateP.text().trim();
+                    const yearMonth = $dateSpan.text().trim();
+                    const dateText = `${yearMonth}-${day}`;
+                    pubDate = timezone(parseDate(dateText), +8);
+                }
+            }
+
+            return {
+                title: title.trim(),
+                link: link.trim(),
+                pubDate,
+            };
+        })
+        .filter((item) => item.title && item.link);
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const newItem = {
+                    ...item,
+                    description: '',
+                };
+
+                try {
+                    const linkHost = new URL(item.link).hostname;
+                    if (host === linkHost) {
+                        const response = await ofetch(item.link);
+                        const $ = load(response);
+
+                        // 尝试多种可能的内容选择器
+                        const contentSelectors = ['.v_news_content', '.content-detail', '.article-content', '.wp_articlecontent', '#main-content', '.content', '.news-content', '.infodetail'];
+
+                        for (const selector of contentSelectors) {
+                            const content = $(selector).html();
+                            if (content) {
+                                newItem.description = content;
+                                break;
+                            }
+                        }
+
+                        // 如果没找到内容，返回链接提示
+                        if (!newItem.description) {
+                            newItem.description = `<p>请访问原网页查看内容：<a href="${item.link}">${item.title}</a></p>`;
+                        }
+                    } else {
+                        // 外部链接
+                        newItem.description = `<p>外部链接：<a href="${item.link}">${item.title}</a></p>`;
+                    }
+                } catch {
+                    newItem.description = `<p>获取内容失败，请访问原网页：<a href="${item.link}">${item.title}</a></p>`;
+                }
+
+                return newItem;
+            })
+        )
+    );
+
+    return {
+        title: `湘潭大学团委 - ${typeDict[type][0]}`,
+        link: listUrl,
+        item: items,
+    };
+};
+
+export const route: Route = {
+    name: '团委',
+    path: '/tw/:type?',
+    example: '/xtu/tw/tzgg',
+    url: 'tw.xtu.edu.cn',
+    handler,
+    categories: ['university'],
+    maintainers: ['zzy00747'],
+    parameters: {
+        type: '栏目类型，见下表，默认为通知公告',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    description: `| 栏目 | 参数 | 说明 |
+| ---- | ---- | ---- |
+| 通知公告 | tzgg | 团委通知公告 |
+| 校内新闻 | xnxw | 校内新闻动态 |`,
+};

--- a/lib/routes/xtu/www.ts
+++ b/lib/routes/xtu/www.ts
@@ -1,0 +1,134 @@
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+import { Route } from '@/types';
+
+const rootUrl = 'https://www.xtu.edu.cn/';
+const host = 'www.xtu.edu.cn';
+
+const handler: Route['handler'] = async (ctx) => {
+    const type = ctx.req.param('type') ?? 'tzgg';
+    const typeDict = {
+        tzgg: ['通知公告', 'index/tzgg.htm'],
+        xdw: ['湘大新闻', 'index/xdw.htm'],
+    };
+
+    if (!typeDict[type]) {
+        throw new Error(`Invalid type: ${type}`);
+    }
+
+    const listUrl = `${rootUrl}${typeDict[type][1]}`;
+
+    const response = await ofetch(listUrl);
+    const $ = load(response);
+
+    const list = $('.list_rg li, .list_lb li')
+        .toArray()
+        .map((item) => {
+            const $item = $(item);
+            const $a = $item.find('a').first();
+            const $span = $item.find('span').first();
+
+            let title = $a.attr('title') || $item.find('h2').text() || $a.text() || '';
+            let link = $a.attr('href') || '';
+
+            // 处理相对路径
+            if (link && !link.startsWith('http')) {
+                if (link.startsWith('../')) {
+                    link = rootUrl + link.replace('../', '');
+                } else if (link.startsWith('./')) {
+                    link = rootUrl + link.replace('./', '');
+                } else if (link.startsWith('/')) {
+                    link = rootUrl.slice(0, -1) + link;
+                } else {
+                    link = rootUrl + link;
+                }
+            }
+
+            // 日期格式: 2026.04.17
+            const dateText = $span.text().trim().replace(/\./g, '-');
+            const pubDate = dateText ? timezone(parseDate(dateText), +8) : undefined;
+
+            return {
+                title: title.trim(),
+                link: link.trim(),
+                pubDate,
+            };
+        })
+        .filter((item) => item.title && item.link);
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const newItem = {
+                    ...item,
+                    description: '',
+                };
+
+                try {
+                    const linkHost = new URL(item.link).hostname;
+                    if (host === linkHost) {
+                        const response = await ofetch(item.link);
+                        const $ = load(response);
+
+                        // 尝试多种可能的内容选择器
+                        const contentSelectors = ['.v_news_content', '.content-detail', '.article-content', '.wp_articlecontent', '#main-content', '.content', '.news-content', '.infodetail'];
+
+                        for (const selector of contentSelectors) {
+                            const content = $(selector).html();
+                            if (content) {
+                                newItem.description = content;
+                                break;
+                            }
+                        }
+
+                        // 如果没找到内容，返回链接提示
+                        if (!newItem.description) {
+                            newItem.description = `<p>请访问原网页查看内容：<a href="${item.link}">${item.title}</a></p>`;
+                        }
+                    } else {
+                        // 外部链接
+                        newItem.description = `<p>外部链接：<a href="${item.link}">${item.title}</a></p>`;
+                    }
+                } catch {
+                    newItem.description = `<p>获取内容失败，请访问原网页：<a href="${item.link}">${item.title}</a></p>`;
+                }
+
+                return newItem;
+            })
+        )
+    );
+
+    return {
+        title: `湘潭大学官网 - ${typeDict[type][0]}`,
+        link: listUrl,
+        item: items,
+    };
+};
+
+export const route: Route = {
+    name: '学校官网',
+    path: '/www/:type?',
+    example: '/xtu/www/tzgg',
+    url: 'www.xtu.edu.cn',
+    handler,
+    categories: ['university'],
+    maintainers: ['zzy00747'],
+    parameters: {
+        type: '栏目类型，见下表，默认为通知公告',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    description: `| 栏目 | 参数 | 说明 |
+| ---- | ---- | ---- |
+| 通知公告 | tzgg | 学校通知公告 |
+| 湘大新闻 | xdw | 湘大新闻动态 |`,
+};


### PR DESCRIPTION
<!--If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route-->

## Involved Issue / 该 PR 相关 Issue
Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/xtu/jwc/tzgg
/xtu/jwc/xkjs
/xtu/www/tzgg
/xtu/www/xdw
/xtu/tw/tzgg
/xtu/tw/xnxw
/xtu/nic/dt
/xtu/nic/tzgg
/xtu/cyxy/dxscxcyxljhxm
/xtu/cyxy/scjs
/xtu/jwxy/tzgg
/xtu/jwxy/xwdt
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随路由规范
  - [x] Documentation / 文档说明
  - [x] Full text / 全文获取
  - [x] Use cache / 使用缓存
  - [ ] Anti-bot or rate limit / 反爬/频率限制
  - [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / 日期和时间
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

添加湘潭大学 (Xiangtan University) 相关 RSS 路由，包括：

- **教务处通知公告** (`/xtu/jwc/:type?`)
  - `tzgg` - 首页综合通知公告
  - `xkjs` - 学科竞赛通知公告

- **学校官网** (`/xtu/www/:type?`)
  - `tzgg` - 学校通知公告
  - `xdw` - 湘大新闻动态

- **团委** (`/xtu/tw/:type?`)
  - `tzgg` - 团委通知公告
  - `xnxw` - 校内新闻动态

- **网络与信息中心** (`/xtu/nic/:type?`)
  - `dt` - 中心新闻动态
  - `tzgg` - 网络动态通知公告

- **创新创业学院** (`/xtu/cyxy/:type?`)
  - `dxscxcyxljhxm` - 大学生创新创业训练计划项目
  - `scjs` - 双创竞赛（互联网+、挑战杯等）

- **计算机学院** (`/xtu/jwxy/:type?`)
  - `tzgg` - 学院通知公告
  - `xwdt` - 学院新闻动态

所有路由均使用 Cheerio 解析 HTML，使用 `cache.tryGet` 避免重复请求，正确解析日期和时区（东八区）。