### PR TITLE
feat: add zaihua news route

### DIFF
--- a/lib/routes/zaihua/index.ts
+++ b/lib/routes/zaihua/index.ts
@@ -21,6 +21,13 @@ type NewsArticleJsonLd = Record<string, unknown> & {
     dateModified?: string;
 };
 
+type Video = {
+    src: string;
+    poster?: string;
+    width?: string;
+    height?: string;
+};
+
 export const route: Route = {
     path: '/',
     categories: ['new-media'],
@@ -45,7 +52,7 @@ export const route: Route = {
     maintainers: ['Circloud'],
     handler,
     url: 'www.zaihua.news',
-    description: '在花新闻的全文内容，包含文章图片。',
+    description: '在花新闻的全文内容，包含文章图片和视频。',
     view: ViewType.Articles,
 };
 
@@ -77,8 +84,10 @@ const fetchArticle = (item: Item & { link: string }) =>
         cleanupContent($, content);
 
         const imageUrls = extractImageUrls($);
+        const videos = extractVideos($);
         const contentHtml = content.html() ?? item.content ?? item.contentSnippet;
         const imageHtml = renderImages(imageUrls);
+        const videoHtml = renderVideos(videos);
         const pubDate = $('meta[property="article:published_time"]').attr('content') ?? jsonLd?.datePublished ?? item.isoDate ?? item.pubDate;
         const updated = $('meta[property="article:modified_time"]').attr('content') ?? jsonLd?.dateModified;
         const title = jsonLd?.headline || $('article h1').first().text() || item.title || item.link;
@@ -86,7 +95,7 @@ const fetchArticle = (item: Item & { link: string }) =>
         return {
             title,
             link: item.link,
-            description: [contentHtml, imageHtml].filter(Boolean).join(''),
+            description: [contentHtml, imageHtml, videoHtml].filter(Boolean).join(''),
             pubDate: pubDate ? parseDate(pubDate) : undefined,
             updated: updated ? parseDate(updated) : undefined,
             author,
@@ -132,7 +141,63 @@ const extractImageUrls = ($: CheerioAPI) => {
     return [...new Set(galleryImages)];
 };
 
+const extractVideos = ($: CheerioAPI): Video[] => {
+    const videos = $('video[data-feed-video], video[src]')
+        .toArray()
+        .flatMap((element) => {
+            const video = $(element);
+            const src = video.attr('src');
+
+            if (!src) {
+                return [];
+            }
+
+            return [
+                {
+                    src: normalizeUrl(src),
+                    poster: normalizeOptionalUrl(video.attr('poster')),
+                    width: video.attr('width'),
+                    height: video.attr('height'),
+                },
+            ];
+        });
+
+    const seen = new Set<string>();
+
+    return videos.filter((video) => {
+        if (seen.has(video.src)) {
+            return false;
+        }
+
+        seen.add(video.src);
+
+        return true;
+    });
+};
+
 const renderImages = (imageUrls: string[]) => imageUrls.map((src) => `<p><img src="${escapeAttribute(src)}"></p>`).join('');
+
+const renderVideos = (videos: Video[]) =>
+    videos
+        .map((video) => {
+            const attrs = [
+                `src="${escapeAttribute(video.src)}"`,
+                video.poster ? `poster="${escapeAttribute(video.poster)}"` : '',
+                video.width ? `width="${escapeAttribute(video.width)}"` : '',
+                video.height ? `height="${escapeAttribute(video.height)}"` : '',
+                'controls',
+                'preload="metadata"',
+            ]
+                .filter(Boolean)
+                .join(' ');
+
+            return `<p><video ${attrs}></video></p>`;
+        })
+        .join('');
+
+const normalizeUrl = (url: string) => (url.startsWith('/') ? new URL(url, rootUrl).href : url);
+
+const normalizeOptionalUrl = (url?: string) => (url ? normalizeUrl(url) : undefined);
 
 const extractNewsArticleJsonLd = ($: CheerioAPI) =>
     $('script[type="application/ld+json"]')

--- a/lib/routes/zaihua/index.ts
+++ b/lib/routes/zaihua/index.ts
@@ -1,0 +1,171 @@
+import type { Cheerio, CheerioAPI } from 'cheerio';
+import { load } from 'cheerio';
+import type { Element } from 'domhandler';
+import pMap from 'p-map';
+import type { Item } from 'rss-parser';
+
+import type { DataItem, Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.zaihua.news';
+const feedUrl = `${rootUrl}/rss.xml`;
+const author = '在花';
+
+type NewsArticleJsonLd = Record<string, unknown> & {
+    headline?: string;
+    datePublished?: string;
+    dateModified?: string;
+};
+
+export const route: Route = {
+    path: '/',
+    categories: ['new-media'],
+    example: '/zaihua',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.zaihua.news/', 'www.zaihua.news/rss.xml'],
+            target: '',
+        },
+    ],
+    name: '最新',
+    maintainers: ['Circloud'],
+    handler,
+    url: 'www.zaihua.news',
+    description: '在花新闻的全文内容，包含文章图片。',
+    view: ViewType.Articles,
+};
+
+async function handler() {
+    const feedResponse = await ofetch(feedUrl, {
+        parseResponse: (text) => text,
+    });
+    const feed = await parser.parseString(feedResponse);
+    const list = feed.items.filter((item): item is Item & { link: string } => Boolean(item.link));
+    const items = await pMap(list, (item) => fetchArticle(item), { concurrency: 3 });
+
+    return {
+        title: feed.title ?? author,
+        link: rootUrl,
+        feedLink: feedUrl,
+        description: feed.description,
+        item: items,
+        language: 'zh-CN',
+    };
+}
+
+const fetchArticle = (item: Item & { link: string }) =>
+    cache.tryGet(item.link, async (): Promise<DataItem> => {
+        const response = await ofetch(item.link);
+        const $ = load(response);
+        const jsonLd = extractNewsArticleJsonLd($);
+        const content = $('.msg-prose').first();
+
+        cleanupContent($, content);
+
+        const imageUrls = extractImageUrls($);
+        const contentHtml = content.html() ?? item.content ?? item.contentSnippet;
+        const imageHtml = renderImages(imageUrls);
+        const pubDate = $('meta[property="article:published_time"]').attr('content') ?? jsonLd?.datePublished ?? item.isoDate ?? item.pubDate;
+        const updated = $('meta[property="article:modified_time"]').attr('content') ?? jsonLd?.dateModified;
+        const title = jsonLd?.headline || $('article h1').first().text() || item.title || item.link;
+
+        return {
+            title,
+            link: item.link,
+            description: [contentHtml, imageHtml].filter(Boolean).join(''),
+            pubDate: pubDate ? parseDate(pubDate) : undefined,
+            updated: updated ? parseDate(updated) : undefined,
+            author,
+        };
+    });
+
+const cleanupContent = ($: CheerioAPI, content: Cheerio<Element>) => {
+    content.find('script, style').remove();
+    content.find('[class]').removeAttr('class');
+    content.find('[style]').removeAttr('style');
+    content.find('[data-astro-cid]').removeAttr('data-astro-cid');
+
+    content.children('p').each((_, element) => {
+        const paragraph = $(element);
+        const links = new Set(
+            paragraph
+                .find('a')
+                .toArray()
+                .map((link) => $(link).attr('href'))
+        );
+
+        if (links.has('http://t.me/ZaiHuaPd') && links.has('https://t.me/zaihua_news') && links.has('http://t.me/ZaiHuabot')) {
+            paragraph.remove();
+        }
+    });
+
+    content.find('a').each((_, element) => {
+        const link = $(element);
+        const href = link.attr('href');
+
+        if (href?.startsWith('/')) {
+            link.attr('href', new URL(href, rootUrl).href);
+        }
+    });
+};
+
+const extractImageUrls = ($: CheerioAPI) => {
+    const galleryImages = $('[data-lightbox-src]')
+        .toArray()
+        .map((element) => $(element).attr('data-lightbox-src') ?? $(element).find('img').attr('src'))
+        .flatMap((src) => (src ? [src] : []));
+
+    return [...new Set(galleryImages)];
+};
+
+const renderImages = (imageUrls: string[]) => imageUrls.map((src) => `<p><img src="${escapeAttribute(src)}"></p>`).join('');
+
+const extractNewsArticleJsonLd = ($: CheerioAPI) =>
+    $('script[type="application/ld+json"]')
+        .toArray()
+        .flatMap((element) => {
+            try {
+                return collectJsonLdObjects(JSON.parse($(element).text()));
+            } catch {
+                return [];
+            }
+        })
+        .find((item) => isNewsArticle(item));
+
+const collectJsonLdObjects = (value: unknown): NewsArticleJsonLd[] => {
+    if (Array.isArray(value)) {
+        return value.flatMap((item) => collectJsonLdObjects(item));
+    }
+
+    if (!isRecord(value)) {
+        return [];
+    }
+
+    const graph = Array.isArray(value['@graph']) ? value['@graph'].flatMap((item) => collectJsonLdObjects(item)) : [];
+
+    return [value, ...graph] as NewsArticleJsonLd[];
+};
+
+const isNewsArticle = (value: NewsArticleJsonLd) => {
+    const type = value['@type'];
+
+    return type === 'NewsArticle' || (Array.isArray(type) && type.includes('NewsArticle'));
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+const escapeAttribute = (value: string) => value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;');

--- a/lib/routes/zaihua/namespace.ts
+++ b/lib/routes/zaihua/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '在花',
+    url: 'www.zaihua.news',
+    lang: 'zh-CN',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zaihua
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds a full-content route for [zaihua news (在花新闻)](https://www.zaihua.news/).

The route uses the official RSS feed as the item index, then fetches article pages to extract the main article body and real gallery images/videos.

Zaihua news originally posted their content on [Telegram](https://t.me/zaihuapd), and recently I found their website. This route provides an alterative solution to subscribe to this feed bypassing the potential network issue with Telegram route with all content types perserved.