### PR TITLE
fix(route/xueqiu): fix stock_info failure caused by WAF challenge

### DIFF
--- a/lib/routes/xueqiu/cookies.ts
+++ b/lib/routes/xueqiu/cookies.ts
@@ -11,7 +11,8 @@ export const parseToken = (link: string) =>
             const page = await context.newPage();
             await page.route('**/*', (route) => {
                 const request = route.request();
-                request.resourceType() === 'document' ? route.continue() : route.abort();
+                const type = request.resourceType();
+                (type === 'document' || type === 'script') ? route.continue() : route.abort();
             });
             await page.goto(link, {
                 waitUntil: 'domcontentloaded',

--- a/lib/routes/xueqiu/stock-info.ts
+++ b/lib/routes/xueqiu/stock-info.ts
@@ -1,7 +1,7 @@
-import { load } from 'cheerio';
 import queryString from 'query-string';
 import sanitizeHtml from 'sanitize-html';
 
+import InvalidParameterError from '@/errors/types/invalid-parameter';
 import { parseToken } from '@/routes/xueqiu/cookies';
 import type { Route } from '@/types';
 import got from '@/utils/got';
@@ -15,7 +15,7 @@ export const route: Route = {
     features: {
         requireConfig: false,
         requirePuppeteer: false,
-        antiCrawler: false,
+        antiCrawler: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
@@ -29,36 +29,49 @@ export const route: Route = {
     name: '股票信息',
     maintainers: ['YuYang'],
     handler,
-    description: `| 公告         | 新闻 | 研报     |
-| ------------ | ---- | -------- |
-| announcement | news | research |`,
+    description: `| 全部 | 讨论    | 交易  | 资讯 | 公告         |
+| ---- | ------- | ----- | ---- | ------------ |
+| all  | discuss | trans | news | announcement |`,
+};
+
+// The two endpoints below correspond to the tabs on the stock page (xueqiu.com/S/:id).
+// `source` is the API query value; `label` is the human-readable name shown in the feed title.
+// `all` / `discuss` / `trans` are served by the search endpoint; `news` / `announcement`
+// are served by the timeline endpoint (the search endpoint ignores these two sources).
+const typeMap = {
+    all: { source: 'all', label: '全部', endpoint: 'search' },
+    discuss: { source: 'user', label: '讨论', endpoint: 'search' },
+    trans: { source: 'trans', label: '交易', endpoint: 'search' },
+    news: { source: '自选股新闻', label: '资讯', endpoint: 'timeline' },
+    announcement: { source: '公告', label: '公告', endpoint: 'timeline' },
 };
 
 async function handler(ctx) {
     const id = ctx.req.param('id');
     const type = ctx.req.param('type') || 'announcement';
-    const count = 10;
-    const page = 1;
-    const typename = {
-        announcement: '公告',
-        news: '自选股新闻',
-        research: '研报',
-        all: 'all',
-    };
-    const source = typename[type];
+    if (!Object.hasOwn(typeMap, type)) {
+        throw new InvalidParameterError(`Invalid type: ${type}. Supported types: ${Object.keys(typeMap).join(', ')}`);
+    }
+    const { source, label, endpoint } = typeMap[type];
 
     const link = `https://xueqiu.com/S/${id}`;
-    const res1 = await got({
+    const cookie = await parseToken(link);
+
+    // Fetch the stock name from the lightweight quote API (the name is rendered
+    // client-side on the page, so it cannot be scraped from the static HTML)
+    const quoteRes = await got({
         method: 'get',
-        url: link,
+        url: 'https://stock.xueqiu.com/v5/stock/quote.json',
+        searchParams: queryString.stringify({ symbol: id }),
+        headers: {
+            Cookie: cookie,
+            Referer: link,
+        },
     });
+    const stock_name = quoteRes.data.data?.quote?.name || id;
 
-    const token = await parseToken(link);
-    const $ = load(res1.data); // 使用 cheerio 加载返回的 HTML
-    const stock_name = $('.stock-name').text().split('(', 1)[0];
-
-    let query_url = 'https://xueqiu.com/statuses';
-    query_url += source === 'all' ? '/search.json' : '/stock_timeline.json';
+    // Use the api.xueqiu.com domain; the WAF blocks these endpoints on xueqiu.com
+    const query_url = endpoint === 'search' ? 'https://api.xueqiu.com/query/v1/symbol/search/status.json' : 'https://api.xueqiu.com/statuses/stock_timeline.json';
 
     const res2 = await got({
         method: 'get',
@@ -67,23 +80,23 @@ async function handler(ctx) {
             symbol_id: id,
             symbol: id,
             source,
-            count,
-            page,
-            sort: 'alpha',
+            count: 10,
+            page: 1,
+            sort: endpoint === 'search' ? 'time' : 'alpha',
             comment: '0',
             hl: '0',
         }),
         headers: {
-            Cookie: token,
+            Cookie: cookie,
             Referer: link,
         },
     });
 
     const data = res2.data.list;
     return {
-        title: `${id} ${stock_name} - ${source}`,
+        title: `${id} ${stock_name} - ${label}`,
         link,
-        description: `${stock_name} - ${source}`,
+        description: `${stock_name} - ${label}`,
         item: data.map((item) => ({
             title: item.title || sanitizeHtml(item.description, { allowedTags: [], allowedAttributes: {} }),
             description: item.description,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

NOROUTE

## Example for the Proposed Route(s) / 路由地址示例

```routes
/xueqiu/stock_info/SH600519
/xueqiu/stock_info/SH600519/all
/xueqiu/stock_info/SH600519/discuss
/xueqiu/stock_info/SH600519/trans
/xueqiu/stock_info/SH600519/news
/xueqiu/stock_info/SH600519/announcement
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This is a bug-fix for the existing `/xueqiu/stock_info` route, which was broken by Alibaba Cloud WAF.

本 PR 修复已有的 `/xueqiu/stock_info` 路由，此前因阿里云 WAF 拦截而失效。

**What was broken / 问题**

- Cookie acquisition could not pass the WAF challenge.
- The data request hit `xueqiu.com`, which the WAF blocks for these endpoints (returns a challenge page instead of JSON), so the route threw and returned 503.
- Cookie 获取无法通过 WAF challenge；数据请求走的是 `xueqiu.com`，该域名下这些接口会被 WAF 拦截（返回 challenge 页而非 JSON），导致路由报错 503。

**What this PR does / 改动**

- `cookies.ts`: allow the `script` resource type in the `page.route` filter so the WAF challenge scripts can execute, enabling cookie extraction via Patchright. / 放行 `script` 资源类型，使 WAF challenge 脚本可执行，从而能正确取到 cookie。
- `stock-info.ts`: request data from `api.xueqiu.com` instead of `xueqiu.com` to bypass the WAF. / 数据请求改用 `api.xueqiu.com` 域名以绕过 WAF。
- `stock-info.ts`: align the supported types with the tabs on the stock page — `all` / `discuss` / `trans` / `news` / `announcement`. `all` / `discuss` / `trans` use the symbol search endpoint; `news` / `announcement` use the stock timeline endpoint. The previously broken `research` type (its data source no longer exists upstream) is removed. / 将支持的类型与个股页面的标签页对齐；移除上游已无数据源的 `research` 类型。
- `stock-info.ts`: fetch the stock name from the lightweight quote API, since it is rendered client-side and cannot be scraped from the static HTML. / 股票名称改用轻量的 quote 接口获取（页面为客户端渲染，静态 HTML 抓不到）。
- `stock-info.ts`: throw `InvalidParameterError` for unsupported types. / 不支持的类型抛出 `InvalidParameterError`。

All five types were verified end-to-end against multiple stocks (SH600519 / SZ000002 / SZ300750) and return real data. / 五种类型均已对多只股票端到端验证，返回真实数据。
