### PR TITLE
fix(route/zhihu): generate __zse_ck with JSDOM

### DIFF
--- a/lib/routes/zhihu/posts.ts
+++ b/lib/routes/zhihu/posts.ts
@@ -45,7 +45,7 @@ async function handler(ctx) {
     const userProfile = await cache.tryGet(`zhihu:posts:profile:${id}`, async () => {
         // Read the profile from the API instead of scraping the user's HTML
         // homepage, which is now rate-limited (403) more aggressively than the API.
-        const profileApiPath = `/api/v4/${usertype === 'people' ? 'members' : 'org'}/${id}`;
+        const profileApiPath = `/api/v4/members/${id}`;
 
         const result = await ofetch(`https://www.zhihu.com${profileApiPath}`, {
             headers: {
@@ -62,7 +62,7 @@ async function handler(ctx) {
         };
     });
 
-    const apiPath = `/api/v4/${usertype === 'people' ? 'members' : 'org'}/${id}/articles?${new URLSearchParams({
+    const apiPath = `/api/v4/members/${id}/articles?${new URLSearchParams({
         include:
             'data[*].comment_count,suggest_edit,is_normal,thumbnail_extra_info,thumbnail,can_comment,comment_permission,admin_closed_comment,content,voteup_count,created,updated,upvoted_followees,voting,review_info,reaction_instruction,is_labeled,label_info;data[*].vessay_info;data[*].author.badge[?(type=best_answerer)].topics;data[*].author.vip_info;',
         offset: '0',

--- a/lib/routes/zhihu/posts.ts
+++ b/lib/routes/zhihu/posts.ts
@@ -1,11 +1,9 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
-import type { Articles, Profile } from './types';
+import type { Articles } from './types';
 import { getSignedHeader, header, processImage } from './utils';
 
 export const route: Route = {
@@ -45,18 +43,23 @@ async function handler(ctx) {
     const usertype = ctx.req.param('usertype');
 
     const userProfile = await cache.tryGet(`zhihu:posts:profile:${id}`, async () => {
-        const userAPIPath = `/${usertype === 'people' ? 'people' : 'org'}/${id}`;
+        // Read the profile from the API instead of scraping the user's HTML
+        // homepage, which is now rate-limited (403) more aggressively than the API.
+        const profileApiPath = `/api/v4/${usertype === 'people' ? 'members' : 'org'}/${id}`;
 
-        const result = await ofetch(`https://www.zhihu.com${userAPIPath}`, {
+        const result = await ofetch(`https://www.zhihu.com${profileApiPath}`, {
             headers: {
                 ...header,
-                ...(await getSignedHeader(`https://www.zhihu.com/${usertype}/${id}/`, userAPIPath)),
+                ...(await getSignedHeader(`https://www.zhihu.com/${usertype}/${id}/`, profileApiPath)),
                 Referer: `https://www.zhihu.com/${usertype}/${id}/`,
             },
         });
-        const $ = load(result);
-        const data = JSON.parse($('#js-initialData').text());
-        return data?.initialState?.entities?.users[id] as Profile;
+
+        return {
+            name: result.name,
+            headline: result.headline,
+            avatarUrl: result.avatar_url,
+        };
     });
 
     const apiPath = `/api/v4/${usertype === 'people' ? 'members' : 'org'}/${id}/articles?${new URLSearchParams({

--- a/lib/routes/zhihu/utils.ts
+++ b/lib/routes/zhihu/utils.ts
@@ -1,10 +1,14 @@
+import { Script } from 'node:vm';
+
 import { load } from 'cheerio';
+import { JSDOM, VirtualConsole } from 'jsdom';
 
 import { config } from '@/config';
 import cache from '@/utils/cache';
-import logger from '@/utils/logger';
+import { generateHeaders } from '@/utils/header-generator';
 import md5 from '@/utils/md5';
-import playwright from '@/utils/playwright';
+import ofetch from '@/utils/ofetch';
+import wait from '@/utils/wait';
 
 import { encrypt as g_encrypt } from './execlib/x-zse-96-v3';
 
@@ -68,94 +72,166 @@ const getCookieValueFrom = (cookieStr: string | undefined, key: string) =>
 
 export const getCookieValueByKey = (key: string) => getCookieValueFrom(config.zhihu.cookies as string | undefined, key);
 
-// Zhihu's web API needs a self-consistent triple: the `d_c0` cookie, the
-// `__zse_ck` cookie, and the `x-zse-96`/`x-zse-93` request signature (derived
-// from `d_c0`). `__zse_ck` is computed at runtime by Zhihu's obfuscated JS from
-// the device fingerprint plus `d_c0`, it rotates every few days, and the backend
-// cross-checks it against `d_c0`, so it has to be produced by a real browser.
-//
-// On top of that, most content (column item lists, answers, user activities,
-// ...) now also requires the `z_c0` login cookie, which can only be obtained by
-// logging in. Provide it in ZHIHU_COOKIES (copied from a logged-in browser);
-// without it those endpoints return 403.
-//
-// So we run Zhihu's JS in a real browser seeded with the configured cookies, let
-// it compute a fresh `__zse_ck` for the (logged-in) session, and harvest the
-// whole cookie jar. The rotating `__zse_ck` is refreshed on a timer, so the only
-// thing the user maintains is the long-lived `d_c0`/`z_c0`.
-//
-// Recommended ZHIHU_COOKIES: `d_c0=...; z_c0=...` (omit `__zse_ck` so it is
-// refreshed automatically; a pinned `__zse_ck` is trusted as-is and will expire).
-const ZSE_CK_CACHE_KEY = 'zhihu:browser-cookies';
-// `__zse_ck` rotates every few days; re-harvest at most this often so we are not
-// launching a browser on every request.
-const ZSE_CK_TTL = 30 * 60;
+let isUnreachableRuntimeErrorGuarded = false;
+const pendingZseCredentials = new Map<string, Promise<{ dc0: string; zseCk: string; ua: string }>>();
 
-const harvestBrowserCookies = (seedCookies?: string): Promise<string> =>
-    cache.tryGet(
-        ZSE_CK_CACHE_KEY,
-        async () => {
-            const context = await playwright();
-            try {
-                const page = await context.newPage();
+const preventUnreachableRuntimeError = () => {
+    if (isUnreachableRuntimeErrorGuarded) {
+        return;
+    }
+    isUnreachableRuntimeErrorGuarded = true;
+    process.on('unhandledRejection', (reason) => {
+        const error = reason as { name?: string; message?: string } | undefined;
+        if (error?.name === 'RuntimeError' && error.message === 'unreachable') {
+            return;
+        }
+        throw reason;
+    });
+};
 
-                if (seedCookies) {
-                    const seeded = seedCookies
-                        .split(';')
-                        .map((pair) => pair.trim())
-                        .filter(Boolean)
-                        .map((pair) => {
-                            // Split on the first '=' only: values such as the
-                            // base64-ish `z_c0` contain further '=' characters.
-                            const idx = pair.indexOf('=');
-                            return idx === -1 ? { name: '', value: pair, domain: '.zhihu.com', path: '/' } : { name: pair.slice(0, idx), value: pair.slice(idx + 1), domain: '.zhihu.com', path: '/' };
-                        })
-                        .filter((c) => c.name);
-                    if (seeded.length) {
-                        await context.addCookies(seeded);
-                    }
-                }
+const generateZseCk = async (url: string, apiPath: string, configuredDc0: string) => {
+    preventUnreachableRuntimeError();
 
-                await page.goto('https://www.zhihu.com/', { waitUntil: 'domcontentloaded' });
+    // `__zse_ck` is checked against the user-agent that generated it.
+    const ua = generateHeaders()['user-agent'];
+    const headers = { 'user-agent': ua };
 
-                // Wait until Zhihu's JS has computed and set `__zse_ck` (it is
-                // written to `document.cookie` alongside `d_c0`).
-                try {
-                    await page.waitForFunction(() => /(?:^|;\s*)__zse_ck=/.test(document.cookie) && /(?:^|;\s*)d_c0=/.test(document.cookie), null, { polling: 300, timeout: 10000 });
-                } catch {
-                    // token did not appear in time; harvest whatever cookies exist
-                }
+    let dc0 = configuredDc0;
+    if (!dc0) {
+        const seed = await ofetch.raw('https://www.zhihu.com/explore', {
+            headers,
+            redirect: 'manual',
+            ignoreResponseError: true,
+        });
+        dc0 =
+            (seed.headers.getSetCookie?.() ?? [])
+                .find((line) => line.startsWith('d_c0='))
+                ?.split(';', 1)[0]
+                .slice('d_c0='.length) || '';
+    }
+    if (!dc0) {
+        throw new Error('zhihu: failed to obtain a guest d_c0 cookie');
+    }
 
-                const cookies = await context.cookies();
-                return cookies
-                    .filter(({ domain }) => domain === 'zhihu.com' || domain.endsWith('.zhihu.com'))
-                    .map(({ name, value }) => (name ? `${name}=${value}` : value))
-                    .join('; ');
-            } finally {
-                await context.close();
-            }
+    const challenge = await ofetch.raw(`https://www.zhihu.com${apiPath}`, {
+        headers: {
+            ...headers,
+            cookie: `d_c0=${dc0}; __zse_ck=005_x-x`,
+            referer: url,
+            'x-requested-with': 'fetch',
         },
-        ZSE_CK_TTL,
-        false
-    );
+        ignoreResponseError: true,
+    });
+    const html = challenge._data as string;
+    const meta = html.match(/id="zh-zse-ck"[^>]*content="([^"]*)"/)?.[1];
+    const hash = html.match(/zse-ck\/v4\/([a-f0-9]+)\.js/)?.[1];
+    if (!meta || !hash) {
+        throw new Error('zhihu: challenge page did not contain an URL to __zse_ck meta/script');
+    }
+
+    const vmScript = await ofetch<string>(`https://static.zhihu.com/zse-ck/v4/${hash}.js`, {
+        headers,
+        parseResponse: (text) => text,
+    });
+    const dom = new JSDOM(`<!doctype html><html><head><meta id="zh-zse-ck" content="${meta}"><script data-assets-tracker-config='{"appName":"zse_ck"}'></script></head><body></body></html>`, {
+        url,
+        referrer: 'https://www.zhihu.com/',
+        runScripts: 'outside-only',
+        pretendToBeVisual: true,
+        virtualConsole: new VirtualConsole(),
+    });
+    const { window } = dom;
+    Object.defineProperties(window.navigator, {
+        userAgent: { value: ua, configurable: true },
+        webdriver: { value: false, configurable: true },
+    });
+    window.TextEncoder = TextEncoder;
+    window.TextDecoder = TextDecoder as typeof window.TextDecoder;
+    window.atob = (value: string) => Buffer.from(value, 'base64').toString('binary');
+    window.btoa = (value: string) => Buffer.from(value, 'binary').toString('base64');
+    Object.assign(window, { __g: {} });
+
+    const cookieDescriptor = Object.getOwnPropertyDescriptor(window.Document.prototype, 'cookie');
+    if (!cookieDescriptor?.get || !cookieDescriptor.set) {
+        window.close();
+        throw new Error('zhihu: JSDOM did not provide document.cookie accessors');
+    }
+    const tokenPromise = new Promise<string>((resolve) => {
+        Object.defineProperty(window.document, 'cookie', {
+            configurable: true,
+            get: cookieDescriptor.get,
+            set(value: string) {
+                Reflect.apply(cookieDescriptor.set, window.document, [value]);
+                const token = value.match(/__zse_ck=([^;]+)/)?.[1];
+                if (token?.includes('-')) {
+                    resolve(token);
+                }
+            },
+        });
+    });
+
+    let zseCk: string | undefined;
+    try {
+        // Zhihu's challenge is intentionally delivered as executable JavaScript.
+        new Script(vmScript).runInContext(dom.getInternalVMContext());
+        zseCk = (await Promise.race([tokenPromise, wait(3000)])) as string | undefined;
+    } finally {
+        window.close();
+    }
+    if (!zseCk) {
+        throw new Error('zhihu: WASM VM did not produce a __zse_ck');
+    }
+    return { dc0, zseCk, ua };
+};
+
+const getGeneratedZseCredentials = (url: string, apiPath: string, configuredDc0: string) => {
+    const cacheKey = `zhihu:zse-ck:v4:${configuredDc0 ? md5(configuredDc0) : 'guest'}`;
+    const pending = pendingZseCredentials.get(cacheKey);
+    if (pending) {
+        return pending;
+    }
+
+    const created = (async () => {
+        try {
+            return await cache.tryGet(cacheKey, () => generateZseCk(url, apiPath, configuredDc0), config.cache.contentExpire, false);
+        } finally {
+            pendingZseCredentials.delete(cacheKey);
+        }
+    })();
+    pendingZseCredentials.set(cacheKey, created);
+    return created;
+};
+
+const mergeGeneratedCookies = (configured: string, dc0: string, zseCk: string) => {
+    const remaining = configured
+        .split(';')
+        .map((pair) => pair.trim())
+        .filter((pair) => {
+            const name = pair.split('=', 1)[0];
+            return name && name !== 'd_c0' && name !== '__zse_ck';
+        });
+    return [`__zse_ck=${zseCk}`, `d_c0=${dc0}`, ...remaining].join('; ');
+};
 
 export const getSignedHeader = async (url: string, apiPath: string) => {
     const configured = (config?.zhihu?.cookies as string | undefined) || '';
 
-    // If a complete, self-consistent pair (`d_c0` + `__zse_ck`) is configured,
-    // trust it as-is. Otherwise harvest a fresh, consistent pair from a real
-    // browser, seeding any configured cookies (notably the `z_c0` login cookie).
+    const configuredDc0 = getCookieValueFrom(configured, 'd_c0');
+    const configuredZseCk = getCookieValueFrom(configured, '__zse_ck');
+
+    // A configured pair may have been generated with a different user-agent, so
+    // preserve the previous behavior and trust it as-is. Generated credentials
+    // always return their matching user-agent.
     let cookieStr: string;
-    if (getCookieValueFrom(configured, 'd_c0') && getCookieValueFrom(configured, '__zse_ck')) {
+    let ua: string | undefined;
+    if (configuredDc0 && configuredZseCk) {
         cookieStr = configured;
     } else {
-        cookieStr = await harvestBrowserCookies(configured);
-        if (!getCookieValueFrom(cookieStr, '__zse_ck') || !getCookieValueFrom(cookieStr, 'd_c0')) {
-            logger.warn('zhihu: failed to harvest a valid __zse_ck/d_c0 pair from the browser; requests may be rejected with 403.');
-        }
-        if (!getCookieValueFrom(cookieStr, 'z_c0')) {
-            logger.warn('zhihu: no z_c0 login cookie configured; most content (column items, answers, activities) requires login and will return 403. Set ZHIHU_COOKIES=d_c0=...; z_c0=... copied from a logged-in browser.');
-        }
+        const credentials = await getGeneratedZseCredentials(url, apiPath, configuredDc0);
+        // Login cookies only belong to the configured d_c0 session. Do not mix
+        // an isolated z_c0 with a newly-created guest session.
+        cookieStr = configuredDc0 ? mergeGeneratedCookies(configured, credentials.dc0, credentials.zseCk) : `__zse_ck=${credentials.zseCk}; d_c0=${credentials.dc0}`;
+        ua = credentials.ua;
     }
 
     // Sign with the same `d_c0` that is sent, otherwise the backend rejects the
@@ -167,6 +243,7 @@ export const getSignedHeader = async (url: string, apiPath: string) => {
 
     return {
         cookie: cookieStr,
+        ...(ua && { 'user-agent': ua }),
         'x-zse-96': xzse96,
         'x-app-za': 'OS=Web',
         'x-zse-93': xzse93,

--- a/lib/routes/zhihu/utils.ts
+++ b/lib/routes/zhihu/utils.ts
@@ -2,8 +2,9 @@ import { load } from 'cheerio';
 
 import { config } from '@/config';
 import cache from '@/utils/cache';
+import logger from '@/utils/logger';
 import md5 from '@/utils/md5';
-import ofetch from '@/utils/ofetch';
+import playwright from '@/utils/playwright';
 
 import { encrypt as g_encrypt } from './execlib/x-zse-96-v3';
 
@@ -58,87 +59,114 @@ export const processImage = (content: string) => {
     return $.html();
 };
 
-export const getCookieValueByKey = (key: string) =>
-    config.zhihu.cookies
+const getCookieValueFrom = (cookieStr: string | undefined, key: string) =>
+    cookieStr
         ?.split(';')
         .map((e) => e.trim())
         .find((e) => e.startsWith(key + '='))
         ?.slice(key.length + 1) || '';
 
-export const getSignedHeader = async (url: string, apiPath: string) => {
-    if (config?.zhihu?.cookies) {
-        const dc0 = getCookieValueByKey('d_c0');
+export const getCookieValueByKey = (key: string) => getCookieValueFrom(config.zhihu.cookies as string | undefined, key);
 
-        const xzse93 = '101_3_3.0';
-        const f = `${xzse93}+${apiPath}+${dc0}`;
-        const xzse96 = '2.0_' + g_encrypt(md5(f));
+// Zhihu's web API needs a self-consistent triple: the `d_c0` cookie, the
+// `__zse_ck` cookie, and the `x-zse-96`/`x-zse-93` request signature (derived
+// from `d_c0`). `__zse_ck` is computed at runtime by Zhihu's obfuscated JS from
+// the device fingerprint plus `d_c0`, it rotates every few days, and the backend
+// cross-checks it against `d_c0`, so it has to be produced by a real browser.
+//
+// On top of that, most content (column item lists, answers, user activities,
+// ...) now also requires the `z_c0` login cookie, which can only be obtained by
+// logging in. Provide it in ZHIHU_COOKIES (copied from a logged-in browser);
+// without it those endpoints return 403.
+//
+// So we run Zhihu's JS in a real browser seeded with the configured cookies, let
+// it compute a fresh `__zse_ck` for the (logged-in) session, and harvest the
+// whole cookie jar. The rotating `__zse_ck` is refreshed on a timer, so the only
+// thing the user maintains is the long-lived `d_c0`/`z_c0`.
+//
+// Recommended ZHIHU_COOKIES: `d_c0=...; z_c0=...` (omit `__zse_ck` so it is
+// refreshed automatically; a pinned `__zse_ck` is trusted as-is and will expire).
+const ZSE_CK_CACHE_KEY = 'zhihu:browser-cookies';
+// `__zse_ck` rotates every few days; re-harvest at most this often so we are not
+// launching a browser on every request.
+const ZSE_CK_TTL = 30 * 60;
 
-        // If __zse_ck is absent from ZHIHU_COOKIES, fetch it automatically from
-        // Zhihu's public static JS. The value is site-wide (not user-specific)
-        // and requires no login, but it expires and must be kept up to date.
-        let cookieStr = config.zhihu.cookies;
-        if (!getCookieValueByKey('__zse_ck')) {
-            const zseCk = await cache.tryGet('zhihu:zse_ck', async () => {
-                const response = await ofetch.raw('https://static.zhihu.com/zse-ck/v3.js');
-                const script = await response._data.text();
-                return script.match(/__g\.ck\|\|"([\w+/=\\]*)",_=/)?.[1] || '';
-            });
-            if (zseCk) {
-                cookieStr += `; __zse_ck=${zseCk}`;
+const harvestBrowserCookies = (seedCookies?: string): Promise<string> =>
+    cache.tryGet(
+        ZSE_CK_CACHE_KEY,
+        async () => {
+            const context = await playwright();
+            try {
+                const page = await context.newPage();
+
+                if (seedCookies) {
+                    const seeded = seedCookies
+                        .split(';')
+                        .map((pair) => pair.trim())
+                        .filter(Boolean)
+                        .map((pair) => {
+                            // Split on the first '=' only: values such as the
+                            // base64-ish `z_c0` contain further '=' characters.
+                            const idx = pair.indexOf('=');
+                            return idx === -1 ? { name: '', value: pair, domain: '.zhihu.com', path: '/' } : { name: pair.slice(0, idx), value: pair.slice(idx + 1), domain: '.zhihu.com', path: '/' };
+                        })
+                        .filter((c) => c.name);
+                    if (seeded.length) {
+                        await context.addCookies(seeded);
+                    }
+                }
+
+                await page.goto('https://www.zhihu.com/', { waitUntil: 'domcontentloaded' });
+
+                // Wait until Zhihu's JS has computed and set `__zse_ck` (it is
+                // written to `document.cookie` alongside `d_c0`).
+                try {
+                    await page.waitForFunction(() => /(?:^|;\s*)__zse_ck=/.test(document.cookie) && /(?:^|;\s*)d_c0=/.test(document.cookie), null, { polling: 300, timeout: 10000 });
+                } catch {
+                    // token did not appear in time; harvest whatever cookies exist
+                }
+
+                const cookies = await context.cookies();
+                return cookies
+                    .filter(({ domain }) => domain === 'zhihu.com' || domain.endsWith('.zhihu.com'))
+                    .map(({ name, value }) => (name ? `${name}=${value}` : value))
+                    .join('; ');
+            } finally {
+                await context.close();
             }
-        }
+        },
+        ZSE_CK_TTL,
+        false
+    );
 
-        return {
-            cookie: cookieStr,
-            'x-zse-96': xzse96,
-            'x-app-za': 'OS=Web',
-            'x-zse-93': xzse93,
-        };
+export const getSignedHeader = async (url: string, apiPath: string) => {
+    const configured = (config?.zhihu?.cookies as string | undefined) || '';
+
+    // If a complete, self-consistent pair (`d_c0` + `__zse_ck`) is configured,
+    // trust it as-is. Otherwise harvest a fresh, consistent pair from a real
+    // browser, seeding any configured cookies (notably the `z_c0` login cookie).
+    let cookieStr: string;
+    if (getCookieValueFrom(configured, 'd_c0') && getCookieValueFrom(configured, '__zse_ck')) {
+        cookieStr = configured;
+    } else {
+        cookieStr = await harvestBrowserCookies(configured);
+        if (!getCookieValueFrom(cookieStr, '__zse_ck') || !getCookieValueFrom(cookieStr, 'd_c0')) {
+            logger.warn('zhihu: failed to harvest a valid __zse_ck/d_c0 pair from the browser; requests may be rejected with 403.');
+        }
+        if (!getCookieValueFrom(cookieStr, 'z_c0')) {
+            logger.warn('zhihu: no z_c0 login cookie configured; most content (column items, answers, activities) requires login and will return 403. Set ZHIHU_COOKIES=d_c0=...; z_c0=... copied from a logged-in browser.');
+        }
     }
-    // NOTICE: this method is out of date.
-    // Because the API of zhihu.com has changed, we must use the value of `d_c0` (extracted from cookies) to calculate
-    // `x-zse-96`. So first get `d_c0`, then get the actual data of a ZhiHu question. In this way, we don't need to
-    // require users to set the cookie in environmental variables anymore.
 
-    // fisrt: get cookie(dc_0) from zhihu.com
-    const { dc0, zseCk } = await cache.tryGet('zhihu:cookies:d_c0', async () => {
-        if (getCookieValueByKey('d_c0') && getCookieValueByKey('__zse_ck')) {
-            return { dc0: getCookieValueByKey('d_c0'), zseCk: getCookieValueByKey('__zse_ck') };
-        }
-        const response1 = await ofetch.raw('https://static.zhihu.com/zse-ck/v3.js');
-        const script = await response1._data.text();
-        const zseCk = script.match(/__g\.ck\|\|"([\w+/=\\]*)",_=/)?.[1];
-        const response2 = zseCk
-            ? await ofetch.raw(url, {
-                  headers: {
-                      cookie: `${response1.headers
-                          .getSetCookie()
-                          .map((s) => s.split(';', 1)[0])
-                          .join('; ')}; __zse_ck=${zseCk}`,
-                  },
-              })
-            : null;
-
-        const dc0 =
-            (response2 || response1).headers
-                .getSetCookie()
-                .find((s) => s.startsWith('d_c0='))
-                ?.split(';', 1)[0]
-                .trim()
-                .slice('d_c0='.length) || '';
-
-        return { dc0, zseCk };
-    });
-
-    // calculate x-zse-96, refer to https://github.com/srx-2000/spider_collection/issues/18
+    // Sign with the same `d_c0` that is sent, otherwise the backend rejects the
+    // request. Refer to https://github.com/srx-2000/spider_collection/issues/18
+    const dc0 = getCookieValueFrom(cookieStr, 'd_c0');
     const xzse93 = '101_3_3.0';
     const f = `${xzse93}+${apiPath}+${dc0}`;
     const xzse96 = '2.0_' + g_encrypt(md5(f));
 
-    const zc0 = getCookieValueByKey('z_c0');
-
     return {
-        cookie: `__zse_ck=${zseCk}; d_c0=${dc0}${zc0 ? `;z_c0=${zc0}` : ''}`,
+        cookie: cookieStr,
         'x-zse-96': xzse96,
         'x-app-za': 'OS=Web',
         'x-zse-93': xzse93,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #20402

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

<!-- This PR changes shared zhihu helpers/routes (lib/routes/zhihu/*), not adding a route. It cannot be exercised in CI without Zhihu cookies, hence NOROUTE. -->

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Two related fixes for Zhihu's tightened anti-crawler:

**1. Generate `__zse_ck` with JSDOM.** The previous v3 static value no longer works. The implementation now obtains a `d_c0`, requests Zhihu's v4 challenge with a consistent user-agent, executes the dynamically discovered challenge script in JSDOM, and captures the generated `__zse_ck` from `document.cookie`. The matching `d_c0`, `__zse_ck`, and user-agent are cached together, with the cache scoped by a configured `d_c0`; concurrent cache misses are coalesced.

Most content (column items, answers, activities) also requires the `z_c0` login cookie. Recommended config: `ZHIHU_COOKIES=d_c0=...; z_c0=...` (omit `__zse_ck` so it is refreshed automatically). Other configured cookies are preserved only when they belong to the same configured `d_c0` session. A fully pinned `d_c0` + `__zse_ck` pair is still honored for backward compatibility.

**2. `/zhihu/posts` via the members API.** The route no longer scrapes the user's HTML homepage for profile data. Both people and org profiles/articles now use `/api/v4/members/:id`, because the old `/api/v4/org/:id` endpoints return 404.

Verification:

- `oxlint`, ESLint, and formatting checks pass for the changed files.
- Node and Worker builds both pass.
- End-to-end smoke-tested in an isolated process on the production host with a real logged-in session: `/zhihu/posts/people/matianfu` and `/zhihu/posts/org/huo-rong-an-quan-shi-yan-shi` both returned `200 application/xml` with RSS content.

Supersedes #21321 and covers #22425.
