### PR TITLE
fix(route/hbr): support new /topic/subject/<slug> URLs and Latest/From the Store tabs

### DIFF
--- a/lib/routes/hbr/topic.ts
+++ b/lib/routes/hbr/topic.ts
@@ -6,19 +6,18 @@ import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
-    path: '/topic/:topic?/:type?',
+    path: ['/topic/subject/:topic/:type?', '/topic/:topic?/:type?'],
     categories: ['new-media'],
-    example: '/hbr/topic/Leadership/Popular',
+    example: '/hbr/topic/subject/decision-making-and-problem-solving',
     parameters: {
-        topic: 'Topic, can be found in URL, Leadership by default',
+        topic: 'Topic slug, can be found in the URL. HBR now serves topics under `hbr.org/topic/subject/<slug>`, so use the part after `subject/` (e.g. `decision-making-and-problem-solving`). Leadership by default.',
         type: {
-            description: 'Type, see below, Popular by default',
+            description: 'Stream, see below, Latest by default',
             options: [
-                { value: 'Popular', label: 'Popular' },
+                { value: 'Latest', label: 'Latest' },
                 { value: 'From the Store', label: 'From the Store' },
-                { value: 'For You', label: 'For You' },
             ],
-            default: 'Popular',
+            default: 'Latest',
         },
     },
     features: {
@@ -31,43 +30,54 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['hbr.org/topic/:topic?', 'hbr.org/'],
+            source: ['hbr.org/topic/subject/:topic', 'hbr.org/topic/:topic?', 'hbr.org/'],
         },
     ],
     name: 'Topic',
     maintainers: ['nczitzk', 'pseudoyu'],
     handler,
-    description: `| POPULAR | FROM THE STORE | FOR YOU |
-| ------- | -------------- | ------- |
-| Popular | From the Store | For You |
+    description: `| Latest | From the Store |
+| ------ | -------------- |
+| Latest | From the Store |
 
 ::: tip
-Click here to view [All Topics](https://hbr.org/topics)
+HBR now serves topics under \`hbr.org/topic/subject/<slug>\`. Copy the part after \`subject/\` as the \`topic\` parameter. Click here to view [All Topics](https://hbr.org/topics).
 :::`,
 };
 
 async function handler(ctx) {
-    const topic = ctx.req.param('topic') ?? 'Leadership';
-    const type = ctx.req.param('type') ?? 'Popular';
+    const topic = ctx.req.param('topic') ?? 'leadership';
+    const type = ctx.req.param('type') ?? 'Latest';
 
     const rootUrl = 'https://hbr.org';
-    const currentUrl = `${rootUrl}/topic/${topic}`;
+    // Mirror HBR's own URL layout: current pages live under /topic/subject/<slug>,
+    // legacy ones under /topic/<slug>. Detect which form was requested.
+    const isSubject = ctx.req.path.includes('/topic/subject/');
+    const currentUrl = `${rootUrl}/topic/${isSubject ? 'subject/' : ''}${topic}`;
 
     const response = await ofetch(currentUrl);
 
     const $ = load(response);
 
-    const list = $(`stream-content[data-stream-name="${type}"]`)
+    // Each tab is a <stream-content data-stream-name="..."> block. Fall back to
+    // the first stream when the requested name is absent, so the route keeps
+    // working if HBR renames or reorders the tabs.
+    const matched = $(`stream-content[data-stream-name="${type}"]`);
+    const container = matched.length ? matched : $('stream-content').first();
+
+    const list = container
         .find('.stream-item')
         .toArray()
         .map((item) => {
             item = $(item);
 
+            const url = item.attr('data-url') ?? '';
+
             return {
                 title: item.attr('data-title'),
                 author: item.attr('data-authors'),
                 category: item.attr('data-topic'),
-                link: `${rootUrl}${item.attr('data-url')}`,
+                link: url.startsWith('http') ? url : `${rootUrl}${url}`,
             };
         });
 


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/hbr/topic/subject/decision-making-and-problem-solving
/hbr/topic/leadership
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随路由规范
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] Date and time / 日期和时间
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Updates the existing `hbr` topic route (not a new namespace). HBR migrated topic
pages to `hbr.org/topic/subject/<slug>` with "Latest" / "From the Store" tabs; the
old `/topic/<name>` + "Popular"/"For You" structure no longer returns items.

- accept both `/topic/subject/:topic/:type?` and the legacy `/topic/:topic?/:type?`
- build the upstream URL to match whichever form was requested
- default `type` to `Latest`; options are `Latest` / `From the Store`
- fall back to the first `stream-content` block if the named stream is absent
- add a radar rule for `hbr.org/topic/subject/:topic`

HBR serves anti-bot-protected pages; the route reads server-rendered HTML and
caches article bodies.