### PR TITLE
feat(route): add 新世纪评级 research routes

### DIFF
--- a/lib/routes/shxsj/namespace.ts
+++ b/lib/routes/shxsj/namespace.ts
@@ -1,0 +1,9 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '新世纪评级',
+    url: 'www.shxsj.com',
+    categories: ['finance'],
+    description: '上海新世纪资信评估投资服务有限公司',
+    lang: 'zh-CN',
+};

--- a/lib/routes/shxsj/research.ts
+++ b/lib/routes/shxsj/research.ts
@@ -5,6 +5,7 @@ import { ViewType } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
 
 interface ArticleNav {
     id: number;
@@ -76,7 +77,7 @@ const handler = async (ctx: Context): Promise<Data> => {
                 const item: DataItem = {
                     title: detail.title || article.title,
                     description,
-                    pubDate: dateStr ? parseDate(dateStr) : undefined,
+                    pubDate: dateStr ? timezone(parseDate(dateStr), +8) : undefined,
                     link,
                     guid: `shxsj:${article.id}`,
                     category: detail.nav?.filter((n) => n.pid !== 0).map((n) => n.title) ?? (article.cate_name ? [article.cate_name] : undefined),

--- a/lib/routes/shxsj/research.ts
+++ b/lib/routes/shxsj/research.ts
@@ -1,0 +1,161 @@
+import type { Context } from 'hono';
+
+import type { Data, DataItem, Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+interface ArticleNav {
+    id: number;
+    pid: number;
+    title: string;
+    temp_id: number;
+}
+
+interface ArticleListItem {
+    id: number;
+    cid: string;
+    title: string;
+    image?: string;
+    add_time: string;
+    synopsis?: string;
+    cate_name?: string;
+    nav?: ArticleNav[];
+    pdf?: Array<{ name?: string; url?: string }>;
+}
+
+interface ArticleDetail extends ArticleListItem {
+    content?: string;
+}
+
+const CATEGORY_MAP: Record<string, string> = {
+    '80': '宏观经济研究',
+    '85': '区域信用研究',
+    '90': '行业信用研究',
+    '95': '债券市场研究',
+    '177': '评级发展研究',
+    '101': '评级市场表现研究',
+    '168': '主权研究',
+    '109': '专题研究',
+};
+
+const baseUrl = 'http://www.shxsj.com';
+
+const handler = async (ctx: Context): Promise<Data> => {
+    const { cid } = ctx.req.param();
+    const limit = Number.parseInt(ctx.req.query('limit') ?? '15', 10);
+
+    const listResponse = await ofetch<{
+        code: number;
+        data: { list: { data: ArticleListItem[] } };
+    }>(`${baseUrl}/serve/api/article_api/get_cid_article`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: { cid: Number(cid), page: 1 },
+        responseType: 'json',
+    });
+
+    const list = (listResponse.data?.list?.data ?? []).slice(0, limit);
+
+    const items: DataItem[] = (await Promise.all(
+        list.map((article) =>
+            cache.tryGet(`shxsj:article:${article.id}`, async (): Promise<DataItem> => {
+                const detailResponse = await ofetch<{ code: number; data: ArticleDetail }>(`${baseUrl}/serve/api/article_api/visit`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: { id: article.id },
+                    responseType: 'json',
+                });
+                const detail = detailResponse.data ?? ({} as ArticleDetail);
+
+                const link = `${baseUrl}/page?template=8&pageid=${article.id}&mid=2&listype=1`;
+                const description = detail.content || article.synopsis || '';
+                const dateStr = detail.add_time || article.add_time;
+
+                const item: DataItem = {
+                    title: detail.title || article.title,
+                    description,
+                    pubDate: dateStr ? parseDate(dateStr) : undefined,
+                    link,
+                    guid: `shxsj:${article.id}`,
+                    category: detail.nav?.filter((n) => n.pid !== 0).map((n) => n.title) ?? (article.cate_name ? [article.cate_name] : undefined),
+                    language: 'zh-CN',
+                };
+
+                const pdfItem = (detail.pdf ?? article.pdf ?? [])[0];
+                if (pdfItem?.url) {
+                    const pdfUrl = new URL(pdfItem.url, baseUrl).href;
+                    return {
+                        ...item,
+                        enclosure_url: pdfUrl,
+                        enclosure_type: 'application/pdf',
+                        enclosure_title: pdfItem.name || item.title,
+                    };
+                }
+
+                return item;
+            })
+        )
+    )) as DataItem[];
+
+    const categoryName = CATEGORY_MAP[cid] ?? `分类 ${cid}`;
+
+    return {
+        title: `新世纪评级 - ${categoryName}`,
+        link: `${baseUrl}/page?template=2&pageid=${cid}&mid=5`,
+        description: `上海新世纪资信评估投资服务有限公司 - ${categoryName}`,
+        item: items,
+        language: 'zh-CN',
+        allowEmpty: true,
+    };
+};
+
+export const route: Route = {
+    path: '/research/:cid',
+    name: '信用研究',
+    url: 'www.shxsj.com',
+    maintainers: ['KwToPA'],
+    handler,
+    example: '/shxsj/research/80',
+    parameters: {
+        cid: '研究分类 ID，对应关系详见下表',
+    },
+    description: `分类 ID 与研究类型对应：
+
+| cid | 研究类型         |
+| --- | ---------------- |
+| 80  | 宏观经济研究     |
+| 85  | 区域信用研究     |
+| 90  | 行业信用研究     |
+| 95  | 债券市场研究     |
+| 177 | 评级发展研究     |
+| 101 | 评级市场表现研究 |
+| 168 | 主权研究         |
+| 109 | 专题研究         |
+
+cid 即源站 URL 中的 \`pageid\`，例如 \`http://www.shxsj.com/page?template=2&pageid=80&mid=5\` 对应 cid = 80。`,
+    categories: ['finance'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.shxsj.com/page'],
+            target: (_, url) => {
+                if (!url) {
+                    return '';
+                }
+                const pageid = new URL(url).searchParams.get('pageid');
+                return pageid && CATEGORY_MAP[pageid] ? `/shxsj/research/${pageid}` : '';
+            },
+        },
+    ],
+    view: ViewType.Articles,
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

  Close #21538

  ## Example for the Proposed Route(s) / 路由地址示例

  ```routes
  /shxsj/research/80
  /shxsj/research/85
  /shxsj/research/90
  /shxsj/research/95
  /shxsj/research/177
  /shxsj/research/101
  /shxsj/research/168
  /shxsj/research/109
  ```

  ## New RSS Route Checklist / 新 RSS 路由检查表

  - [x] New Route / 新的路由
      - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随
  [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
  - [ ] Anti-bot or rate limit / 反爬/频率限制
      - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
  - [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) /
  [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
      - [x] Parsed / 可以解析
      - [x] Correct time zone / 时区正确
  - [ ] New package added / 添加了新的包
  - [ ] `Puppeteer`

  ## Note / 说明

  为 **上海新世纪资信评估投资服务有限公司（新世纪评级）** 新增 8 个研究分类订阅源，对应 Issue #21538 中列出的全部分类：

  | cid | 研究分类 | 路径 |
  | --- | --- | --- |
  | 80 | 宏观经济研究 | `/shxsj/research/80` |
  | 85 | 区域信用研究 | `/shxsj/research/85` |
  | 90 | 行业信用研究 | `/shxsj/research/90` |
  | 95 | 债券市场研究 | `/shxsj/research/95` |
  | 177 | 评级发展研究 | `/shxsj/research/177` |
  | 101 | 评级市场表现研究 | `/shxsj/research/101` |
  | 168 | 主权研究 | `/shxsj/research/168` |
  | 109 | 专题研究 | `/shxsj/research/109` |

  ### 实现要点

  - **数据源用官方 API，未做 HTML scraping**：
    - 列表：`POST /serve/api/article_api/get_cid_article` body `{ cid, page }`
    - 详情：`POST /serve/api/article_api/visit` body `{ id }`
  - **`responseType: 'json'` 是必需的**：API 响应头是 `Content-Type: text/html; charset=UTF-8` 但 body 是 JSON，ofetch 默认会按
   content-type 当 text 处理，必须显式声明。
  - **时区**：API 返回的 `add_time`（如 `"2026-06-01"`）是 Asia/Shanghai 当地时间裸字符串，已用 `@/utils/timezone` 修正为 `+8`
  时区，避免在非 +8 服务器上 pubDate 偏移 8 小时。
  - **Radar 用函数 target**：源站列表页 URL 是 query 形式 `/page?template=2&pageid=80&mid=5`，无法用 `:param` 直接匹配，所以
  radar.target 用函数从 `URL.searchParams.get('pageid')` 取值映射到路由。
  - **附件**：若 API 返回 `pdf` 字段（部分研究报告有），自动挂为 `application/pdf` enclosure。
  - **缓存**：详情请求按 article id 用 `cache.tryGet` 缓存。
  - **分类**：从详情 `nav` 字段中的面包屑（过滤掉顶级"信用研究"）作为 RSS `<category>`。

  ### 测试

  本地 `pnpm dev` 验证 8 个 cid 全部返回 HTTP 200 + 15 items，标题/链接/正文/日期/附件 PDF 均正常。