### PR TITLE
fix(twitter): handle TweetPreviewDisplay for subscriber-only posts

### DIFF
--- a/lib/routes/twitter/api/mobile-api/api.ts
+++ b/lib/routes/twitter/api/mobile-api/api.ts
@@ -145,7 +145,34 @@ function gatherLegacyFromData(entries, filterNested, userId) {
     for (const entry of filteredEntries) {
         if (entry.entryId) {
             const content = entry.content || entry.item;
-            let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+            // 处理订阅者专属预览帖子（必须在 tweet.tweet 替换之前判断）
+            if (tweet?.__typename === 'TweetPreviewDisplay') {
+                const preview = tweet.tweet;
+                if (preview?.rest_id) {
+                    const userResult = preview.core?.user_results?.result;
+                    const screenName = userResult?.core?.screen_name ?? '';
+                    const fakeLegacy = {
+                        id_str: preview.rest_id,
+                        full_text: `🔒 [Subscribers Only] ${preview.text ?? ''}`,
+                        created_at: preview.created_at ?? '',
+                        entities: { urls: [], hashtags: [], symbols: [], user_mentions: [] },
+                        user_id_str: userResult?.rest_id ?? '',
+                        user: {
+                            name: userResult?.core?.name ?? screenName,
+                            screen_name: screenName,
+                            profile_image_url_https: userResult?.avatar?.image_url ?? '',
+                        },
+                        favorite_count: preview.favorite_count ?? 0,
+                        reply_count: preview.reply_count ?? 0,
+                        retweet_count: preview.retweet_count ?? 0,
+                    };
+                    if (userId === undefined || fakeLegacy.user_id_str === userId + '') {
+                        tweets.push(fakeLegacy);
+                    }
+                }
+                continue;
+            }
             if (tweet && tweet.tweet) {
                 tweet = tweet.tweet;
             }

--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -337,11 +337,34 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
     for (const entry of filteredEntries) {
         if (entry.entryId) {
             const content = entry.content || entry.item;
-            let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+            // 处理订阅者专属预览帖子（必须在 tweet.tweet 替换之前判断）
+            if (tweet?.__typename === 'TweetPreviewDisplay') {
+                const preview = tweet.tweet;
+                if (preview?.rest_id) {
+                    const userResult = preview.core?.user_results?.result;
+                    const screenName = userResult?.core?.screen_name ?? '';
+                    const fakeLegacy: any = {
+                        id_str: preview.rest_id,
+                        full_text: `🔒 [Subscribers Only] ${preview.text ?? ''}`,
+                        created_at: preview.created_at ?? '',
+                        entities: { urls: [], hashtags: [], symbols: [], user_mentions: [] },
+                        user_id_str: userResult?.rest_id ?? '',
+                        favorite_count: preview.favorite_count ?? 0,
+                        reply_count: preview.reply_count ?? 0,
+                        retweet_count: preview.retweet_count ?? 0,
+                    };
+                    hydrateLegacyUser(fakeLegacy, { core: preview.core, rest_id: preview.rest_id });
+                    if (userId === undefined || fakeLegacy.user_id_str === userId + '') {
+                        tweets.push(fakeLegacy);
+                    }
+                }
+                continue;
+            }
             if (tweet && tweet.tweet) {
                 tweet = tweet.tweet;
             }
-            if (tweet) {
+if (tweet) {
                 const retweet = tweet.legacy?.retweeted_status_result?.result;
                 for (const t of [tweet, retweet]) {
                     if (!t?.legacy) {


### PR DESCRIPTION
## Route

- /twitter/user/:id

## Problem

Subscriber-only posts are completely missing from the RSS feed generated
by `/twitter/user/:id`.

## Root Cause

The X API returns subscriber-only posts with `__typename: "TweetPreviewDisplay"`,
which has a different data structure from regular `Tweet` objects. The parser
silently dropped these entries because the type was not handled.

## Solution

Add a handler for `TweetPreviewDisplay` in both `web-api/utils.ts` and
`mobile-api/api.ts`. The check must occur before the `tweet = tweet.tweet`
reassignment. The available preview text is included in the feed with a
🔒 prefix to indicate the post requires a subscription.

## Testing

Tested against a Twitter account with subscriber-only posts.
Before: subscriber posts missing from feed.
After: subscriber posts appear with `🔒 [Subscribers Only]` prefix.