### PR TITLE
feat(route): add EFE Noticias route

### DIFF
--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -67,6 +67,7 @@ async function handler(ctx) {
 
     const items = [];
     for (const link of [...links].slice(0, limit)) {
+        // eslint-disable-next-line no-await-in-loop -- sequential to avoid 429 rate limiting
         const item = await cache.tryGet(link, async () => {
             const detail = await ofetch(link);
             const $detail = load(detail);

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -58,7 +58,7 @@ async function handler(ctx) {
     const $ = load(response);
 
     const links = new Set<string>();
-    $(`.elementor-loop-container .elementor-post a[href^="${rootUrl}/${category}/"]`).each((_, el) => {
+    $(`.elementor-loop-container a[href^="${rootUrl}/${category}/"]`).each((_, el) => {
         const href = $(el).attr('href');
         if (href && /\/\d{4}-\d{2}-\d{2}\//.test(href)) {
             links.add(href);

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -1,4 +1,5 @@
 import { load } from 'cheerio';
+import pMap from 'p-map';
 
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
@@ -62,8 +63,9 @@ async function handler(ctx) {
         .map((el) => $(el).attr('href'))
         .filter((href): href is string => !!href && href.startsWith(`${rootUrl}/${category}/`) && /\/\d{4}-\d{2}-\d{2}\//.test(href));
 
-    const items = await Promise.all(
-        links.slice(0, limit).map((link) =>
+    const items = await pMap(
+        links.slice(0, limit),
+        (link) =>
             cache.tryGet(link, async () => {
                 const detail = await ofetch(link);
                 const $detail = load(detail);
@@ -83,8 +85,8 @@ async function handler(ctx) {
                     pubDate,
                     description,
                 };
-            })
-        )
+            }),
+        { concurrency: 2 }
     );
 
     return {

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -58,9 +58,9 @@ async function handler(ctx) {
     const $ = load(response);
 
     const links = new Set<string>();
-    $(`.elementor-loop-container a[href^="${rootUrl}/${category}/"]`).each((_, el) => {
+    $(`.e-loop-item .elementor-widget-theme-post-title a[href]`).each((_, el) => {
         const href = $(el).attr('href');
-        if (href && /\/\d{4}-\d{2}-\d{2}\//.test(href)) {
+        if (href && href.startsWith(`${rootUrl}/${category}/`) && /\/\d{4}-\d{2}-\d{2}\//.test(href)) {
             links.add(href);
         }
     });

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -58,7 +58,7 @@ async function handler(ctx) {
     const $ = load(response);
 
     const links = new Set<string>();
-    $(`.e-loop-item .elementor-widget-theme-post-title a[href]`).each((_, el) => {
+    $('.e-loop-item .elementor-widget-theme-post-title a[href]').each((_, el) => {
         const href = $(el).attr('href');
         if (href && href.startsWith(`${rootUrl}/${category}/`) && /\/\d{4}-\d{2}-\d{2}\//.test(href)) {
             links.add(href);

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -25,7 +25,7 @@ export const route: Route = {
     name: 'Category',
     maintainers: ['mlkgrnt'],
     example: '/efe/mundo',
-    parameters: { category: 'Categoría, por defecto mundo', limit: 'Número de noticias, por defecto 20' },
+    parameters: { category: 'Categoría, por defecto mundo' },
     handler,
     categories: ['new-media'],
     features: {
@@ -53,9 +53,9 @@ async function handler(ctx) {
     const $ = load(response);
 
     const links = new Set<string>();
-    $(`a[href^="${rootUrl}/${category}/"]`).each((_, el) => {
+    $('.elementor-loop-container a[href]').each((_, el) => {
         const href = $(el).attr('href');
-        if (href && href.match(/\/\d{4}-\d{2}-\d{2}\//)) {
+        if (href && href.startsWith(`${rootUrl}/${category}/`) && /\/\d{4}-\d{2}-\d{2}\//.test(href)) {
             links.add(href);
         }
     });
@@ -71,15 +71,15 @@ async function handler(ctx) {
                 const pubDate = dateMatch ? parseDate(dateMatch[1]) : undefined;
 
                 const image = $detail('meta[property="og:image"]').attr('content');
-                const content = $detail('.elementor-widget-theme-post-content').first();
-                content.find('.auto-banner, .srr-main').remove();
+                const content = $detail('.elementor-widget-theme-post-content');
+                content.find('.auto-banner').remove();
                 content.find('img').each((_, el) => {
                     const img = $detail(el);
                     const src = img.attr('src') || '';
                     if (/logo-efe|logo-EFE-Comunica|GIF-CUENTA-ATRAS/i.test(src)) {
                         img.remove();
                     } else {
-                        for (const attr of ['srcset', 'data-recalc-dims', 'fetchpriority', 'decoding', 'loading', 'class', 'style', 'width', 'height']) {
+                        for (const attr of ['srcset', 'data-recalc-dims', 'fetchpriority', 'class', 'style', 'width', 'height']) {
                             img.removeAttr(attr);
                         }
                     }

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -57,13 +57,10 @@ async function handler(ctx) {
     const response = await ofetch(pageUrl);
     const $ = load(response);
 
-    const links: string[] = [];
-    $('.e-loop-item .elementor-widget-theme-post-title a[href]').each((_, el) => {
-        const href = $(el).attr('href');
-        if (href && href.startsWith(`${rootUrl}/${category}/`) && /\/\d{4}-\d{2}-\d{2}\//.test(href)) {
-            links.push(href);
-        }
-    });
+    const links = $('.e-loop-item .elementor-widget-theme-post-title a[href]')
+        .toArray()
+        .map((el) => $(el).attr('href'))
+        .filter((href): href is string => !!href && href.startsWith(`${rootUrl}/${category}/`) && /\/\d{4}-\d{2}-\d{2}\//.test(href));
 
     const items = await Promise.all(
         links.slice(0, limit).map((link) =>

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -57,39 +57,38 @@ async function handler(ctx) {
     const response = await ofetch(pageUrl);
     const $ = load(response);
 
-    const links = new Set<string>();
+    const links: string[] = [];
     $('.e-loop-item .elementor-widget-theme-post-title a[href]').each((_, el) => {
         const href = $(el).attr('href');
         if (href && href.startsWith(`${rootUrl}/${category}/`) && /\/\d{4}-\d{2}-\d{2}\//.test(href)) {
-            links.add(href);
+            links.push(href);
         }
     });
 
-    const items = [];
-    for (const link of [...links].slice(0, limit)) {
-        // eslint-disable-next-line no-await-in-loop -- sequential to avoid 429 rate limiting
-        const item = await cache.tryGet(link, async () => {
-            const detail = await ofetch(link);
-            const $detail = load(detail);
+    const items = await Promise.all(
+        links.slice(0, limit).map((link) =>
+            cache.tryGet(link, async () => {
+                const detail = await ofetch(link);
+                const $detail = load(detail);
 
-            const title = $detail('title').text();
-            const dateMatch = detail.match(/"datePublished":\s*"([^"]+)"/);
-            const pubDate = dateMatch ? parseDate(dateMatch[1]) : undefined;
+                const title = $detail('title').text();
+                const dateMatch = detail.match(/"datePublished":\s*"([^"]+)"/);
+                const pubDate = dateMatch ? parseDate(dateMatch[1]) : undefined;
 
-            const image = $detail('meta[property="og:image"]').attr('content');
-            const content = $detail('.elementor-widget-theme-post-content');
-            content.find('.auto-banner').remove();
-            const description = (image ? `<figure><img src="${image}"></figure>` : '') + (content.html() || '');
+                const image = $detail('meta[property="og:image"]').attr('content');
+                const content = $detail('.elementor-widget-theme-post-content');
+                content.find('.auto-banner').remove();
+                const description = (image ? `<figure><img src="${image}"></figure>` : '') + (content.html() || '');
 
-            return {
-                title,
-                link,
-                pubDate,
-                description,
-            };
-        });
-        items.push(item);
-    }
+                return {
+                    title,
+                    link,
+                    pubDate,
+                    description,
+                };
+            })
+        )
+    );
 
     return {
         title: `EFE Noticias - ${categories[category] || category}`,

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -25,7 +25,12 @@ export const route: Route = {
     name: 'Category',
     maintainers: ['mlkgrnt'],
     example: '/efe/mundo',
-    parameters: { category: 'Categoría, por defecto mundo' },
+    parameters: {
+        category: {
+            description: 'Category slug, see table below. Defaults to mundo.',
+            default: 'mundo',
+        },
+    },
     handler,
     categories: ['new-media'],
     features: {
@@ -53,9 +58,9 @@ async function handler(ctx) {
     const $ = load(response);
 
     const links = new Set<string>();
-    $('.elementor-loop-container a[href]').each((_, el) => {
+    $(`.elementor-loop-container .elementor-post a[href^="${rootUrl}/${category}/"]`).each((_, el) => {
         const href = $(el).attr('href');
-        if (href && href.startsWith(`${rootUrl}/${category}/`) && /\/\d{4}-\d{2}-\d{2}\//.test(href)) {
+        if (href && /\/\d{4}-\d{2}-\d{2}\//.test(href)) {
             links.add(href);
         }
     });
@@ -66,24 +71,13 @@ async function handler(ctx) {
                 const detail = await ofetch(link);
                 const $detail = load(detail);
 
-                const title = $detail('title').first().text();
+                const title = $detail('title').text();
                 const dateMatch = detail.match(/"datePublished":\s*"([^"]+)"/);
                 const pubDate = dateMatch ? parseDate(dateMatch[1]) : undefined;
 
                 const image = $detail('meta[property="og:image"]').attr('content');
                 const content = $detail('.elementor-widget-theme-post-content');
                 content.find('.auto-banner').remove();
-                content.find('img').each((_, el) => {
-                    const img = $detail(el);
-                    const src = img.attr('src') || '';
-                    if (/logo-efe|logo-EFE-Comunica|GIF-CUENTA-ATRAS/i.test(src)) {
-                        img.remove();
-                    } else {
-                        for (const attr of ['srcset', 'data-recalc-dims', 'fetchpriority', 'class', 'style', 'width', 'height']) {
-                            img.removeAttr(attr);
-                        }
-                    }
-                });
                 const description = (image ? `<figure><img src="${image}"></figure>` : '') + (content.html() || '');
 
                 return {

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -1,0 +1,104 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const rootUrl = 'https://efe.com';
+
+const categories: Record<string, string> = {
+    mundo: 'Mundo',
+    espana: 'España',
+    economia: 'Economía',
+    cultura: 'Cultura',
+    'ciencia-y-tecnologia': 'Ciencia y Tecnología',
+    deportes: 'Deportes',
+    salud: 'Salud',
+    'medio-ambiente': 'Medio Ambiente',
+    educacion: 'Educación',
+    'euro-efe': 'EuroEFE',
+};
+
+export const route: Route = {
+    path: '/:category?',
+    name: 'Category',
+    maintainers: ['mlkgrnt'],
+    example: '/efe/mundo',
+    parameters: { category: 'Categoría, por defecto mundo', limit: 'Número de noticias, por defecto 20' },
+    handler,
+    categories: ['new-media'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['efe.com/:category'],
+            target: '/:category',
+        },
+    ],
+};
+
+async function handler(ctx) {
+    const category = ctx.req.param('category') || 'mundo';
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 20;
+    const pageUrl = `${rootUrl}/${category}/`;
+
+    const response = await ofetch(pageUrl);
+    const $ = load(response);
+
+    const links = new Set<string>();
+    $(`a[href^="${rootUrl}/${category}/"]`).each((_, el) => {
+        const href = $(el).attr('href');
+        if (href && href.match(/\/\d{4}-\d{2}-\d{2}\//)) {
+            links.add(href);
+        }
+    });
+
+    const items = await Promise.all(
+        [...links].slice(0, limit).map((link) =>
+            cache.tryGet(link, async () => {
+                const detail = await ofetch(link);
+                const $detail = load(detail);
+
+                const title = $detail('title').first().text();
+                const dateMatch = detail.match(/"datePublished":\s*"([^"]+)"/);
+                const pubDate = dateMatch ? parseDate(dateMatch[1]) : undefined;
+
+                const image = $detail('meta[property="og:image"]').attr('content');
+                const content = $detail('.elementor-widget-theme-post-content').first();
+                content.find('.auto-banner, .srr-main').remove();
+                content.find('img').each((_, el) => {
+                    const img = $detail(el);
+                    const src = img.attr('src') || '';
+                    if (/logo-efe|logo-EFE-Comunica|GIF-CUENTA-ATRAS/i.test(src)) {
+                        img.remove();
+                    } else {
+                        for (const attr of ['srcset', 'data-recalc-dims', 'fetchpriority', 'decoding', 'loading', 'class', 'style', 'width', 'height']) {
+                            img.removeAttr(attr);
+                        }
+                    }
+                });
+                const description = (image ? `<figure><img src="${image}"></figure>` : '') + (content.html() || '');
+
+                return {
+                    title,
+                    link,
+                    pubDate,
+                    description,
+                };
+            })
+        )
+    );
+
+    return {
+        title: `EFE Noticias - ${categories[category] || category}`,
+        link: pageUrl,
+        item: items,
+    };
+}

--- a/lib/routes/efe/index.ts
+++ b/lib/routes/efe/index.ts
@@ -65,30 +65,30 @@ async function handler(ctx) {
         }
     });
 
-    const items = await Promise.all(
-        [...links].slice(0, limit).map((link) =>
-            cache.tryGet(link, async () => {
-                const detail = await ofetch(link);
-                const $detail = load(detail);
+    const items = [];
+    for (const link of [...links].slice(0, limit)) {
+        const item = await cache.tryGet(link, async () => {
+            const detail = await ofetch(link);
+            const $detail = load(detail);
 
-                const title = $detail('title').text();
-                const dateMatch = detail.match(/"datePublished":\s*"([^"]+)"/);
-                const pubDate = dateMatch ? parseDate(dateMatch[1]) : undefined;
+            const title = $detail('title').text();
+            const dateMatch = detail.match(/"datePublished":\s*"([^"]+)"/);
+            const pubDate = dateMatch ? parseDate(dateMatch[1]) : undefined;
 
-                const image = $detail('meta[property="og:image"]').attr('content');
-                const content = $detail('.elementor-widget-theme-post-content');
-                content.find('.auto-banner').remove();
-                const description = (image ? `<figure><img src="${image}"></figure>` : '') + (content.html() || '');
+            const image = $detail('meta[property="og:image"]').attr('content');
+            const content = $detail('.elementor-widget-theme-post-content');
+            content.find('.auto-banner').remove();
+            const description = (image ? `<figure><img src="${image}"></figure>` : '') + (content.html() || '');
 
-                return {
-                    title,
-                    link,
-                    pubDate,
-                    description,
-                };
-            })
-        )
-    );
+            return {
+                title,
+                link,
+                pubDate,
+                description,
+            };
+        });
+        items.push(item);
+    }
 
     return {
         title: `EFE Noticias - ${categories[category] || category}`,

--- a/lib/routes/efe/namespace.ts
+++ b/lib/routes/efe/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'EFE Noticias',
+    url: 'efe.com',
+    lang: 'es',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/efe/mundo
/efe/espana
/efe/economia
/efe/cultura
/efe/ciencia-y-tecnologia
/efe/deportes
/efe/salud
/efe/medio-ambiente
/efe/educacion
/efe/euro-efe
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows Script Standard / 跟随路由规范
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [ ] No
- [x] Date and time / 日期和时间
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds EFE (Agencia EFE) Spanish news route with 10 categories.