### PR TITLE
feat: add GXNAS blog route

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     rsshub:
-        build: .
+        image: franksun123/rsshub
         restart: always
         ports:
             - '1200:1200'
@@ -16,21 +16,6 @@ services:
             retries: 3
         depends_on:
             - redis
-
-    redis:
-        image: redis:alpine
-        restart: always
-        volumes:
-            - redis-data:/data
-        healthcheck:
-            test: ['CMD', 'redis-cli', 'ping']
-            interval: 30s
-            timeout: 10s
-            retries: 5
-            start_period: 5s
-
-volumes:
-    redis-data:
 
     redis:
         image: redis:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,28 +6,9 @@ services:
             - '1200:1200'
         environment:
             NODE_ENV: production
-            CACHE_TYPE: redis
-            REDIS_URL: 'redis://redis:6379/'
-            FLARESOLVERR_URL: http://flaresolverr:8191/v1
+            FLARESOLVERR_URL: http://192.168.1.190:8191/v1
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:1200/healthz']
             interval: 30s
             timeout: 10s
             retries: 3
-        depends_on:
-            - redis
-
-    redis:
-        image: redis:alpine
-        restart: always
-        volumes:
-            - redis-data:/data
-        healthcheck:
-            test: ['CMD', 'redis-cli', 'ping']
-            interval: 30s
-            timeout: 10s
-            retries: 5
-            start_period: 5s
-
-volumes:
-    redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,22 @@
+version: '3.8'
 services:
     rsshub:
-        image: franksun123/rsshub
+        image: franksun123/rsshub:latest
+        container_name: rsshubfrank
         restart: always
-        ports:
-            - '1200:1200'
+        network_mode: host
         environment:
-            NODE_ENV: production
-            FLARESOLVERR_URL: http://192.168.1.190:8191/v1
-        healthcheck:
-            test: ['CMD', 'curl', '-f', 'http://localhost:1200/healthz']
-            interval: 30s
-            timeout: 10s
-            retries: 3
+            - NODE_ENV=production
+            - CACHE_TYPE=redis
+            - REDIS_URL=redis://127.0.0.1:6379/0
+            - FLARESOLVERR_URL=http://127.0.0.1:8191/v1
+        depends_on:
+            - redis
+
+    redis:
+        image: redis:alpine
+        container_name: rsshub-redis
+        restart: always
+        network_mode: host
+        volumes:
+            - ./redis-data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
     rsshub:
-        # two ways to enable Playwright:
-        # * comment out marked lines, then use this image instead: diygod/rsshub:chromium-bundled
-        # * (consumes more disk space and memory) leave everything unchanged
-        image: diygod/rsshub # or ghcr.io/diygod/rsshub
+        build: .
         restart: always
         ports:
             - '1200:1200'
@@ -11,7 +8,7 @@ services:
             NODE_ENV: production
             CACHE_TYPE: redis
             REDIS_URL: 'redis://redis:6379/'
-            PLAYWRIGHT_WS_ENDPOINT: 'ws://browserless:3000' # marked
+            FLARESOLVERR_URL: http://flaresolverr:8191/v1
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:1200/healthz']
             interval: 30s
@@ -19,20 +16,21 @@ services:
             retries: 3
         depends_on:
             - redis
-            - browserless # marked
 
-    browserless: # marked
-        image: browserless/chrome # marked
-        restart: always # marked
-        ulimits: # marked
-            core: # marked
-                hard: 0 # marked
-                soft: 0 # marked
-        healthcheck: # marked
-            test: ['CMD', 'curl', '-f', 'http://localhost:3000/pressure'] # marked
-            interval: 30s # marked
-            timeout: 10s # marked
-            retries: 3 # marked
+    redis:
+        image: redis:alpine
+        restart: always
+        volumes:
+            - redis-data:/data
+        healthcheck:
+            test: ['CMD', 'redis-cli', 'ping']
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 5s
+
+volumes:
+    redis-data:
 
     redis:
         image: redis:alpine

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -1,8 +1,35 @@
 import { load } from 'cheerio';
 
 import type { DataItem, Route } from '@/types';
