### PR TITLE
fix(route/twitter): defensive fallback for missing profile_image_url (avoid /twitter/user/* 503)

### DIFF
--- a/lib/routes/twitter/user.ts
+++ b/lib/routes/twitter/user.ts
@@ -88,7 +88,7 @@ async function handler(ctx) {
     return {
         title: `Twitter @${userInfo?.name}`,
         link: `https://x.com/${userInfo?.screen_name}`,
-        image: profileImageUrl.replace(/_normal.jpg$/, '.jpg'),
+        image: profileImageUrl?.replace(/_normal.jpg$/, '.jpg') ?? 'https://abs.twimg.com/sticky/default_profile_images/default_profile_400x400.png',
         description: userInfo?.description,
         item:
             data &&


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Defensive guard related to #22136 (does not fix the root cause; see "Scope" below).

## Example for the Proposed Route(s) / 路由地址示例

```routes
/twitter/user/:id
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Provided as ISO 8601 / UTC / 以 ISO 8601 / UTC 提供
- [ ] [Author](https://docs.rsshub.app/joinus/advanced/script-standard#%E5%88%9B%E5%BB%BA%E4%B8%80%E4%B8%AA%E4%BB%A3%E7%A0%81%E6%96%87%E4%BB%B6) in `namespace.ts` is included / `namespace.ts` 中含有 [作者](https://docs.rsshub.app/zh/joinus/advanced/script-standard#%E5%88%9B%E5%BB%BA%E4%B8%80%E4%B8%AA%E4%BB%A3%E7%A0%81%E6%96%87%E4%BB%B6)
- [X] Bug fix / 修复 bug

## Note / 说明

### Summary

`lib/routes/twitter/user.ts:91` calls `profileImageUrl.replace(...)` without optional chaining. When `api.getUser(id)` returns user info whose `profile_image_url` / `profile_image_url_https` fields are missing (observed when X changes the API contract — see #22136), `profileImageUrl` resolves to `undefined`, and the unguarded `.replace()` call throws `TypeError: Cannot read properties of undefined (reading 'replace')`, making the entire `/twitter/user/*` route return HTTP 503.

### Diff

```diff
-        image: profileImageUrl.replace(/_normal.jpg$/, '.jpg'),
+        image: profileImageUrl?.replace(/_normal.jpg$/, '.jpg') ?? 'https://abs.twimg.com/sticky/default_profile_images/default_profile_400x400.png',
```

One-line change: add optional chaining and fall back to X's official default profile image when the field is missing.

### Scope

- **Defensive only**: prevents a single missing field from collapsing the entire route into 503. Returns a feed with X's default avatar instead.
- **Does NOT fix the root cause**: the underlying X API contract change (which causes `profile_image_url` to be missing in the first place) is tracked in #22136 and requires updates to `gql-id-resolver` / query IDs / GraphQL features in `lib/routes/twitter/api/web-api/`.
- Does not affect the happy path: when `profileImageUrl` is present, behavior is unchanged.

### Why this is still valuable even after #22136 root cause lands

This is a generic defensive guard against future X API contract changes. X has historically renamed / removed fields on `UserByScreenName` multiple times. With this guard in place, future similar regressions degrade gracefully (default avatar) instead of crashing the entire route with a confusing `TypeError`.

### Symptom reference (from #22136)

```
info: <-- GET /twitter/user/dscassoc
info: twitter gql-id-resolver: fetching fresh query IDs from Twitter JS bundles
error: Error in /twitter/user/dscassoc: TypeError: Cannot read properties of undefined (reading 'replace')
info: --> GET /twitter/user/dscassoc 503 14s
```
