### PR TITLE
route(bloomberg): add AI channel

### DIFF
--- a/lib/bloomberg-route.test.ts
+++ b/lib/bloomberg-route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ofetch from '@/utils/ofetch';
+
+import { route } from './routes/bloomberg/index';
+import { parseLineupNewsList } from './routes/bloomberg/utils';
+
+vi.mock('@/utils/ofetch', () => ({
+    default: vi.fn(),
+}));
+
+const createContext = (limit?: string) => ({
+    req: {
+        query: (key: string) => (key === 'limit' ? limit : undefined),
+    },
+});
+
+describe('bloomberg route', () => {
+    beforeEach(() => {
+        vi.mocked(ofetch).mockReset();
+    });
+
+    it('documents the AI sectionfront channel', () => {
+        const site = route.parameters?.site;
+
+        expect(route.example).toBe('/bloomberg/bbiz');
+        expect(route.name).toBe('Site');
+        expect(route.description).toContain('| ai           | AI');
+        expect(typeof site).toBe('object');
+        expect(site).toMatchObject({
+            description: 'Site ID, can be found below',
+        });
+        expect(site && typeof site === 'object' && 'options' in site ? site.options : []).toContainEqual({
+            value: 'ai',
+            label: 'AI',
+        });
+    });
+
+    it('parses lineup stories for the AI sectionfront', async () => {
+        vi.mocked(ofetch).mockResolvedValue({
+            html: `
+                <article class="story-list-story" data-id="FIRST" data-updated-at="2026-06-14T08:00:00.000Z">
+                    <a class="story-list-story__info__headline-link" href="/news/articles/2026-06-14/first-ai-story">First AI Story</a>
+                </article>
+                <article class="story-list-story" data-id="DUPLICATE">
+                    <a class="story-list-story__info__headline-link" href="/news/articles/2026-06-14/first-ai-story">Duplicate AI Story</a>
+                </article>
+                <article>
+                    <time datetime="2026-06-13T08:00:00.000Z"></time>
+                    <a href="https://www.bloomberg.com/news/articles/2026-06-13/second-ai-story">Second AI Story</a>
+                </article>
+            `,
+        });
+
+        const list = await parseLineupNewsList('ai', createContext('2'));
+
+        expect(ofetch).toHaveBeenCalledWith('https://www.bloomberg.com/lineup/api/lazy_load_stories?slug=ai&page=1', {
+            headers: {
+                accept: 'application/json',
+                referer: 'https://www.bloomberg.com/ai',
+            },
+        });
+        expect(list).toEqual([
+            {
+                title: 'First AI Story',
+                link: 'https://www.bloomberg.com/news/articles/2026-06-14/first-ai-story',
+                pubDate: new Date('2026-06-14T08:00:00.000Z'),
+                guid: 'bloomberg:FIRST',
+            },
+            {
+                title: 'Second AI Story',
+                link: 'https://www.bloomberg.com/news/articles/2026-06-13/second-ai-story',
+                pubDate: new Date('2026-06-13T08:00:00.000Z'),
+            },
+        ]);
+    });
+
+    it('throws a clear error when the lineup API returns no HTML', async () => {
+        vi.mocked(ofetch).mockResolvedValue({});
+
+        await expect(parseLineupNewsList('ai', createContext())).rejects.toThrow('Unable to fetch Bloomberg ai channel stories. The lineup API returned no HTML.');
+    });
+});

--- a/lib/routes/bloomberg/index.ts
+++ b/lib/routes/bloomberg/index.ts
@@ -3,10 +3,11 @@ import pMap from 'p-map';
 import type { Route } from '@/types';
 import { ViewType } from '@/types';
 
