### PR TITLE
fix: the /metrics endpoint is registered in lib/regi... in registry.ts

### DIFF
--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -259,8 +259,14 @@ app.get('/', index);
 app.get('/healthz', healthz);
 app.get('/robots.txt', robotstxt);
 if (config.debugInfo !== 'false') {
-    // Only enable tracing in debug mode
-    app.get('/metrics', metrics);
+    // Only enable tracing in debug mode; restrict to localhost to prevent info disclosure
+    app.get('/metrics', async (ctx, next) => {
+        const ip = ctx.req.header('x-forwarded-for')?.split(',')[0].trim() || ctx.env?.remoteAddr?.hostname || '';
+        if (ip !== '127.0.0.1' && ip !== '::1' && ip !== 'localhost' && ip !== '') {
+            return ctx.text('Forbidden', 403);
+        }
+        return next();
+    }, metrics);
 }
 if (!config.isPackage && !process.env.VERCEL_ENV && !isWorker) {
     app.use(


### PR DESCRIPTION
## Summary
Fix high severity security issue in `lib/registry.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `lib/registry.ts:263` |

**Description**: The /metrics endpoint is registered in lib/registry.ts at line 263 without any authentication middleware or IP allowlisting. This endpoint exposes Prometheus-format telemetry data including internal route names, request rates, error rates, latency histograms, and infrastructure details. Any unauthenticated external party can query this endpoint to enumerate the application's internal topology and identify potential attack targets.

## Changes
- `lib/registry.ts`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
