### PR TITLE
feat(route): add Le Monde

### DIFF
--- a/lib/routes/le-monde/index.ts
+++ b/lib/routes/le-monde/index.ts
@@ -1,0 +1,140 @@
+import type { Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const ROOT_URL = 'https://www.lemonde.fr';
+
+const feedMap: Record<string, string> = {
+    '': `${ROOT_URL}/rss/une.xml`,
+    international: `${ROOT_URL}/international/rss_full.xml`,
+    politique: `${ROOT_URL}/politique/rss_full.xml`,
+    economie: `${ROOT_URL}/economie/rss_full.xml`,
+    societe: `${ROOT_URL}/societe/rss_full.xml`,
+    culture: `${ROOT_URL}/culture/rss_full.xml`,
+    sport: `${ROOT_URL}/sport/rss_full.xml`,
+    planete: `${ROOT_URL}/planete/rss_full.xml`,
+    pixels: `${ROOT_URL}/pixels/rss_full.xml`,
+    sciences: `${ROOT_URL}/sciences/rss_full.xml`,
+    idees: `${ROOT_URL}/idees/rss_full.xml`,
+    sante: `${ROOT_URL}/sante/rss_full.xml`,
+    em: `${ROOT_URL}/em/rss_full.xml`,
+    'en-continu': `${ROOT_URL}/en-continu/rss_full.xml`,
+    decodeurs: `${ROOT_URL}/decodeurs/rss_full.xml`,
+};
+
+export const route: Route = {
+    path: '/:category?',
+    categories: ['traditional-media'],
+    example: '/le-monde',
+    view: ViewType.Articles,
+    parameters: {
+        category: {
+            description: 'Category slug, see table below. Defaults to homepage.',
+            default: '',
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['lemonde.fr/:category'],
+            target: '/:category',
+        },
+    ],
+    name: 'News',
+    maintainers: ['mlkgrnt'],
+    handler,
+    description: `| Category      | Description            |
+| ------------- | ---------------------- |
+| (empty)       | Homepage / Top stories |
+| international | International          |
+| politique     | Politics               |
+| economie      | Economy                |
+| societe       | Society                |
+| culture       | Culture                |
+| sport         | Sports                 |
+| planete       | Environment            |
+| pixels        | Tech / Digital         |
+| sciences      | Sciences               |
+| idees         | Opinions               |
+| sante         | Health                 |
+| em            | M le mag               |
+| en-continu    | Live / Breaking        |
+| decodeurs     | Fact-checking          |`,
+};
+
+async function handler(ctx) {
+    const category = ctx.req.param('category') ?? '';
+    const feedUrl = feedMap[category];
+
+    if (!feedUrl) {
+        throw new Error(`Invalid category: ${category}`);
+    }
+
+    const xml = await ofetch(feedUrl, { responseType: 'text' });
+    const { load } = await import('cheerio');
+    const $ = load(xml, { xml: true });
+
+    const channel = $('channel').first();
+    const feedTitle = channel.children('title').first().text();
+    const feedLink = channel.children('link').first().text() || ROOT_URL;
+
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 20;
+
+    const items = $('item')
+        .toArray()
+        .slice(0, limit)
+        .map((el) => {
+            const item = $(el);
+            const link = item.children('link').first().text() || item.children('guid').first().text();
+            const title = item.children('title').first().text();
+            const pubDateText = item.children('pubDate').first().text();
+            const summary = item.children('description').first().text();
+            const imageUrl = item.find(String.raw`media\:content`).attr('url') || item.find('content').attr('url');
+            const imageCredit = item.find(String.raw`media\:credit`).text();
+
+            let description = '';
+            if (imageUrl) {
+                description += `<img src="${imageUrl}" />`;
+            }
+            if (imageCredit) {
+                description += `<p><em>${imageCredit}</em></p>`;
+            }
+            if (summary) {
+                description += summary;
+            }
+
+            return {
+                title,
+                link,
+                pubDate: pubDateText ? parseDate(pubDateText) : undefined,
+                description,
+                guid: link,
+            };
+        })
+        .filter((item) => item.link);
+
+    return {
+        title: feedTitle || 'Le Monde',
+        link: feedLink,
+        description: feedTitle || 'Le Monde',
+        language: 'fr',
+        item: items.map((item) =>
+            cache.tryGet(item.link, () => ({
+                title: item.title,
+                link: item.link,
+                pubDate: item.pubDate,
+                description: item.description,
+                guid: item.guid,
+            }))
+        ),
+    };
+}

--- a/lib/routes/le-monde/namespace.ts
+++ b/lib/routes/le-monde/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Le Monde',
+    url: 'lemonde.fr',
+    lang: 'fr',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/le-monde
/le-monde/international
/le-monde/politique
/le-monde/economie
/le-monde/societe
/le-monde/culture
/le-monde/sport
/le-monde/planete
/le-monde/pixels
/le-monde/sciences
/le-monde/idees
/le-monde/sante
/le-monde/em
/le-monde/en-continu
/le-monde/decodeurs
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? — RSS feed, no anti-crawler needed
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包 — cheerio (already in project dependencies)
- [x] `Puppeteer` — not used

## Note / 说明

Adds a route for Le Monde (lemonde.fr), a major French newspaper. Parses official RSS feeds extracting titles, descriptions, publication dates, and article images from `media:content` elements. Supports 15 category feeds via path parameter.