### PR TITLE
fix(route/4gamers): handle InsertOneAdsSection

### DIFF
--- a/lib/routes/4gamers/utils.tsx
+++ b/lib/routes/4gamers/utils.tsx
@@ -39,6 +39,7 @@ const parseItem = async (item) => {
             .map((section) => {
                 switch (section['@type']) {
                     case 'ContentAdsSection':
+                    case 'InsertOneAdsSection':
                     case 'ScrollerAdsSection':
                     case 'textScrollerAdsSection':
                         return '';


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/4gamers/tag/限時免費
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This fixes an existing 4Gamers route failure.

4Gamers article detail API can now return `InsertOneAdsSection`. The route already skips other ad section types, but this new type was not handled, so `parseItem` threw `Unhandled section type` for affected articles such as `sub=79044`.

Validation:

- Confirmed `https://www.4gamers.com.tw/site/api/news/find-section?sub=79044` includes `InsertOneAdsSection`.
- Ran `git diff --check`.
- Ran `TMPDIR=/tmp TEMP=/tmp TMP=/tmp pnpm exec lint-staged --diff HEAD~1`.
- User verified the route locally after the fix.