### PR TITLE
fix: fix timezone for GMT+8

### DIFF
--- a/lib/routes/sdmuseum/exhibitions.tsx
+++ b/lib/routes/sdmuseum/exhibitions.tsx
@@ -5,6 +5,7 @@ import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
 
 import { namespace } from './namespace';
 
@@ -108,7 +109,7 @@ export const route: Route = {
                         const $detail = load(detailResponse.data);
 
                         const pubDateStr = $detail('meta[name="PubDate"]').attr('content') || '';
-                        const pubDate = parseDate(pubDateStr, 'YYYY-MM-DD HH:mm');
+                        const pubDate = timezone(parseDate(pubDateStr, 'YYYY-MM-DD HH:mm'), +8);
 
                         const description = renderToString(
                             <div>

--- a/lib/routes/sdmuseum/exhibitions.tsx
+++ b/lib/routes/sdmuseum/exhibitions.tsx
@@ -109,7 +109,7 @@ export const route: Route = {
                         const $detail = load(detailResponse.data);
 
                         const pubDateStr = $detail('meta[name="PubDate"]').attr('content') || '';
-                        const pubDate = timezone(parseDate(pubDateStr, 'YYYY-MM-DD HH:mm'), +8);
+                        const pubDate = timezone(parseDate(pubDateStr, 'YYYY-MM-DD HH:mm'), 8);
 
                         const description = renderToString(
                             <div>

--- a/lib/routes/shanghaimuseum/news.ts
+++ b/lib/routes/shanghaimuseum/news.ts
@@ -1,5 +1,6 @@
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
 
 export const route = {
     path: '/information/news/:type?',
@@ -67,7 +68,7 @@ export const route = {
 
             return {
                 title: item.titleDecoded || item.title,
-                pubDate: parseDate(item.issueTime),
+                pubDate: timezone(parseDate(item.issueTime), +8),
                 category: item.infoType?.entryItemName || item.bulletinInfoType?.entryItemName,
                 link: itemLink,
             };

--- a/lib/routes/shanghaimuseum/news.ts
+++ b/lib/routes/shanghaimuseum/news.ts
@@ -68,7 +68,7 @@ export const route = {
 
             return {
                 title: item.titleDecoded || item.title,
-                pubDate: timezone(parseDate(item.issueTime), +8),
+                pubDate: timezone(parseDate(item.issueTime), 8),
                 category: item.infoType?.entryItemName || item.bulletinInfoType?.entryItemName,
                 link: itemLink,
             };

--- a/lib/routes/shanghaimuseum/offline-exhibit.tsx
+++ b/lib/routes/shanghaimuseum/offline-exhibit.tsx
@@ -3,6 +3,7 @@ import { renderToString } from 'hono/jsx/dom/server';
 import type { Route } from '@/types';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
 
 import { namespace } from './namespace';
 
@@ -32,7 +33,7 @@ export const route: Route = {
         },
     ],
     handler: async (ctx) => {
-        const type = ctx.req.param('type')?.toUpperCase();
+        const type = ctx.req.param('type');
 
         const baseUrl = 'https://www.shanghaimuseum.net';
         const apiUrl = `${baseUrl}/mu/frontend/pg/display/search-exhibit`;
@@ -73,7 +74,7 @@ export const route: Route = {
             const itemLink = `${baseUrl}/mu/frontend/pg/article/id/${item.code}`;
             const imgUrl = item.picPath ? `${baseUrl}/${item.picPath}` : '';
             const location = item.exhibitPlace || '上海博物馆';
-            const pubDate = parseDate(item.issueTime);
+            const pubDate = timezone(parseDate(item.issueTime), +8);
 
             const fullDuration = item.exhibitDateRange || '';
             const [startDate, endDate] = fullDuration.includes(' - ') ? fullDuration.split(' - ').map((s) => s.trim()) : [fullDuration, ''];

--- a/lib/routes/shanghaimuseum/offline-exhibit.tsx
+++ b/lib/routes/shanghaimuseum/offline-exhibit.tsx
@@ -74,7 +74,7 @@ export const route: Route = {
             const itemLink = `${baseUrl}/mu/frontend/pg/article/id/${item.code}`;
             const imgUrl = item.picPath ? `${baseUrl}/${item.picPath}` : '';
             const location = item.exhibitPlace || '上海博物馆';
-            const pubDate = timezone(parseDate(item.issueTime), +8);
+            const pubDate = timezone(parseDate(item.issueTime), 8);
 
             const fullDuration = item.exhibitDateRange || '';
             const [startDate, endDate] = fullDuration.includes(' - ') ? fullDuration.split(' - ').map((s) => s.trim()) : [fullDuration, ''];


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close # None

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/shanghaimuseum/display/offline-exhibit
/shanghaimuseum/display/offline-exhibit/PAST
/shanghaimuseum/display/offline-exhibit/PRESENT
/sdmuseum/news
/sdmuseum/exhibitions
/shanghaimuseum/information/news
/shanghaimuseum/information/news/all
/shanghaimuseum/information/news/news
/shanghaimuseum/information/news/bulletin
/shanghaimuseum/information/news/finance
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Mainly ddd timezone for those GMT+8 time pubDate used.
Also remove Uppercase for Shanghaimuseum.