### PR TITLE
feat: add language-aware ChatGPT translation parameters

### DIFF
--- a/lib/middleware/parameter.test.ts
+++ b/lib/middleware/parameter.test.ts
@@ -1,4 +1,5 @@
 import Parser from 'rss-parser';
+import { http, HttpResponse } from 'msw';
 import { describe, expect, it, vi } from 'vitest';
 
 process.env.OPENAI_API_KEY = 'sk-1234567890';
@@ -458,5 +459,34 @@ describe('openai', () => {
         const parsedDescriptionOnly = await parser.parseString(await responseDescriptionOnly.text());
         expect(parsedDescriptionOnly.items[0].title).not.toContain('AI processed content.');
         expect(parsedDescriptionOnly.items[0].content).toContain('AI processed content.');
+    });
+
+    it('supports target language override via query', async () => {
+        const { default: server } = await import('@/setup.test');
+        const originalInput = config.openai.inputOption;
+
+        server.use(
+            http.post('https://api.openai.mock/v1/chat/completions', async ({ request }) => {
+                const body = (await request.json()) as { messages?: Array<{ content?: string }> };
+                const prompt = body.messages?.[0]?.content ?? '';
+
+                if (prompt.includes('into Japanese')) {
+                    return HttpResponse.json({
+                        choices: [{ message: { content: '日本語タイトル' } }],
+                    });
+                }
+
+                return HttpResponse.json({
+                    choices: [{ message: { content: 'AI processed content.' } }],
+                });
+            })
+        );
+
+        config.openai.inputOption = 'title';
+        const response = await app.request('/test/gpt?chatgpt=true&chatgpt_to=Japanese&chatgpt_from=English');
+        const parsed = await parser.parseString(await response.text());
+        expect(parsed.items[0].title).toBe('日本語タイトル');
+
+        config.openai.inputOption = originalInput;
     });
 });

--- a/lib/middleware/parameter.test.ts
+++ b/lib/middleware/parameter.test.ts
@@ -1,5 +1,5 @@
-import Parser from 'rss-parser';
 import { http, HttpResponse } from 'msw';
+import Parser from 'rss-parser';
 import { describe, expect, it, vi } from 'vitest';
 
 process.env.OPENAI_API_KEY = 'sk-1234567890';

--- a/lib/middleware/parameter.ts
+++ b/lib/middleware/parameter.ts
@@ -56,6 +56,43 @@ const getAiCompletion = async (prompt: string, text: string) => {
     return response.choices[0].message.content;
 };
 