-import { parseArticle, parseNewsList, rootUrl } from './utils';
+import { parseArticle, parseLineupNewsList, parseNewsList, rootUrl, websiteUrl } from './utils';
 
 const siteTitleMapping = {
     '/': 'News',
+    ai: 'AI',
     bpol: 'Politics',
     bbiz: 'Business',
     markets: 'Markets',
@@ -19,6 +20,8 @@ const siteTitleMapping = {
     businessweek: 'Businessweek',
     citylab: 'CityLab',
 };
+
+const lineupSites = new Set(['ai']);
 
 export const route: Route = {
     path: '/:site?',
@@ -39,11 +42,12 @@ export const route: Route = {
         supportPodcast: false,
         supportScihub: false,
     },
-    name: 'Bloomberg Site',
+    name: 'Site',
     maintainers: ['bigfei'],
     description: `| Site ID      | Title        |
 | ------------ | ------------ |
 | /            | News         |
+| ai           | AI           |
 | bpol         | Politics     |
 | bbiz         | Business     |
 | markets      | Markets      |
@@ -60,9 +64,10 @@ export const route: Route = {
 
 async function handler(ctx) {
     const site = ctx.req.param('site');
-    const currentUrl = site ? `${rootUrl}/${site}/sitemap_news.xml` : `${rootUrl}/sitemap_news.xml`;
+    const currentUrl = site ? `${websiteUrl}/${site}` : websiteUrl;
+    const sourceUrl = site ? `${rootUrl}/${site}/sitemap_news.xml` : `${rootUrl}/sitemap_news.xml`;
 
-    const list = await parseNewsList(currentUrl, ctx);
+    const list = site && lineupSites.has(site) ? await parseLineupNewsList(site, ctx) : await parseNewsList(sourceUrl, ctx);
     const items = await pMap(list, (item) => parseArticle(item), { concurrency: 1 });
     return {
         title: `Bloomberg - ${siteTitleMapping[site ?? '/']}`,

--- a/lib/routes/bloomberg/utils.ts
+++ b/lib/routes/bloomberg/utils.ts
@@ -13,6 +13,7 @@ import { renderLedeMedia } from './templates/lede-media';
 import { renderVideoMedia } from './templates/video-media';
 
 const rootUrl = 'https://www.bloomberg.com/feeds';
+const websiteUrl = 'https://www.bloomberg.com';
 const idSel = 'script[id^="article-info"][type="application/json"], script[class^="article-info"][type="application/json"], script#dvz-config';
 const idUrl = 'https://www.bloomberg.com/article/api/story/id/';
 
@@ -91,6 +92,53 @@ const parseNewsList = async (url, ctx) => {
             };
             return item;
         });
+};
+
+const parseLineupNewsList = async (slug, ctx) => {
+    const currentUrl = `${websiteUrl}/${slug}`;
+    const apiUrl = `${websiteUrl}/lineup/api/lazy_load_stories?slug=${slug}&page=1`;
+    const response = await ofetch(apiUrl, {
+        headers: {
+            accept: 'application/json',
+            referer: currentUrl,
+        },
+    });
+
+    if (!response.html) {
+        throw new Error(`Unable to fetch Bloomberg ${slug} channel stories. The lineup API returned no HTML.`);
+    }
+
+    const $ = load(response.html);
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 50;
+    const seenLinks = new Set<string>();
+    const items = $('article')
+        .toArray()
+        .map((article) => {
+            const articleElement = $(article);
+            const headline = articleElement.find('a.story-list-story__info__headline-link, a[href*="/news/"]').first();
+            const href = headline.attr('href');
+            if (!href) {
+                return;
+            }
+
+            const link = new URL(href, websiteUrl).href;
+            if (seenLinks.has(link)) {
+                return;
+            }
+            seenLinks.add(link);
+
+            const id = articleElement.attr('data-id');
+            return {
+                title: headline.text(),
+                link,
+                ...(articleElement.attr('data-updated-at') || articleElement.find('time').attr('datetime') ? { pubDate: parseDate(articleElement.attr('data-updated-at') || articleElement.find('time').attr('datetime')) } : {}),
+                ...(id ? { guid: `bloomberg:${id}` } : {}),
+            };
+        })
+        .filter((item) => item?.title && item.link)
+        .slice(0, limit);
+
+    return items;
 };
 
 const parseArticle = (item) =>
@@ -607,4 +655,4 @@ const documentToHtmlString = async (document) => {
     return str;
 };
 
-export { parseArticle, parseNewsList, rootUrl };
+export { parseArticle, parseLineupNewsList, parseNewsList, rootUrl, websiteUrl };


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue


## Example for the Proposed Route(s) / 路由地址示例

```routes
/bloomberg/ai
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
- [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
- [x] Full text / 全文获取
- [x] Use cache / 使用缓存
- [x] Anti-bot or rate limit / 反爬/频率限制
- [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [x] Parsed / 可以解析
- [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

### Summary

- Add `ai` as a Bloomberg site option for `/bloomberg/ai`.
- Fetch AI sectionfront stories through Bloomberg's lineup HTML API while preserving the existing sitemap flow for current Bloomberg channels.
- Add unit coverage for AI route documentation, lineup story parsing, duplicate link handling, `limit`, and empty lineup responses.

### Validation

- `mise exec -- pnpm vitest run lib/bloomberg-route.test.ts` passed.
- `mise exec -- pnpm exec oxlint --type-aware lib/routes/bloomberg/index.ts lib/routes/bloomberg/utils.ts lib/bloomberg-route.test.ts` passed.
- `mise exec -- pnpm exec oxfmt lib/routes/bloomberg/index.ts lib/routes/bloomberg/utils.ts lib/bloomberg-route.test.ts --check` passed.
- `mise exec -- pnpm build:routes` passed.
- `git diff --check` passed.
- `mise exec -- pnpm format:check` passed with existing repository warnings only.

Full `mise exec -- pnpm test` was attempted after installing Patchright Chromium. The new Bloomberg tests passed, but the full suite still failed due to local environment dependencies outside this change: `lib/utils/cache.test.ts > cache > redis` requires a local Redis server, and `lib/worker.worker.test.ts` emitted an undici `setTypeOfService EINVAL` unhandled error on this macOS/Node 24 environment.