### PR TITLE
feat(route/transform): add date format to params

### DIFF
--- a/lib/routes/rsshub/transform/html.ts
+++ b/lib/routes/rsshub/transform/html.ts
@@ -6,6 +6,7 @@ import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
     path: '/transform/html/:url/:routeParams',
@@ -43,6 +44,7 @@ Specify options (in the format of query string) in parameter \`routeParams\` par
 | \`itemDescAttr\`    | The attributes of \`descrption\` element as description                                                       | \`string\`      | Element html             |
 | \`itemPubDate\`     | The HTML elements as \`pubDate\` in \`item\` using CSS selector                                               | \`string\`      | \`item\` element         |
 | \`itemPubDateAttr\` | The attributes of \`pubDate\` element as pubDate                                                              | \`string\`      | Element html             |
+| \`itemPubDateFmt\`  | Date format string for \`day.js\`                                                                             | \`string\`      |                          |
 | \`itemContent\`     | The HTML elements as \`description\` in \`item\` using CSS selector ( in \`itemLink\` page for full content ) | \`string\`      |                          |
 | \`encoding\`        | The encoding of the HTML content                                                                              | \`string\`      | utf-8                    |
 
@@ -103,7 +105,8 @@ Specify options (in the format of query string) in parameter \`routeParams\` par
                     const desc = routeParams.get('itemDescAttr') ? descEle.attr(routeParams.get('itemDescAttr')) : descEle.html();
 
                     const pubDateEle = routeParams.get('itemPubDate') ? item.find(routeParams.get('itemPubDate')) : item;
-                    const pubDate = routeParams.get('itemPubDateAttr') ? pubDateEle.attr(routeParams.get('itemPubDateAttr')) : pubDateEle.html();
+                    const pubDateRaw = routeParams.get('itemPubDateAttr') ? pubDateEle.attr(routeParams.get('itemPubDateAttr')) : pubDateEle.html();
+                    const pubDate = routeParams.get('itemPubDateFmt') ? parseDate(pubDateRaw, routeParams.get('itemPubDateFmt')) : pubDateRaw;
 
                     return {
                         title,

--- a/lib/routes/rsshub/transform/html.ts
+++ b/lib/routes/rsshub/transform/html.ts
@@ -139,7 +139,7 @@ Specify options (in the format of query string) in parameter \`routeParams\` par
                         }
 
                         const $ = load(decoder.decode(response.data));
-                        const content = $(itemContentSelector).html();
+                        const content = $(itemContentSelector).text();
                         if (!content) {
                             return item;
                         }

--- a/lib/routes/rsshub/transform/json.ts
+++ b/lib/routes/rsshub/transform/json.ts
@@ -4,6 +4,7 @@ import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { Route } from '@/types';
 import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
 
 function jsonGet(obj, attr) {
     if (typeof attr !== 'string') {
@@ -49,6 +50,8 @@ export const route: Route = {
 | \`itemLinkPrefix\` | Optional Prefix for \`itemLink\` value       | \`string\`        | None                                       |
 | \`itemDesc\`       | The JSON Path as \`description\` in \`item\` | \`string\`        | None                                       |
 | \`itemPubDate\`    | The JSON Path as \`pubDate\` in \`item\`     | \`string\`        | None                                       |
+| \`itemPubDateFmt\` | Date format string for \`day.js\`            | \`string\`        | None                                       |
+
 
 ::: tip
 JSON Path only supports format like \`a.b.c\`. if you need to access arrays, like \`a[0].b\`, you can write it as \`a.0.b\`.
@@ -103,11 +106,15 @@ async function handler(ctx) {
         if (link && !link.startsWith('http')) {
             link = `${new URL(url).origin}${link}`;
         }
+
+        const pubDateRaw = routeParams.get('itemPubDate') ? jsonGet(item, routeParams.get('itemPubDate')) : '';
+        const pubDate = routeParams.get('itemPubDateFmt') ? parseDate(pubDateRaw, routeParams.get('itemPubDateFmt')) : pubDateRaw;
+
         return {
             title: jsonGet(item, routeParams.get('itemTitle')),
             link,
             description: routeParams.get('itemDesc') ? jsonGet(item, routeParams.get('itemDesc')) : '',
-            pubDate: routeParams.get('itemPubDate') ? jsonGet(item, routeParams.get('itemPubDate')) : '',
+            pubDate,
         };
     });
 

--- a/lib/routes/rsshub/transform/json.ts
+++ b/lib/routes/rsshub/transform/json.ts
@@ -108,7 +108,7 @@ async function handler(ctx) {
         }
 
         const pubDateRaw = routeParams.get('itemPubDate') ? jsonGet(item, routeParams.get('itemPubDate')) : '';
-        const pubDate = routeParams.get('itemPubDateFmt') ? parseDate(pubDateRaw, routeParams.get('itemPubDateFmt')) : pubDateRaw;
+        const pubDate = pubDateRaw && routeParams.get('itemPubDateFmt') ? parseDate(pubDateRaw, routeParams.get('itemPubDateFmt')) : pubDateRaw;
 
         return {
             title: jsonGet(item, routeParams.get('itemTitle')),


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
/rsshub/transform/html/https%3A%2F%2Fblog%2Ecloudflare%2Ecom%2F/item=article&itemTitle=h2&itemPubDate=p%2Efw5&itemPubDateFmt=YYYY%2DMM%2DDD&itemDesc=p%2Efw4
/rsshub/transform/json/https%3A%2F%2Fapi.github.com%2Frepos%2Fginuerzh%2Fgost%2Freleases/title=Gost%20releases&itemTitle=tag_name&itemLink=html_url&itemDesc=body&itemPubDate=published_at&itemPubDateFmt=YYYY-MM-DD
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Simple date parsing with day.js as recommended by the [docs](https://rsshub-doc.pages.dev/en/joinus/pub-date.html#use-utilities-class).