### PR TITLE
fix(twitter): handle TweetPreviewDisplay for subscriber-only posts

### DIFF
--- a/lib/routes/twitter/api/mobile-api/api.ts
+++ b/lib/routes/twitter/api/mobile-api/api.ts
@@ -145,7 +145,34 @@ function gatherLegacyFromData(entries, filterNested, userId) {
     for (const entry of filteredEntries) {
         if (entry.entryId) {
             const content = entry.content || entry.item;
-            let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+            // 处理订阅者专属预览帖子（必须在 tweet.tweet 替换之前判断）
+            if (tweet?.__typename === 'TweetPreviewDisplay') {
+                const preview = tweet.tweet;
+                if (preview?.rest_id) {
+                    const userResult = preview.core?.user_results?.result;
+                    const screenName = userResult?.core?.screen_name ?? '';
+                    const fakeLegacy = {
+                        id_str: preview.rest_id,
+                        full_text: `🔒 [Subscribers Only] ${preview.text ?? ''}`,
+                        created_at: preview.created_at ?? '',
+                        entities: { urls: [], hashtags: [], symbols: [], user_mentions: [] },
+                        user_id_str: userResult?.rest_id ?? '',
+                        user: {
+                            name: userResult?.core?.name ?? screenName,
+                            screen_name: screenName,
+                            profile_image_url_https: userResult?.avatar?.image_url ?? '',
+                        },
+                        favorite_count: preview.favorite_count ?? 0,
+                        reply_count: preview.reply_count ?? 0,
+                        retweet_count: preview.retweet_count ?? 0,
+                    };
+                    if (userId === undefined || fakeLegacy.user_id_str === userId + '') {
+                        tweets.push(fakeLegacy);
+                    }
+                }
+                continue;
+            }
             if (tweet && tweet.tweet) {
                 tweet = tweet.tweet;
             }

--- a/lib/routes/twitter/api/mobile-api/api.ts
+++ b/lib/routes/twitter/api/mobile-api/api.ts
@@ -145,13 +145,12 @@ function gatherLegacyFromData(entries, filterNested, userId) {
     for (const entry of filteredEntries) {
         if (entry.entryId) {
             const content = entry.content || entry.item;
-let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+            let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
             // Handle subscriber-only preview posts (must check before tweet.tweet reassignment)
             if (tweet?.__typename === 'TweetPreviewDisplay') {
                 const preview = tweet.tweet;
                 if (preview?.rest_id) {
                     const userResult = preview.core?.user_results?.result;
-                    const screenName = userResult?.core?.screen_name ?? '';
                     const fakeLegacy = {
                         id_str: preview.rest_id,
                         full_text: `🔒 [Subscribers Only] ${preview.text ?? ''}`,
@@ -159,8 +158,8 @@ let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet
                         entities: { urls: [], hashtags: [], symbols: [], user_mentions: [] },
                         user_id_str: userResult?.rest_id ?? '',
                         user: {
-                            name: userResult?.core?.name ?? screenName,
-                            screen_name: screenName,
+                            name: userResult?.core?.name ?? userResult?.core?.screen_name ?? '',
+                            screen_name: userResult?.core?.screen_name ?? '',
                             profile_image_url_https: userResult?.avatar?.image_url ?? '',
                         },
                         favorite_count: preview.favorite_count ?? 0,

--- a/lib/routes/twitter/api/mobile-api/api.ts
+++ b/lib/routes/twitter/api/mobile-api/api.ts
@@ -146,7 +146,7 @@ function gatherLegacyFromData(entries, filterNested, userId) {
         if (entry.entryId) {
             const content = entry.content || entry.item;
 let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
-            // 处理订阅者专属预览帖子（必须在 tweet.tweet 替换之前判断）
+            // Handle subscriber-only preview posts (must check before tweet.tweet reassignment)
             if (tweet?.__typename === 'TweetPreviewDisplay') {
                 const preview = tweet.tweet;
                 if (preview?.rest_id) {

--- a/lib/routes/twitter/api/mobile-api/api.ts
+++ b/lib/routes/twitter/api/mobile-api/api.ts
@@ -146,32 +146,6 @@ function gatherLegacyFromData(entries, filterNested, userId) {
         if (entry.entryId) {
             const content = entry.content || entry.item;
             let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
-            // Handle subscriber-only preview posts (must check before tweet.tweet reassignment)
-            if (tweet?.__typename === 'TweetPreviewDisplay') {
-                const preview = tweet.tweet;
-                if (preview?.rest_id) {
-                    const userResult = preview.core?.user_results?.result;
-                    const fakeLegacy = {
-                        id_str: preview.rest_id,
-                        full_text: `🔒 [Subscribers Only] ${preview.text ?? ''}`,
-                        created_at: preview.created_at ?? '',
-                        entities: { urls: [], hashtags: [], symbols: [], user_mentions: [] },
-                        user_id_str: userResult?.rest_id ?? '',
-                        user: {
-                            name: userResult?.core?.name ?? userResult?.core?.screen_name ?? '',
-                            screen_name: userResult?.core?.screen_name ?? '',
-                            profile_image_url_https: userResult?.avatar?.image_url ?? '',
-                        },
-                        favorite_count: preview.favorite_count ?? 0,
-                        reply_count: preview.reply_count ?? 0,
-                        retweet_count: preview.retweet_count ?? 0,
-                    };
-                    if (userId === undefined || fakeLegacy.user_id_str === userId + '') {
-                        tweets.push(fakeLegacy);
-                    }
-                }
-                continue;
-            }
             if (tweet && tweet.tweet) {
                 tweet = tweet.tweet;
             }

--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -337,11 +337,34 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
     for (const entry of filteredEntries) {
         if (entry.entryId) {
             const content = entry.content || entry.item;
-            let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+            // 处理订阅者专属预览帖子（必须在 tweet.tweet 替换之前判断）
+            if (tweet?.__typename === 'TweetPreviewDisplay') {
+                const preview = tweet.tweet;
+                if (preview?.rest_id) {
+                    const userResult = preview.core?.user_results?.result;
+                    const screenName = userResult?.core?.screen_name ?? '';
+                    const fakeLegacy: any = {
+                        id_str: preview.rest_id,
+                        full_text: `🔒 [Subscribers Only] ${preview.text ?? ''}`,
+                        created_at: preview.created_at ?? '',
+                        entities: { urls: [], hashtags: [], symbols: [], user_mentions: [] },
+                        user_id_str: userResult?.rest_id ?? '',
+                        favorite_count: preview.favorite_count ?? 0,
+                        reply_count: preview.reply_count ?? 0,
+                        retweet_count: preview.retweet_count ?? 0,
+                    };
+                    hydrateLegacyUser(fakeLegacy, { core: preview.core, rest_id: preview.rest_id });
+                    if (userId === undefined || fakeLegacy.user_id_str === userId + '') {
+                        tweets.push(fakeLegacy);
+                    }
+                }
+                continue;
+            }
             if (tweet && tweet.tweet) {
                 tweet = tweet.tweet;
             }
-            if (tweet) {
+if (tweet) {
                 const retweet = tweet.legacy?.retweeted_status_result?.result;
                 for (const t of [tweet, retweet]) {
                     if (!t?.legacy) {

--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -337,8 +337,8 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
     for (const entry of filteredEntries) {
         if (entry.entryId) {
             const content = entry.content || entry.item;
-let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
-            // 处理订阅者专属预览帖子（必须在 tweet.tweet 替换之前判断）
+            let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet_results?.result;
+            // Handle subscriber-only preview posts (must check before tweet.tweet reassignment)
             if (tweet?.__typename === 'TweetPreviewDisplay') {
                 const preview = tweet.tweet;
                 if (preview?.rest_id) {
@@ -363,7 +363,7 @@ let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet
             if (tweet && tweet.tweet) {
                 tweet = tweet.tweet;
             }
-if (tweet) {
+            if (tweet) {
                 const retweet = tweet.legacy?.retweeted_status_result?.result;
                 for (const t of [tweet, retweet]) {
                     if (!t?.legacy) {

--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -345,7 +345,7 @@ export function gatherLegacyFromData(entries: any[], filterNested?: string[], us
                     const userResult = preview.core?.user_results?.result;
                     const fakeLegacy: any = {
                         id_str: preview.rest_id,
-                        full_text: `🔒 [Subscribers Only] ${preview.text ?? ''}`,
+                        full_text: `[Subscribers Only] ${preview.text ?? ''}`,
                         created_at: preview.created_at ?? '',
                         entities: { urls: [], hashtags: [], symbols: [], user_mentions: [] },
                         user_id_str: userResult?.rest_id ?? '',

--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -343,7 +343,6 @@ let tweet = content?.content?.tweetResult?.result || content?.itemContent?.tweet
                 const preview = tweet.tweet;
                 if (preview?.rest_id) {
                     const userResult = preview.core?.user_results?.result;
-                    const screenName = userResult?.core?.screen_name ?? '';
                     const fakeLegacy: any = {
                         id_str: preview.rest_id,
                         full_text: `🔒 [Subscribers Only] ${preview.text ?? ''}`,

--- a/lib/routes/twitter/namespace.ts
+++ b/lib/routes/twitter/namespace.ts
@@ -30,6 +30,9 @@ export const namespace: Namespace = {
 | \`count\`                        | \`count\` parameter passed to Twitter API, only available in \`/twitter/user\`                                                           | Unspecified/Integer    | Unspecified                               |
 | \`onlyMedia\`                    | Only get tweets with a media                                                                                                         | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                                   |
 | \`mediaNumber \`                 | Number the medias                                                                                                                    | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                                   |
+| \`showEmojiForSubscriberOnly\`  | Use "🔒" as prefix for subscriber-only posts                                                                                         | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                                   |
+| \`showSymbolForSubscriberOnly\` | Use "[Subscribers Only]" as prefix for subscriber-only posts                                                                         | \`0\`/\`1\`/\`true\`/\`false\` | \`true\`                                    |
+| \`showFullPrefixForSubscriberOnly\` | Use "🔒 [Subscribers Only]" as prefix for subscriber-only posts                                                                 | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                                   |                                                                         | \`0\`/\`1\`/\`true\`/\`false\` | \`true\`                                    |                                                                                                                    | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`                                   |
 
 Specify different option values than default values to improve readability. The URL
 

--- a/lib/routes/twitter/utils.ts
+++ b/lib/routes/twitter/utils.ts
@@ -66,6 +66,9 @@ const ProcessFeed = (ctx, { data = [] }, params = {}) => {
         sizeOfAuthorAvatar: fallback(params.sizeOfAuthorAvatar, queryToInteger(routeParams.get('sizeOfAuthorAvatar')), 48),
         sizeOfQuotedAuthorAvatar: fallback(params.sizeOfQuotedAuthorAvatar, queryToInteger(routeParams.get('sizeOfQuotedAuthorAvatar')), 24),
         mediaNumber: fallback(params.mediaNumber, queryToInteger(routeParams.get('mediaNumber')), false),
+        showEmojiForSubscriberOnly: fallback(params.showEmojiForSubscriberOnly, queryToBoolean(routeParams.get('showEmojiForSubscriberOnly')), false),
+        showSymbolForSubscriberOnly: fallback(params.showSymbolForSubscriberOnly, queryToBoolean(routeParams.get('showSymbolForSubscriberOnly')), true),
+        showFullPrefixForSubscriberOnly: fallback(params.showFullPrefixForSubscriberOnly, queryToBoolean(routeParams.get('showFullPrefixForSubscriberOnly')), false),
     };
 
     params = mergedParams;
@@ -85,6 +88,9 @@ const ProcessFeed = (ctx, { data = [] }, params = {}) => {
         showTimestampInDescription,
         showQuotedInTitle,
         mediaNumber,
+        showEmojiForSubscriberOnly,
+        showSymbolForSubscriberOnly,
+        showFullPrefixForSubscriberOnly,
         widthOfPics,
         heightOfPics,
         sizeOfAuthorAvatar,
@@ -198,6 +204,12 @@ const ProcessFeed = (ctx, { data = [] }, params = {}) => {
     };
 
     return data.map((item) => {
+        // Handle subscriber-only prefix based on user preference
+        if (item.full_text?.startsWith('[Subscribers Only]')) {
+            const text = item.full_text.replace('[Subscribers Only] ', '');
+            const prefix = showFullPrefixForSubscriberOnly ? '🔒 [Subscribers Only] ' : showEmojiForSubscriberOnly ? '🔒 ' : showSymbolForSubscriberOnly ? '[Subscribers Only] ' : '';
+            item.full_text = `${prefix}${text}`;
+        }
         const originalItem = item;
         item = item.retweeted_status || item;
         item.full_text = item.full_text || item.text;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fix subscriber-only posts (`TweetPreviewDisplay`) not appearing in `/twitter/user/:id` feed.

The X API returns subscriber-only posts with `__typename: "TweetPreviewDisplay"`, which has a different structure from regular `Tweet` objects. The parser silently dropped these entries because the type was not handled.

Added a handler in both `web-api/utils.ts` and `mobile-api/api.ts`. The check must occur before the `tweet = tweet.tweet` reassignment. Preview text is included in the feed with a 🔒 prefix.