+import logger from '@/utils/logger';
+import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
-import { getPlaywrightPage } from '@/utils/playwright';
+
+const FLARESOLVERR_URL = process.env.FLARESOLVERR_URL || 'http://flaresolverr:8191/v1';
+const SESSION_ID = 'gxnas_session';
+
+// Session singleton: create once, reuse across requests
+let sessionCreated = false;
+
+async function ensureSession() {
+    if (sessionCreated) {
+        return;
+    }
+    try {
+        logger.debug(`Creating FlareSolverr session: ${SESSION_ID}`);
+        await ofetch(FLARESOLVERR_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: { cmd: 'sessions.create', session: SESSION_ID },
+        });
+        sessionCreated = true;
+        logger.debug(`FlareSolverr session created: ${SESSION_ID}`);
+    } catch (e) {
+        // Session might already exist from a previous run
+        logger.debug(`Session creation failed (may already exist): ${(e as Error).message}`);
+        sessionCreated = true;
+    }
+}
 
 export const route: Route = {
     path: '/',
@@ -17,12 +44,13 @@ export const route: Route = {
     name: '最新文章',
     maintainers: ['Franklittleboy'],
     handler,
-    description: `::: warning
-该网站受 Cloudflare 保护，自建实例需要 Chromium 支持（默认已包含）。
+    description: `:::warning
+该网站受 Cloudflare 保护，需要配置 FlareSolverr 服务（[文档](https://github.com/FlareSolverr/FlareSolverr)）。
+环境变量 \`FLARESOLVERR_URL\` 默认为 \`http://flaresolverr:8191/v1\`。
 :::`,
     features: {
         requireConfig: false,
-        requirePuppeteer: true,
+        requirePuppeteer: false,
         antiCrawler: true,
         supportBT: false,
         supportPodcast: false,
@@ -33,19 +61,24 @@ export const route: Route = {
 async function handler() {
     const rootUrl = 'https://wp.gxnas.com';
 
-    const { page, destroy } = await getPlaywrightPage('about:blank');
+    await ensureSession();
 
-    // Only load document resources to speed up page load
-    await page.setRequestInterception(true);
-    page.on('request', (request) => {
-        request.resourceType() === 'document' ? request.continue() : request.abort();
+    logger.debug(`Fetching ${rootUrl} via FlareSolverr session ${SESSION_ID}`);
+    const result = await ofetch(FLARESOLVERR_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: {
+            cmd: 'request.get',
+            url: rootUrl,
+            session: SESSION_ID,
+            maxTimeout: 180000,
+        },
     });
 
-    await page.goto(rootUrl, { waitUntil: 'domcontentloaded' });
-
-    const html = await page.content();
-    await page.close();
-    await destroy();
+    const html = result?.solution?.response;
+    if (!html) {
+        throw new Error('FlareSolverr 返回内容为空');
+    }
 
     const $ = load(html);
 

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -1,0 +1,71 @@
+import { load } from 'cheerio';
+
+import type { DataItem, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/',
+    categories: ['blog'],
+    example: '/gxnas',
+    radar: [
+        {
+            source: ['wp.gxnas.com/'],
+        },
+    ],
+    url: 'wp.gxnas.com/',
+    name: '最新文章',
+    maintainers: ['Franklittleboy'],
+    handler,
+    description: 'GXNAS博客最新文章',
+};
+
+async function handler() {
+    const rootUrl = 'https://wp.gxnas.com';
+
+    const response = await ofetch(rootUrl);
+    const $ = load(response);
+
+    const items = $('.article-panel')
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+
+            const titleEl = $el.find('.header .title a');
+            const title = titleEl.text().trim();
+            const link = titleEl.attr('href');
+
+            const categoryEl = $el.find('.header .label');
+            const category = categoryEl.text().trim();
+
+            const contentEl = $el.find('.content');
+            const description = contentEl.html() || '';
+
+            const thumbEl = $el.find('.a-thumb img');
+            const image = thumbEl.attr('src');
+
+            // Date format: 2023年11月17日
+            const dateText = $el.find('.a-meta span').first().text().trim();
+            let pubDate: Date | undefined;
+            const m = dateText.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
+            if (m) {
+                pubDate = new Date(parseInt(m[1]), parseInt(m[2]) - 1, parseInt(m[3]));
+            }
+
+            return {
+                title,
+                link,
+                description: image ? `<img src="${image}"><br>${description}` : description,
+                category,
+                pubDate: pubDate ? parseDate(pubDate) : undefined,
+            } as DataItem;
+        })
+        .filter((item) => item.title && item.link);
+
+    return {
+        title: 'GXNAS博客',
+        link: rootUrl,
+        item: items,
+        description: 'GXNAS博客 - NAS博客|NAS社区|NAS交流|NAS技术|群晖教程|软路由',
+    };
+}

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -3,6 +3,9 @@ import { load } from 'cheerio';
 import type { DataItem, Route } from '@/types';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
+import logger from '@/utils/logger';
+
+const FLARESOLVERR_URL = process.env.FLARESOLVERR_URL || 'http://flaresolverr:8191/v1';
 
 export const route: Route = {
     path: '/',
@@ -31,8 +34,24 @@ export const route: Route = {
 async function handler() {
     const rootUrl = 'https://wp.gxnas.com';
 
-    const response = await ofetch(rootUrl);
-    const $ = load(response);
+    logger.debug(`Fetching ${rootUrl} via FlareSolverr at ${FLARESOLVERR_URL}`);
+
+    const result = await ofetch(FLARESOLVERR_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: {
+            cmd: 'request.get',
+            url: rootUrl,
+            maxTimeout: 60000,
+        },
+    });
+
+    const html = result?.solution?.response;
+    if (!html) {
+        throw new Error('FlareSolverr 返回内容为空');
+    }
+
+    const $ = load(html);
 
     const items = $('.article-panel')
         .toArray()

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -18,6 +18,14 @@ export const route: Route = {
     maintainers: ['Franklittleboy'],
     handler,
     description: 'GXNAS博客最新文章',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
 };
 
 async function handler() {
@@ -47,9 +55,10 @@ async function handler() {
             // Date format: 2023年11月17日
             const dateText = $el.find('.a-meta span').first().text().trim();
             let pubDate: Date | undefined;
+
             const m = dateText.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
             if (m) {
-                pubDate = new Date(parseInt(m[1]), parseInt(m[2]) - 1, parseInt(m[3]));
+                pubDate = new Date(Number.parseInt(m[1]), Number.parseInt(m[2]) - 1, Number.parseInt(m[3]));
             }
 
             return {
@@ -57,7 +66,7 @@ async function handler() {
                 link,
                 description: image ? `<img src="${image}"><br>${description}` : description,
                 category,
-                pubDate: pubDate ? parseDate(pubDate) : undefined,
+                pubDate: pubDate && parseDate(pubDate),
             } as DataItem;
         })
         .filter((item) => item.title && item.link);

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -1,7 +1,7 @@
 import { load } from 'cheerio';
 import type { DataItem, Route } from '@/types';
-import { parseDate } from '@/utils/parse-date';
 import { getPlaywrightPage } from '@/utils/playwright';
+import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
     path: '/',

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -1,7 +1,7 @@
 import { load } from 'cheerio';
-import type { DataItem, Route } from '@/types';
 import { getPlaywrightPage } from '@/utils/playwright';
 import { parseDate } from '@/utils/parse-date';
+import type { DataItem, Route } from '@/types';
 
 export const route: Route = {
     path: '/',

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -1,11 +1,34 @@
 import { load } from 'cheerio';
-
 import type { DataItem, Route } from '@/types';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 import logger from '@/utils/logger';
 
 const FLARESOLVERR_URL = process.env.FLARESOLVERR_URL || 'http://flaresolverr:8191/v1';
+const SESSION_ID = 'gxnas_session';
+
+// Session singleton: create once, reuse across requests
+let sessionCreated = false;
+
+async function ensureSession() {
+    if (sessionCreated) {
+        return;
+    }
+    try {
+        logger.debug(`Creating FlareSolverr session: ${SESSION_ID}`);
+        await ofetch(FLARESOLVERR_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: { cmd: 'sessions.create', session: SESSION_ID },
+        });
+        sessionCreated = true;
+        logger.debug(`FlareSolverr session created: ${SESSION_ID}`);
+    } catch (e) {
+        // Session might already exist from a previous run
+        logger.debug(`Session creation failed (may already exist): ${(e as Error).message}`);
+        sessionCreated = true;
+    }
+}
 
 export const route: Route = {
     path: '/',
@@ -34,15 +57,17 @@ export const route: Route = {
 async function handler() {
     const rootUrl = 'https://wp.gxnas.com';
 
-    logger.debug(`Fetching ${rootUrl} via FlareSolverr at ${FLARESOLVERR_URL}`);
+    await ensureSession();
 
+    logger.debug(`Fetching ${rootUrl} via FlareSolverr session ${SESSION_ID}`);
     const result = await ofetch(FLARESOLVERR_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: {
             cmd: 'request.get',
             url: rootUrl,
-            maxTimeout: 60000,
+            session: SESSION_ID,
+            maxTimeout: 120000,
         },
     });
 
@@ -57,24 +82,19 @@ async function handler() {
         .toArray()
         .map((el) => {
             const $el = $(el);
-
             const titleEl = $el.find('.header .title a');
             const title = titleEl.text().trim();
             const link = titleEl.attr('href');
-
             const categoryEl = $el.find('.header .label');
             const category = categoryEl.text().trim();
-
             const contentEl = $el.find('.content');
             const description = contentEl.html() || '';
-
             const thumbEl = $el.find('.a-thumb img');
             const image = thumbEl.attr('src');
 
             // Date format: 2023年11月17日
             const dateText = $el.find('.a-meta span').first().text().trim();
             let pubDate: Date | undefined;
-
             const m = dateText.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
             if (m) {
                 pubDate = new Date(Number.parseInt(m[1]), Number.parseInt(m[2]) - 1, Number.parseInt(m[3]));

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -1,7 +1,7 @@
 import { load } from 'cheerio';
-import { getPlaywrightPage } from '@/utils/playwright';
-import { parseDate } from '@/utils/parse-date';
 import type { DataItem, Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import { getPlaywrightPage } from '@/utils/playwright';
 
 export const route: Route = {
     path: '/',

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -1,34 +1,7 @@
 import { load } from 'cheerio';
 import type { DataItem, Route } from '@/types';
-import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
-import logger from '@/utils/logger';
-
-const FLARESOLVERR_URL = process.env.FLARESOLVERR_URL || 'http://flaresolverr:8191/v1';
-const SESSION_ID = 'gxnas_session';
-
-// Session singleton: create once, reuse across requests
-let sessionCreated = false;
-
-async function ensureSession() {
-    if (sessionCreated) {
-        return;
-    }
-    try {
-        logger.debug(`Creating FlareSolverr session: ${SESSION_ID}`);
-        await ofetch(FLARESOLVERR_URL, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: { cmd: 'sessions.create', session: SESSION_ID },
-        });
-        sessionCreated = true;
-        logger.debug(`FlareSolverr session created: ${SESSION_ID}`);
-    } catch (e) {
-        // Session might already exist from a previous run
-        logger.debug(`Session creation failed (may already exist): ${(e as Error).message}`);
-        sessionCreated = true;
-    }
-}
+import { getPlaywrightPage } from '@/utils/playwright';
 
 export const route: Route = {
     path: '/',
@@ -43,10 +16,12 @@ export const route: Route = {
     name: '最新文章',
     maintainers: ['Franklittleboy'],
     handler,
-    description: 'GXNAS博客最新文章',
+    description: `::: warning
+该网站受 Cloudflare 保护，自建实例需要 Chromium 支持（默认已包含）。
+:::`,
     features: {
         requireConfig: false,
-        requirePuppeteer: false,
+        requirePuppeteer: true,
         antiCrawler: true,
         supportBT: false,
         supportPodcast: false,
@@ -57,24 +32,19 @@ export const route: Route = {
 async function handler() {
     const rootUrl = 'https://wp.gxnas.com';
 
-    await ensureSession();
+    const { page, destroy } = await getPlaywrightPage('about:blank');
 
-    logger.debug(`Fetching ${rootUrl} via FlareSolverr session ${SESSION_ID}`);
-    const result = await ofetch(FLARESOLVERR_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: {
-            cmd: 'request.get',
-            url: rootUrl,
-            session: SESSION_ID,
-            maxTimeout: 180000,
-        },
+    // Only load document resources to speed up page load
+    await page.setRequestInterception(true);
+    page.on('request', (request) => {
+        request.resourceType() === 'document' ? request.continue() : request.abort();
     });
 
-    const html = result?.solution?.response;
-    if (!html) {
-        throw new Error('FlareSolverr 返回内容为空');
-    }
+    await page.goto(rootUrl, { waitUntil: 'domcontentloaded' });
+
+    const html = await page.content();
+    await page.close();
+    await destroy();
 
     const $ = load(html);
 

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -67,7 +67,7 @@ async function handler() {
             cmd: 'request.get',
             url: rootUrl,
             session: SESSION_ID,
-            maxTimeout: 120000,
+            maxTimeout: 180000,
         },
     });
 

--- a/lib/routes/gxnas/index.ts
+++ b/lib/routes/gxnas/index.ts
@@ -1,4 +1,5 @@
 import { load } from 'cheerio';
+
 import type { DataItem, Route } from '@/types';
 import { parseDate } from '@/utils/parse-date';
 import { getPlaywrightPage } from '@/utils/playwright';

--- a/lib/routes/gxnas/namespace.ts
+++ b/lib/routes/gxnas/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'GXNAS博客',
+    url: 'wp.gxnas.com',
+    description: 'GXNAS博客 - NAS技术交流',
+    lang: 'zh-CN',
+};


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/gxnas
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add RSS feed for [GXNAS博客](https://wp.gxnas.com), a Chinese NAS technology blog covering Synology tutorials, soft routers, and AI topics.

The site uses Cloudflare protection which blocks the WordPress `/feed/` endpoint, so this route scrapes the homepage HTML for article list instead. Full article content is not fetched because detail pages also return Cloudflare block pages from server-side requests.