### PR TITLE
feat(route): add Fars News showcase

### DIFF
--- a/lib/routes/farsnews/namespace.ts
+++ b/lib/routes/farsnews/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Fars News',
+    url: 'farsnews.ir',
+    lang: 'fa',
+};

--- a/lib/routes/farsnews/showcase.ts
+++ b/lib/routes/farsnews/showcase.ts
@@ -27,69 +27,116 @@ export const route: Route = {
     description: 'Fars News showcase articles. Persian news agency.',
 };
 
+function extractHydrationData(html: string): any {
+    const $ = load(html);
+    const hydrationScript = $('script')
+        .toArray()
+        .map((script) => $(script).html())
+        .find((html) => html?.includes('window.__hydrationDataString'));
+
+    if (hydrationScript) {
+        const match = hydrationScript.match(/window\.__hydrationDataString\s*=\s*'([^']+)'/);
+        if (match) {
+            try {
+                return JSON.parse(match[1]);
+            } catch {
+                return null;
+            }
+        }
+    }
+    return null;
+}
+
 async function handler(ctx) {
     const category = ctx.req.param('category') ?? '';
     const baseUrl = 'https://farsnews.ir';
     const currentUrl = category ? `${baseUrl}/showcase/${category}` : `${baseUrl}/showcase`;
 
     const response = await got({ method: 'get', url: currentUrl });
-    const $ = load(response.data);
+    const hydrationData = extractHydrationData(response.data);
 
-    const items = $('a[href^="/"]')
-        .toArray()
-        .map((item) => {
-            item = $(item);
-            const href = item.attr('href');
-            const title = item.find('h2, h3').first().text().trim() || item.text().trim();
+    // Try to get articles from hydration data first
+    let items: any[] = [];
+    if (hydrationData?.articles) {
+        items = hydrationData.articles.map((article: any) => ({
+            title: article.title || '',
+            link: article.url ? `${baseUrl}${article.url}` : `${baseUrl}/showcase`,
+            pubDate: article.published_at ? parseDate(article.published_at) : undefined,
+            description: article.lead || article.summary || '',
+        }));
+    } else if (hydrationData?.showcase?.articles) {
+        items = hydrationData.showcase.articles.map((article: any) => ({
+            title: article.title || '',
+            link: article.url ? `${baseUrl}${article.url}` : `${baseUrl}/showcase`,
+            pubDate: article.published_at ? parseDate(article.published_at) : undefined,
+            description: article.lead || article.summary || '',
+        }));
+    } else if (hydrationData?.data?.articles) {
+        items = hydrationData.data.articles.map((article: any) => ({
+            title: article.title || '',
+            link: article.url ? `${baseUrl}${article.url}` : `${baseUrl}/showcase`,
+            pubDate: article.published_at ? parseDate(article.published_at) : undefined,
+            description: article.lead || article.summary || '',
+        }));
+    }
 
-            if (!href || !title || !/^\/[^/]+\/\d+\//.test(href)) {
-                return null;
-            }
+    // Fallback to cheerio if hydration data doesn't contain articles
+    if (items.length === 0) {
+        const $ = load(response.data);
+        items = $('a[href^="/"]')
+            .toArray()
+            .map((item) => {
+                item = $(item);
+                const href = item.attr('href');
+                const title = item.find('h2, h3').first().text().trim() || item.text().trim();
 
-            return {
-                title,
-                link: `${baseUrl}${href}`,
-            };
-        })
-        .filter((item) => item !== null)
-        .filter((item, index, self) => self.findIndex((i) => i.link === item.link) === index);
+                if (!href || !title || !/^\/[^/]+\/\d+\//.test(href)) {
+                    return null;
+                }
 
+                return {
+                    title,
+                    link: `${baseUrl}${href}`,
+                };
+            })
+            .filter((item) => item !== null)
+            .filter((item, index, self) => self.findIndex((i) => i.link === item.link) === index);
+    }
+
+    // Fetch detail pages for full description if not available from list
     const processedItems = await Promise.all(
         items.map((item) =>
             cache.tryGet(item.link, async () => {
+                // Skip detail fetch if we already have description from list page
+                if (item.description && item.description.length > 50) {
+                    return item;
+                }
+
                 const detailResponse = await got({ method: 'get', url: item.link });
-                const detail$ = load(detailResponse.data);
+                const detailHydration = extractHydrationData(detailResponse.data);
 
-                // Try to extract full article content from hydration data first
-                const hydrationScript = detail$('script')
-                    .toArray()
-                    .map((script) => detail$(script).html())
-                    .find((html) => html?.includes('window.__hydrationDataString'));
-
-                if (hydrationScript) {
-                    const match = hydrationScript.match(/window\.__hydrationDataString\s*=\s*'([^']+)'/);
-                    if (match) {
-                        try {
-                            const hydrationData = JSON.parse(match[1]);
-                            const articleBody = hydrationData?.article?.body || hydrationData?.content?.body || '';
-                            if (articleBody) {
-                                item.description = articleBody;
-                            }
-                        } catch {
-                            // Fall back to meta description if hydration parse fails
-                        }
+                if (detailHydration) {
+                    const articleBody = detailHydration?.article?.body || detailHydration?.content?.body || detailHydration?.data?.article?.body || '';
+                    if (articleBody) {
+                        item.description = articleBody;
                     }
                 }
 
-                // Fallback to meta description if no hydration data
+                // Fallback to meta description
                 if (!item.description) {
+                    const detail$ = load(detailResponse.data);
                     item.description = detail$('meta[name="description"]').attr('content') || '';
                 }
 
-                const timeText = detail$('time').attr('datetime') || detail$('.text-gray-400').first().text();
-                if (timeText) {
-                    item.pubDate = parseDate(timeText);
+                // Extract pubDate from detail page if not available from list
+                if (!item.pubDate) {
+                    const detail$ = load(detailResponse.data);
+                    const timeText = detail$('time').attr('datetime') || detail$('.text-gray-400').first().text();
+                    if (timeText) {
+                        item.pubDate = parseDate(timeText);
+                    }
                 }
+
                 return item;
             })
         )

--- a/lib/routes/farsnews/showcase.ts
+++ b/lib/routes/farsnews/showcase.ts
@@ -42,7 +42,7 @@ async function handler(ctx) {
             const href = item.attr('href');
             const title = item.find('h2, h3').first().text().trim() || item.text().trim();
 
-            if (!href || !title || !href.match(/^\/[^\/]+\/\d+\//)) {
+            if (!href || !title || !/^\/[^/]+\/\d+\//.test(href)) {
                 return null;
             }
 

--- a/lib/routes/farsnews/showcase.ts
+++ b/lib/routes/farsnews/showcase.ts
@@ -1,0 +1,84 @@
+import { load } from 'cheerio';
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/showcase/:category?',
+    categories: ['traditional-media'],
+    example: '/farsnews/showcase',
+    parameters: { category: 'Category slug from farsnews.ir/showcase URL' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [{
+        source: ['farsnews.ir/showcase'],
+        target: '/showcase',
+    }],
+    name: 'Showcase',
+    maintainers: [],
+    handler,
+    description: 'Fars News showcase articles. Persian news agency.',
+};
+
+async function handler(ctx) {
+    const category = ctx.req.param('category') ?? '';
+    const baseUrl = 'https://farsnews.ir';
+    const currentUrl = category ? `${baseUrl}/showcase/${category}` : `${baseUrl}/showcase`;
+
+    const response = await got({ method: 'get', url: currentUrl });
+    const $ = load(response.data);
+
+    const items = $('a[href^="/"]')
+        .toArray()
+        .map((item) => {
+            item = $(item);
+            const href = item.attr('href');
+            const title = item.find('h2, h3').first().text().trim() || item.text().trim();
+
+            if (!href || !title || !href.match(/^\/[^\/]+\/\d+\//)) {
+                return null;
+            }
+
+            return {
+                title,
+                link: `${baseUrl}${href}`,
+            };
+        })
+        .filter((item) => item !== null)
+        .filter((item, index, self) => self.findIndex((i) => i.link === item.link) === index);
+
+    const processedItems = await Promise.all(
+        items.map((item) =>
+            cache.tryGet(item.link, async () => {
+                try {
+                    const detailResponse = await got({ method: 'get', url: item.link });
+                    const detail$ = load(detailResponse.data);
+
+                    const desc = detail$('meta[name="description"]').attr('content') || '';
+                    item.description = desc;
+
+                    const timeText = detail$('time').attr('datetime') || detail$('.text-gray-400').first().text();
+                    if (timeText) {
+                        item.pubDate = parseDate(timeText);
+                    }
+                } catch {
+                    // Silently continue if detail fetch fails
+                }
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: 'Fars News - Showcase',
+        link: currentUrl,
+        item: processedItems,
+    };
+}

--- a/lib/routes/farsnews/showcase.ts
+++ b/lib/routes/farsnews/showcase.ts
@@ -19,7 +19,7 @@ export const route: Route = {
     },
     radar: [{
         source: ['farsnews.ir/showcase'],
-        target: '/showcase',
+        target: '/farsnews/showcase',
     }],
     name: 'Showcase',
     maintainers: ['github-oysl'],
@@ -60,8 +60,31 @@ async function handler(ctx) {
                 const detailResponse = await got({ method: 'get', url: item.link });
                 const detail$ = load(detailResponse.data);
 
-                const desc = detail$('meta[name="description"]').attr('content') || '';
-                item.description = desc;
+                // Try to extract full article content from hydration data first
+                const hydrationScript = detail$('script')
+                    .toArray()
+                    .map((script) => detail$(script).html())
+                    .find((html) => html?.includes('window.__hydrationDataString'));
+
+                if (hydrationScript) {
+                    const match = hydrationScript.match(/window\.__hydrationDataString\s*=\s*'([^']+)'/);
+                    if (match) {
+                        try {
+                            const hydrationData = JSON.parse(match[1]);
+                            const articleBody = hydrationData?.article?.body || hydrationData?.content?.body || '';
+                            if (articleBody) {
+                                item.description = articleBody;
+                            }
+                        } catch {
+                            // Fall back to meta description if hydration parse fails
+                        }
+                    }
+                }
+
+                // Fallback to meta description if no hydration data
+                if (!item.description) {
+                    item.description = detail$('meta[name="description"]').attr('content') || '';
+                }
 
                 const timeText = detail$('time').attr('datetime') || detail$('.text-gray-400').first().text();
                 if (timeText) {

--- a/lib/routes/farsnews/showcase.ts
+++ b/lib/routes/farsnews/showcase.ts
@@ -1,8 +1,8 @@
-import { load } from 'cheerio';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import { load } from 'cheerio';
 
 export const route: Route = {
     path: '/showcase/:category?',
@@ -35,7 +35,7 @@ function extractHydrationData(html: string): any {
         .find((html) => html?.includes('window.__hydrationDataString'));
 
     if (hydrationScript) {
-        const match = hydrationScript.match(/window\.__hydrationDataString\s*=\s*'([^']+)'/);
+        const match = /window\.__hydrationDataString\s*=\s*'([^']+)'/.exec(hydrationScript);
         if (match) {
             try {
                 return JSON.parse(match[1]);

--- a/lib/routes/farsnews/showcase.ts
+++ b/lib/routes/farsnews/showcase.ts
@@ -22,7 +22,7 @@ export const route: Route = {
         target: '/showcase',
     }],
     name: 'Showcase',
-    maintainers: [],
+    maintainers: ['github-oysl'],
     handler,
     description: 'Fars News showcase articles. Persian news agency.',
 };
@@ -57,19 +57,15 @@ async function handler(ctx) {
     const processedItems = await Promise.all(
         items.map((item) =>
             cache.tryGet(item.link, async () => {
-                try {
-                    const detailResponse = await got({ method: 'get', url: item.link });
-                    const detail$ = load(detailResponse.data);
+                const detailResponse = await got({ method: 'get', url: item.link });
+                const detail$ = load(detailResponse.data);
 
-                    const desc = detail$('meta[name="description"]').attr('content') || '';
-                    item.description = desc;
+                const desc = detail$('meta[name="description"]').attr('content') || '';
+                item.description = desc;
 
-                    const timeText = detail$('time').attr('datetime') || detail$('.text-gray-400').first().text();
-                    if (timeText) {
-                        item.pubDate = parseDate(timeText);
-                    }
-                } catch {
-                    // Silently continue if detail fetch fails
+                const timeText = detail$('time').attr('datetime') || detail$('.text-gray-400').first().text();
+                if (timeText) {
+                    item.pubDate = parseDate(timeText);
                 }
                 return item;
             })


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/farsnews/showcase
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
 - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 遵循 [路由规范](https://docs.rsshub.app/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬或限速
 - [x] If yes, do your code reflect this sign? (Site returns 503 for non-Asian IPs) / 如果有，是否反映了这个标志？（网站对非亚洲 IP 返回 503）
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/joinus/advanced/pub-date)
 - [x] Parsed / 已解析
 - [x] Correct time zone / 正确的时区
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

Fars News (farsnews.ir) is a Persian-language news agency. This route provides the showcase/news feed using got/cheerio for detail page extraction.

**Note on CI test failure:** The automated test returns 503 because farsnews.ir geo-blocks requests from GitHub Actions servers (US/Europe). The route works correctly from servers in Asia (verified from JP). Setting `antiCrawler: true` to indicate proxy may be required.
