### PR TITLE
feat(route): add southplus forum 

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -191,6 +191,8 @@ type ConfigEnvKeys =
     | 'SIS001_BASE_URL'
     | 'SKEB_BEARER_TOKEN'
     | 'SORRYCC_COOKIES'
+    | 'SOUTHPLUS_COOKIE'
+    | 'SOUTHPLUS_UA'
     | 'SPOTIFY_CLIENT_ID'
     | 'SPOTIFY_CLIENT_SECRET'
     | 'SPOTIFY_REFRESHTOKEN'
@@ -400,6 +402,10 @@ export type Config = {
     };
     douban: {
         cookie?: string;
+    };
+    southplus: {
+        cookie?: string;
+        ua?: string;
     };
     ehentai: {
         ipb_member_id?: string;
@@ -902,6 +908,10 @@ const calculateValue = () => {
         },
         douban: {
             cookie: envs.DOUBAN_COOKIE,
+        },
+        southplus: {
+            cookie: envs.SOUTHPLUS_COOKIE,
+            ua: envs.SOUTHPLUS_UA,
         },
         ehentai: {
             ipb_member_id: envs.EH_IPB_MEMBER_ID,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -403,10 +403,6 @@ export type Config = {
     douban: {
         cookie?: string;
     };
-    southplus: {
-        cookie?: string;
-        ua?: string;
-    };
     ehentai: {
         ipb_member_id?: string;
         ipb_pass_hash?: string;
@@ -609,6 +605,10 @@ export type Config = {
     };
     sorrycc: {
         cookie?: string;
+    };
+    southplus: {
+        cookie?: string;
+        ua?: string;
     };
     spotify: {
         clientId?: string;
@@ -909,10 +909,6 @@ const calculateValue = () => {
         douban: {
             cookie: envs.DOUBAN_COOKIE,
         },
-        southplus: {
-            cookie: envs.SOUTHPLUS_COOKIE,
-            ua: envs.SOUTHPLUS_UA,
-        },
         ehentai: {
             ipb_member_id: envs.EH_IPB_MEMBER_ID,
             ipb_pass_hash: envs.EH_IPB_PASS_HASH,
@@ -1115,6 +1111,10 @@ const calculateValue = () => {
         },
         sorrycc: {
             cookie: envs.SORRYCC_COOKIES,
+        },
+        southplus: {
+            cookie: envs.SOUTHPLUS_COOKIE,
+            ua: envs.SOUTHPLUS_UA,
         },
         spotify: {
             clientId: envs.SPOTIFY_CLIENT_ID,

--- a/lib/routes/south-plus/forum.ts
+++ b/lib/routes/south-plus/forum.ts
@@ -1,0 +1,201 @@
+import { load } from 'cheerio';
+import pMap from 'p-map';
+
+import { config } from '@/config';
+import ConfigNotFoundError from '@/errors/types/config-not-found';
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import { parseDate } from '@/utils/parse-date';
+
+const BASE_URL = 'https://south-plus.net';
+
+const DEFAULT_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0';
+
+async function handler(ctx) {
+    const fid = ctx.req.param('fid') ?? '8';
+    const cookie = config.southplus.cookie;
+    const ua = config.southplus.ua || DEFAULT_UA;
+
+    const forumUrl = `${BASE_URL}/thread.php?fid-${fid}.html`;
+
+    const headers: Record<string, string> = {
+        'User-Agent': ua,
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'zh-CN,zh;q=0.9',
+        Referer: 'https://south-plus.net/index.php',
+    };
+    if (cookie) {
+        headers.Cookie = cookie;
+    }
+
+    const response = await fetch(forumUrl, { headers });
+    const html = await response.text();
+    const $ = load(html);
+
+    // Check if access is denied
+    const pageTitle = $('head > title').text();
+    if (pageTitle.includes('没有权限') || pageTitle.includes('没有登录') || pageTitle.includes('认证版块')) {
+        if (!cookie) {
+            throw new ConfigNotFoundError('此版块需要登录才能访问。请配置 SOUTHPLUS_COOKIE 环境变量。');
+        }
+        throw new ConfigNotFoundError('Cookie 已过期或无效，无法访问此版块。请更新 SOUTHPLUS_COOKIE 环境变量。');
+    }
+
+    // Parse thread list
+    // Thread rows have class="tr3 t_one"
+    // Structure: 5 td columns
+    //   [0] status icon
+    //   [1] category + title (h3 > a#a_ajax_XXXX) + page links
+    //   [2] author (a.bl) + post date (div.f10.gray2)
+    //   [3] replies/views
+    //   [4] last post date (a.f10) + last poster (span.gray2)
+    const threadList = $('tr.tr3.t_one')
+        .toArray()
+        .filter((item) => {
+            const $item = $(item);
+            const threadLink = $item.find('a[id^="a_ajax_"]').attr('href');
+            return Boolean(threadLink);
+        })
+        .map((item) => {
+            const $item = $(item);
+            const titleEl = $item.find('a[id^="a_ajax_"]');
+            const threadLink = titleEl.attr('href');
+            const title = titleEl.text().trim();
+            const link = threadLink ? new URL(threadLink, BASE_URL).href : '';
+
+            // Author in column 2
+            const author = $item.find('a.bl[href*="action-show-uid"]').text().trim();
+
+            // Thread post date in column 2 (div.f10.gray2)
+            const postDateText = $item.find('div.f10.gray2').first().text().trim();
+
+            // Last post date in column 4 (a.f10)
+            const lastPostDateText = $item.find('td.tal.y-style a.f10').last().text().trim();
+
+            // Use last post date as pubDate for RSS sorting
+            const pubDate = parseDate(lastPostDateText) || parseDate(postDateText);
+
+            // Thread category tag (e.g. [自购], [公告]) in column 1
+            const category = $item.find('a.s8').first().text().trim();
+
+            return {
+                title,
+                link,
+                author,
+                pubDate,
+                category: category ? [category] : undefined,
+            };
+        });
+
+    // Optionally fetch full content for each thread (with cache)
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 50;
+    const items = await pMap(
+        threadList.slice(0, limit),
+        (item) =>
+            cache.tryGet(item.link, async () => {
+                try {
+                    const detailResponse = await fetch(item.link, { headers });
+                    const detailHtml = await detailResponse.text();
+                    const $detail = load(detailHtml);
+
+                    // Get the main post content
+                    // PHPWind: <div class="f14" id="read_tpc"> for the first post
+                    const contentEl = $detail('#read_tpc');
+                    if (contentEl.length > 0) {
+                        item.description = contentEl.html() ?? '';
+                    }
+
+                    // Get the original post date from tiptop area
+                    const dateEl = $detail('.tiptop .fl.gray');
+                    if (dateEl.length > 0) {
+                        const dateText = dateEl.first().text().trim();
+                        const dateMatch = dateText.match(/(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/);
+                        if (dateMatch) {
+                            item.pubDate = parseDate(dateMatch[1]);
+                        }
+                    }
+
+                    // Get the author from the detail page
+                    const authorEl = $detail('.r_two a[href*="action-show-uid"] strong');
+                    if (authorEl.length > 0) {
+                        item.author = authorEl.first().text().trim();
+                    }
+                } catch {
+                    // If detail page fails, keep the list page data
+                }
+
+                return item;
+            }),
+        { concurrency: 3 }
+    );
+
+    return {
+        title: $('head > title').text().trim(),
+        link: forumUrl,
+        description: $('meta[name="description"]').attr('content'),
+        language: 'zh-CN',
+        item: items,
+    };
+}
+
+export const route: Route = {
+    path: '/forum/:fid?',
+    categories: ['bbs'],
+    example: '/south-plus/forum/8',
+    parameters: {
+        fid: '论坛版块 ID，默认为 8（ACG交流）。可在 thread.php?fid-XXX.html 中找到。常用 fid 见下方说明',
+    },
+    description: `::: tip 常用版块 ID
+
+| fid | 版块名称 | 需要登录 |
+| --- | -------- | :------: |
+| 48  | 询问求物 |    是    |
+| 8   | ACG 交流 |    否    |
+| 12  | 轻小说   |    是    |
+| 9   | 茶馆     |    是    |
+| 201 | COSPLAY  |    是    |
+| 6   | 游戏资源 |    是    |
+| 5   | 实用漫画 |    是    |
+| 4   | 实用动画 |    是    |
+| 128 | 同人音声 |    是    |
+| 208 | AI 交流  |    是    |
+
+:::
+
+::: tip Cookie 示例
+
+\`\`\`
+eb9e6_winduser=XXXX...XXXX%3D%3D; eb9e6_cknum=YYYY...YYYY%3D; eb9e6_ck_info=%2F%09; cf_clearance=ZZZZ...ZZZZ; eb9e6_lastpos=other; eb9e6_ol_offset=123456; eb9e6_readlog=%2C...; eb9e6_threadlog=%2C...; eb9e6_lastvisit=...; peacemaker=1
+\`\`\`
+
+\`eb9e6_winduser\` 和 \`eb9e6_cknum\` 是必需的认证 cookie，其余可选。
+:::`,
+    features: {
+        requireConfig: [
+            {
+                name: 'SOUTHPLUS_COOKIE',
+                optional: true,
+                description: '登录 Cookie，格式为分号+空格分隔的 key=value 对。核心字段：eb9e6_winduser（认证令牌）、eb9e6_cknum（会话校验）。从浏览器登录后导出完整 cookie 字符串即可。',
+            },
+            {
+                name: 'SOUTHPLUS_UA',
+                optional: true,
+                description: '浏览器 User-Agent，需与获取 Cookie 时使用的浏览器版本一致。默认为 Firefox 151。',
+            },
+        ],
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['south-plus.net/thread.php', 'snow-plus.net/thread.php'],
+            target: '/forum/:fid',
+        },
+    ],
+    name: '论坛帖子',
+    maintainers: ['NicholasYZ'],
+    handler,
+};

--- a/lib/routes/south-plus/forum.ts
+++ b/lib/routes/south-plus/forum.ts
@@ -13,16 +13,18 @@ const BASE_URL = 'https://south-plus.net';
 async function handler(ctx) {
     const fid = ctx.req.param('fid') ?? '8';
     const cookie = config.southplus.cookie;
-    const ua = config.southplus.ua || config.trueUA;
+    const ua = config.southplus.ua;
 
     const forumUrl = `${BASE_URL}/thread.php?fid-${fid}.html`;
 
     const headers: Record<string, string> = {
-        'User-Agent': ua,
         Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'zh-CN,zh;q=0.9',
         Referer: 'https://south-plus.net/index.php',
     };
+    if (ua) {
+        headers['User-Agent'] = ua;
+    }
     if (cookie) {
         headers.Cookie = cookie;
     }
@@ -166,7 +168,7 @@ eb9e6_winduser=XXXX...XXXX%3D%3D; eb9e6_cknum=YYYY...YYYY%3D; eb9e6_ck_info=%2F%
 ::: tip UA 说明
 South Plus 服务器会校验 Cookie 与浏览器 User-Agent 的绑定关系。Cookie 仅在登录时使用的浏览器版本下有效，不同版本或不同平台的 UA 均会被拒绝。
 
-如需更换 Cookie，请同时更新 \`SOUTHPLUS_UA\` 为对应浏览器的 UA 字符串。
+如需更换 Cookie，请同时设置 \`SOUTHPLUS_UA\` 为对应浏览器的 UA 字符串。未设置时 RSSHub 会自动生成随机的浏览器 UA。
 
 如果 Cookie 是通过代理获取的，需设置 RSSHub 全局环境变量 \`PROXY_URI\`（如 \`http://host:port\`），否则服务器会拒绝认证。
 :::
@@ -181,7 +183,7 @@ South Plus 服务器会校验 Cookie 与浏览器 User-Agent 的绑定关系。C
             {
                 name: 'SOUTHPLUS_UA',
                 optional: true,
-                description: '浏览器 User-Agent，需与获取 Cookie 时使用的浏览器版本完全一致。可从浏览器 F12 → Network → 请求头中复制。未设置时使用 RSSHub 内置 UA。',
+                description: '浏览器 User-Agent，需与获取 Cookie 时使用的浏览器版本完全一致。可从浏览器 F12 → Network → 请求头中复制。未设置时由 RSSHub 自动生成随机浏览器 UA。',
             },
         ],
         requirePuppeteer: false,

--- a/lib/routes/south-plus/forum.ts
+++ b/lib/routes/south-plus/forum.ts
@@ -5,6 +5,7 @@ import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
 const BASE_URL = 'https://south-plus.net';
@@ -26,8 +27,7 @@ async function handler(ctx) {
         headers.Cookie = cookie;
     }
 
-    const response = await fetch(forumUrl, { headers });
-    const html = await response.text();
+    const html = await ofetch(forumUrl, { headers });
     const $ = load(html);
 
     // Check if access is denied
@@ -50,26 +50,26 @@ async function handler(ctx) {
     const threadList = $('tr.tr3.t_one a[id^="a_ajax_"]')
         .toArray()
         .map((item) => {
-            const $item = $(item);
-            const titleEl = $item.find('a[id^="a_ajax_"]');
-            const threadLink = titleEl.attr('href');
-            const title = titleEl.text().trim();
+            const $el = $(item);
+            const $row = $el.closest('tr');
+            const threadLink = $el.attr('href');
+            const title = $el.text().trim();
             const link = threadLink ? new URL(threadLink, BASE_URL).href : '';
 
             // Author in column 2
-            const author = $item.find('a.bl[href*="action-show-uid"]').text().trim();
+            const author = $row.find('a.bl[href*="action-show-uid"]').text().trim();
 
             // Thread post date in column 2 (div.f10.gray2)
-            const postDateText = $item.find('div.f10.gray2').first().text().trim();
+            const postDateText = $row.find('div.f10.gray2').first().text().trim();
 
             // Last post date in column 4 (a.f10)
-            const lastPostDateText = $item.find('td.tal.y-style a.f10').last().text().trim();
+            const lastPostDateText = $row.find('td.tal.y-style a.f10').last().text().trim();
 
             // Use last post date as pubDate for RSS sorting
             const pubDate = parseDate(lastPostDateText) || parseDate(postDateText);
 
             // Thread category tag (e.g. [自购], [公告]) in column 1
-            const category = $item.find('a.s8').first().text().trim();
+            const category = $row.find('a.s8').first().text().trim();
 
             return {
                 title,
@@ -87,8 +87,7 @@ async function handler(ctx) {
         (item) =>
             cache.tryGet(item.link, async () => {
                 try {
-                    const detailResponse = await fetch(item.link, { headers });
-                    const detailHtml = await detailResponse.text();
+                    const detailHtml = await ofetch(item.link, { headers });
                     const $detail = load(detailHtml);
 
                     // Get the main post content
@@ -96,22 +95,22 @@ async function handler(ctx) {
                     const contentEl = $detail('#read_tpc');
                     if (contentEl.length > 0) {
                         item.description = contentEl.html() ?? '';
-                    }
 
-                    // Get the original post date from tiptop area
-                    const dateEl = $detail('.tiptop .fl.gray');
-                    if (dateEl.length > 0) {
-                        const dateText = dateEl.first().text().trim();
-                        const dateMatch = dateText.match(/(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/);
-                        if (dateMatch) {
-                            item.pubDate = parseDate(dateMatch[1]);
+                        // Get the original post date from tiptop area
+                        const dateEl = $detail('.tiptop .fl.gray');
+                        if (dateEl.length > 0) {
+                            const dateText = dateEl.first().text().trim();
+                            const dateMatch = dateText.match(/(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/);
+                            if (dateMatch) {
+                                item.pubDate = parseDate(dateMatch[1]);
+                            }
                         }
-                    }
 
-                    // Get the author from the detail page
-                    const authorEl = $detail('.r_two a[href*="action-show-uid"] strong');
-                    if (authorEl.length > 0) {
-                        item.author = authorEl.first().text().trim();
+                        // Get the author from the detail page
+                        const authorEl = $detail('.r_two a[href*="action-show-uid"] strong');
+                        if (authorEl.length > 0) {
+                            item.author = authorEl.first().text().trim();
+                        }
                     }
                 } catch {
                     // If detail page fails, keep the list page data

--- a/lib/routes/south-plus/forum.ts
+++ b/lib/routes/south-plus/forum.ts
@@ -6,7 +6,6 @@ import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import { parseDate } from '@/utils/parse-date';
-import proxy from '@/utils/proxy';
 
 const BASE_URL = 'https://south-plus.net';
 
@@ -27,7 +26,7 @@ async function handler(ctx) {
         headers.Cookie = cookie;
     }
 
-    const response = await fetch(forumUrl, { headers, dispatcher: proxy.dispatcher });
+    const response = await fetch(forumUrl, { headers });
     const html = await response.text();
     const $ = load(html);
 
@@ -93,7 +92,7 @@ async function handler(ctx) {
         (item) =>
             cache.tryGet(item.link, async () => {
                 try {
-                    const detailResponse = await fetch(item.link, { headers, dispatcher: proxy.dispatcher });
+                    const detailResponse = await fetch(item.link, { headers });
                     const detailHtml = await detailResponse.text();
                     const $detail = load(detailHtml);
 

--- a/lib/routes/south-plus/forum.ts
+++ b/lib/routes/south-plus/forum.ts
@@ -6,15 +6,14 @@ import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import { parseDate } from '@/utils/parse-date';
+import proxy from '@/utils/proxy';
 
 const BASE_URL = 'https://south-plus.net';
-
-const DEFAULT_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0';
 
 async function handler(ctx) {
     const fid = ctx.req.param('fid') ?? '8';
     const cookie = config.southplus.cookie;
-    const ua = config.southplus.ua || DEFAULT_UA;
+    const ua = config.southplus.ua || config.trueUA;
 
     const forumUrl = `${BASE_URL}/thread.php?fid-${fid}.html`;
 
@@ -28,7 +27,7 @@ async function handler(ctx) {
         headers.Cookie = cookie;
     }
 
-    const response = await fetch(forumUrl, { headers });
+    const response = await fetch(forumUrl, { headers, dispatcher: proxy.dispatcher });
     const html = await response.text();
     const $ = load(html);
 
@@ -94,7 +93,7 @@ async function handler(ctx) {
         (item) =>
             cache.tryGet(item.link, async () => {
                 try {
-                    const detailResponse = await fetch(item.link, { headers });
+                    const detailResponse = await fetch(item.link, { headers, dispatcher: proxy.dispatcher });
                     const detailHtml = await detailResponse.text();
                     const $detail = load(detailHtml);
 
@@ -169,6 +168,15 @@ eb9e6_winduser=XXXX...XXXX%3D%3D; eb9e6_cknum=YYYY...YYYY%3D; eb9e6_ck_info=%2F%
 \`\`\`
 
 \`eb9e6_winduser\` 和 \`eb9e6_cknum\` 是必需的认证 cookie，其余可选。
+:::
+
+::: tip UA 说明
+South Plus 服务器会校验 Cookie 与浏览器 User-Agent 的绑定关系。Cookie 仅在登录时使用的浏览器版本下有效，不同版本或不同平台的 UA 均会被拒绝。
+
+如需更换 Cookie，请同时更新 \`SOUTHPLUS_UA\` 为对应浏览器的 UA 字符串。
+
+如果 Cookie 是通过代理获取的，需设置 RSSHub 全局环境变量 \`PROXY_URI\`（如 \`http://host:port\`），否则服务器会拒绝认证。
+:::
 :::`,
     features: {
         requireConfig: [
@@ -180,7 +188,7 @@ eb9e6_winduser=XXXX...XXXX%3D%3D; eb9e6_cknum=YYYY...YYYY%3D; eb9e6_ck_info=%2F%
             {
                 name: 'SOUTHPLUS_UA',
                 optional: true,
-                description: '浏览器 User-Agent，需与获取 Cookie 时使用的浏览器版本一致。默认为 Firefox 151。',
+                description: '浏览器 User-Agent，需与获取 Cookie 时使用的浏览器版本完全一致。可从浏览器 F12 → Network → 请求头中复制。未设置时使用 RSSHub 内置 UA。',
             },
         ],
         requirePuppeteer: false,

--- a/lib/routes/south-plus/forum.ts
+++ b/lib/routes/south-plus/forum.ts
@@ -47,13 +47,8 @@ async function handler(ctx) {
     //   [2] author (a.bl) + post date (div.f10.gray2)
     //   [3] replies/views
     //   [4] last post date (a.f10) + last poster (span.gray2)
-    const threadList = $('tr.tr3.t_one')
+    const threadList = $('tr.tr3.t_one a[id^="a_ajax_"]')
         .toArray()
-        .filter((item) => {
-            const $item = $(item);
-            const threadLink = $item.find('a[id^="a_ajax_"]').attr('href');
-            return Boolean(threadLink);
-        })
         .map((item) => {
             const $item = $(item);
             const titleEl = $item.find('a[id^="a_ajax_"]');

--- a/lib/routes/south-plus/forum.ts
+++ b/lib/routes/south-plus/forum.ts
@@ -62,16 +62,16 @@ async function handler(ctx) {
             const author = $row.find('a.bl[href*="action-show-uid"]').text().trim();
 
             // Thread post date in column 2 (div.f10.gray2)
-            const postDateText = $row.find('div.f10.gray2').first().text().trim();
+            const postDateText = $row.find('div.f10.gray2').text().trim();
 
             // Last post date in column 4 (a.f10)
-            const lastPostDateText = $row.find('td.tal.y-style a.f10').last().text().trim();
+            const lastPostDateText = $row.find('td.tal.y-style a.f10').text().trim();
 
             // Use last post date as pubDate for RSS sorting
             const pubDate = parseDate(lastPostDateText) || parseDate(postDateText);
 
             // Thread category tag (e.g. [自购], [公告]) in column 1
-            const category = $row.find('a.s8').first().text().trim();
+            const category = $row.find('a.s8').text().trim();
 
             return {
                 title,

--- a/lib/routes/south-plus/forum.ts
+++ b/lib/routes/south-plus/forum.ts
@@ -3,14 +3,14 @@ import pMap from 'p-map';
 
 import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
-import type { Route } from '@/types';
+import type { Data, DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
 const BASE_URL = 'https://south-plus.net';
 
-async function handler(ctx) {
+async function handler(ctx): Promise<Data> {
     const fid = ctx.req.param('fid') ?? '8';
     const cookie = config.southplus.cookie;
     const ua = config.southplus.ua;
@@ -49,7 +49,7 @@ async function handler(ctx) {
     //   [2] author (a.bl) + post date (div.f10.gray2)
     //   [3] replies/views
     //   [4] last post date (a.f10) + last poster (span.gray2)
-    const threadList = $('tr.tr3.t_one a[id^="a_ajax_"]')
+    const threadList: DataItem[] = $('tr.tr3.t_one a[id^="a_ajax_"]')
         .toArray()
         .map((item) => {
             const $el = $(item);
@@ -87,9 +87,9 @@ async function handler(ctx) {
     const items = await pMap(
         threadList.slice(0, limit),
         (item) =>
-            cache.tryGet(item.link, async () => {
+            cache.tryGet(item.link!, async () => {
                 try {
-                    const detailHtml = await ofetch(item.link, { headers });
+                    const detailHtml = await ofetch(item.link!, { headers });
                     const $detail = load(detailHtml);
 
                     // Get the main post content

--- a/lib/routes/south-plus/forum.ts
+++ b/lib/routes/south-plus/forum.ts
@@ -83,7 +83,7 @@ async function handler(ctx): Promise<Data> {
         });
 
     // Optionally fetch full content for each thread (with cache)
-    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 50;
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 50;
     const items = await pMap(
         threadList.slice(0, limit),
         (item) =>

--- a/lib/routes/south-plus/namespace.ts
+++ b/lib/routes/south-plus/namespace.ts
@@ -1,0 +1,21 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'South Plus',
+    url: 'south-plus.net',
+    description: `::: tip
+South Plus (南 +) 是一个基于 PHPWind 架构的 ACG 综合交流论坛。
+
+部分板块需要登录才能访问，请配置 \`SOUTHPLUS_COOKIE\` 环境变量。
+
+**获取 Cookie 步骤：**
+
+1. 在浏览器中登录 [snow-plus.net](https://snow-plus.net) 或 [south-plus.net](https://south-plus.net)
+2. 确认右上角显示用户名和「退出」链接（而非「登录」）
+3. 按 F12 → Application/Storage → Cookies → 选择站点域名
+4. 将所有 cookie 拼接为单行：\`key1=value1; key2=value2; ...\`
+5. 核心 cookie 为 \`eb9e6_winduser\`（认证令牌）和 \`eb9e6_cknum\`（会话校验）
+
+:::`,
+    lang: 'zh-CN',
+};

--- a/lib/routes/south-plus/namespace.ts
+++ b/lib/routes/south-plus/namespace.ts
@@ -8,13 +8,14 @@ South Plus (南 +) 是一个基于 PHPWind 架构的 ACG 综合交流论坛。
 
 部分板块需要登录才能访问，请配置 \`SOUTHPLUS_COOKIE\` 环境变量。
 
-**获取 Cookie 步骤：**
+**获取 Cookie 和 User-Agent 步骤：**
 
-1. 在浏览器中登录 [snow-plus.net](https://snow-plus.net) 或 [south-plus.net](https://south-plus.net)
+1. 在浏览器中登录 [south-plus.net](https://south-plus.net) 或 [snow-plus.net](https://snow-plus.net)
 2. 确认右上角显示用户名和「退出」链接（而非「登录」）
-3. 按 F12 → Application/Storage → Cookies → 选择站点域名
-4. 将所有 cookie 拼接为单行：\`key1=value1; key2=value2; ...\`
-5. 核心 cookie 为 \`eb9e6_winduser\`（认证令牌）和 \`eb9e6_cknum\`（会话校验）
+3. 按 F12 → **Network**（网络）→ 刷新页面 → 点击任意请求 → **Request Headers**（请求头）
+4. 复制 \`Cookie\` 字段的完整值（单行，分号 + 空格分隔），设置为 \`SOUTHPLUS_COOKIE\`
+5. 复制 \`User-Agent\` 字段的值，设置为 \`SOUTHPLUS_UA\`（Cookie 与 UA 版本绑定，必须匹配）
+6. 如果 Cookie 是通过代理获取的，需设置 RSSHub 全局环境变量 \`PROXY_URI\`（如 \`http://host:port\`）
 
 :::`,
     lang: 'zh-CN',


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #4541

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
   /south-plus/forum/8
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制 （PHPwind自身无限制，考虑到CF限制了并发数）
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
    - [x] `p-map` 并发控制 (concurrency=3)
    - [x] 完整浏览器请求头 (UA / Accept / Accept-Language / Referer)
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析  (`parseDate` 解析 `YYYY-MM-DD HH:MM`)
    - [x] Correct time zone /  时区正确 (UTC+8)
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

   为 [South Plus](https://south-plus.net)（南+）添加 RSS 路由。

   ### 特性

   - 支持公开和需登录的版块（通过 `SOUTHPLUS_COOKIE` 环境变量认证）
   - 全文抓取 + `cache.tryGet` 缓存
   - `p-map` 并发控制（每次 3 个请求）
   - 路由描述中包含常用 fid 对照表和 Cookie 示例

   ### 涉及文件

| 文件                                 | 变更                                  |
| ------------------------------------ | ------------------------------------- |
| `lib/config.ts`                      | +7 行，添加 `SOUTHPLUS_COOKIE` 配置项 |
| `lib/routes/south-plus/namespace.ts` | 新建，命名空间定义 + Cookie 获取指南  |
| `lib/routes/south-plus/forum.ts`     | 新建，路由处理器（188 行）            |

   ### 测试

在docker环境中测试通过

   ```
   /south-plus/forum/8        → 200 OK, 50 items (公开版块)
   /south-plus/forum/128      → 200 OK, 50 items (需 Cookie)