### PR TITLE
fix(route): repair u3c3 search and drop sticky promo rows

### DIFF
--- a/lib/routes/u3c3/index.ts
+++ b/lib/routes/u3c3/index.ts
@@ -23,7 +23,7 @@ export const route: Route = {
 };
 
 async function handler(ctx) {
-    const { type, keywoard, preview } = ctx.req.param();
+    const { type, keyword, preview } = ctx.req.param();
     // should be:
     // undefined
     // U3C3
@@ -36,9 +36,18 @@ async function handler(ctx) {
     const rootURL = 'https://www.u3c3.com';
     let currentURL;
     let title;
-    if (keywoard) {
-        currentURL = `${rootURL}/?search=${keywoard}`;
-        title = `search ${keywoard} - u3c3`;
+    if (keyword) {
+        // u3c3 search needs an anti-scrape token: its search box (search21() JS on the
+        // homepage) redirects to /?search2=<token>&search=<kw>. The token rotates and is
+        // embedded in the page, so scrape it live; hitting /?search=<kw> alone silently
+        // returns the homepage listing (the long-standing "always 國產原创" bug).
+        const { data: home } = await got(rootURL);
+        const varName = home.match(/search2="\s*\+\s*(\w+)/)?.[1];
+        const token = varName ? home.match(new RegExp(String.raw`(?<!/)\bvar\s+${varName}\s*=\s*"([^"]+)"`))?.[1] : undefined;
+        currentURL = token
+            ? `${rootURL}/?search2=${token}&search=${encodeURIComponent(keyword)}`
+            : `${rootURL}/?search=${encodeURIComponent(keyword)}`;
+        title = `search ${keyword} - u3c3`;
     } else if (type === undefined) {
         currentURL = rootURL;
         title = 'home - u3c3';
@@ -52,22 +61,27 @@ async function handler(ctx) {
 
     const list = $('body > div.container > div.table-responsive > table > tbody > tr')
         .toArray()
-        .map((item) => {
-            item = $(item);
-            const title = item.find('td:nth-of-type(2) > a ').attr('title');
-            const guid = rootURL + item.find('td:nth-of-type(2) > a').attr('href');
-            const link = guid;
-            const pubDate = item.find('td:nth-of-type(5)').text();
-            const enclosure_url = item.find('td:nth-of-type(3) > a:nth-of-type(2)').attr('href');
-            return {
-                title,
-                guid,
-                link,
-                pubDate,
-
-                enclosure_url,
-                enclosure_type: 'application/x-bittorrent',
-            };
+        .flatMap((el) => {
+            const item = $(el);
+            const a = item.find('td:nth-of-type(2) > a');
+            const href = a.attr('href');
+            // Skip u3c3's sticky promo rows that appear on every page (home AND search):
+            // category-nav rows (href="/?type=…") and external ad rows (href="http://…",
+            // e.g. the "國產原创" entries). Real torrent rows always link to /view.
+            if (!href || !href.startsWith('/view')) {
+                return [];
+            }
+            const guid = rootURL + href;
+            return [
+                {
+                    title: a.attr('title'),
+                    guid,
+                    link: guid,
+                    pubDate: item.find('td:nth-of-type(5)').text(),
+                    enclosure_url: item.find('td:nth-of-type(3) > a:nth-of-type(2)').attr('href'),
+                    enclosure_type: 'application/x-bittorrent',
+                },
+            ];
         });
 
     const items = preview

--- a/lib/routes/u3c3/index.ts
+++ b/lib/routes/u3c3/index.ts
@@ -61,27 +61,22 @@ async function handler(ctx) {
 
     const list = $('body > div.container > div.table-responsive > table > tbody > tr')
         .toArray()
-        .flatMap((el) => {
+        // Skip u3c3's sticky promo rows that appear on every page (home AND search):
+        // category-nav rows (href="/?type=…") and external ad rows (href="http://…",
+        // e.g. the "國產原创" entries). Real torrent rows always link to /view.
+        .filter((el) => $(el).find('td:nth-of-type(2) > a').attr('href')?.startsWith('/view'))
+        .map((el) => {
             const item = $(el);
             const a = item.find('td:nth-of-type(2) > a');
-            const href = a.attr('href');
-            // Skip u3c3's sticky promo rows that appear on every page (home AND search):
-            // category-nav rows (href="/?type=…") and external ad rows (href="http://…",
-            // e.g. the "國產原创" entries). Real torrent rows always link to /view.
-            if (!href || !href.startsWith('/view')) {
-                return [];
-            }
-            const guid = rootURL + href;
-            return [
-                {
-                    title: a.attr('title'),
-                    guid,
-                    link: guid,
-                    pubDate: item.find('td:nth-of-type(5)').text(),
-                    enclosure_url: item.find('td:nth-of-type(3) > a:nth-of-type(2)').attr('href'),
-                    enclosure_type: 'application/x-bittorrent',
-                },
-            ];
+            const guid = rootURL + a.attr('href');
+            return {
+                title: a.attr('title'),
+                guid,
+                link: guid,
+                pubDate: item.find('td:nth-of-type(5)').text(),
+                enclosure_url: item.find('td:nth-of-type(3) > a:nth-of-type(2)').attr('href'),
+                enclosure_type: 'application/x-bittorrent',
+            };
         });
 
     const items = preview


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/u3c3/search/狂飙
/u3c3/Video
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This fixes the `u3c3` route, whose search has been silently broken — every query returned the same homepage listing (the recurring "always 國產原创" results).

**Three issues fixed:**

1. **Typo `keywoard`.** The handler destructured `const { type, keywoard, preview }` (misspelled), so `keyword` was always `undefined`, the `if (keyword)` search branch never ran, and every request fell through to fetching the homepage.

2. **Missing anti-scrape token.** u3c3 has since added a token to its search: its search box (`search21()` JS on the homepage) redirects to `/?search2=<token>&search=<kw>`. Hitting `/?search=<kw>` alone returns the homepage. The token rotates and is embedded in the page, so it is now scraped live from the homepage before building the search URL (with a graceful fallback to the old URL if it can't be found).

3. **Sticky promo rows.** u3c3 prepends fixed promo rows to every page — category-nav links (`href="/?type=…"`) and external ad links (`href="http://…"`, which surface as the `國產原创` entries with a malformed `guid`). These appear in search results too. The parser now keeps only rows whose detail link points to `/view`, which are the real torrent entries.

Verified against live u3c3: results are now query-specific (e.g. `狂飙` returns matching torrents; a title with no entries returns empty) instead of always returning the homepage, and the promo rows no longer appear.
