### PR TITLE
fix(route/xueqiu): fix stock_info failure caused by WAF challenge

### DIFF
--- a/lib/routes/xueqiu/cookies.ts
+++ b/lib/routes/xueqiu/cookies.ts
@@ -11,7 +11,8 @@ export const parseToken = (link: string) =>
             const page = await context.newPage();
             await page.route('**/*', (route) => {
                 const request = route.request();
-                request.resourceType() === 'document' ? route.continue() : route.abort();
+                const type = request.resourceType();
+                (type === 'document' || type === 'script') ? route.continue() : route.abort();
             });
             await page.goto(link, {
                 waitUntil: 'domcontentloaded',

--- a/lib/routes/xueqiu/stock-info.ts
+++ b/lib/routes/xueqiu/stock-info.ts
@@ -48,14 +48,19 @@ async function handler(ctx) {
     const source = typename[type];
 
     const link = `https://xueqiu.com/S/${id}`;
+    const cookie = await parseToken(link);
+
     const res1 = await got({
         method: 'get',
         url: link,
+        headers: {
+            Cookie: cookie,
+            Referer: 'https://xueqiu.com/',
+        },
     });
 
-    const token = await parseToken(link);
-    const $ = load(res1.data); // 使用 cheerio 加载返回的 HTML
-    const stock_name = $('.stock-name').text().split('(', 1)[0];
+    const $ = load(res1.data);
+    const stock_name = $('.stock-name').text().split('(', 1)[0] || id;
 
     let query_url = 'https://xueqiu.com/statuses';
     query_url += source === 'all' ? '/search.json' : '/stock_timeline.json';
@@ -74,7 +79,7 @@ async function handler(ctx) {
             hl: '0',
         }),
         headers: {
-            Cookie: token,
+            Cookie: cookie,
             Referer: link,
         },
     });


### PR DESCRIPTION
## Involved Issue

Close #

## Example for the Proposed Route(s)

```routes
/xueqiu/stock_info/SH600585
/xueqiu/stock_info/SZ000002
/xueqiu/stock_info/SH600585/announcement
/xueqiu/stock_info/SH600585/news
/xueqiu/stock_info/SH600585/research
```

## Note

Fix the `/xueqiu/stock_info/:id/:type?` route which was failing for stocks like SH600585.

### Root Cause
1. **cookies.ts**: `page.route` filter aborted non-document resources including `script`, preventing WAF challenge scripts from loading in Patchright.
2. **stock-info.ts**: `parseToken(link)` was called AFTER the first page request, so cookies weren't available and the request got WAF-blocked HTML.

### Changes
- `cookies.ts`: allow `script` resource type through `page.route` filter
- `stock-info.ts`: call `parseToken(link)` before first page request, pass cookie and referer
- `stock-info.ts`: fallback to `id` parameter if stock name extraction fails

This route uses Patchright (headless browser) to obtain visitor-level cookies. No user login required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)