### PR TITLE
fix(route/xueqiu): fix stock_info failure caused by WAF challenge

### DIFF
--- a/lib/routes/xueqiu/cookies.ts
+++ b/lib/routes/xueqiu/cookies.ts
@@ -11,7 +11,8 @@ export const parseToken = (link: string) =>
             const page = await context.newPage();
             await page.route('**/*', (route) => {
                 const request = route.request();
-                request.resourceType() === 'document' ? route.continue() : route.abort();
+                const type = request.resourceType();
+                (type === 'document' || type === 'script') ? route.continue() : route.abort();
             });
             await page.goto(link, {
                 waitUntil: 'domcontentloaded',

--- a/lib/routes/xueqiu/stock-info.ts
+++ b/lib/routes/xueqiu/stock-info.ts
@@ -2,7 +2,7 @@ import { load } from 'cheerio';
 import queryString from 'query-string';
 import sanitizeHtml from 'sanitize-html';
 
-import { parseToken } from '@/routes/xueqiu/cookies';
+import { parseToken, UA } from '@/routes/xueqiu/cookies';
 import type { Route } from '@/types';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
@@ -48,14 +48,20 @@ async function handler(ctx) {
     const source = typename[type];
 
     const link = `https://xueqiu.com/S/${id}`;
+    const cookie = await parseToken(link);
+
     const res1 = await got({
         method: 'get',
         url: link,
+        headers: {
+            Cookie: cookie,
+            Referer: 'https://xueqiu.com/',
+            'User-Agent': UA,
+        },
     });
 
-    const token = await parseToken(link);
     const $ = load(res1.data); // 使用 cheerio 加载返回的 HTML
-    const stock_name = $('.stock-name').text().split('(', 1)[0];
+    const stock_name = $('.stock-name').text().split('(', 1)[0] || id;
 
     let query_url = 'https://xueqiu.com/statuses';
     query_url += source === 'all' ? '/search.json' : '/stock_timeline.json';
@@ -74,8 +80,9 @@ async function handler(ctx) {
             hl: '0',
         }),
         headers: {
-            Cookie: token,
+            Cookie: cookie,
             Referer: link,
+            'User-Agent': UA,
         },
     });
 


### PR DESCRIPTION
## Summary
Fix the `/xueqiu/stock_info/:id/:type?` route which was failing for stocks like SH600585.

## Root Cause
Xueqiu.com now uses Alibaba Cloud WAF protection that requires JavaScript execution. Two issues were causing the route to fail:

1. **`cookies.ts`: WAF scripts blocked** — The `page.route` filter in `parseToken` was aborting all non-document resource types, including `script`. This prevented the external WAF challenge script from loading, making the Patchright browser unable to solve the WAF challenge and obtain valid cookies.

2. **`stock-info.ts`: Wrong request order** — `parseToken(link)` was called AFTER the first `got` request to the stock page. The first request went without cookies and got WAF-blocked HTML, making stock name extraction fail.

## Changes

### `cookies.ts`
- Allow `script` resource type through the `page.route` filter so WAF challenge scripts can execute

### `stock-info.ts`
- Call `parseToken(link)` BEFORE the first page request so cookies are available to bypass WAF
- Add `Cookie`, `Referer`, and `User-Agent` headers to the first request for proper WAF bypass
- Add `User-Agent` header to the API request
- Add fallback to `id` parameter when stock name extraction fails

## Note
This route does **not** require user login. It uses Patchright (headless browser) to obtain visitor-level cookies automatically. No `XUEQIU_COOKIES` configuration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)