### PR TITLE
feat(route/gettyimages): add Australia image search

### DIFF
--- a/lib/routes/gettyimages/description.tsx
+++ b/lib/routes/gettyimages/description.tsx
@@ -1,0 +1,8 @@
+import { renderToString } from 'hono/jsx/dom/server';
+
+export const renderSearchItemDescription = (imageSrc: string): string =>
+    renderToString(
+        <figure>
+            <img src={imageSrc} />
+        </figure>
+    );

--- a/lib/routes/gettyimages/namespace.ts
+++ b/lib/routes/gettyimages/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Getty Images Australia',
+    url: 'www.gettyimages.com.au',
+    lang: 'en',
+};

--- a/lib/routes/gettyimages/search.ts
+++ b/lib/routes/gettyimages/search.ts
@@ -40,7 +40,7 @@ export const route: Route = {
         },
     ],
     name: 'Search',
-    maintainers: ['siyan'],
+    maintainers: ['QwQ-OvO'],
     handler,
 };
 

--- a/lib/routes/gettyimages/search.ts
+++ b/lib/routes/gettyimages/search.ts
@@ -8,7 +8,9 @@ import type { DataItem, Route } from '@/types';
 import { ViewType } from '@/types';
 import ofetch from '@/utils/ofetch';
 
-const getTitleFromElement = ($element: Cheerio<Element>): string | undefined => $element.attr('aria-label') || $element.find('img').attr('alt') || $element.text().trim() || undefined;
+import { renderSearchItemDescription } from './description';
+
+const getTitleFromElement = ($element: Cheerio<Element>): string | undefined => $element.attr('aria-label') || $element.find('img').attr('alt') || $element.text() || undefined;
 
 const getImageFromElement = ($element: Cheerio<Element>): string | undefined =>
     $element.find('img').attr('src') || $element.find('img').attr('data-src') || $element.find('img').attr('data-lazy-src') || $element.find('img').attr('data-image-src');
@@ -86,7 +88,7 @@ async function handler(ctx: Context) {
             title,
             link: normalizedLink,
             guid: normalizedLink,
-            description: image ? `<img src="${image}">` : undefined,
+            description: image ? renderSearchItemDescription(image) : undefined,
         });
     }
 

--- a/lib/routes/gettyimages/search.ts
+++ b/lib/routes/gettyimages/search.ts
@@ -1,0 +1,98 @@
+import type { Cheerio, CheerioAPI } from 'cheerio';
+import { load } from 'cheerio';
+import type { Element } from 'domhandler';
+import type { Context } from 'hono';
+
+import { config } from '@/config';
+import type { DataItem, Route } from '@/types';
+import { ViewType } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+const getTitleFromElement = ($element: Cheerio<Element>): string | undefined => $element.attr('aria-label') || $element.find('img').attr('alt') || $element.text().trim() || undefined;
+
+const getImageFromElement = ($element: Cheerio<Element>): string | undefined =>
+    $element.find('img').attr('src') || $element.find('img').attr('data-src') || $element.find('img').attr('data-lazy-src') || $element.find('img').attr('data-image-src');
+
+export const route: Route = {
+    path: '/search/:keyword',
+    categories: ['picture'],
+    view: ViewType.Pictures,
+    description:
+        'Image search results on the first page only. Radar cannot extract the `phrase` query string; subscribe with `/gettyimages/search/:keyword` manually (e.g. `/gettyimages/search/kangaroo`). The listing does not provide reliable publish dates.',
+    url: 'www.gettyimages.com.au',
+    example: '/gettyimages/search/kangaroo',
+    parameters: {
+        keyword: 'Search keyword',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.gettyimages.com.au/search/2/image'],
+            target: '/search/:keyword',
+        },
+    ],
+    name: 'Search',
+    maintainers: ['siyan'],
+    handler,
+};
+
+async function handler(ctx: Context) {
+    const keyword = ctx.req.param('keyword');
+    if (!keyword) {
+        throw new Error('Missing required parameter: keyword');
+    }
+
+    const baseUrl = 'https://www.gettyimages.com.au';
+    const searchUrl = `${baseUrl}/search/2/image?phrase=${encodeURIComponent(keyword)}`;
+
+    const response = await ofetch<string>(searchUrl, {
+        headers: {
+            'User-Agent': config.trueUA,
+        },
+    });
+    const $: CheerioAPI = load(response);
+
+    const seen = new Set<string>();
+    const list: DataItem[] = [];
+    for (const element of $('a[href^="/detail/"]').toArray()) {
+        const $element: Cheerio<Element> = $(element);
+        const href = $element.attr('href');
+        if (!href) {
+            continue;
+        }
+
+        const link = new URL(href, baseUrl);
+        link.search = '';
+        link.hash = '';
+        const normalizedLink = link.toString();
+
+        if (seen.has(normalizedLink)) {
+            continue;
+        }
+        seen.add(normalizedLink);
+
+        const title = getTitleFromElement($element) || normalizedLink;
+        const image = getImageFromElement($element);
+
+        list.push({
+            title,
+            link: normalizedLink,
+            guid: normalizedLink,
+            description: image ? `<img src="${image}">` : undefined,
+        });
+    }
+
+    return {
+        title: `Getty Images Australia - ${keyword}`,
+        link: searchUrl,
+        item: list,
+    };
+}


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。
不要填写 /gettyimages/search/:keyword 这类路径参数形式；应写具体示例值（CI 也会校验）。

Please include route starts with /, with all required and optional parameters in the `routes` section. Fail to comply will result in your pull request being closed automatically.
-->

```routes
/gettyimages/search/kangaroo
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
- [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
- [ ] Full text / 全文获取
- [ ] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [ ] Parsed / 可以解析
- [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds **Getty Images Australia** (`www.gettyimages.com.au`) image search at `/gettyimages/search/:keyword` (subscribe with a concrete keyword). First search results page only; preview images in `description` via `renderToString` + JSX. The listing does not provide reliable per-item dates, so `pubDate` is omitted per [no-date](https://docs.rsshub.app/joinus/advanced/pub-date) guidance. Radar matches the search landing URL; users choose the keyword in the route path. User-Agent uses `config.trueUA`.
