### PR TITLE
feat: add shanxi museum temporary exhibition route

### DIFF
--- a/lib/routes/shanximuseum/namespace.ts
+++ b/lib/routes/shanximuseum/namespace.ts
@@ -1,0 +1,10 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Shanxi Museum',
+    url: 'www.shanximuseum.com.cn',
+
+    zh: {
+        name: '山西博物馆',
+    },
+};

--- a/lib/routes/shanximuseum/temporary.tsx
+++ b/lib/routes/shanximuseum/temporary.tsx
@@ -177,7 +177,6 @@ export const route = {
                 title: `当前暂无${titleTag}`,
                 description: '<p>官方目前没有提供相关的展览数据。</p>',
                 link: `${baseUrl}/sx/exhibition/temporary.html`,
-                pubDate: timezone(new Date(), +8),
                 // fixed guid
                 guid: `shanxi-museum-empty-${fetchTypes.join('-')}`,
             });

--- a/lib/routes/shanximuseum/temporary.tsx
+++ b/lib/routes/shanximuseum/temporary.tsx
@@ -80,12 +80,8 @@ export const route = {
 
                     const description = renderToString(
                         <div>
-                            {imgUrl && (
-                                <>
-                                    <img src={imgUrl} />
-                                    <br />
-                                </>
-                            )}
+                            <img src={imgUrl} />
+                            <br />
                             <p>
                                 <b>地点：</b>
                                 {location || '参考展览图片'}

--- a/lib/routes/shanximuseum/temporary.tsx
+++ b/lib/routes/shanximuseum/temporary.tsx
@@ -1,0 +1,193 @@
+import { renderToString } from 'hono/jsx/dom/server';
+
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+import { namespace } from './namespace';
+
+export const route = {
+    path: '/exhibition/temporary/:type?',
+    categories: ['travel'],
+    example: '/shanximuseum/exhibition/temporary/now&future', // default w/o type, shows all exhibitions (now, future and past)
+    parameters: {
+        type: 'Temporary Exhibition type, supported values: now （正在展出）、future（即将展出）、now&future（正在展出&即将展出）、past（往期展览）。Supports multiple status combinations separated by &, + or , (e.g., now&future). Default: All exhibitions (now, future and past).',
+    },
+    name: 'Temporary Exhibitions',
+    maintainers: ['magazian'],
+    radar: [
+        {
+            source: ['www.shanximuseum.com.cn/sx/exhibition/temporary.html'],
+            target: '/exhibition/temporary',
+        },
+    ],
+    handler: async (ctx) => {
+        let typeParam = ctx.req.param('type')?.toLowerCase();
+
+        let fetchTypes = ['now', 'future', 'past'];
+
+        if (typeParam) {
+            // replace list or offset with past to support old links like /temporary/list or /temporary/offset
+            typeParam = typeParam.replaceAll(/list|offset/g, 'past');
+
+            // support /now&future, /now+future, /now,future
+            const requestedTypes = typeParam.split(/[&+,|-]/);
+
+            const validTypes = requestedTypes.filter((t) => ['now', 'future', 'past'].includes(t));
+
+            if (validTypes.length > 0) {
+                fetchTypes = [...new Set<string>(validTypes)];
+            }
+        }
+
+        const baseUrl = 'https://www.shanximuseum.com.cn';
+        const apiUrl = `${baseUrl}/sx/exhibition`;
+
+        const apiConfig = {
+            now: { endpoint: '/temporary_now', name: '正在展出', query: {} },
+            future: { endpoint: '/temporary_future', name: '即将展出', query: {} },
+            past: {
+                endpoint: '/temporary_list',
+                name: '往期展览',
+                query: {
+                    offset: 0,
+                    count: 20,
+                    year: '',
+                    keyword: '',
+                },
+            },
+        };
+
+        const museumName = namespace.zh?.name || namespace.name;
+
+        let titleTag = '全部展览';
+
+        // combine titletag with & if user specified type
+        if (typeParam && fetchTypes.length > 0) {
+            titleTag = fetchTypes.map((t) => apiConfig[t].name).join(' & ');
+
+            // all 3 titletag combination should be named as default
+            if (fetchTypes.length === 3) {
+                titleTag = '全部展览';
+            }
+        }
+
+        const responses = await Promise.all(
+            fetchTypes.map(async (t) => {
+                const config = apiConfig[t];
+
+                const response = await got({
+                    method: 'get',
+                    url: `${apiUrl}${config.endpoint}`,
+                    searchParams: {
+                        ...config.query,
+                        _: Date.now(),
+                    },
+                });
+
+                let list = response.data;
+                if (list && list.data) {
+                    list = list.data;
+                }
+
+                if (list && !Array.isArray(list)) {
+                    if (list.list && Array.isArray(list.list)) {
+                        list = list.list;
+                    } else if (list.rows && Array.isArray(list.rows)) {
+                        list = list.rows;
+                    }
+                }
+
+                if (!Array.isArray(list)) {
+                    list = [];
+                }
+
+                return list.map((item) => {
+                    const title = item.title;
+                    const itemLink = item.fullurl || `${baseUrl}${item.url}`;
+                    const pubDate = timezone(parseDate(item.publishtime * 1000), +8);
+                    const startDate = item.start_time ? item.start_time.split(' ')[0] : '';
+                    const endDate = item.end_time ? item.end_time.split(' ')[0] : '';
+                    const fullDuration = item.display_time || '';
+                    const location = item.area || '';
+                    const imgUrl = item.image.startsWith('http') ? item.image : `${baseUrl}${item.image}`;
+
+                    const description = renderToString(
+                        <div>
+                            {imgUrl && (
+                                <>
+                                    <img src={imgUrl} />
+                                    <br />
+                                </>
+                            )}
+                            <p>
+                                <b>地点：</b>
+                                {location || '参考展览图片'}
+                                {/* location is only defined on the exhibition poster, cannot fetch directly from the website */}
+                            </p>
+                            <p>
+                                <b>开展：</b>
+                                {startDate || '未定/常设'}
+                            </p>
+                            <p>
+                                <b>闭展：</b>
+                                {endDate || '未定/常设'}
+                            </p>
+
+                            {fullDuration && (
+                                <p>
+                                    <small>
+                                        原始展期：
+                                        {fullDuration.split('\n').map((line, i) => (
+                                            <span key={i}>
+                                                {line}
+                                                <br />
+                                            </span>
+                                        ))}
+                                    </small>
+                                </p>
+                            )}
+                        </div>
+                    );
+
+                    return {
+                        title,
+                        link: itemLink,
+                        pubDate,
+                        description,
+                        // For further .ics file processing
+                        _extra: {
+                            museumName,
+                            title,
+                            location,
+                            startDate, // format: YYYY-MM-DD or '未定/常设'
+                            endDate, // format: YYYY-MM-DD or '未定/常设'
+                            itemLink,
+                        },
+                    };
+                });
+            })
+        );
+
+        const items = responses.flat();
+
+        // return information if there is no exhibition available to fix "route is empty" issue.
+        if (items.length === 0) {
+            items.push({
+                title: `当前暂无${titleTag}`,
+                description: '<p>官方目前没有提供相关的展览数据。</p>',
+                link: `${baseUrl}/sx/exhibition/temporary.html`,
+                pubDate: timezone(new Date(), +8),
+                // fixed guid
+                guid: `shanxi-museum-empty-${fetchTypes.join('-')}`,
+            });
+        }
+
+        return {
+            title: `${museumName} - 临时展览 - ${titleTag}`,
+            link: `${baseUrl}/sx/exhibition/temporary.html`,
+            language: 'zh-CN',
+            item: items,
+        };
+    },
+};

--- a/lib/routes/shanximuseum/temporary.tsx
+++ b/lib/routes/shanximuseum/temporary.tsx
@@ -56,85 +56,79 @@ export const route = {
             fetchTypes.map(async (t) => {
                 const config = apiConfig[t as keyof typeof apiConfig];
 
-                const response = await got({
-                    method: 'get',
-                    url: `${apiUrl}${config.endpoint}`,
-                    searchParams: {
-                        ...config.query,
-                        _: Date.now(),
-                    },
-                });
-
-                const resData = response.data?.data; // The actual data is nested under the 'data' property in the response
-                const list = Array.isArray(resData?.list) ? resData.list : []; // resData may be undefined or not an array, resDate.list is an array
-
-                return list.map((item) => {
-                    const title = item.title;
-                    const itemLink = item.fullurl;
-                    const pubDate = timezone(parseDate(item.publishtime * 1000)); // Unix timestamp in seconds, convert to milliseconds
-                    const startDate = item.start_time.split(' ')[0];
-                    const endDate = item.end_time.split(' ')[0];
-                    const fullDuration = item.display_time;
-                    const location = item.area;
-                    const imgUrl = `${baseUrl}${item.image}`;
-
-                    const description = renderToString(
-                        <div>
-                            <img src={imgUrl} />
-                            <br />
-                            <p>
-                                <b>地点：</b>
-                                {location || '参考展览图片'}
-                                {/* location is only defined on the exhibition poster, cannot fetch directly from the website */}
-                            </p>
-                            <p>
-                                <b>开展：</b>
-                                {startDate || '未定/常设'}
-                            </p>
-                            <p>
-                                <b>闭展：</b>
-                                {endDate || '未定/常设'}
-                            </p>
-
-                            {fullDuration && (
-                                <p>
-                                    <small>原始展期：{fullDuration}</small>
-                                </p>
-                            )}
-                        </div>
-                    );
-
-                    return {
-                        title,
-                        link: itemLink,
-                        pubDate,
-                        description,
-                        // For further .ics file processing
-                        _extra: {
-                            museumName,
-                            title,
-                            location,
-                            startDate, // format: YYYY-MM-DD or '未定/常设'
-                            endDate, // format: YYYY-MM-DD or '未定/常设'
-                            itemLink,
+                // add trycatch to prevent one failed request, espacially for now/future exhibition.
+                try {
+                    const response = await got({
+                        method: 'get',
+                        url: `${apiUrl}${config.endpoint}`,
+                        searchParams: {
+                            ...config.query,
+                            _: Date.now(),
                         },
-                    };
-                });
+                    });
+
+                    const resData = response.data?.data; // The actual data is nested under the 'data' property in the response
+                    const list = Array.isArray(resData?.list) ? resData.list : []; // resData may be undefined or not an array, resDate.list is an array
+
+                    return list.map((item) => {
+                        const title = item.title;
+                        const itemLink = item.fullurl;
+                        const pubDate = timezone(parseDate(item.publishtime * 1000)); // Unix timestamp in seconds, convert to milliseconds
+                        const startDate = item.start_time.split(' ')[0];
+                        const endDate = item.end_time.split(' ')[0];
+                        const fullDuration = item.display_time;
+                        const location = item.area;
+                        const imgUrl = `${baseUrl}${item.image}`;
+
+                        const description = renderToString(
+                            <div>
+                                <img src={imgUrl} />
+                                <br />
+                                <p>
+                                    <b>地点：</b>
+                                    {location || '参考展览图片'}
+                                    {/* location is only defined on the exhibition poster, cannot fetch directly from the website */}
+                                </p>
+                                <p>
+                                    <b>开展：</b>
+                                    {startDate || '未定/常设'}
+                                </p>
+                                <p>
+                                    <b>闭展：</b>
+                                    {endDate || '未定/常设'}
+                                </p>
+
+                                {fullDuration && (
+                                    <p>
+                                        <small>原始展期：{fullDuration}</small>
+                                    </p>
+                                )}
+                            </div>
+                        );
+
+                        return {
+                            title,
+                            link: itemLink,
+                            pubDate,
+                            description,
+                            // For further .ics file processing
+                            _extra: {
+                                museumName,
+                                title,
+                                location,
+                                startDate, // format: YYYY-MM-DD or '未定/常设'
+                                endDate, // format: YYYY-MM-DD or '未定/常设'
+                                itemLink,
+                            },
+                        };
+                    });
+                } catch {
+                    return [];
+                }
             })
         );
 
         const items = responses.flat();
-
-        // return information if there is no exhibition available to fix "route is empty" issue.
-        if (items.length === 0) {
-            items.push({
-                title: `当前暂无${titleTag}`,
-                description: '<p>官方目前没有提供相关的展览数据。</p>',
-                link: `${baseUrl}/sx/exhibition/temporary.html`,
-                // fixed guid
-                guid: `shanxi-museum-empty-${fetchTypes.join('-')}`,
-            });
-        }
 
         return {
             title: `${museumName} - 临时展览 - ${titleTag}`,

--- a/lib/routes/shanximuseum/temporary.tsx
+++ b/lib/routes/shanximuseum/temporary.tsx
@@ -65,13 +65,13 @@ export const route = {
                     },
                 });
 
-                const resData = response.data?.data ?? response.data;
-                const list = Array.isArray(resData) ? resData : Array.isArray(resData?.list) ? resData.list : [];
+                const resData = response.data?.data; // The actual data is nested under the 'data' property in the response
+                const list = Array.isArray(resData?.list) ? resData.list : []; // resData may be undefined or not an array, resDate.list is an array
 
                 return list.map((item) => {
                     const title = item.title;
                     const itemLink = item.fullurl;
-                    const pubDate = timezone(parseDate(item.publishtime * 1000), +8);
+                    const pubDate = timezone(parseDate(item.publishtime * 1000)); // Unix timestamp in seconds, convert to milliseconds
                     const startDate = item.start_time.split(' ')[0];
                     const endDate = item.end_time.split(' ')[0];
                     const fullDuration = item.display_time;

--- a/lib/routes/shanximuseum/temporary.tsx
+++ b/lib/routes/shanximuseum/temporary.tsx
@@ -22,32 +22,22 @@ export const route = {
         },
     ],
     handler: async (ctx) => {
-        let typeParam = ctx.req.param('type')?.toLowerCase();
-
-        let fetchTypes = ['now', 'future', 'past'];
-
-        if (typeParam) {
-            // replace list or offset with past to support old links like /temporary/list or /temporary/offset
-            typeParam = typeParam.replaceAll(/list|offset/g, 'past');
-
-            // support /now&future, /now+future, /now,future
-            const requestedTypes = typeParam.split(/[&+,|-]/);
-
-            const validTypes = requestedTypes.filter((t) => ['now', 'future', 'past'].includes(t));
-
-            if (validTypes.length > 0) {
-                fetchTypes = [...new Set<string>(validTypes)];
-            }
-        }
+        const typeParam = ctx.req.param('type');
+        // Support multiple status combinations separated by &, + or , (e.g., now&future)
+        const fetchTypes = typeParam ? [...new Set(typeParam.split(/[&+,|-]/))] : ['now', 'future', 'past'];
 
         const baseUrl = 'https://www.shanximuseum.com.cn';
         const apiUrl = `${baseUrl}/sx/exhibition`;
 
         const apiConfig = {
             now: { endpoint: '/temporary_now', name: '正在展出', query: {} },
-            future: { endpoint: '/temporary_future', name: '即将展出', query: {} },
+            future: {
+                endpoint: '/temporary_future',
+                name: '即将展出',
+                query: {},
+            },
             past: {
-                endpoint: '/temporary_list',
+                endpoint: '/temporary_list', // the same endpoint as the exhibition list page, but with different query parameters
                 name: '往期展览',
                 query: {
                     offset: 0,
@@ -60,21 +50,11 @@ export const route = {
 
         const museumName = namespace.zh?.name || namespace.name;
 
-        let titleTag = '全部展览';
-
-        // combine titletag with & if user specified type
-        if (typeParam && fetchTypes.length > 0) {
-            titleTag = fetchTypes.map((t) => apiConfig[t].name).join(' & ');
-
-            // all 3 titletag combination should be named as default
-            if (fetchTypes.length === 3) {
-                titleTag = '全部展览';
-            }
-        }
+        const titleTag = fetchTypes.length === 3 ? '全部展览' : fetchTypes.map((t) => apiConfig[t as keyof typeof apiConfig]?.name).join(' & ');
 
         const responses = await Promise.all(
             fetchTypes.map(async (t) => {
-                const config = apiConfig[t];
+                const config = apiConfig[t as keyof typeof apiConfig];
 
                 const response = await got({
                     method: 'get',
@@ -85,32 +65,18 @@ export const route = {
                     },
                 });
 
-                let list = response.data;
-                if (list && list.data) {
-                    list = list.data;
-                }
-
-                if (list && !Array.isArray(list)) {
-                    if (list.list && Array.isArray(list.list)) {
-                        list = list.list;
-                    } else if (list.rows && Array.isArray(list.rows)) {
-                        list = list.rows;
-                    }
-                }
-
-                if (!Array.isArray(list)) {
-                    list = [];
-                }
+                const resData = response.data?.data ?? response.data;
+                const list = Array.isArray(resData) ? resData : Array.isArray(resData?.list) ? resData.list : [];
 
                 return list.map((item) => {
                     const title = item.title;
-                    const itemLink = item.fullurl || `${baseUrl}${item.url}`;
+                    const itemLink = item.fullurl;
                     const pubDate = timezone(parseDate(item.publishtime * 1000), +8);
-                    const startDate = item.start_time ? item.start_time.split(' ')[0] : '';
-                    const endDate = item.end_time ? item.end_time.split(' ')[0] : '';
-                    const fullDuration = item.display_time || '';
-                    const location = item.area || '';
-                    const imgUrl = item.image.startsWith('http') ? item.image : `${baseUrl}${item.image}`;
+                    const startDate = item.start_time.split(' ')[0];
+                    const endDate = item.end_time.split(' ')[0];
+                    const fullDuration = item.display_time;
+                    const location = item.area;
+                    const imgUrl = `${baseUrl}${item.image}`;
 
                     const description = renderToString(
                         <div>
@@ -136,15 +102,7 @@ export const route = {
 
                             {fullDuration && (
                                 <p>
-                                    <small>
-                                        原始展期：
-                                        {fullDuration.split('\n').map((line, i) => (
-                                            <span key={i}>
-                                                {line}
-                                                <br />
-                                            </span>
-                                        ))}
-                                    </small>
+                                    <small>原始展期：{fullDuration}</small>
                                 </p>
                             )}
                         </div>


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close # None

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/shanximuseum/exhibition/temporary
/shanximuseum/exhibition/temporary/now
/shanximuseum/exhibition/temporary/future
/shanximuseum/exhibition/temporary/past
/shanximuseum/exhibition/temporary/now&future
/shanximuseum/exhibition/temporary/now&past
/shanximuseum/exhibition/temporary/past&future
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
