### PR TITLE
fix: connect playwright ws endpoint via protocol

### DIFF
--- a/lib/bilibili-video-route.test.ts
+++ b/lib/bilibili-video-route.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cacheMock = {
+    getCookie: vi.fn(),
+    getConfiguredCookie: vi.fn(),
+    getUsernameAndFaceFromUID: vi.fn(),
+    getVideoSubtitleAttachment: vi.fn(),
+};
+
+const destroy = vi.fn();
+const getPlaywrightPage = vi.fn();
+const goto = vi.fn();
+const on = vi.fn();
+const setCookie = vi.fn();
+const setRequestInterception = vi.fn();
+const waitForResponse = vi.fn();
+
+const page = {
+    goto,
+    on,
+    setCookie,
+    setRequestInterception,
+    waitForResponse,
+};
+
+vi.mock('@/routes/bilibili/cache', () => ({
+    default: cacheMock,
+}));
+
+vi.mock('@/utils/playwright', () => ({
+    getPlaywrightPage,
+}));
+
+vi.mock('@/utils/logger', () => ({
+    default: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    },
+}));
+
+const createContext = () =>
+    ({
+        req: {
+            param: (name: string) => {
+                if (name === 'uid') {
+                    return '646730844';
+                }
+            },
+            query: (name: string) => {
+                if (name === 'format') {
+                    return 'json';
+                }
+            },
+        },
+    }) as any;
+
+describe('/bilibili/user/video/:uid', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        cacheMock.getCookie.mockReset();
+        cacheMock.getConfiguredCookie.mockReset();
+        cacheMock.getUsernameAndFaceFromUID.mockReset();
+        cacheMock.getVideoSubtitleAttachment.mockReset();
+        destroy.mockReset();
+        getPlaywrightPage.mockReset();
+        goto.mockReset();
+        on.mockReset();
+        setCookie.mockReset();
+        setRequestInterception.mockReset();
+        waitForResponse.mockReset();
+    });
+
+    it('falls back to browser mode by opening the user page before the video page', async () => {
+        cacheMock.getCookie.mockRejectedValueOnce(new Error('cookie unavailable'));
+        cacheMock.getConfiguredCookie.mockReturnValue(undefined);
+        cacheMock.getUsernameAndFaceFromUID.mockResolvedValue(['雷军', 'https://example.com/face.jpg']);
+        cacheMock.getVideoSubtitleAttachment.mockResolvedValue([]);
+        waitForResponse.mockResolvedValue({
+            headers: () => ({ 'content-type': 'application/json; charset=utf-8' }),
+            json: () => ({
+                code: 0,
+                data: {
+                    list: {
+                        vlist: [
+                            {
+                                aid: 1,
+                                author: '雷军',
+                                bvid: 'BV1xx411c7mD',
+                                comment: 10,
+                                created: 1_700_000_000,
+                                description: 'video description',
+                                length: '01:02',
+                                pic: 'https://example.com/cover.jpg',
+                                title: 'Video title',
+                            },
+                        ],
+                    },
+                },
+            }),
+            request: () => ({
+                method: () => 'GET',
+                resourceType: () => 'fetch',
+            }),
+            status: () => 200,
+            url: () => 'https://api.bilibili.com/x/space/wbi/arc/search',
+        });
+        goto.mockResolvedValue(undefined);
+        getPlaywrightPage.mockImplementation(async (_url, options) => {
+            await options.onBeforeLoad?.(page);
+            return {
+                destroy,
+                page,
+            };
+        });
+
+        const { route } = await import('@/routes/bilibili/video');
+        const data = await route.handler(createContext());
+
+        expect(getPlaywrightPage).toHaveBeenCalledWith(
+            'https://space.bilibili.com/646730844',
+            expect.objectContaining({
+                closeTimeout: 90000,
+                gotoConfig: { waitUntil: 'domcontentloaded' },
+                noGoto: true,
+            })
+        );
+        expect(waitForResponse.mock.invocationCallOrder[0]).toBeLessThan(goto.mock.invocationCallOrder[0]);
+        expect(waitForResponse).toHaveBeenCalledWith(expect.any(Function), { timeout: 45000 });
+        const isVideoListResponse = waitForResponse.mock.calls[0][0];
+        expect(
+            isVideoListResponse({
+                headers: () => ({ 'content-type': 'application/json; charset=utf-8' }),
+                request: () => ({
+                    method: () => 'GET',
+                    resourceType: () => 'fetch',
+                }),
+                url: () => 'https://api.bilibili.com/x/space/wbi/arc/search',
+            })
+        ).toBe(true);
+        expect(
+            isVideoListResponse({
+                headers: () => ({ 'content-type': 'text/html' }),
+                request: () => ({
+                    method: () => 'GET',
+                    resourceType: () => 'fetch',
+                }),
+                url: () => 'https://api.bilibili.com/x/space/wbi/arc/search',
+            })
+        ).toBe(false);
+        expect(goto).toHaveBeenNthCalledWith(1, 'https://space.bilibili.com/646730844', { waitUntil: 'domcontentloaded' });
+        expect(goto).toHaveBeenCalledWith('https://space.bilibili.com/646730844/video', { timeout: 45000, waitUntil: 'domcontentloaded' });
+        expect(cacheMock.getCookie).toHaveBeenCalledTimes(1);
+        expect(data.item).toHaveLength(1);
+        expect(data.item[0].title).toBe('Video title');
+    });
+});

