### PR TITLE
feat(route): add EFE Noticias route

### DIFF
--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -71,6 +71,13 @@ async function handler(ctx) {
 
                 const image = $detail('meta[property="og:image"]').attr('content');
                 const content = $detail('article .entry-content, article .elementor-widget-theme-post-content').first();
+                content.find('.auto-banner, .srr-main').remove();
+                content.find('img').each((_, el) => {
+                    const src = $detail(el).attr('src') || '';
+                    if (/logo-efe|logo-EFE-Comunica|GIF-CUENTA-ATRAS/i.test(src)) {
+                        $detail(el).remove();
+                    }
+                });
                 const description = content.html() || '';
 
                 return {

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -22,7 +22,7 @@ const categories: Record<string, string> = {
 
 export const route: Route = {
     path: '/:category?',
-    name: 'Noticias',
+    name: 'Category',
     maintainers: ['mlkgrnt'],
     example: '/efe/mundo',
     parameters: { category: 'Categoría, por defecto mundo' },
@@ -85,7 +85,8 @@ async function handler(ctx) {
                     link,
                     pubDate,
                     description,
-                    image,
+                    enclosure_url: image,
+                    enclosure_type: 'image/jpeg',
                 };
             })
         )

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -1,0 +1,92 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const rootUrl = 'https://efe.com';
+
+const categories: Record<string, string> = {
+    mundo: 'Mundo',
+    espana: 'España',
+    economia: 'Economía',
+    cultura: 'Cultura',
+    'ciencia-y-tecnologia': 'Ciencia y Tecnología',
+    deportes: 'Deportes',
+    salud: 'Salud',
+    'medio-ambiente': 'Medio Ambiente',
+    educacion: 'Educación',
+    'euro-efe': 'EuroEFE',
+};
+
+export const route: Route = {
+    path: '/:category?',
+    name: 'Noticias',
+    maintainers: ['mlkgrnt'],
+    example: '/efe/mundo',
+    parameters: { category: 'Categoría, por defecto mundo' },
+    handler,
+    categories: ['new-media'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['efe.com/:category'],
+            target: '/:category',
+        },
+    ],
+};
+
+async function handler(ctx) {
+    const category = ctx.req.param('category') || 'mundo';
+    const pageUrl = `${rootUrl}/${category}/`;
+
+    const response = await ofetch(pageUrl);
+    const $ = load(response);
+
+    const links = new Set<string>();
+    $(`a[href^="${rootUrl}/${category}/"]`).each((_, el) => {
+        const href = $(el).attr('href');
+        if (href && href.match(/\/\d{4}-\d{2}-\d{2}\//)) {
+            links.add(href);
+        }
+    });
+
+    const items = await Promise.all(
+        [...links].slice(0, 20).map((link) =>
+            cache.tryGet(link, async () => {
+                const detail = await ofetch(link);
+                const $detail = load(detail);
+
+                const title = $detail('title').first().text().trim();
+                const dateMatch = detail.match(/"datePublished":\s*"([^"]+)"/);
+                const pubDate = dateMatch ? parseDate(dateMatch[1]) : undefined;
+
+                const image = $detail('meta[property="og:image"]').attr('content');
+                const content = $detail('article .entry-content, article .elementor-widget-theme-post-content').first();
+                const description = content.html() || '';
+
+                return {
+                    title,
+                    link,
+                    pubDate,
+                    description,
+                    image,
+                };
+            })
+        )
+    );
+
+    return {
+        title: `EFE Noticias - ${categories[category] || category}`,
+        link: pageUrl,
+        item: items,
+    };
+}

--- a/lib/routes/efe/namespace.ts
+++ b/lib/routes/efe/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'EFE Noticias',
+    url: 'efe.com',
+    lang: 'es',
+};


### PR DESCRIPTION
## Involved Issue / Related PR

None

## Pull Request Checklist

- [x] No lint errors (`pnpm lint`)
- [x] Route path: `/efe/:category?`
- [x] Namespace: `efe`

## Example Routes

```routes
/efe/mundo
/efe/espana
/efe/economia
/efe/cultura
/efe/ciencia-y-tecnologia
/efe/deportes
/efe/salud
/efe/medio-ambiente
/efe/educacion
/efe/euro-efe
```

## New Route Checklist

- [x] Route file exists in `lib/routes/efe/`
- [x] Namespace file exists in `lib/routes/efe/namespace.ts`
- [x] Uses `parseDate` for date fields