### PR TITLE
fix(route/twitter): prevent "@undefined" username in feed metadata

### DIFF
--- a/lib/routes/twitter/api/web-api/api.ts
+++ b/lib/routes/twitter/api/web-api/api.ts
@@ -164,10 +164,11 @@ const getList = async (id: string, params?: Record<string, any>) =>
 
 const getUser = async (id: string) => {
     const userData: any = await getUserData(id);
+    const result = (userData.data?.user || userData.data?.user_result)?.result;
     return {
-        profile_image_url: userData.data?.user?.result?.avatar?.image_url,
-        ...userData.data?.user?.result?.core,
-        ...(userData.data?.user || userData.data?.user_result)?.result?.legacy,
+        profile_image_url: result?.avatar?.image_url,
+        ...result?.core,
+        ...result?.legacy,
     };
 };
 

--- a/lib/routes/twitter/user.ts
+++ b/lib/routes/twitter/user.ts
@@ -84,11 +84,13 @@ async function handler(ctx) {
     }
 
     const profileImageUrl = userInfo?.profile_image_url || userInfo?.profile_image_url_https;
+    const screenName = userInfo?.screen_name || (id.startsWith('+') ? undefined : id);
+    const displayName = userInfo?.name || screenName || id;
 
     return {
-        title: `Twitter @${userInfo?.name}`,
-        link: `https://x.com/${userInfo?.screen_name}`,
-        image: profileImageUrl.replace(/_normal.jpg$/, '.jpg'),
+        title: `Twitter @${displayName}`,
+        link: screenName ? `https://x.com/${screenName}` : 'https://x.com/',
+        image: profileImageUrl?.replace(/_normal.jpg$/, '.jpg'),
         description: userInfo?.description,
         item:
             data &&


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/twitter/user/_RSSHub
/twitter/user/+44196397
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Bug fix only — no new route, no new package, no new docs.

`/twitter/user/:id` feeds intermittently render with `Twitter @undefined`
in the title and `https://x.com/undefined` as the self-link. Two latent
defects produce this:

1. `lib/routes/twitter/api/web-api/api.ts` — `getUser` reads `core` only
   from `data.user.result.core` while `legacy` falls back to
   `data.user_result`. For `+UID` lookups (`UserByRestId`) Twitter serves
   the response under `data.user_result`, and `screen_name`/`name` now
   live in `core`, so the merged object loses both.
2. `lib/routes/twitter/user.ts` — the handler builds `title` /  `link`
   from `userInfo?.name` / `userInfo?.screen_name`. Optional chaining
   prevents a crash, but template literals stringify `undefined` to
   `"undefined"`. `profileImageUrl.replace(...)` was also not null-safe
   and threw `TypeError: Cannot read properties of undefined (reading
   'replace')` when both image fields were absent (cf. #11590, #12854).

The handler now falls back through `userInfo.name -> userInfo.screen_name
-> route id` for the title, uses a safe self-link (empty path for `+UID`
lookups so it does not produce `https://x.com/+12345678`, the raw `id`
otherwise), and chains `?.` on the avatar replace.

### Behaviour

| `userInfo` | `id` | title | link |
| - | - | - | - |
| `{ name, screen_name, profile_image_url, ... }` | `_RSSHub` | `Twitter @<name>` | `https://x.com/<screen_name>` |
| `{ screen_name, profile_image_url }` | `_RSSHub` | `Twitter @<screen_name>` | `https://x.com/<screen_name>` |
| `{ profile_image_url }` | `_RSSHub` | `Twitter @_RSSHub` | `https://x.com/_RSSHub` |
| `{}` | `_RSSHub` | `Twitter @_RSSHub` | `https://x.com/_RSSHub` |
| `{ profile_image_url }` | `+12345678` | `Twitter @+12345678` | `https://x.com/` |
| `{}` | `+12345678` | `Twitter @+12345678` | `https://x.com/` |

`pnpm lint` and `pnpm format:check` pass on the changed files; `tsc
--noEmit` baseline is unchanged.