--- a/lib/routes/bilibili/cache.ts
+++ b/lib/routes/bilibili/cache.ts
@@ -20,8 +20,8 @@ const subtitleLimiterQueue = new RateLimiterQueue(subtitleLimiter, {
     maxQueueSize: 4800,
 });
 
-const getCookie = (disableConfig = false) => {
-    if (Object.keys(config.bilibili.cookies).length > 0 && !disableConfig) {
+const getConfiguredCookie = () => {
+    if (Object.keys(config.bilibili.cookies).length > 0) {
         // Update b_lsid in cookies
         for (const key of Object.keys(config.bilibili.cookies)) {
             const cookie = config.bilibili.cookies[key];
@@ -33,6 +33,14 @@ const getCookie = (disableConfig = false) => {
 
         return config.bilibili.cookies[Object.keys(config.bilibili.cookies)[Math.floor(Math.random() * Object.keys(config.bilibili.cookies).length)]] || '';
     }
+};
+
+const getCookie = (disableConfig = false) => {
+    const configuredCookie = disableConfig ? undefined : getConfiguredCookie();
+    if (configuredCookie !== undefined) {
+        return configuredCookie;
+    }
+
     const key = 'bili-cookie';
     return cache.tryGet(key, async () => {
         let waitForRequest = new Promise<string>((resolve) => {
@@ -374,6 +382,7 @@ const getArticleDataFromCvid = async (cvid, uid) => {
 
 export default {
     getCookie,
+    getConfiguredCookie,
     getWbiVerifyString,
     getUsernameFromUID,
     getUsernameAndFaceFromUID,

--- a/lib/routes/bilibili/video.ts
+++ b/lib/routes/bilibili/video.ts
@@ -60,8 +60,38 @@ interface VideoListResponse {
     message?: string;
 }
 
+type BrowserResponse = Awaited<ReturnType<Page['waitForResponse']>>;
+
 const videoListApiPath = '/x/space/wbi/arc/search';
 const allowedBrowserRequestTypes = new Set(['document', 'script', 'xhr', 'fetch', 'image', 'font', 'stylesheet', 'other']);
+const browserResponseTimeout = 45000;
+const browserCloseTimeout = 90000;
+
+const getErrorMessage = (error: unknown) => (error instanceof Error ? error.message : String(error));
+
+const isVideoListApiJsonResponse = (response: BrowserResponse) => {
+    const request = response.request();
+    const contentType = response.headers()['content-type'];
+    return response.url().includes(videoListApiPath) && request.method() === 'GET' && (request.resourceType() === 'xhr' || request.resourceType() === 'fetch') && contentType?.includes('application/json');
+};
+
+const waitForVideoListResponse = async (page: Page) => {
+    try {
+        return {
+            response: await page.waitForResponse(isVideoListApiJsonResponse, { timeout: browserResponseTimeout }),
+        };
+    } catch (error) {
+        return { error };
+    }
+};
+
+const navigateToVideoPage = async (page: Page, videoUrl: string) => {
+    try {
+        await page.goto(videoUrl, { timeout: browserResponseTimeout, waitUntil: 'domcontentloaded' });
+    } catch (error) {
+        logger.warn(`[bilibili/video] video page navigation did not finish before the response wait ended: ${getErrorMessage(error)}`);
+    }
+};
 
 async function applyCookie(page: Page, cookie: string) {
     const cookies = cookie
@@ -116,26 +146,18 @@ async function fetchVideoListFromApi(uid: string): Promise<VideoListData> {
 }
 
 async function fetchVideoListFromBrowser(uid: string): Promise<VideoListData> {
-    const cookie = await cache.getCookie();
-    if (!cookie) {
-        throw new Error('Bilibili cookie is required to fetch video list in browser mode');
-    }
+    const cookie = cache.getConfiguredCookie();
+    const userUrl = `https://space.bilibili.com/${uid}`;
+    const videoUrl = `${userUrl}/video`;
+    logger.info(`[bilibili/video] fetching via playwright: ${videoUrl}`);
 
-    const url = `https://space.bilibili.com/${uid}/video`;
-    logger.info(`[bilibili/video] fetching via playwright: ${url}`);
-
-    let videoListResponsePromise: ReturnType<Page['waitForResponse']> | undefined;
-    const { destroy } = await getPlaywrightPage(url, {
+    const { destroy, page } = await getPlaywrightPage(userUrl, {
+        closeTimeout: browserCloseTimeout,
+        noGoto: true,
         onBeforeLoad: async (page) => {
-            await applyCookie(page, cookie);
-
-            videoListResponsePromise = page.waitForResponse(
-                (response) => {
-                    const request = response.request();
-                    return response.url().includes(videoListApiPath) && request.method() === 'GET' && (request.resourceType() === 'xhr' || request.resourceType() === 'fetch');
-                },
-                { timeout: 30000 }
-            );
+            if (cookie) {
+                await applyCookie(page, cookie);
+            }
 
             await page.setRequestInterception(true);
             page.on('request', (request) => {
@@ -146,16 +168,16 @@ async function fetchVideoListFromBrowser(uid: string): Promise<VideoListData> {
     });
 
     try {
-        if (!videoListResponsePromise) {
-            throw new Error('Failed to initialize Bilibili video list response watcher');
+        const videoListResponsePromise = waitForVideoListResponse(page);
+        await page.goto(userUrl, { waitUntil: 'domcontentloaded' });
+        void navigateToVideoPage(page, videoUrl);
+
+        const videoListResponseResult = await videoListResponsePromise;
+        if ('error' in videoListResponseResult) {
+            throw new Error(`Bilibili browser mode did not receive a JSON video list response within ${browserResponseTimeout}ms: ${getErrorMessage(videoListResponseResult.error)}`);
         }
 
-        const response = await videoListResponsePromise;
-        const contentType = response.headers()['content-type'];
-        if (!contentType?.includes('application/json')) {
-            throw new Error(`Bilibili browser mode returned non-JSON response with status ${response.status()}; BILIBILI_COOKIE_* may be required`);
-        }
-
+        const response = videoListResponseResult.response;
         const data = (await response.json()) as VideoListResponse;
         if (data.code) {
             logger.error(JSON.stringify(data.data));

--- a/lib/utils/playwright.mock.test.ts
+++ b/lib/utils/playwright.mock.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+const connect = vi.fn();
 const connectOverCDP = vi.fn();
 const launch = vi.fn();
 
@@ -54,6 +55,7 @@ const proxyMock = {
 
 vi.mock('playwright', () => ({
     chromium: {
+        connect,
         connectOverCDP,
         launch,
     },
@@ -78,6 +80,7 @@ const loadPlaywright = async () => {
 
 const resetMocks = () => {
     createBrowserMocks();
+    connect.mockReset();
     connectOverCDP.mockReset();
     launch.mockReset();
     routeContinue.mockReset();
@@ -97,6 +100,7 @@ createBrowserMocks();
 describe('getPlaywrightPage (mocked)', () => {
     it('connects via ws endpoint and runs onBeforeLoad', async () => {
         resetMocks();
+        connect.mockResolvedValue(browser);
         connectOverCDP.mockResolvedValue(browser);
         launch.mockResolvedValue(browser);
         page.goto.mockResolvedValue(undefined);
@@ -112,12 +116,90 @@ describe('getPlaywrightPage (mocked)', () => {
             onBeforeLoad,
         });
 
-        const endpoint = connectOverCDP.mock.calls[0][0] as string;
-        expect(endpoint).toContain('launch=');
+        const endpoint = connect.mock.calls[0][0] as string;
+        expect(connectOverCDP).not.toHaveBeenCalled();
+        expect(endpoint).toContain('launch-options=');
+        expect(endpoint).not.toContain('launch=');
+        const launchOptions = JSON.parse(new URL(endpoint).searchParams.get('launch-options') || '{}');
+        expect(launchOptions.args).not.toContainEqual(expect.stringContaining('--user-agent='));
         expect(onBeforeLoad).toHaveBeenCalled();
 
         await result.destroy();
         expect(close).toHaveBeenCalled();
+    });
+
+    it('does not override the browser user agent', async () => {
+        resetMocks();
+        launch.mockResolvedValue(browser);
+        page.goto.mockResolvedValue(undefined);
+        proxyMock.getCurrentProxy.mockReturnValue(null);
+
+        const getPlaywrightPage = await loadPlaywright();
+        await getPlaywrightPage('https://example.com');
+
+        expect(launch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                args: expect.not.arrayContaining([expect.stringContaining('--user-agent=')]),
+            })
+        );
+        expect(browser.newContext).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                userAgent: expect.any(String),
+            })
+        );
+    });
+
+    it('supports extending the browser auto close timeout', async () => {
+        vi.useFakeTimers();
+        try {
+            resetMocks();
+            launch.mockResolvedValue(browser);
+            browser.close.mockResolvedValue(undefined);
+            page.goto.mockResolvedValue(undefined);
+            proxyMock.getCurrentProxy.mockReturnValue(null);
+
+            const getPlaywrightPage = await loadPlaywright();
+            const close = browser.close;
+            await getPlaywrightPage('https://example.com', {
+                closeTimeout: 90000,
+                noGoto: true,
+            });
+
+            await vi.advanceTimersByTimeAsync(89999);
+            expect(close).not.toHaveBeenCalled();
+
+            await vi.advanceTimersByTimeAsync(1);
+            expect(close).toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('handles requestfinished events after the remote page closes', async () => {
+        resetMocks();
+        launch.mockResolvedValue(browser);
+        page.goto.mockResolvedValue(undefined);
+        proxyMock.getCurrentProxy.mockReturnValue(null);
+
+        const getPlaywrightPage = await loadPlaywright();
+        const handler = vi.fn();
+        const rawOn = page.on;
+        await getPlaywrightPage('https://example.com', {
+            onBeforeLoad: (page) => {
+                page.on('requestfinished', handler);
+            },
+        });
+
+        const finishedHandler = rawOn.mock.calls.find(([event]) => event === 'requestfinished')?.[1];
+        await finishedHandler?.({
+            response: vi.fn().mockRejectedValue(new Error('closed')),
+            url: () => 'https://example.com/api',
+        });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        const finishedRequest = handler.mock.calls[0][0];
+        expect(finishedRequest.response()).toBeNull();
+        expect(finishedRequest.url()).toBe('https://example.com/api');
     });
 
     it('marks proxy failed when navigation throws with multi-proxy', async () => {

--- a/lib/utils/playwright.ts
+++ b/lib/utils/playwright.ts
@@ -96,7 +96,7 @@ const getProxyOptions = (currentProxy: ProxyState | null | undefined) => {
 };
 
 const getLaunchOptions = (currentProxy?: ProxyState | null): LaunchOptions => ({
-    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-blink-features=AutomationControlled', '--window-position=0,0', '--ignore-certificate-errors', '--ignore-certificate-errors-spki-list', `--user-agent=${config.ua}`],
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-blink-features=AutomationControlled', '--window-position=0,0', '--ignore-certificate-errors', '--ignore-certificate-errors-spki-list'],
     executablePath: config.chromiumExecutablePath || undefined,
     headless: true,
     ...getProxyOptions(currentProxy),
@@ -104,7 +104,6 @@ const getLaunchOptions = (currentProxy?: ProxyState | null): LaunchOptions => ({
 
 const getContextOptions = (): BrowserContextOptions => ({
     ignoreHTTPSErrors: true,
-    userAgent: config.ua,
 });
 
 const createRouteRequest = (route: Route): HandledRouteRequest => {
@@ -204,7 +203,12 @@ const patchPage = (page: PlaywrightPage, context: BrowserContext): Page => {
         }
         if (event === 'requestfinished') {
             originalOn(event, async (request) => {
-                const response = await request.response();
+                let response: PlaywrightResponse | null = null;
+                try {
+                    response = await request.response();
+                } catch {
+                    // The remote browser may close before Playwright resolves the response.
+                }
                 await (handler as RequestFinishedHandler)(createFinishedRequest(request, response));
             });
             return compatPage;
@@ -241,20 +245,20 @@ const createCompatBrowser = async (browser: PlaywrightBrowser, contextOptions: B
 
 const launchBrowser = async (currentProxy?: ProxyState | null) => {
     const launchOptions = getLaunchOptions(currentProxy);
-    const browser = config.playwrightWSEndpoint ? await chromium.connectOverCDP(getEndpointWithLaunchOptions(config.playwrightWSEndpoint, launchOptions)) : await chromium.launch(launchOptions);
+    const browser = config.playwrightWSEndpoint ? await chromium.connect(getEndpointWithLaunchOptions(config.playwrightWSEndpoint, launchOptions)) : await chromium.launch(launchOptions);
     return createCompatBrowser(browser, getContextOptions());
 };
 
 const getEndpointWithLaunchOptions = (endpoint: string, launchOptions: LaunchOptions) => {
     const endpointURL = new URL(endpoint);
-    endpointURL.searchParams.set('launch', JSON.stringify(launchOptions));
+    endpointURL.searchParams.set('launch-options', JSON.stringify(launchOptions));
     return endpointURL.toString();
 };
 
-const scheduleClose = (browser: Browser) => {
+const scheduleClose = (browser: Browser, timeout = 30000) => {
     setTimeout(() => {
         void browser.close();
-    }, 30000);
+    }, timeout);
 };
 
 /**
@@ -278,6 +282,7 @@ export const setBrowserBinding = (_binding: any) => {};
 export const getPlaywrightPage = async (
     url: string,
     instanceOptions: {
+        closeTimeout?: number;
         gotoConfig?: GotoOptions;
         noGoto?: boolean;
         onBeforeLoad?: (page: Page, browser?: Browser) => Promise<void> | void;
@@ -300,7 +305,7 @@ export const getPlaywrightPage = async (
     const currentProxyState = currentProxy && allowProxy ? currentProxy : null;
     const hasProxy = Boolean(getProxyOptions(currentProxyState).proxy);
     const browser = await launchBrowser(currentProxyState);
-    scheduleClose(browser);
+    scheduleClose(browser, instanceOptions.closeTimeout);
     const page = await browser.newPage();
 
     if (hasProxy && currentProxyState) {

--- a/lib/utils/playwright.worker.ts
+++ b/lib/utils/playwright.worker.ts
@@ -172,7 +172,6 @@ const patchPage = (page: PlaywrightPage, context: BrowserContext): Page => {
 const createCompatBrowser = async (browser: PlaywrightBrowser): Promise<Browser> => {
     const context = await browser.newContext({
         ignoreHTTPSErrors: true,
-        userAgent: config.ua,
     });
     const compatBrowser = browser as Browser;
     const originalClose = browser.close.bind(browser);


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bilibili/user/video/646730844
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

- Connect `PLAYWRIGHT_WS_ENDPOINT` via the Playwright protocol endpoint with `chromium.connect()` instead of CDP, and pass remote launch options through `launch-options`.
- Stop overriding Playwright's browser user agent in Node and Worker contexts.
- Update the Bilibili user video browser fallback to open the user space page before `/video`, and wait for the JSON `arc/search` response across that navigation flow.
- Extend the Bilibili browser fallback close timeout and tolerate closed remote pages while handling `requestfinished` events.

Test plan:

- `pnpm vitest run lib/bilibili-video-route.test.ts lib/utils/playwright.mock.test.ts`
- `pnpm exec oxlint --type-aware lib/utils/playwright.ts lib/utils/playwright.worker.ts lib/utils/playwright.mock.test.ts lib/routes/bilibili/video.ts lib/routes/bilibili/cache.ts lib/bilibili-video-route.test.ts`
- `pnpm exec oxfmt lib/utils/playwright.ts lib/utils/playwright.worker.ts lib/utils/playwright.mock.test.ts lib/routes/bilibili/video.ts lib/routes/bilibili/cache.ts lib/bilibili-video-route.test.ts --check`
- `pnpm build:routes`
- Attempted live smoke for `/bilibili/user/video/646730844?format=json` with `PLAYWRIGHT_WS_ENDPOINT=wss://cloudflare-patchright.rss3.workers.dev/playwright`; repeated checks were blocked by the remote browser endpoint returning 500 or Bilibili returning 412 / risk-control responses.
