### PR TITLE
fix(route): null check for uploadDate in Al Jazeera

### DIFF
--- a/lib/routes/aljazeera/index.tsx
+++ b/lib/routes/aljazeera/index.tsx
@@ -87,7 +87,8 @@ async function handler(ctx) {
                     pubDate = detailResponse.match(/"datePublished": ?"(.*?)",/)[1];
                 } else {
                     // uploadDate replaces datePublished for video articles
-                    const uploadDate = detailResponse.match(/"uploadDate": ?"(.*?)",/)[1];
+                    const uploadDateMatch = detailResponse.match(/"uploadDate": ?"(.*?)",/);
+                    const uploadDate = uploadDateMatch ? uploadDateMatch[1] : null;
 
                     pubDate = uploadDate && uploadDate.length > 1 ? uploadDate : content('div.date-simple > span:nth-child(2)').text();
                 }


### PR DESCRIPTION
## Involved Issue

Close #N/A

## Example for the Proposed Route(s)

```routes
/aljazeera/english
/aljazeera/arabic
/aljazeera/chinese
```

## Description

Fix TypeError when both datePublished and uploadDate are missing in Al Jazeera articles. The English version returns articles without these fields, causing a crash on line 90.