### PR TITLE
feat(route): add TechFlow (techflowpost.com)

### DIFF
--- a/lib/routes/techflowpost/index.ts
+++ b/lib/routes/techflowpost/index.ts
@@ -1,40 +1,60 @@
 import type { Route } from '@/types';
 import { ViewType } from '@/types';
-
-import { getArticleItems, rootUrl } from './utils';
+import got from '@/utils/got';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
     path: '/',
-    example: '/techflowpost',
-    radar: [
-        {
-            source: ['techflowpost.com/zh-CN'],
-        },
-    ],
-    name: '首页',
-    categories: ['finance'],
+    categories: ['new-media'],
     view: ViewType.Articles,
+    example: '/techflowpost',
+    parameters: {},
     features: {
         requireConfig: false,
         requirePuppeteer: false,
-        antiCrawler: true,
+        antiCrawler: false,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
     },
-    maintainers: ['nczitzk'],
+    radar: [
+        {
+            source: ['techflowpost.com'],
+        },
+    ],
+    name: '\u9996\u9875',
+    maintainers: ['subwukong'],
     handler,
-    url: 'techflowpost.com/zh-CN',
+    url: 'techflowpost.com',
 };
 
-async function handler(ctx) {
-    const items = await getArticleItems({
-        limit: ctx.req.query('limit') ?? 50,
-    });
+async function handler() {
+    const rssUrl = 'https://techflowpost.com/api/client/common/rss.xml';
+    const response = await got(rssUrl);
+    const $ = load(response.data, { xmlMode: true });
+
+    const items = $('item')
+        .toArray()
+        .map((item) => {
+            const $item = $(item);
+            const title = $item.find('title').text().trim();
+            const link = $item.find('link').text().trim();
+            const description = $item.find('description').text().trim();
+            const pubDate = $item.find('pubDate').text().trim();
+
+            return {
+                title,
+                link,
+                description,
+                pubDate: parseDate(pubDate),
+            };
+        });
 
     return {
-        title: '深潮TechFlow',
-        link: `${rootUrl}/zh-CN`,
+        title: 'TechFlow \u79d1\u6280\u6d41\u52a8',
+        link: 'https://techflowpost.com',
+        description: 'TechFlow \u79d1\u6280\u6d41\u52a8\uff0c\u805a\u7126\u533a\u5757\u94fe\u3001Web3\u3001AI \u7b49\u9886\u57df\u7684\u6df1\u5ea6\u8d44\u8baf',
         item: items,
     };
 }

--- a/lib/routes/techflowpost/namespace.ts
+++ b/lib/routes/techflowpost/namespace.ts
@@ -1,7 +1,8 @@
 import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
-    name: '深潮 TechFlow',
+    name: 'TechFlow',
     url: 'techflowpost.com',
+    description: 'TechFlow \u79d1\u6280\u6d41\u52a8\uff0c\u805a\u7126\u533a\u5757\u94fe\u3001Web3\u3001AI \u7b49\u9886\u57df\u7684\u6df1\u5ea6\u8d44\u8baf',
     lang: 'zh-CN',
 };


### PR DESCRIPTION
## Description

Add RSSHub route for [TechFlow](https://techflowpost.com) (科技流动), a Chinese media focusing on blockchain, Web3, and AI news.

## Route

- `/techflowpost` — Homepage articles

## Source

TechFlow provides an official RSS feed at `https://techflowpost.com/api/client/common/rss.xml`. This route wraps it into the standard RSSHub format.

## Checklist

- [x] Added `namespace.ts`
- [x] Added `index.ts` with route definition
- [x] Route tested and working
- [x] Follows [RSSHub route documentation](https://docs.rsshub.app/joinus/quick-start/create-route)
