### PR TITLE
docs(parameter): clarify limit param behavior — slice, not source restriction

### DIFF
--- a/lib/middleware/parameter.ts
+++ b/lib/middleware/parameter.ts
@@ -284,7 +284,8 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
             });
         }
 
-        // limit
+        // limit: 截取已有 items 数组（不是从源头限制数量）
+        // 注意：此参数在缓存之后执行，带/不带 limit 的请求会命中同一缓存但返回不同结果
         if (ctx.req.query('limit')) {
             data.item = data.item.slice(0, Number.parseInt(ctx.req.query('limit')!));
         }


### PR DESCRIPTION
## Fix for Issue #8166

### Problem
The `limit` parameter's actual behavior is to **slice the already-retrieved items array** using `.slice(0, n)`, not to restrict how many items are fetched from the source.

### Changes
Added explanatory comments to `lib/middleware/parameter.ts`.

### Testing
The existing behavior is unchanged — only comments added to clarify intent.

### Related
Fixes #8166 (opened Sep 9, 2021)

---

```routes
NOROUTE
```