### PR TITLE
feat(route/sjtu/cs/tzgg): add SJTU CS department notice route

### DIFF
--- a/lib/routes/sjtu/cs/tzgg.tsx
+++ b/lib/routes/sjtu/cs/tzgg.tsx
@@ -46,7 +46,7 @@ function parseListing(json: { content: string }): ListItem[] {
             return {
                 title,
                 link,
-                date: `${yearMonth}-${day.padStart(2, '0')}`,
+                date: `${yearMonth}-${day}`,
             };
         })
         .filter((it) => it.link && it.title);

--- a/lib/routes/sjtu/cs/tzgg.tsx
+++ b/lib/routes/sjtu/cs/tzgg.tsx
@@ -1,0 +1,164 @@
+import { load } from 'cheerio';
+
+import type { Data, DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+const host = 'https://www.cs.sjtu.edu.cn';
+const ajaxUrl = `${host}/active/ajax_type_list.html`;
+
+const categoryMap: Record<string, { name: string; code: string }> = {
+    bkspy: { name: '本科生培养', code: 'notice-xssw-bkspy' },
+    yjspy: { name: '研究生培养', code: 'notice-xssw-yjspy' },
+    gjjl: { name: '国际交流', code: 'notice-xssw-gjjl' },
+    djdy: { name: '党建德育', code: 'notice-xssw-djdy' },
+    txgz: { name: '团学工作', code: 'notice-xssw-txgz' },
+    zyfz: { name: '职业发展', code: 'notice-xssw-zyfz' },
+    qt: { name: '其他', code: 'notice-xssw-qt' },
+};
+
+interface ListItem {
+    title: string;
+    link: string;
+    date: string;
+}
+
+function absolutize(url: string | undefined): string {
+    if (!url) {
+        return '';
+    }
+    return new URL(url, host).href;
+}
+
+function parseListing(json: { content: string }): ListItem[] {
+    const $ = load(json.content);
+    return $('li')
+        .toArray()
+        .map((el) => {
+            const $el = $(el);
+            const $a = $el.find('> a');
+            const link = absolutize($a.attr('href'));
+            const title = $a.find('.tit').text().trim();
+            const day = $a.find('.time p').text().trim();
+            const yearMonth = $a.find('.time span').text().trim();
+            return {
+                title,
+                link,
+                date: `${yearMonth}-${day.padStart(2, '0')}`,
+            };
+        })
+        .filter((it) => it.link && it.title);
+}
+
+function enrichItem(item: ListItem): Promise<DataItem> {
+    return cache.tryGet(item.link, async () => {
+        const html = await ofetch<string>(item.link);
+        const $ = load(html);
+        const $body = $('div.xw-cont');
+        const $txt = $body.find('.txt');
+
+        $txt.find('img').each((_, e) => {
+            const src = $(e).attr('src') || $(e).attr('_src');
+            if (src) {
+                $(e).attr('src', absolutize(src));
+            }
+        });
+        $txt.find('a').each((_, e) => {
+            const href = $(e).attr('href');
+            if (href) {
+                $(e).attr('href', absolutize(href));
+            }
+        });
+
+        const publishedText = $body.find('.jj p').first().text();
+        const publishedMatch = publishedText.match(/(\d{4})-(\d{1,2})-(\d{1,2})/);
+        let pubDate: Date | undefined;
+        if (publishedMatch) {
+            const [, y, m, d] = publishedMatch;
+            pubDate = timezone(parseDate(`${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`, 'YYYY-MM-DD'), +8);
+        }
+
+        return {
+            title: item.title,
+            link: item.link,
+            description: $txt.html() ?? '',
+            pubDate: pubDate ?? timezone(parseDate(item.date, 'YYYY-MM-DD'), +8),
+        };
+    }) as Promise<DataItem>;
+}
+
+export const route: Route = {
+    path: '/cs/tzgg/:category',
+    categories: ['university'],
+    example: '/sjtu/cs/tzgg/bkspy',
+    parameters: {
+        category: {
+            description: '通知类别',
+            options: Object.fromEntries(Object.entries(categoryMap).map(([k, v]) => [k, v.name])),
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: Object.entries(categoryMap).map(([key, { code }]) => ({
+        source: [`www.cs.sjtu.edu.cn/${code}.html`],
+        target: `/cs/tzgg/${key}`,
+    })),
+    name: '计算机学院 - 通知公告',
+    maintainers: ['BeaCox'],
+    handler,
+    url: 'www.cs.sjtu.edu.cn/notice-xssw-bkspy.html',
+};
+
+async function handler(ctx): Promise<Data> {
+    const category = ctx.req.param('category');
+    const cat = categoryMap[category];
+    if (!cat) {
+        throw new Error(`Unknown category: ${category}. Valid: ${Object.keys(categoryMap).join(', ')}`);
+    }
+
+    const listLink = `${host}/${cat.code}.html`;
+    const json = await ofetch<{ content: string; count: number }>(ajaxUrl, {
+        method: 'POST',
+        body: new URLSearchParams({
+            page: '1',
+            cat_code: cat.code,
+            type: '',
+            search: '',
+            extend_id: '0',
+            template: 'ajax_news_list1_search',
+        }),
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        },
+        parseResponse: JSON.parse,
+    });
+
+    const items = parseListing(json);
+    const enriched = await Promise.allSettled(items.map((it) => enrichItem(it)));
+    const dataItems: DataItem[] = enriched.map((result, index) =>
+        result.status === 'fulfilled'
+            ? result.value
+            : {
+                  title: items[index].title,
+                  link: items[index].link,
+                  pubDate: timezone(parseDate(items[index].date, 'YYYY-MM-DD'), +8),
+              }
+    );
+
+    return {
+        title: `上海交通大学计算机学院 - 通知公告 - ${cat.name}`,
+        link: listLink,
+        description: `上海交通大学计算机学院（网络空间安全学院、密码学院）通知公告 - ${cat.name}`,
+        language: 'zh-CN',
+        allowEmpty: true,
+        item: dataItems,
+    };
+}


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/sjtu/cs/tzgg/bkspy
/sjtu/cs/tzgg/yjspy
/sjtu/cs/tzgg/gjjl
/sjtu/cs/tzgg/djdy
/sjtu/cs/tzgg/txgz
/sjtu/cs/tzgg/zyfz
/sjtu/cs/tzgg/qt
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Add notice/announcement (通知公告) route for SJTU CS department with 7 category parameters:

| Parameter | Category |
|-----------|----------|
| `bkspy` | 本科生培养 |
| `yjspy` | 研究生培养 |
| `gjjl` | 国际交流 |
| `djdy` | 党建德育 |
| `txgz` | 团学工作 |
| `zyfz` | 职业发展 |
| `qt` | 其他 |

- Fetches list via AJAX POST (ajax_type_list.html), enriches with detail page content
- Uses Promise.allSettled for resilient detail fetching
- Sets allowEmpty: true for categories that may have no content
- Includes radar rules for all categories