### PR TITLE
feat(route): add user likes activity for Hugging Face

### DIFF
--- a/lib/routes/huggingface/user-likes.ts
+++ b/lib/routes/huggingface/user-likes.ts
@@ -1,0 +1,80 @@
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+interface LikedRepo {
+    name: string;
+    type: string;
+}
+
+interface UserLike {
+    createdAt: string;
+    repo: LikedRepo;
+}
+
+const getRepoLink = (repo: LikedRepo): string => {
+    switch (repo.type) {
+        case 'dataset':
+            return `https://huggingface.co/datasets/${repo.name}`;
+        case 'space':
+            return `https://huggingface.co/spaces/${repo.name}`;
+        case 'paper':
+            return `https://huggingface.co/papers/${repo.name}`;
+        case 'collection':
+            return `https://huggingface.co/collections/${repo.name}`;
+        default:
+            return `https://huggingface.co/${repo.name}`;
+    }
+};
+
+export const route: Route = {
+    path: '/activity/:user/likes',
+    categories: ['programming'],
+    example: '/huggingface/activity/dotwee/likes',
+    parameters: {
+        user: 'Hugging Face username',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['huggingface.co/:user/activity/likes'],
+            target: '/activity/:user/likes',
+        },
+    ],
+    name: 'User Likes Activity',
+    maintainers: ['dotwee'],
+    handler,
+    url: 'huggingface.co',
+};
+
+async function handler(ctx) {
+    const { user } = ctx.req.param();
+    const link = `https://huggingface.co/${user}/activity/likes`;
+
+    const likes = await ofetch<UserLike[]>(`https://huggingface.co/api/users/${user}/likes`);
+
+    const items = likes.map((like) => {
+        const repoType = like.repo.type || 'model';
+
+        return {
+            title: `${user} liked ${like.repo.name}`,
+            link: getRepoLink(like.repo),
+            description: `${user} liked this ${repoType}.`,
+            category: [repoType],
+            pubDate: parseDate(like.createdAt),
+        };
+    });
+
+    return {
+        title: `${user} - Likes Activity`,
+        link,
+        item: items,
+    };
+}


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/huggingface/activity/dotwee/likes
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This PR introduces a new route to fetch and display user likes activity from Hugging Face, including links to liked repositories and their types.  

The route is accessible via '/activity/:user/likes' and supports various repository types such as datasets, spaces, papers, and collections.

This is done by parsing the JSON provided through the HuggingFace API.

E.g.: `https://huggingface.co/api/users/dotwee/likes`

Which provides the following JSON data (and gets parsed in this new route handler):

```json
[
    {
        "createdAt": "2026-03-07T15:06:20.000Z",
        "repo": {
            "name": "TeichAI/GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-GGUF",
            "type": "model"
        }
    },
    {
        "createdAt": "2026-02-27T17:24:06.000Z",
        "repo": {
            "name": "huihui-ai/Huihui-Qwen3.5-27B-abliterated",
            "type": "model"
        }
    },
    {
        "createdAt": "2025-11-12T12:20:05.000Z",
        "repo": {
            "name": "mlx-community/DeepSeek-OCR-8bit",
            "type": "model"
        }
    },
    {
        "createdAt": "2024-11-28T15:11:07.000Z",
        "repo": {
            "name": "LSX-UniWue/LLaMmlein_1B_prerelease",
            "type": "model"
        }
    }
]
```