### PR TITLE
docs(parameter): clarify limit param — slice not source restriction

### DIFF
--- a/lib/middleware/parameter.ts
+++ b/lib/middleware/parameter.ts
@@ -284,7 +284,8 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
             });
         }
 
-        // limit
+        // limit: slices the existing items array (does not restrict items fetched from source)
+        // Note: this parameter is applied after caching — requests with and without limit share the same cache but return different results
         if (ctx.req.query('limit')) {
             data.item = data.item.slice(0, Number.parseInt(ctx.req.query('limit')!));
         }


### PR DESCRIPTION
## Fix for Issue #8166 — clarify `limit` parameter behavior

### Problem
The `limit` parameter's actual behavior is to **slice the already-retrieved items array** using `.slice(0, n)`, not to restrict how many items are fetched from the source.

### Changes
Added explanatory comments to `lib/middleware/parameter.ts`:

```typescript
// limit: slices the existing items array (does not restrict items fetched from source)
// Note: this parameter is applied after caching — requests with and without limit share the same cache but return
// different results
```

### Motivation
Clarifies behavior documented in Issue #8166: developers assumed `limit=10` fetches only 10 items from the source, when it actually fetches all and slices after.

```routes
NOROUTE
```

## Checklist

- [x] This PR relates to an existing issue and does not add a new route
- [x] Changes are documented where applicable
