### PR TITLE
feat(route/4chan): add filters for sticky threads and reply count

### DIFF
--- a/lib/routes/4chan/catalog.tsx
+++ b/lib/routes/4chan/catalog.tsx
@@ -1,17 +1,15 @@
-import type { Context } from "hono";
+import type { Context } from 'hono';
 
-import type { Route } from "@/types";
-import got from "@/utils/got";
+import type { Route } from '@/types';
+import got from '@/utils/got';
 
-import type { CatalogApiReturn } from "./utils";
-import { parseParams, processCatalog } from "./utils";
+import type { CatalogApiReturn } from './utils';
+import { parseParams, processCatalog } from './utils';
 
 const handler = async (ctx: Context) => {
     const { board } = ctx.req.param();
-    const viewOptions = parseParams(ctx.req.param("routeParams"));
-    const { data }: { data: CatalogApiReturn } = await got(
-        `https://a.4cdn.org/${board}/catalog.json`,
-    );
+    const viewOptions = parseParams(ctx.req.param('routeParams'));
+    const { data }: { data: CatalogApiReturn } = await got(`https://a.4cdn.org/${board}/catalog.json`);
 
     return {
         title: `4chan's /${board}/`,
@@ -21,12 +19,12 @@ const handler = async (ctx: Context) => {
 };
 
 export const route: Route = {
-    path: "/:board/catalog/:routeParams?",
-    categories: ["bbs"],
-    example: "/4chan/g/catalog",
+    path: '/:board/catalog/:routeParams?',
+    categories: ['bbs'],
+    example: '/4chan/g/catalog',
     parameters: {
-        board: "4chan board",
-        routeParams: "extra parameters, see the table above",
+        board: '4chan board',
+        routeParams: 'extra parameters, see the table above',
     },
     features: {
         requirePuppeteer: false,
@@ -36,11 +34,11 @@ export const route: Route = {
         supportScihub: false,
     },
     name: "Board's catalog",
-    maintainers: ["heisenshark"],
+    maintainers: ['heisenshark'],
     radar: [
         {
-            source: ["boards.4chan.org/:board/"],
-            target: "/:board/catalog",
+            source: ['boards.4chan.org/:board/'],
+            target: '/:board/catalog',
         },
     ],
     description: `Specify options (in the format of query string) in parameter \`routeParams\` to control extra features for threads

--- a/lib/routes/4chan/catalog.tsx
+++ b/lib/routes/4chan/catalog.tsx
@@ -1,15 +1,17 @@
-import type { Context } from 'hono';
+import type { Context } from "hono";
 
-import type { Route } from '@/types';
-import got from '@/utils/got';
+import type { Route } from "@/types";
+import got from "@/utils/got";
 
-import type { CatalogApiReturn } from './utils';
-import { parseParams, processCatalog } from './utils';
+import type { CatalogApiReturn } from "./utils";
+import { parseParams, processCatalog } from "./utils";
 
 const handler = async (ctx: Context) => {
     const { board } = ctx.req.param();
-    const viewOptions = parseParams(ctx.req.param('routeParams'));
-    const { data }: { data: CatalogApiReturn } = await got(`https://a.4cdn.org/${board}/catalog.json`);
+    const viewOptions = parseParams(ctx.req.param("routeParams"));
+    const { data }: { data: CatalogApiReturn } = await got(
+        `https://a.4cdn.org/${board}/catalog.json`,
+    );
 
     return {
         title: `4chan's /${board}/`,
@@ -19,12 +21,12 @@ const handler = async (ctx: Context) => {
 };
 
 export const route: Route = {
-    path: '/:board/catalog/:routeParams?',
-    categories: ['bbs'],
-    example: '/4chan/g/catalog',
+    path: "/:board/catalog/:routeParams?",
+    categories: ["bbs"],
+    example: "/4chan/g/catalog",
     parameters: {
-        board: '4chan board',
-        routeParams: 'extra parameters, see the table above',
+        board: "4chan board",
+        routeParams: "extra parameters, see the table above",
     },
     features: {
         requirePuppeteer: false,
@@ -34,19 +36,22 @@ export const route: Route = {
         supportScihub: false,
     },
     name: "Board's catalog",
-    maintainers: ['heisenshark'],
+    maintainers: ["heisenshark"],
     radar: [
         {
-            source: ['boards.4chan.org/:board/'],
-            target: '/:board/catalog',
+            source: ["boards.4chan.org/:board/"],
+            target: "/:board/catalog",
         },
     ],
-    description: `Specify options (in the format of query string) in parameter \`routeParams\` to control some extra features for Tweets
+    description: `Specify options (in the format of query string) in parameter \`routeParams\` to control extra features for threads
 
 | Key               | Description                                      | Accepts                | Defaults to |
 | ----------------- | ------------------------------------------------ | ---------------------- | ----------- |
 | \`showReplyCount\`  | Show number of replies of each thread in catalog | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`     |
 | \`showLastReplies\` | Show last 5 replies of each thread               | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`     |
-| \`revealSpoilers\`  | Don't wrap images tagged as spoilers             | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`     |`,
+| \`revealSpoilers\`  | Don't wrap images tagged as spoilers             | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`     |
+| \`excludeSticky\`  | Filter out sticky threads                        | \`0\`/\`1\`/\`true\`/\`false\` | \`false\`     |
+| \`minReplies\`     | Minimum replies per thread                       | Integer                | None        |
+| \`maxReplies\`     | Maximum replies per thread                       | Integer                | None        |`,
     handler,
 };

--- a/lib/routes/4chan/utils.tsx
+++ b/lib/routes/4chan/utils.tsx
@@ -1,47 +1,128 @@
-import { raw } from 'hono/html';
-import { renderToString } from 'hono/jsx/dom/server';
-import sanitizeHtml from 'sanitize-html';
+import { raw } from "hono/html";
+import { renderToString } from "hono/jsx/dom/server";
+import sanitizeHtml from "sanitize-html";
 
-import { parseDate } from '@/utils/parse-date';
-import { queryToBoolean } from '@/utils/readable-social';
+import { parseDate } from "@/utils/parse-date";
+import { queryToBoolean } from "@/utils/readable-social";
 
-const parseParams = (routeParams: string) => {
-    const parsed = new URLSearchParams(routeParams);
+const parseParams = (routeParams?: string) => {
+    const parsed = new URLSearchParams(routeParams ?? "");
+    const minRepliesRaw = parsed.get("minReplies");
+    const maxRepliesRaw = parsed.get("maxReplies");
+    const minReplies =
+        minRepliesRaw === null ? undefined : Number(minRepliesRaw);
+    const maxReplies =
+        maxRepliesRaw === null ? undefined : Number(maxRepliesRaw);
     const viewOptions = {
-        includeLastReplies: !!queryToBoolean(parsed.get('showLastReplies')),
-        includeReplyCount: !!queryToBoolean(parsed.get('showReplyCount')),
-        revealSpoilers: !!queryToBoolean(parsed.get('revealSpoilers')),
+        excludeSticky: !!queryToBoolean(parsed.get("excludeSticky")),
+        includeLastReplies: !!queryToBoolean(parsed.get("showLastReplies")),
+        includeReplyCount: !!queryToBoolean(parsed.get("showReplyCount")),
+        maxReplies: Number.isFinite(maxReplies) ? maxReplies : undefined,
+        minReplies: Number.isFinite(minReplies) ? minReplies : undefined,
+        revealSpoilers: !!queryToBoolean(parsed.get("revealSpoilers")),
     };
     return viewOptions;
 };
 
-const processCatalog = ({ data, board, viewOptions }: { data: CatalogApiReturn; board: string; viewOptions: ViewOptions }) => {
+const processCatalog = ({
+    data,
+    board,
+    viewOptions,
+}: {
+    data: CatalogApiReturn;
+    board: string;
+    viewOptions: ViewOptions;
+}) => {
     const transformedData = data.flatMap((page) => page.threads);
-    return transformedData.map((thread) => ({
+    const filteredData = transformedData.filter((thread) => {
+        if (viewOptions.excludeSticky && thread.sticky) {
+            return false;
+        }
+
+        const replies = thread.replies ?? 0;
+        if (
+            viewOptions.minReplies !== undefined &&
+            replies < viewOptions.minReplies
+        ) {
+            return false;
+        }
+
+        if (
+            viewOptions.maxReplies !== undefined &&
+            replies > viewOptions.maxReplies
+        ) {
+            return false;
+        }
+
+        return true;
+    });
+
+    return filteredData.map((thread) => ({
         author: `${thread.name} ${thread.trip ?? thread.no}`,
-        description: renderToString(renderPost({ post: thread, board, viewOptions })),
+        description: renderToString(
+            renderPost({ post: thread, board, viewOptions }),
+        ),
         link: `https://boards.4chan.org/${board}/thread/${thread.no}`,
         pubDate: parseDate(thread.time * 1000),
-        title: thread.sub ?? sanitizeHtml(thread.com?.split('<br>')[0] ?? '', { allowedTags: [] }),
+        title:
+            thread.sub ??
+            sanitizeHtml(thread.com?.split("<br>")[0] ?? "", {
+                allowedTags: [],
+            }),
     }));
 };
 
-const renderPost = ({ post, board, viewOptions }: { post: ChanPost; board: string; viewOptions: ViewOptions }) => {
+const renderPost = ({
+    post,
+    board,
+    viewOptions,
+}: {
+    post: ChanPost;
+    board: string;
+    viewOptions: ViewOptions;
+}) => {
     let media = <></>;
     switch (post.ext) {
-        case '.jpg':
-        case '.png':
-        case '.gif':
-            media = <img width={post.w} height={post.h} style="" src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`} />;
+        case ".jpg":
+        case ".png":
+        case ".gif":
+            media = (
+                <img
+                    width={post.w}
+                    height={post.h}
+                    style=""
+                    src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`}
+                />
+            );
             break;
-        case '.pdf':
-            media = <embed src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`} width="100%" height="500px"></embed>;
+        case ".pdf":
+            media = (
+                <embed
+                    src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`}
+                    width="100%"
+                    height="500px"
+                ></embed>
+            );
             break;
-        case '.swf':
-            media = <embed src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`} type="application/x-shockwave-flash" width={post.w} height={post.h} />;
+        case ".swf":
+            media = (
+                <embed
+                    src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`}
+                    type="application/x-shockwave-flash"
+                    width={post.w}
+                    height={post.h}
+                />
+            );
             break;
-        case '.webm':
-            media = <video src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`} loop controls class="full-image"></video>;
+        case ".webm":
+            media = (
+                <video
+                    src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`}
+                    loop
+                    controls
+                    class="full-image"
+                ></video>
+            );
             break;
         default:
             break;
@@ -67,9 +148,14 @@ const renderPost = ({ post, board, viewOptions }: { post: ChanPost; board: strin
                     <br />
                 </>
             )}
-            {raw(post.com ?? '')}
+            {raw(post.com ?? "")}
             {media}
-            {viewOptions.includeLastReplies && post.last_replies?.map((n) => <div className="post reply">{renderPost({ post: n, board, viewOptions })}</div>)}
+            {viewOptions.includeLastReplies &&
+                post.last_replies?.map((n) => (
+                    <div className="post reply">
+                        {renderPost({ post: n, board, viewOptions })}
+                    </div>
+                ))}
         </>
     );
     return renderedPost;
@@ -95,7 +181,7 @@ interface ChanPost {
     com?: string;
     tim?: number;
     filename: string;
-    ext: '.jpg' | '.png' | '.gif' | '.pdf' | '.swf' | '.webm';
+    ext: ".jpg" | ".png" | ".gif" | ".pdf" | ".swf" | ".webm";
     fsize: number;
     md5: string;
     w?: number;

--- a/lib/routes/4chan/utils.tsx
+++ b/lib/routes/4chan/utils.tsx
@@ -24,7 +24,7 @@ const parseParams = (routeParams?: string) => {
 
 const processCatalog = ({ data, board, viewOptions }: { data: CatalogApiReturn; board: string; viewOptions: ViewOptions }) => {
     const transformedData = data.flatMap((page) => page.threads);
-    const filteredData = transformedData.filter((thread) => {
+    return transformedData.filter((thread) => {
         if (viewOptions.excludeSticky && thread.sticky) {
             return false;
         }
@@ -39,9 +39,7 @@ const processCatalog = ({ data, board, viewOptions }: { data: CatalogApiReturn; 
         }
 
         return true;
-    });
-
-    return filteredData.map((thread) => ({
+    }).map((thread) => ({
         author: `${thread.name} ${thread.trip ?? thread.no}`,
         description: renderToString(renderPost({ post: thread, board, viewOptions })),
         link: `https://boards.4chan.org/${board}/thread/${thread.no}`,

--- a/lib/routes/4chan/utils.tsx
+++ b/lib/routes/4chan/utils.tsx
@@ -1,38 +1,28 @@
-import { raw } from "hono/html";
-import { renderToString } from "hono/jsx/dom/server";
-import sanitizeHtml from "sanitize-html";
+import { raw } from 'hono/html';
+import { renderToString } from 'hono/jsx/dom/server';
+import sanitizeHtml from 'sanitize-html';
 
-import { parseDate } from "@/utils/parse-date";
-import { queryToBoolean } from "@/utils/readable-social";
+import { parseDate } from '@/utils/parse-date';
+import { queryToBoolean } from '@/utils/readable-social';
 
 const parseParams = (routeParams?: string) => {
-    const parsed = new URLSearchParams(routeParams ?? "");
-    const minRepliesRaw = parsed.get("minReplies");
-    const maxRepliesRaw = parsed.get("maxReplies");
-    const minReplies =
-        minRepliesRaw === null ? undefined : Number(minRepliesRaw);
-    const maxReplies =
-        maxRepliesRaw === null ? undefined : Number(maxRepliesRaw);
+    const parsed = new URLSearchParams(routeParams ?? '');
+    const minRepliesRaw = parsed.get('minReplies');
+    const maxRepliesRaw = parsed.get('maxReplies');
+    const minReplies = minRepliesRaw === null ? undefined : Number(minRepliesRaw);
+    const maxReplies = maxRepliesRaw === null ? undefined : Number(maxRepliesRaw);
     const viewOptions = {
-        excludeSticky: !!queryToBoolean(parsed.get("excludeSticky")),
-        includeLastReplies: !!queryToBoolean(parsed.get("showLastReplies")),
-        includeReplyCount: !!queryToBoolean(parsed.get("showReplyCount")),
+        excludeSticky: !!queryToBoolean(parsed.get('excludeSticky')),
+        includeLastReplies: !!queryToBoolean(parsed.get('showLastReplies')),
+        includeReplyCount: !!queryToBoolean(parsed.get('showReplyCount')),
         maxReplies: Number.isFinite(maxReplies) ? maxReplies : undefined,
         minReplies: Number.isFinite(minReplies) ? minReplies : undefined,
-        revealSpoilers: !!queryToBoolean(parsed.get("revealSpoilers")),
+        revealSpoilers: !!queryToBoolean(parsed.get('revealSpoilers')),
     };
     return viewOptions;
 };
 
-const processCatalog = ({
-    data,
-    board,
-    viewOptions,
-}: {
-    data: CatalogApiReturn;
-    board: string;
-    viewOptions: ViewOptions;
-}) => {
+const processCatalog = ({ data, board, viewOptions }: { data: CatalogApiReturn; board: string; viewOptions: ViewOptions }) => {
     const transformedData = data.flatMap((page) => page.threads);
     const filteredData = transformedData.filter((thread) => {
         if (viewOptions.excludeSticky && thread.sticky) {
@@ -40,17 +30,11 @@ const processCatalog = ({
         }
 
         const replies = thread.replies ?? 0;
-        if (
-            viewOptions.minReplies !== undefined &&
-            replies < viewOptions.minReplies
-        ) {
+        if (viewOptions.minReplies !== undefined && replies < viewOptions.minReplies) {
             return false;
         }
 
-        if (
-            viewOptions.maxReplies !== undefined &&
-            replies > viewOptions.maxReplies
-        ) {
+        if (viewOptions.maxReplies !== undefined && replies > viewOptions.maxReplies) {
             return false;
         }
 
@@ -59,70 +43,29 @@ const processCatalog = ({
 
     return filteredData.map((thread) => ({
         author: `${thread.name} ${thread.trip ?? thread.no}`,
-        description: renderToString(
-            renderPost({ post: thread, board, viewOptions }),
-        ),
+        description: renderToString(renderPost({ post: thread, board, viewOptions })),
         link: `https://boards.4chan.org/${board}/thread/${thread.no}`,
         pubDate: parseDate(thread.time * 1000),
-        title:
-            thread.sub ??
-            sanitizeHtml(thread.com?.split("<br>")[0] ?? "", {
-                allowedTags: [],
-            }),
+        title: thread.sub ?? sanitizeHtml(thread.com?.split('<br>')[0] ?? '', { allowedTags: [] }),
     }));
 };
 
-const renderPost = ({
-    post,
-    board,
-    viewOptions,
-}: {
-    post: ChanPost;
-    board: string;
-    viewOptions: ViewOptions;
-}) => {
+const renderPost = ({ post, board, viewOptions }: { post: ChanPost; board: string; viewOptions: ViewOptions }) => {
     let media = <></>;
     switch (post.ext) {
-        case ".jpg":
-        case ".png":
-        case ".gif":
-            media = (
-                <img
-                    width={post.w}
-                    height={post.h}
-                    style=""
-                    src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`}
-                />
-            );
+        case '.jpg':
+        case '.png':
+        case '.gif':
+            media = <img width={post.w} height={post.h} style="" src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`} />;
             break;
-        case ".pdf":
-            media = (
-                <embed
-                    src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`}
-                    width="100%"
-                    height="500px"
-                ></embed>
-            );
+        case '.pdf':
+            media = <embed src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`} width="100%" height="500px"></embed>;
             break;
-        case ".swf":
-            media = (
-                <embed
-                    src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`}
-                    type="application/x-shockwave-flash"
-                    width={post.w}
-                    height={post.h}
-                />
-            );
+        case '.swf':
+            media = <embed src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`} type="application/x-shockwave-flash" width={post.w} height={post.h} />;
             break;
-        case ".webm":
-            media = (
-                <video
-                    src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`}
-                    loop
-                    controls
-                    class="full-image"
-                ></video>
-            );
+        case '.webm':
+            media = <video src={`https://i.4cdn.org/${board}/${post.tim}${post.ext}`} loop controls class="full-image"></video>;
             break;
         default:
             break;
@@ -148,14 +91,9 @@ const renderPost = ({
                     <br />
                 </>
             )}
-            {raw(post.com ?? "")}
+            {raw(post.com ?? '')}
             {media}
-            {viewOptions.includeLastReplies &&
-                post.last_replies?.map((n) => (
-                    <div className="post reply">
-                        {renderPost({ post: n, board, viewOptions })}
-                    </div>
-                ))}
+            {viewOptions.includeLastReplies && post.last_replies?.map((n) => <div className="post reply">{renderPost({ post: n, board, viewOptions })}</div>)}
         </>
     );
     return renderedPost;
@@ -181,7 +119,7 @@ interface ChanPost {
     com?: string;
     tim?: number;
     filename: string;
-    ext: ".jpg" | ".png" | ".gif" | ".pdf" | ".swf" | ".webm";
+    ext: '.jpg' | '.png' | '.gif' | '.pdf' | '.swf' | '.webm';
     fsize: number;
     md5: string;
     w?: number;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

n/a

## Example for the Proposed Route(s) / 路由地址示例

```routes
/4chan/g/catalog/excludeSticky=1&minReplies=10
/4chan/g/catalog/minReplies=20&maxReplies=200
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds optional filtering parameters for existing 4chan catalog route: `excludeSticky`, `minReplies`, `maxReplies`.