### PR TITLE
feat(route): add hex2077 AI daily RSS route

### DIFF
--- a/lib/routes/hex2077/daily.ts
+++ b/lib/routes/hex2077/daily.ts
@@ -1,0 +1,134 @@
+import { load } from 'cheerio';
+import type { Route, DataItem } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+const BASE = 'https://hex2077.dev';
+
+const SECTION_IDS = [
+    '产品与功能更新',
+    '前沿研究',
+    '行业展望与社会影响',
+    '开源top项目',
+    '社媒分享',
+];
+
+const SECTION_NAMES = [
+    '产品与功能更新',
+    '前沿研究',
+    '行业展望与社会影响',
+    '开源TOP项目',
+    '社媒分享',
+];
+
+function extractSection($: cheerio.CheerioAPI, sectionName: string): string[] {
+    const ol = $(`h3[id="${sectionName}"]`).nextAll('ol').first();
+    if (!ol.length) {
+        return [];
+    }
+
+    const items: string[] = [];
+    ol.find('> li').each((_, liEl) => {
+        const text = $(liEl).text().trim().replace(/\s+/g, ' ');
+        if (text) {
+            items.push(text);
+        }
+    });
+    return items;
+}
+
+export const route: Route = {
+    name: 'AI 日报',
+    categories: ['programming'],
+    path: '/daily/:section?',
+    example: '/hex2077/daily',
+    maintainers: ['fc525260'],
+    parameters: {
+        section: {
+            description:
+                '栏目序号（可选）：1=产品与功能更新，2=前沿研究，3=行业展望与社会影响，4=开源TOP项目，5=社媒分享。留空返回全文。',
+        },
+    },
+    handler: async (ctx) => {
+        const sectionParam = ctx.req.param('section');
+        const sectionIndex = sectionParam ? parseInt(sectionParam, 10) - 1 : -1;
+
+        // ── Step 1: 从 listing 页获取最新文章 ─────────────────
+        const listingHtml = await ofetch<string>(BASE + '/docs/');
+        const $ = load(listingHtml);
+
+        const paths: string[] = [];
+        $('a[href^="/docs/20"]').each((_, el) => {
+            const href = $(el).attr('href') || '';
+            if (/^\/docs\/\d{4}-\d{2}\/\d{4}-\d{2}-\d{2}\/$/.test(href)) {
+                paths.push(href);
+            }
+        });
+
+        paths.sort((a, b) => b.localeCompare(a));
+        const latestPath = paths[0];
+        if (!latestPath) {
+            throw new Error('未找到日报文章');
+        }
+
+        const dateLabel = latestPath.match(/\d{4}-\d{2}-\d{2}/)?.[0] || '';
+        const articleUrl = BASE + latestPath;
+
+        // ── Step 2: 抓取详情页 ─────────────────────────────
+        const detailHtml = await ofetch<string>(articleUrl);
+        const $d = load(detailHtml);
+
+        // ── Step 3: 解析并组装 RSS item ────────────────────
+        const items: DataItem[] = [];
+
+        if (sectionIndex >= 0 && sectionIndex < SECTION_IDS.length) {
+            // 单栏目模式
+            const sectionName = SECTION_IDS[sectionIndex];
+            const sectionDisplay = SECTION_NAMES[sectionIndex];
+            const sectionItems = extractSection($d, sectionName);
+
+            for (const [i, text] of sectionItems.entries()) {
+                const firstSentence = text.split(/[。！？.!?]/)[0] || text;
+                items.push({
+                    title: firstSentence.length > 60 ? firstSentence.slice(0, 60) + '…' : firstSentence,
+                    description: text,
+                    link: articleUrl,
+                    guid: `${latestPath}${sectionName}-${i}`,
+                    pubDate: dateLabel ? new Date(dateLabel).toUTCString() : undefined,
+                });
+            }
+
+            return {
+                title: `hex2077 AI日报 · ${sectionDisplay} (${dateLabel})`,
+                link: BASE + '/docs/',
+                description: `hex2077 每日 AI 资讯日报 - ${sectionDisplay}`,
+                language: 'zh-CN',
+                item: items,
+            };
+        } else {
+            // 全文模式：遍历所有栏目
+            for (const [si, sectionName] of SECTION_IDS.entries()) {
+                const sectionDisplay = SECTION_NAMES[si];
+                const sectionItems = extractSection($d, sectionName);
+
+                for (const [i, text] of sectionItems.entries()) {
+                    const firstSentence = text.split(/[。！？.!?]/)[0] || text;
+                    items.push({
+                        title: `[${sectionDisplay}] ${firstSentence.length > 60 ? firstSentence.slice(0, 60) + '…' : firstSentence}`,
+                        description: text,
+                        link: articleUrl,
+                        guid: `${latestPath}${sectionName}-${i}`,
+                        pubDate: dateLabel ? new Date(dateLabel).toUTCString() : undefined,
+                    });
+                }
+            }
+
+            return {
+                title: `hex2077 AI日报 · 全文 (${dateLabel})`,
+                link: BASE + '/docs/',
+                description: 'hex2077 每日 AI 资讯日报 - 全 5 个栏目',
+                language: 'zh-CN',
+                item: items,
+            };
+        }
+    },
+};

