### PR TITLE
fix(route/xueqiu): fix stock_info failure caused by WAF challenge

### DIFF
--- a/lib/routes/xueqiu/cookies.ts
+++ b/lib/routes/xueqiu/cookies.ts
@@ -11,7 +11,8 @@ export const parseToken = (link: string) =>
             const page = await context.newPage();
             await page.route('**/*', (route) => {
                 const request = route.request();
-                request.resourceType() === 'document' ? route.continue() : route.abort();
+                const type = request.resourceType();
+                (type === 'document' || type === 'script') ? route.continue() : route.abort();
             });
             await page.goto(link, {
                 waitUntil: 'domcontentloaded',

--- a/lib/routes/xueqiu/stock-info.ts
+++ b/lib/routes/xueqiu/stock-info.ts
@@ -48,14 +48,19 @@ async function handler(ctx) {
     const source = typename[type];
 
     const link = `https://xueqiu.com/S/${id}`;
+    const cookie = await parseToken(link);
+
     const res1 = await got({
         method: 'get',
         url: link,
+        headers: {
+            Cookie: cookie,
+            Referer: 'https://xueqiu.com/',
+        },
     });
 
-    const token = await parseToken(link);
-    const $ = load(res1.data); // 使用 cheerio 加载返回的 HTML
-    const stock_name = $('.stock-name').text().split('(', 1)[0];
+    const $ = load(res1.data);
+    const stock_name = $('.stock-name').text().split('(', 1)[0] || id;
 
     let query_url = 'https://xueqiu.com/statuses';
     query_url += source === 'all' ? '/search.json' : '/stock_timeline.json';
@@ -74,7 +79,7 @@ async function handler(ctx) {
             hl: '0',
         }),
         headers: {
-            Cookie: token,
+            Cookie: cookie,
             Referer: link,
         },
     });


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/xueqiu/stock_info/SH600585
/xueqiu/stock_info/SZ000002
/xueqiu/stock_info/SH600585/announcement
/xueqiu/stock_info/SH600585/news
/xueqiu/stock_info/SH600585/research
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

Fix the `/xueqiu/stock_info/:id/:type?` route which was failing for stocks like SH600585.

### Root Cause
1. **cookies.ts**: `page.route` filter aborted non-document resources including `script`, preventing WAF challenge scripts from loading in Patchright.
2. **stock-info.ts**: `parseToken(link)` was called AFTER the first page request, so cookies weren't available and the request got WAF-blocked HTML.

### Changes
- `cookies.ts`: allow `script` resource type through `page.route` filter
- `stock-info.ts`: call `parseToken(link)` before first page request
- `stock-info.ts`: pass cookie and referer to first page request
- `stock-info.ts`: fallback to `id` parameter if stock name extraction fails

This route uses Patchright (headless browser) to obtain visitor-level cookies. No user login required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
