### PR TITLE
feat(route): add SJTU ME notices

### DIFF
--- a/lib/routes/sjtu/me/yjs.ts
+++ b/lib/routes/sjtu/me/yjs.ts
@@ -1,0 +1,145 @@
+import { load } from 'cheerio';
+
+import type { Data, DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+const baseUrl = 'https://me.sjtu.edu.cn';
+const request = got.extend({
+    headers: {
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        referer: `${baseUrl}/YanJS/`,
+        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36',
+    },
+});
+
+const typeMap: Record<string, { name: string; path: string }> = {
+    indexnotice: { name: '首页通知公告', path: '/YanJS/indexnotice.html' },
+    notice: { name: '博士研究生通知公告', path: '/YanJS/notice.html' },
+    masternotice: { name: '硕士研究生通知公告', path: '/YanJS/masternotice.html' },
+    indexnews: { name: '教学动态', path: '/YanJS/indexnews.html' },
+    teacheraffairs: { name: '教师事务', path: '/YanJS/teacheraffairs.html' },
+    studentaffairs: { name: '学生事务', path: '/YanJS/studentaffairs.html' },
+    commqu: { name: '常见问题', path: '/YanJS/commqu.html' },
+};
+
+const toAbsoluteUrl = (url: string | undefined, currentUrl: string) => (url ? new URL(url, currentUrl).href : '');
+
+const parsePubDate = (date: string | undefined) => {
+    const match = date?.match(/\d{4}-\d{2}-\d{2}/);
+    return match ? timezone(parseDate(match[0], 'YYYY-MM-DD'), +8) : undefined;
+};
+
+type ArticleItem = DataItem & { link: string };
+
+function fetchArticle(item: ArticleItem): Promise<DataItem> {
+    return cache.tryGet(item.link, async () => {
+        const response = await request(item.link);
+        const $ = load(response.data);
+        const content = $('.d2 .snr').length ? $('.d2 .snr') : $('.news-cont .txt');
+
+        content.find('img').each((_, element) => {
+            const src = $(element).attr('src');
+            if (src) {
+                $(element).attr('src', toAbsoluteUrl(src, item.link));
+            }
+        });
+
+        content.find('a').each((_, element) => {
+            const href = $(element).attr('href');
+            if (href) {
+                $(element).attr('href', toAbsoluteUrl(href, item.link));
+            }
+        });
+
+        return {
+            title: $('.d2 .sbt').text().trim() || $('.news-cont .tit').text().trim() || item.title,
+            link: item.link,
+            pubDate: parsePubDate($('.d2 .ssj').text() || $('.news-cont').text()) ?? item.pubDate,
+            description: content.html() ?? '',
+        };
+    });
+}
+
+export const route: Route = {
+    path: '/me/yjs/:type?',
+    categories: ['university'],
+    example: '/sjtu/me/yjs',
+    parameters: { type: '通知类别，默认为 indexnotice' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: Object.entries(typeMap).map(([type, { path }]) => ({
+        source: [`me.sjtu.edu.cn${path}`],
+        target: `/me/yjs/${type}`,
+    })),
+    name: '机械与动力工程学院研究生教学网',
+    maintainers: ['yyh'],
+    handler,
+    url: 'me.sjtu.edu.cn/YanJS/indexnotice.html',
+    description: `| 首页通知公告 | 博士研究生通知公告 | 硕士研究生通知公告 | 教学动态  | 教师事务       | 学生事务       | 常见问题 |
+| ------------ | ------------------ | ------------------ | --------- | -------------- | -------------- | -------- |
+| indexnotice  | notice             | masternotice       | indexnews | teacheraffairs | studentaffairs | commqu   |`,
+};
+
+async function handler(ctx): Promise<Data> {
+    const type = ctx.req.param('type') ?? 'indexnotice';
+    const config = typeMap[type];
+
+    if (!config) {
+        throw new Error(`Unknown type: ${type}. Valid types: ${Object.keys(typeMap).join(', ')}`);
+    }
+
+    const listUrl = new URL(config.path, baseUrl).href;
+    const response = await request(listUrl);
+    const $ = load(response.data);
+
+    const items = $('.d2 ul.n2 li')
+        .toArray()
+        .map((element) => {
+            const item = $(element);
+            const anchor = item.find('a');
+            const link = toAbsoluteUrl(anchor.attr('href'), listUrl);
+            const title = anchor
+                .text()
+                .replace(/^·\s*/, '')
+                .trim();
+            const pubDate = parsePubDate(item.find('.sj').text());
+
+            return {
+                title,
+                link,
+                pubDate,
+            };
+        })
+        .filter((item) => item.title && item.link);
+
+    const dataItems = await Promise.all(
+        items.map(async (item) => {
+            try {
+                return await fetchArticle(item);
+            } catch {
+                return {
+                    title: item.title,
+                    link: item.link,
+                    pubDate: item.pubDate,
+                };
+            }
+        })
+    );
+
+    return {
+        title: `上海交通大学机械与动力工程学院研究生教学网 - ${config.name}`,
+        link: listUrl,
+        description: `上海交通大学机械与动力工程学院研究生教学网 - ${config.name}`,
+        language: 'zh-CN',
+        item: dataItems,
+    };
+}

--- a/lib/routes/sjtu/me/yjs.ts
+++ b/lib/routes/sjtu/me/yjs.ts
@@ -1,5 +1,6 @@
 import { load } from 'cheerio';
 
+import { config } from '@/config';
 import type { Data, DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
@@ -11,7 +12,7 @@ const request = got.extend({
     headers: {
         accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         referer: `${baseUrl}/YanJS/`,
-        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36',
+        'user-agent': config.trueUA,
     },
 });
 

--- a/lib/routes/sjtu/me/yjs.ts
+++ b/lib/routes/sjtu/me/yjs.ts
@@ -1,6 +1,5 @@
 import { load } from 'cheerio';
 
-import { config } from '@/config';
 import type { Data, DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
@@ -10,9 +9,7 @@ import timezone from '@/utils/timezone';
 const baseUrl = 'https://me.sjtu.edu.cn';
 const request = got.extend({
     headers: {
-        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         referer: `${baseUrl}/YanJS/`,
-        'user-agent': config.trueUA,
     },
 });
 
@@ -82,7 +79,7 @@ export const route: Route = {
         target: `/me/yjs/${type}`,
     })),
     name: '机械与动力工程学院研究生教学网',
-    maintainers: ['yyh'],
+    maintainers: ['yuhangyao211-beep'],
     handler,
     url: 'me.sjtu.edu.cn/YanJS/indexnotice.html',
     description: `| 首页通知公告 | 博士研究生通知公告 | 硕士研究生通知公告 | 教学动态  | 教师事务       | 学生事务       | 常见问题 |


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue


## Example for the Proposed Route(s) / 路由地址示例

```routes
/sjtu/me/yjs
/sjtu/me/yjs/indexnotice
/sjtu/me/yjs/notice
/sjtu/me/yjs/masternotice
/sjtu/me/yjs/indexnews
/sjtu/me/yjs/teacheraffairs
/sjtu/me/yjs/studentaffairs
/sjtu/me/yjs/commqu
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
- [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
- [x] Full text / 全文获取
- [x] Use cache / 使用缓存
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [x] Parsed / 可以解析
- [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Added SJTU Mechanical Engineering announcement feeds for multiple YanJS categories. Detail pages are fetched with cache for full text when available; source detail pages that return 404 gracefully fall back to list metadata.