--- a/lib/routes/hex2077/daily.ts
+++ b/lib/routes/hex2077/daily.ts
@@ -1,6 +1,7 @@
 import { load } from 'cheerio';
 import type { Route, DataItem } from '@/types';
 import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
 
 const BASE = 'https://hex2077.dev';
 
@@ -89,11 +90,11 @@ export const route: Route = {
             for (const [i, text] of sectionItems.entries()) {
                 const firstSentence = text.split(/[。！？.!?]/)[0] || text;
                 items.push({
-                    title: firstSentence.length > 60 ? firstSentence.slice(0, 60) + '…' : firstSentence,
+                    title: firstSentence,
                     description: text,
                     link: articleUrl,
                     guid: `${latestPath}${sectionName}-${i}`,
-                    pubDate: dateLabel ? new Date(dateLabel).toUTCString() : undefined,
+                    pubDate: parseDate(dateLabel),
                 });
             }
 
@@ -113,11 +114,11 @@ export const route: Route = {
                 for (const [i, text] of sectionItems.entries()) {
                     const firstSentence = text.split(/[。！？.!?]/)[0] || text;
                     items.push({
-                        title: `[${sectionDisplay}] ${firstSentence.length > 60 ? firstSentence.slice(0, 60) + '…' : firstSentence}`,
+                        title: `[${sectionDisplay}] ${firstSentence}`,
                         description: text,
                         link: articleUrl,
                         guid: `${latestPath}${sectionName}-${i}`,
-                        pubDate: dateLabel ? new Date(dateLabel).toUTCString() : undefined,
+                        pubDate: parseDate(dateLabel),
                     });
                 }
             }

--- a/lib/routes/hex2077/namespace.ts
+++ b/lib/routes/hex2077/namespace.ts
@@ -2,7 +2,7 @@ import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
     name: 'hex2077 AI 日报',
-    url: 'https://hex2077.dev/docs/',
+    url: 'hex2077.dev/docs',
     lang: 'zh-CN',
     description: 'hex2077.dev 每日发布的 AI 资讯日报，涵盖产品功能、前沿研究、行业影响、开源项目等',
 };

--- a/lib/routes/hex2077/namespace.ts
+++ b/lib/routes/hex2077/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'hex2077 AI 日报',
+    url: 'https://hex2077.dev/docs/',
+    lang: 'zh-CN',
+    description: 'hex2077.dev 每日发布的 AI 资讯日报，涵盖产品功能、前沿研究、行业影响、开源项目等',
+};


### PR DESCRIPTION
### Description

Add RSS route for hex2077.dev AI Daily News. [hex2077.dev/docs/](https://hex2077.dev/docs/) publishes a daily AI news digest in Chinese (AI日报).

**Routes Added:**
- `GET /hex2077/daily` — Full article (all 5 sections)
- `GET /hex2077/daily/4` — Open Source Top Projects (section 4)

**How it works:**
1. Fetch listing page at `/docs/`, extract all article paths matching `/docs/YYYY-MM/YYYY-MM-DD/`
2. Sort by date, pick the latest
3. Fetch article page, locate h3 by id attribute (e.g. `id="开源top项目"`)
4. Extract `<ol><li>` under that h3 as RSS items

### Example for the Proposed Route(s) / 路由地址示例

```routes
/hex2077/daily/4
/hex2077/daily
```

### Related Issues

Closes #22008