### PR TITLE
feat(route): add Fruit Data Kings route (close #20549)

### DIFF
--- a/lib/routes/fruitdatakings/index.ts
+++ b/lib/routes/fruitdatakings/index.ts
@@ -1,0 +1,110 @@
+import { config } from '@/config';
+import type { DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+interface GalleryItem {
+    id: number;
+    imageUrl: string;
+    details: {
+        retailer: string;
+        variety: string;
+        origin: string;
+        weight: string;
+        pack: string;
+        price: string;
+        year: number;
+        week: number;
+        isBio: boolean;
+    };
+}
+
+const baseUrl = 'https://www.fruitdatakings.com';
+
+const handler = async (ctx) => {
+    const { region = 'China', product = 'cherry' } = ctx.req.param();
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 15;
+
+    const cacheKey = `fruitdatakings:${region}:${product}`;
+    const apiUrl = `${baseUrl}/ajax/gallery-proxy/?location=${encodeURIComponent(region)}&product=${encodeURIComponent(product)}`;
+
+    const data = (await cache.tryGet(
+        cacheKey,
+        () =>
+            ofetch(apiUrl, {
+                headers: {
+                    'User-Agent': config.trueUA,
+                },
+            }),
+        2 * 60 * 60
+    )) as GalleryItem[];
+
+    if (!Array.isArray(data) || data.length === 0) {
+        throw ctx.error('No data found for the given region and product', 404);
+    }
+
+    const items: DataItem[] = data.slice(0, limit).map((item) => {
+        const { details } = item;
+        const articleLink = `${baseUrl}/${region.toLowerCase()}/${product.toLowerCase()}/${item.id}/`;
+
+        const description = `<p><strong>${details.variety}</strong> from <strong>${details.origin}</strong></p>
+<p>Retailer: ${details.retailer}</p>
+<p>Price: ${details.price} per ${details.pack} (${details.weight}g)</p>
+${details.isBio ? '<p>Organic (Bio)</p>' : ''}
+<img src="${item.imageUrl}" alt="${details.variety} price photo" />`;
+
+        return {
+            title: `${details.variety} (${details.origin}) - ${details.retailer} - ${details.price} per ${details.pack} (${details.weight}g)`,
+            description,
+            link: articleLink,
+            guid: `fruitdatakings-${region}-${product}-${item.id}`,
+            category: [details.variety, details.origin],
+            pubDate: parseDate(`${details.year}-W${String(details.week).padStart(2, '0')}`, 'YYYY-Www'),
+        };
+    });
+
+    return {
+        title: `Fruit Data Kings - ${product} - ${region}`,
+        description: `Weekly ${product} market price data for ${region} from Fruit Data Kings`,
+        link: `${baseUrl}/${region.toLowerCase()}/${product.toLowerCase()}/`,
+        item: items,
+        allowEmpty: false,
+        image: `${baseUrl}/static/images/blue.1.png`,
+    };
+};
+
+export const route: Route = {
+    path: '/:region{.+}/:product{.+}',
+    name: 'Fruit Price Data',
+    url: 'fruitdatakings.com',
+    maintainers: ['ishowman'],
+    handler,
+    example: '/fruitdatakings/China/cherry',
+    parameters: {
+        region: 'Region name, e.g. China, EU, US',
+        product: 'Product slug, e.g. cherry, kiwi',
+    },
+    description: `\`\`\`
+    | Region | Product | RSSHub Route |
+    | --- | --- | --- |
+    | China | Cherry | [/fruitdatakings/China/cherry](https://rsshub.app/fruitdatakings/China/cherry) |
+    | EU | Kiwi | [/fruitdatakings/EU/kiwi](https://rsshub.app/fruitdatakings/EU/kiwi) |
+\`\`\``,
+    categories: ['other'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['fruitdatakings.com/:region/:product/'],
+            target: '/:region/:product',
+        },
+    ],
+};

--- a/lib/routes/fruitdatakings/namespace.ts
+++ b/lib/routes/fruitdatakings/namespace.ts
@@ -1,0 +1,9 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Fruit Data Kings',
+    url: 'fruitdatakings.com',
+    categories: [],
+    description: '',
+    lang: 'en-US',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #20549

## Example for the Proposed Route(s) / 路由地址示例

```routes
/fruitdatakings/China/cherry
/fruitdatakings/EU/kiwi
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施? Uses API with User-Agent header
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Description / 说明

Add a new RSS route for [Fruit Data Kings](https://www.fruitdatakings.com), a fruit market price data platform that publishes weekly wholesale prices for fruits across different regions.

### Features
- Fetches weekly fruit price data by region and product via API
- Includes caching (2h TTL) to reduce redundant requests
- Proper camelCase naming for API fields (imageUrl, isBio)
- Unique GUID per item with individual article links
- Category extraction for variety and origin
- PubDate parsed from year-week format
- Radar support for RSSHub reader

### Route Details
- Path: `/:region{.+}/:product{.+}`
- Default: `/fruitdatakings/China/cherry`
- Categories: `other`
- No API key required