### PR TITLE
fix(route): zjut design

### DIFF
--- a/lib/routes/zjut/da/index.ts
+++ b/lib/routes/zjut/da/index.ts
@@ -1,22 +1,28 @@
-import { load } from 'cheerio';
-import iconv from 'iconv-lite';
-
-import type { Route } from '@/types';
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 
-const rootUrl = 'http://www.design.zjut.edu.cn/';
-const host = 'http://www.design.zjut.edu.cn/BigClass.jsp?';
+const rootUrl = 'http://www.design.zjut.edu.cn';
+const apiUrl = `${rootUrl}/jsp/api/an`;
 
 const map = new Map([
-    [1, { id: 'bigclassid=16', title: '学院新闻 - 浙工大设建学院' }],
-    [2, { id: 'bigclassid=18', title: '公告通知 - 浙工大设建学院' }],
-    [3, { id: 'bigclassid=5&sid=25', title: '科研申报 - 浙工大设建学院' }],
-    [4, { id: 'bigclassid=5&sid=26', title: '科研成果 - 浙工大设建学院' }],
-    [5, { id: 'bigclassid=5&sid=27', title: '文件与资源 - 浙工大设建学院' }],
-    [6, { id: 'bigclassid=20', title: '学术交流 - 浙工大设建学院' }],
+    [1, { id: '16', title: '学院新闻 - 浙工大设建学院' }],
+    [2, { id: '18', title: '公告通知 - 浙工大设建学院' }],
+    [3, { id: '25', title: '科研申报 - 浙工大设建学院' }],
+    [4, { id: '26', title: '科研成果 - 浙工大设建学院' }],
+    [5, { id: '27', title: '文件与资源 - 浙工大设建学院' }],
+    [6, { id: '20', title: '学术交流 - 浙工大设建学院' }],
 ]);
+
+type Article = {
+    id: string;
+    title: string;
+    content?: string | null;
+    date?: string;
+    url?: string | null;
+};
 
 export const route: Route = {
     path: '/da/:type',
@@ -42,52 +48,56 @@ export const route: Route = {
 
 async function handler(ctx) {
     const type = Number.parseInt(ctx.req.param('type'));
-    const id = map.get(type)?.id;
-    const listResponse = await got(`${host}${id}`, {
-        responseType: 'buffer',
+    const category = map.get(type);
+    if (!category) {
+        throw new InvalidParameterError(`Invalid type: ${type}`);
+    }
+
+    const listResponse = await got(`${apiUrl}/column`, {
+        searchParams: {
+            id: category.id,
+        },
     });
-    listResponse.data = iconv.decode(listResponse.data, 'gbk');
-    const $ = load(listResponse.data);
 
-    const list = $("td[class='newstd'] .news2")
-        .toArray()
-        .map((item) => {
-            item = $(item);
-            const title = item.find('a').text();
-
-            let link = item.find('a').attr('href');
-            if (!link) {
-                return null;
-            }
-            if (!link.startsWith('http')) {
-                link = rootUrl + link;
-            }
-
-            const date = item.next().text().replace('[', '').replace(']', '');
-
-            return {
-                title,
-                description: '',
-                pubDate: parseDate(date),
-                link,
-            };
-        });
+    const list = listResponse.data.data.pages.list as Article[];
 
     const items = await Promise.all(
         list.map((item) =>
-            cache.tryGet(item.link, async () => {
-                const itemsResponse = await got(item.link);
-                const $ = load(itemsResponse.data);
-                item.description = $('div[style="line-height:27px;"]').html();
+            cache.tryGet(item.url?.trim() || `${apiUrl}/news?id=${item.id}`, async (): Promise<DataItem> => {
+                const link = item.url?.trim() || `${apiUrl}/news?id=${item.id}`;
+                if (item.url?.trim()) {
+                    return {
+                        title: item.title,
+                        description: item.content ? makeAbsolute(item.content) : `<a href="${link}" target="_blank" rel="noopener noreferrer">${link}</a>`,
+                        pubDate: item.date ? parseDate(item.date) : undefined,
+                        link,
+                    };
+                }
 
-                return item;
+                const detailResponse = await got(`${apiUrl}/news`, {
+                    searchParams: {
+                        id: item.id,
+                    },
+                });
+                const detail = detailResponse.data.data as Article;
+
+                return {
+                    title: detail.title,
+                    description: makeAbsolute(detail.content ?? item.content ?? ''),
+                    pubDate: detail.date ? parseDate(detail.date) : undefined,
+                    link,
+                };
             })
         )
     );
 
     return {
-        title: map.get(type)?.title,
-        link: `${host}${id}`,
+        title: category.title,
+        link: rootUrl,
         item: items,
     };
+}
+
+function makeAbsolute(html: string) {
+    return html.replaceAll(/(href|src)="(upload\/[^"]+)"/g, (_, attr: string, url: string) => `${attr}="${rootUrl}/${url}"`);
 }

--- a/lib/routes/zjut/da/index.ts
+++ b/lib/routes/zjut/da/index.ts
@@ -63,9 +63,9 @@ async function handler(ctx) {
 
     const items = await Promise.all(
         list.map((item) =>
-            cache.tryGet(item.url?.trim() || `${apiUrl}/news?id=${item.id}`, async (): Promise<DataItem> => {
-                const link = item.url?.trim() || `${apiUrl}/news?id=${item.id}`;
-                if (item.url?.trim()) {
+            cache.tryGet(item.url || `${apiUrl}/news?id=${item.id}`, async (): Promise<DataItem> => {
+                const link = item.url || `${apiUrl}/news?id=${item.id}`;
+                if (item.url) {
                     return {
                         title: item.title,
                         description: item.content ? makeAbsolute(item.content) : `<a href="${link}" target="_blank" rel="noopener noreferrer">${link}</a>`,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zjut/da/1
/zjut/da/2
/zjut/da/3
/zjut/da/4
/zjut/da/5
/zjut/da/6
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fixes the ZJUT Design and Architecture route after the old `BigClass.jsp` upstream started returning 404. The route keeps the existing `/zjut/da/1..6` public category parameters and maps them to the current `www.design.zjut.edu.cn` JSON API.

Validation:

- `pnpm exec oxfmt lib/routes/zjut/da/index.ts --check`
- `pnpm exec oxlint --type-aware lib/routes/zjut/da/index.ts`
- `pnpm exec eslint --cache --concurrency auto lib/routes/zjut/da/index.ts`
- `pnpm run build:routes`
- local RSSHub smoke test: `/zjut/da/1`, `/zjut/da/1..6`, and `/zjut/news/5414` return 200
