### PR TITLE
fix: transform json number item link

### DIFF
--- a/lib/routes/rsshub/transform/json.ts
+++ b/lib/routes/rsshub/transform/json.ts
@@ -93,7 +93,7 @@ async function handler(ctx) {
     }
 
     const items = jsonGet(response.data, routeParams.get('item')).map((item) => {
-        let link = jsonGet(item, routeParams.get('itemLink')).trim();
+        let link = String(jsonGet(item, routeParams.get('itemLink')) ?? '').trim();
         const linkPrefix = routeParams.get('itemLinkPrefix');
 
         if (link && linkPrefix) {

--- a/lib/routes/rsshub/transform/json.ts
+++ b/lib/routes/rsshub/transform/json.ts
@@ -20,7 +20,7 @@ function jsonGet(obj, attr) {
 export const route: Route = {
     path: '/transform/json/:url/:routeParams',
     categories: ['other'],
-    example: '/rsshub/transform/json/https%3A%2F%2Fapi.github.com%2Frepos%2Fginuerzh%2Fgost%2Freleases/title=Gost%20releases&itemTitle=tag_name&itemLink=html_url&itemDesc=body',
+    example: '/rsshub/transform/json/https%3A%2F%2Fapi.cross-7.de%2Fpublic%2Fnews%2F321%2Farticles/title=Aktuelle%20Bekanntmachungen&item=items&itemTitle=name&itemLink=link.slug&itemLinkPrefix=https%3A%2F%2Fwww.gemeinde-altheim.de%2Fgemeinde-altheim%2Faktuelles%2Fnews%3Fc7-item%3D&itemDesc=teaserText&itemPubDate=created',
     parameters: { url: '`encodeURIComponent`ed URL address', routeParams: 'Transformation rules, requires URL encode' },
     features: {
         requireConfig: [
@@ -58,17 +58,20 @@ Parameters parsing in the above example:
 
 | Parameter     | Value                                                                    |
 | ------------- | ------------------------------------------------------------------------ |
-| \`url\`         | \`https://api.github.com/repos/ginuerzh/gost/releases\`                    |
-| \`routeParams\` | \`title=Gost releases&itemTitle=tag_name&itemLink=html_url&itemDesc=body\` |
+| \`url\`         | \`https://api.cross-7.de/public/news/321/articles\`                                                                                                                                                                      |
+| \`routeParams\` | \`title=Aktuelle Bekanntmachungen&item=items&itemTitle=name&itemLink=link.slug&itemLinkPrefix=https%3A%2F%2Fwww.gemeinde-altheim.de%2Fgemeinde-altheim%2Faktuelles%2Fnews%3Fc7-item%3D&itemDesc=teaserText&itemPubDate=created\` |
 
 Parsing of \`routeParams\` parameter:
 
 | Parameter   | Value           |
 | ----------- | --------------- |
-| \`title\`     | \`Gost releases\` |
-| \`itemTitle\` | \`tag_name\`      |
-| \`itemLink\`  | \`html_url\`      |
-| \`itemDesc\`  | \`body\`          |`,
+| \`title\`          | \`Aktuelle Bekanntmachungen\`                                                                       |
+| \`item\`           | \`items\`                                                                                           |
+| \`itemTitle\`      | \`name\`                                                                                            |
+| \`itemLink\`       | \`link.slug\`                                                                                       |
+| \`itemLinkPrefix\` | \`https://www.gemeinde-altheim.de/gemeinde-altheim/aktuelles/news?c7-item=\` |
+| \`itemDesc\`       | \`teaserText\`                                                                                      |
+| \`itemPubDate\`    | \`created\`                                                                                         |`,
 };
 
 async function handler(ctx) {

--- a/lib/routes/rsshub/transform/json.ts
+++ b/lib/routes/rsshub/transform/json.ts
@@ -20,7 +20,7 @@ function jsonGet(obj, attr) {
 export const route: Route = {
     path: '/transform/json/:url/:routeParams',
     categories: ['other'],
-    example: '/rsshub/transform/json/https%3A%2F%2Fapi.cross-7.de%2Fpublic%2Fnews%2F321%2Farticles/title=Aktuelle%20Bekanntmachungen&item=items&itemTitle=name&itemLink=link.slug&itemLinkPrefix=https%3A%2F%2Fwww.gemeinde-altheim.de%2Fgemeinde-altheim%2Faktuelles%2Fnews%3Fc7-item%3D&itemDesc=teaserText&itemPubDate=created',
+    example: '/rsshub/transform/json/https%3A%2F%2Fapi.github.com%2Frepos%2Fginuerzh%2Fgost%2Freleases/title=Gost%20releases&itemTitle=tag_name&itemLink=html_url&itemDesc=body',
     parameters: { url: '`encodeURIComponent`ed URL address', routeParams: 'Transformation rules, requires URL encode' },
     features: {
         requireConfig: [
@@ -58,20 +58,17 @@ Parameters parsing in the above example:
 
 | Parameter     | Value                                                                    |
 | ------------- | ------------------------------------------------------------------------ |
-| \`url\`         | \`https://api.cross-7.de/public/news/321/articles\`                                                                                                                                                                      |
-| \`routeParams\` | \`title=Aktuelle Bekanntmachungen&item=items&itemTitle=name&itemLink=link.slug&itemLinkPrefix=https%3A%2F%2Fwww.gemeinde-altheim.de%2Fgemeinde-altheim%2Faktuelles%2Fnews%3Fc7-item%3D&itemDesc=teaserText&itemPubDate=created\` |
+| \`url\`         | \`https://api.github.com/repos/ginuerzh/gost/releases\`                    |
+| \`routeParams\` | \`title=Gost releases&itemTitle=tag_name&itemLink=html_url&itemDesc=body\` |
 
 Parsing of \`routeParams\` parameter:
 
 | Parameter   | Value           |
 | ----------- | --------------- |
-| \`title\`          | \`Aktuelle Bekanntmachungen\`                                                                       |
-| \`item\`           | \`items\`                                                                                           |
-| \`itemTitle\`      | \`name\`                                                                                            |
-| \`itemLink\`       | \`link.slug\`                                                                                       |
-| \`itemLinkPrefix\` | \`https://www.gemeinde-altheim.de/gemeinde-altheim/aktuelles/news?c7-item=\` |
-| \`itemDesc\`       | \`teaserText\`                                                                                      |
-| \`itemPubDate\`    | \`created\`                                                                                         |`,
+| \`title\`     | \`Gost releases\` |
+| \`itemTitle\` | \`tag_name\`      |
+| \`itemLink\`  | \`html_url\`      |
+| \`itemDesc\`  | \`body\`          |`,
 };
 
 async function handler(ctx) {


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Closes #21997

## Example for the Proposed Route(s) / 路由地址示例

```routes
/rsshub/transform/json/https%3A%2F%2Fapi.cross-7.de%2Fpublic%2Fnews%2F321%2Farticles/title=Aktuelle%20Bekanntmachungen&item=items&itemTitle=name&itemLink=link.slug&itemLinkPrefix=https%3A%2F%2Fwww.gemeinde-altheim.de%2Fgemeinde-altheim%2Faktuelles%2Fnews%3Fc7-item%3D&itemDesc=teaserText&itemPubDate=created
```

## New RSS Route Checklist / 新 RSS 路由检查表

* [ ] New Route / 新的路由
* [x] Follows [[Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [[路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
* [ ] Anti-bot or rate limit / 反爬/频率限制
* [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
* [ ] [[Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)](https://docs.rsshub.app/joinus/advanced/pub-date) / [[日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
* [ ] Parsed / 可以解析
* [ ] Correct time zone / 时区正确
* [ ] New package added / 添加了新的包
* [ ] `Puppeteer`

## Note / 说明

Fix `/rsshub/transform/json/:url/:routeParams` when `itemLink` points to a numeric JSON value.

Previously, the route called `.trim()` on the value returned by `jsonGet(...)`. If the resolved value was a number, it could throw because numbers do not have a `.trim()` method.

This PR converts the resolved `itemLink` value to a string before trimming, and treats `null` / `undefined` as an empty string.

Before:

```ts
let link = jsonGet(item, routeParams.get('itemLink')).trim();
```

After:

```ts
let link = String(jsonGet(item, routeParams.get('itemLink')) ?? '').trim();
```

## Test / 测试

Pre-commit checks passed locally.