+const getChatgptLanguageOptions = (ctx) => {
+    const targetLanguage = ctx.req.query('chatgpt_to') ?? ctx.req.query('chatgpt_lang');
+    const sourceLanguage = ctx.req.query('chatgpt_from');
+
+    return {
+        targetLanguage: targetLanguage?.trim() || undefined,
+        sourceLanguage: sourceLanguage?.trim() || undefined,
+    };
+};
+
+const buildTranslationPrompt = (field: 'title' | 'content', targetLanguage: string, sourceLanguage?: string) => {
+    const fromSegment = sourceLanguage ? ` from ${sourceLanguage}` : '';
+    const contentSegment = field === 'title' ? 'title' : 'content';
+    const formatSegment = field === 'title' ? 'reply only translated text' : 'preserve markdown formatting';
+
+    return `Please translate the following ${contentSegment}${fromSegment} into ${targetLanguage} and ${formatSegment}.`;
+};
+
+const getOpenAiPrompt = (ctx, field: 'title' | 'content') => {
+    const { targetLanguage, sourceLanguage } = getChatgptLanguageOptions(ctx);
+
+    if (!targetLanguage) {
+        return field === 'title' ? config.openai.promptTitle : config.openai.promptDescription;
+    }
+
+    return buildTranslationPrompt(field, targetLanguage, sourceLanguage);
+};
+
+const getOpenAiCachePrefix = (ctx) => {
+    const { targetLanguage, sourceLanguage } = getChatgptLanguageOptions(ctx);
+    if (!targetLanguage && !sourceLanguage) {
+        return 'default';
+    }
+
+    return `${sourceLanguage ?? 'auto'}->${targetLanguage ?? 'default'}`;
+};
+
 const getAuthorString = (item) => {
     let author = '';
     if (item.author) {
@@ -330,14 +367,18 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
 
         // openai
         if (ctx.req.query('chatgpt') && config.openai.apiKey) {
+            const titlePrompt = getOpenAiPrompt(ctx, 'title');
+            const descriptionPrompt = getOpenAiPrompt(ctx, 'content');
+            const cachePrefix = getOpenAiCachePrefix(ctx);
+
             data.item = await Promise.all(
                 data.item.map(async (item) => {
                     try {
                         // handle description
                         if (config.openai.inputOption === 'description' && item.description) {
-                            const description = await cache.tryGet(`openai:description:${item.link}`, async () => {
+                            const description = await cache.tryGet(`openai:${cachePrefix}:description:${item.link}`, async () => {
                                 const description = convert(item.description!);
-                                const descriptionMd = await getAiCompletion(config.openai.promptDescription, description);
+                                const descriptionMd = await getAiCompletion(descriptionPrompt, description);
                                 return md.render(descriptionMd);
                             });
                             // add it to the description
@@ -347,9 +388,9 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
                         }
                         // handle title
                         else if (config.openai.inputOption === 'title' && item.title) {
-                            const title = await cache.tryGet(`openai:title:${item.link}`, async () => {
+                            const title = await cache.tryGet(`openai:${cachePrefix}:title:${item.link}`, async () => {
                                 const title = convert(item.title!);
-                                return await getAiCompletion(config.openai.promptTitle, title);
+                                return await getAiCompletion(titlePrompt, title);
                             });
                             // replace the title
                             if (title !== '') {
@@ -358,18 +399,18 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
                         }
                         // handle both
                         else if (config.openai.inputOption === 'both' && item.title && item.description) {
-                            const title = await cache.tryGet(`openai:title:${item.link}`, async () => {
+                            const title = await cache.tryGet(`openai:${cachePrefix}:title:${item.link}`, async () => {
                                 const title = convert(item.title!);
-                                return await getAiCompletion(config.openai.promptTitle, title);
+                                return await getAiCompletion(titlePrompt, title);
                             });
                             // replace the title
                             if (title !== '') {
                                 item.title = title + '';
                             }
 
-                            const description = await cache.tryGet(`openai:description:${item.link}`, async () => {
+                            const description = await cache.tryGet(`openai:${cachePrefix}:description:${item.link}`, async () => {
                                 const description = convert(item.description!);
-                                const descriptionMd = await getAiCompletion(config.openai.promptDescription, description);
+                                const descriptionMd = await getAiCompletion(descriptionPrompt, description);
                                 return md.render(descriptionMd);
                             });
                             // add it to the description


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #6696
/claim #6696

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

### Summary
- add optional `chatgpt_to` (alias `chatgpt_lang`) and `chatgpt_from` query parameters in the global parameter middleware
- when language overrides are provided, ChatGPT prompt generation translates title/content toward the requested target language
- include language pair in OpenAI cache keys to prevent stale cross-language cache reuse
- add a focused test for the target-language override path
- fix import ordering in `lib/middleware/parameter.test.ts` to satisfy project lint rules

### Validation attempted
- `pnpm install --frozen-lockfile --ignore-scripts` (blocked in this runner by offline-mode store and permissions)
- `npm install --no-audit --no-fund --ignore-scripts --legacy-peer-deps` (blocked by runner `spawn EPERM` while resolving dependencies)

Because dependency installation failed in this environment, the full vitest suite could not be run here. The patch is limited to middleware prompt/cache logic and a targeted test update.
