### PR TITLE
fix: 修复NUAA教务处DOM元素的解析

### DIFF
--- a/lib/routes/nuaa/jwc/jwc.ts
+++ b/lib/routes/nuaa/jwc/jwc.ts
@@ -7,7 +7,7 @@ import { parseDate } from '@/utils/parse-date';
 
 import getCookie from '../utils/pypasswaf';
 
-const host = 'http://aao.nuaa.edu.cn/';
+const host = 'https://aao.nuaa.edu.cn/';
 
 const map = new Map([
     ['tzgg', { title: '通知公告 | 南京航空航天大学教务处', suffix: '8222/list.htm' }],
@@ -53,14 +53,14 @@ async function handler(ctx) {
     const response = await got(link, gotConfig);
     const $ = load(response.data);
 
-    const list = $('#wp_news_w8 ul li')
+    const list = $('#news_list .news_ul .p-list-item a')
         .slice(0, 10)
         .toArray()
         .map((element) => {
             const info = {
-                title: $(element).find('a').text(),
-                link: $(element).find('a').attr('href'),
-                date: $(element).find('span').text(),
+                title: $(element).find('.text .title').text(),
+                link: $(element).attr('href'),
+                date: $(element).find('.date em').text() + '-' + $(element).find('.date span').text(),
             };
             return info;
         });


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue



## Example for the Proposed Route(s) / 路由地址示例

<!--
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

Please include route starts with /, with all required and optional parameters in the `routes` section. Fail to comply will result in your pull request being closed automatically.
```route
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```
如果你的 PR 与路由无关, 请在 `routes` 区域填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
If your changes are not related to route, please fill in `routes` with `NOROUTE`. Fail to comply will result in your PR being closed.
-->

```
/nuaa/jwc/tzgg
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
  - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
- [x] Full text / 全文获取
  - [ ] Use cache / 使用缓存
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
更新了 DOM 元素的解析，适配了新的南航教务处页面样式