### PR TITLE
fix(openai): avoid Cloudflare 403 on article pages

### DIFF
--- a/lib/routes/openai/common.tsx
+++ b/lib/routes/openai/common.tsx
@@ -1,4 +1,5 @@
 import { load } from 'cheerio';
+import { Agent } from 'undici';
 
 import { config } from '@/config';
 import type { DataItem } from '@/types';
@@ -8,11 +9,17 @@ import { parseDate } from '@/utils/parse-date';
 
 export const BASE_URL = new URL('https://openai.com');
 
+// OpenAI article pages return Cloudflare 403 challenges when Undici negotiates HTTP/2.
+const articleDispatcher = new Agent({ allowH2: false });
+
 /** Fetch the details of an article. */
 export const fetchArticleDetails = async (url: string) => {
     // Ensure trailing slash to avoid 301 redirect
     const normalizedUrl = url.endsWith('/') ? url : `${url}/`;
-    const html = await ofetch(normalizedUrl, { responseType: 'text' });
+    const html = await ofetch(normalizedUrl, {
+        dispatcher: articleDispatcher,
+        responseType: 'text',
+    });
     const $ = load(html);
 
     const $article = $('#main article');


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/openai/news
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
