### PR TITLE
fix(route/zhihu): obtain __zse_ck from a browser session

### DIFF
--- a/lib/routes/zhihu/utils.ts
+++ b/lib/routes/zhihu/utils.ts
@@ -2,8 +2,9 @@ import { load } from 'cheerio';
 
 import { config } from '@/config';
 import cache from '@/utils/cache';
+import logger from '@/utils/logger';
 import md5 from '@/utils/md5';
-import ofetch from '@/utils/ofetch';
+import playwright from '@/utils/playwright';
 
 import { encrypt as g_encrypt } from './execlib/x-zse-96-v3';
 
@@ -58,87 +59,114 @@ export const processImage = (content: string) => {
     return $.html();
 };
 
-export const getCookieValueByKey = (key: string) =>
-    config.zhihu.cookies
+const getCookieValueFrom = (cookieStr: string | undefined, key: string) =>
+    cookieStr
         ?.split(';')
         .map((e) => e.trim())
         .find((e) => e.startsWith(key + '='))
         ?.slice(key.length + 1) || '';
 
-export const getSignedHeader = async (url: string, apiPath: string) => {
-    if (config?.zhihu?.cookies) {
-        const dc0 = getCookieValueByKey('d_c0');
+export const getCookieValueByKey = (key: string) => getCookieValueFrom(config.zhihu.cookies as string | undefined, key);
 
-        const xzse93 = '101_3_3.0';
-        const f = `${xzse93}+${apiPath}+${dc0}`;
-        const xzse96 = '2.0_' + g_encrypt(md5(f));
+// Zhihu's web API needs a self-consistent triple: the `d_c0` cookie, the
+// `__zse_ck` cookie, and the `x-zse-96`/`x-zse-93` request signature (derived
+// from `d_c0`). `__zse_ck` is computed at runtime by Zhihu's obfuscated JS from
+// the device fingerprint plus `d_c0`, it rotates every few days, and the backend
+// cross-checks it against `d_c0`, so it has to be produced by a real browser.
+//
+// On top of that, most content (column item lists, answers, user activities,
+// ...) now also requires the `z_c0` login cookie, which can only be obtained by
+// logging in. Provide it in ZHIHU_COOKIES (copied from a logged-in browser);
+// without it those endpoints return 403.
+//
+// So we run Zhihu's JS in a real browser seeded with the configured cookies, let
+// it compute a fresh `__zse_ck` for the (logged-in) session, and harvest the
+// whole cookie jar. The rotating `__zse_ck` is refreshed on a timer, so the only
+// thing the user maintains is the long-lived `d_c0`/`z_c0`.
+//
+// Recommended ZHIHU_COOKIES: `d_c0=...; z_c0=...` (omit `__zse_ck` so it is
+// refreshed automatically; a pinned `__zse_ck` is trusted as-is and will expire).
+const ZSE_CK_CACHE_KEY = 'zhihu:browser-cookies';
+// `__zse_ck` rotates every few days; re-harvest at most this often so we are not
+// launching a browser on every request.
+const ZSE_CK_TTL = 30 * 60;
 
-        // If __zse_ck is absent from ZHIHU_COOKIES, fetch it automatically from
-        // Zhihu's public static JS. The value is site-wide (not user-specific)
-        // and requires no login, but it expires and must be kept up to date.
-        let cookieStr = config.zhihu.cookies;
-        if (!getCookieValueByKey('__zse_ck')) {
-            const zseCk = await cache.tryGet('zhihu:zse_ck', async () => {
-                const response = await ofetch.raw('https://static.zhihu.com/zse-ck/v3.js');
-                const script = await response._data.text();
-                return script.match(/__g\.ck\|\|"([\w+/=\\]*)",_=/)?.[1] || '';
-            });
-            if (zseCk) {
-                cookieStr += `; __zse_ck=${zseCk}`;
+const harvestBrowserCookies = (seedCookies?: string): Promise<string> =>
+    cache.tryGet(
+        ZSE_CK_CACHE_KEY,
+        async () => {
+            const context = await playwright();
+            try {
+                const page = await context.newPage();
+
+                if (seedCookies) {
+                    const seeded = seedCookies
+                        .split(';')
+                        .map((pair) => pair.trim())
+                        .filter(Boolean)
+                        .map((pair) => {
+                            // Split on the first '=' only: values such as the
+                            // base64-ish `z_c0` contain further '=' characters.
+                            const idx = pair.indexOf('=');
+                            return idx === -1 ? { name: '', value: pair, domain: '.zhihu.com', path: '/' } : { name: pair.slice(0, idx), value: pair.slice(idx + 1), domain: '.zhihu.com', path: '/' };
+                        })
+                        .filter((c) => c.name);
+                    if (seeded.length) {
+                        await context.addCookies(seeded);
+                    }
+                }
+
+                await page.goto('https://www.zhihu.com/', { waitUntil: 'domcontentloaded' });
+
+                // Wait until Zhihu's JS has computed and set `__zse_ck` (it is
+                // written to `document.cookie` alongside `d_c0`).
+                try {
+                    await page.waitForFunction(() => /(?:^|;\s*)__zse_ck=/.test(document.cookie) && /(?:^|;\s*)d_c0=/.test(document.cookie), null, { polling: 300, timeout: 10000 });
+                } catch {
+                    // token did not appear in time; harvest whatever cookies exist
+                }
+
+                const cookies = await context.cookies();
+                return cookies
+                    .filter(({ domain }) => domain === 'zhihu.com' || domain.endsWith('.zhihu.com'))
+                    .map(({ name, value }) => (name ? `${name}=${value}` : value))
+                    .join('; ');
+            } finally {
+                await context.close();
             }
-        }
+        },
+        ZSE_CK_TTL,
+        false
+    );
 
-        return {
-            cookie: cookieStr,
-            'x-zse-96': xzse96,
-            'x-app-za': 'OS=Web',
-            'x-zse-93': xzse93,
-        };
+export const getSignedHeader = async (url: string, apiPath: string) => {
+    const configured = (config?.zhihu?.cookies as string | undefined) || '';
+
+    // If a complete, self-consistent pair (`d_c0` + `__zse_ck`) is configured,
+    // trust it as-is. Otherwise harvest a fresh, consistent pair from a real
+    // browser, seeding any configured cookies (notably the `z_c0` login cookie).
+    let cookieStr: string;
+    if (getCookieValueFrom(configured, 'd_c0') && getCookieValueFrom(configured, '__zse_ck')) {
+        cookieStr = configured;
+    } else {
+        cookieStr = await harvestBrowserCookies(configured);
+        if (!getCookieValueFrom(cookieStr, '__zse_ck') || !getCookieValueFrom(cookieStr, 'd_c0')) {
+            logger.warn('zhihu: failed to harvest a valid __zse_ck/d_c0 pair from the browser; requests may be rejected with 403.');
+        }
+        if (!getCookieValueFrom(cookieStr, 'z_c0')) {
+            logger.warn('zhihu: no z_c0 login cookie configured; most content (column items, answers, activities) requires login and will return 403. Set ZHIHU_COOKIES=d_c0=...; z_c0=... copied from a logged-in browser.');
+        }
     }
-    // NOTICE: this method is out of date.
-    // Because the API of zhihu.com has changed, we must use the value of `d_c0` (extracted from cookies) to calculate
-    // `x-zse-96`. So first get `d_c0`, then get the actual data of a ZhiHu question. In this way, we don't need to
-    // require users to set the cookie in environmental variables anymore.
 
-    // fisrt: get cookie(dc_0) from zhihu.com
-    const { dc0, zseCk } = await cache.tryGet('zhihu:cookies:d_c0', async () => {
-        if (getCookieValueByKey('d_c0') && getCookieValueByKey('__zse_ck')) {
-            return { dc0: getCookieValueByKey('d_c0'), zseCk: getCookieValueByKey('__zse_ck') };
-        }
-        const response1 = await ofetch.raw('https://static.zhihu.com/zse-ck/v3.js');
-        const script = await response1._data.text();
-        const zseCk = script.match(/__g\.ck\|\|"([\w+/=\\]*)",_=/)?.[1];
-        const response2 = zseCk
-            ? await ofetch.raw(url, {
-                  headers: {
-                      cookie: `${response1.headers
-                          .getSetCookie()
-                          .map((s) => s.split(';', 1)[0])
-                          .join('; ')}; __zse_ck=${zseCk}`,
-                  },
-              })
-            : null;
-
-        const dc0 =
-            (response2 || response1).headers
-                .getSetCookie()
-                .find((s) => s.startsWith('d_c0='))
-                ?.split(';', 1)[0]
-                .trim()
-                .slice('d_c0='.length) || '';
-
-        return { dc0, zseCk };
-    });
-
-    // calculate x-zse-96, refer to https://github.com/srx-2000/spider_collection/issues/18
+    // Sign with the same `d_c0` that is sent, otherwise the backend rejects the
+    // request. Refer to https://github.com/srx-2000/spider_collection/issues/18
+    const dc0 = getCookieValueFrom(cookieStr, 'd_c0');
     const xzse93 = '101_3_3.0';
     const f = `${xzse93}+${apiPath}+${dc0}`;
     const xzse96 = '2.0_' + g_encrypt(md5(f));
 
-    const zc0 = getCookieValueByKey('z_c0');
-
     return {
-        cookie: `__zse_ck=${zseCk}; d_c0=${dc0}${zc0 ? `;z_c0=${zc0}` : ''}`,
+        cookie: cookieStr,
         'x-zse-96': xzse96,
         'x-app-za': 'OS=Web',
         'x-zse-93': xzse93,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #20402

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

<!-- This PR changes the shared zhihu signing helper (lib/routes/zhihu/utils.ts), not a route. It cannot be exercised in CI without Zhihu cookies, hence NOROUTE. -->

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

`__zse_ck` is generated at runtime by Zhihu's JS from the device fingerprint and `d_c0`, rotates every few days, and is cross-checked against `d_c0` by the backend, so it has to come from a real browser session.

This drives a headless browser, seeded with the configured cookies, to compute a fresh `__zse_ck` for the session, harvests the cookie jar, and caches it for 30 minutes so it is refreshed automatically. `getSignedHeader` then signs `x-zse-96` with the same `d_c0` that is sent.

Most Zhihu content (column items, answers, activities) now also requires the `z_c0` login cookie. Recommended config: `ZHIHU_COOKIES=d_c0=...; z_c0=...` (omit `__zse_ck` so it is refreshed automatically; a pinned `__zse_ck` is trusted as-is and will expire). A fully pinned `d_c0` + `__zse_ck` pair is still honored, so no browser is needed in that case.

Deployed and verified end-to-end: `/zhihu/zhuanlan/<id>` and `/zhihu/people/activities/<id>` return 200 with full items; the harvested cookie is served from cache within the TTL (cold ~18s for the browser launch, warm ~2s).

Supersedes #21321.