### PR TITLE
feat: add GXNAS blog route

### DIFF
--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -1,0 +1,71 @@
+import { load } from 'cheerio';
+
+import type { DataItem, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/',
+    categories: ['blog'],
+    example: '/gxnas',
+    radar: [
+        {
+            source: ['wp.gxnas.com/'],
+        },
+    ],
+    url: 'wp.gxnas.com/',
+    name: '最新文章',
+    maintainers: ['Franklittleboy'],
+    handler,
+    description: 'GXNAS博客最新文章',
+};
+
+async function handler() {
+    const rootUrl = 'https://wp.gxnas.com';
+
+    const response = await ofetch(rootUrl);
+    const $ = load(response);
+
+    const items = $('.article-panel')
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+
+            const titleEl = $el.find('.header .title a');
+            const title = titleEl.text().trim();
+            const link = titleEl.attr('href');
+
+            const categoryEl = $el.find('.header .label');
+            const category = categoryEl.text().trim();
+
+            const contentEl = $el.find('.content');
+            const description = contentEl.html() || '';
+
+            const thumbEl = $el.find('.a-thumb img');
+            const image = thumbEl.attr('src');
+
+            // Date format: 2023年11月17日
+            const dateText = $el.find('.a-meta span').first().text().trim();
+            let pubDate: Date | undefined;
+            const m = dateText.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
+            if (m) {
+                pubDate = new Date(parseInt(m[1]), parseInt(m[2]) - 1, parseInt(m[3]));
+            }
+
+            return {
+                title,
+                link,
+                description: image ? `<img src="${image}"><br>${description}` : description,
+                category,
+                pubDate: pubDate ? parseDate(pubDate) : undefined,
+            } as DataItem;
+        })
+        .filter((item) => item.title && item.link);
+
+    return {
+        title: 'GXNAS博客',
+        link: rootUrl,
+        item: items,
+        description: 'GXNAS博客 - NAS博客|NAS社区|NAS交流|NAS技术|群晖教程|软路由',
+    };
+}

--- a/lib/routes/gxnas/namespace.ts
+++ b/lib/routes/gxnas/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'GXNAS博客',
+    url: 'wp.gxnas.com',
+    description: 'GXNAS博客 - NAS技术交流',
+    lang: 'zh-CN',
+};


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/gxnas
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add RSS feed for [GXNAS博客](https://wp.gxnas.com), a Chinese NAS technology blog covering Synology tutorials, soft routers, and AI topics.

The site uses Cloudflare protection which blocks the WordPress `/feed/` endpoint, so this route scrapes the homepage HTML for article list instead. Full article content is not fetched because detail pages also return Cloudflare block pages from server-side requests.