### PR TITLE
feat(route): make GitHub pulls title and docs consistent with issues

### DIFF
--- a/lib/routes/github/pulls.ts
+++ b/lib/routes/github/pulls.ts
@@ -14,7 +14,29 @@ export const route: Route = {
     path: '/pull/:user/:repo/:state?/:labels?',
     categories: ['programming'],
     example: '/github/pull/DIYgod/RSSHub',
-    parameters: { user: 'User name', repo: 'Repo name', state: 'the state of pull requests. Can be either `open`, `closed`, or `all`. Default: `open`.', labels: 'a list of comma separated label names' },
+    parameters: {
+        user: 'GitHub username',
+        repo: 'GitHub repo name',
+        state: {
+            description: 'the state of pull requests.',
+            default: 'open',
+            options: [
+                {
+                    label: 'Open',
+                    value: 'open',
+                },
+                {
+                    label: 'Closed',
+                    value: 'closed',
+                },
+                {
+                    label: 'All',
+                    value: 'all',
+                },
+            ],
+        },
+        labels: 'a list of comma separated label names',
+    },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -61,7 +83,7 @@ async function handler(ctx) {
 
     return {
         allowEmpty: true,
-        title: `${user}/${repo} Pull requests`,
+        title: `${user}/${repo}${state ? ' ' + state.replace(/^\S/, (s) => s.toUpperCase()) : ''} Pull Requests${labels ? ' - ' + labels : ''}`,
         link: host,
         item: data.map((item) => ({
             title: item.title,

--- a/lib/routes/github/pulls.ts
+++ b/lib/routes/github/pulls.ts
@@ -83,7 +83,7 @@ async function handler(ctx) {
 
     return {
         allowEmpty: true,
-        title: `${user}/${repo}${state ? ' ' + state.replace(/^\S/, (s) => s.toUpperCase()) : ''} Pull Requests${labels ? ' - ' + labels : ''}`,
+        title: `${user}/${repo} ${state.replace(/^\S/, (s) => s.toUpperCase())} Pull Requests${labels ? ' - ' + labels : ''}`,
         link: host,
         item: data.map((item) => ({
             title: item.title,


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #21902 

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/github/pull/DIYgod/RSSHub/open
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
First time ever submitting a PR here!

I'm not really a coder, but I use RSSHub to bridge GitHub updates into IRC for my community. I noticed that the `pulls.ts` route didn't show the "Open/Closed" state in the feed title like the `issues.ts` route does, which was making my users a bit confused!

I tried my best to replicate the logic and metadata structure from `issues.ts` over to `pulls.ts`.

Changes:
- Updated the feed title to dynamically show the state (Open/Closed/All) and any labels.
- Updated the parameter metadata so the documentation looks as clean and organized as the Issues page.

I've tested this locally and it’s working perfectly for my IRC tracker. Hopefully, this helps keep things consistent across the GitHub routes!