### PR TITLE
feat(route/xueqiu): fetch user timeline via API without browser

### DIFF
--- a/lib/routes/xueqiu/user.ts
+++ b/lib/routes/xueqiu/user.ts
@@ -3,10 +3,11 @@ import sanitizeHtml from 'sanitize-html';
 import { parseToken } from '@/routes/xueqiu/cookies';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
-import playwright from '@/utils/playwright';
 
 const rootUrl = 'https://xueqiu.com';
+const apiUrl = 'https://api.xueqiu.com';
 
 export const route: Route = {
     path: '/user/:id/:type?',
@@ -15,8 +16,8 @@ export const route: Route = {
     parameters: { id: '用户 id, 可在用户主页 URL 中找到', type: '动态的类型, 不填则默认全部' },
     features: {
         requireConfig: false,
-        requirePuppeteer: true,
-        antiCrawler: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
@@ -35,9 +36,59 @@ export const route: Route = {
 | 0      | 2    | 4    | 9    | 11   |`,
 };
 
+const stripHtml = (html: string): string => sanitizeHtml(html, { allowedTags: [], allowedAttributes: {} });
+
+// Build a feed item from the timeline list data alone (no detail request).
+const buildListItem = (item: any) => ({
+    title: item.title || stripHtml(item.description || ''),
+    description: item.description || '',
+    pubDate: parseDate(item.created_at),
+    link: rootUrl + item.target,
+});
+
+const buildTitle = (item: any, detail: any): string => {
+    if (item.title) {
+        return item.title;
+    }
+    return stripHtml(item.text || item.description || detail.text || '');
+};
+
+const buildDescription = (detail: any): string => {
+    let text = detail.text ?? detail.description;
+    const images = detail.image_info_list ?? [];
+    for (const img of images) {
+        if (img?.filename) {
+            text += `<br><img src="https://xqimg.imedao.com/${img.filename}">`;
+        }
+    }
+    if (detail.retweeted_status) {
+        text += `<blockquote>${detail.retweeted_status.user.screen_name}:&nbsp;${detail.retweeted_status.text}</blockquote>`;
+    }
+    return text;
+};
+
+const extractProfileImage = (user: any): string | undefined => {
+    if (!user?.profile_image_url || !user?.photo_domain) {
+        return undefined;
+    }
+
+    const imageUrls = user.profile_image_url.split(',').filter(Boolean);
+    if (imageUrls.length === 0) {
+        return undefined;
+    }
+
+    // Priority order for image sizes
+    const sizePriority = ['!180x180.png', '!50x50.png', '!30x30.png'];
+    const selectedImageUrl = sizePriority.map((size) => imageUrls.find((url) => url.includes(size))).find(Boolean) || imageUrls[0];
+    const baseDomain = user.photo_domain.startsWith('//') ? `https:${user.photo_domain}` : user.photo_domain;
+
+    return `${baseDomain}${selectedImageUrl}`;
+};
+
 async function handler(ctx) {
     const id = ctx.req.param('id');
     const type = ctx.req.param('type') || 10;
+    const source = type === '11' ? '买卖' : '';
     const typename = {
         10: '全部',
         0: '原发布',
@@ -48,119 +99,62 @@ async function handler(ctx) {
     };
 
     const link = `${rootUrl}/u/${id}`;
-    const token = await parseToken(link);
+    const cookie = await parseToken(link);
 
-    const context = await playwright();
-    try {
-        const mainPage = await context.newPage();
-
-        await mainPage.setExtraHTTPHeaders({
-            Cookie: token as string,
+    const response = await ofetch(`${apiUrl}/v4/statuses/user_timeline.json`, {
+        query: {
+            user_id: id,
+            type,
+            source,
+        },
+        headers: {
+            Cookie: cookie,
             Referer: link,
-        });
+        },
+    });
 
-        await mainPage.goto(link, {
-            waitUntil: 'domcontentloaded',
-        });
-        await mainPage.waitForFunction(() => document.readyState === 'complete');
+    const data = response.statuses.filter((s) => s.mark !== 1); // 去除置顶动态
 
-        const apiUrl = `${rootUrl}/v4/statuses/user_timeline.json?user_id=${id}&type=${type}`;
-        const response = await mainPage.evaluate(async (url) => {
-            const response = await fetch(url);
-            return response.json();
-        }, apiUrl);
+    const items = await Promise.all(
+        data.map((item) =>
+            cache.tryGet(item.target, async () => {
+                // legal_user_visible 为 true 时列表已含完整内容，无需再请求详情
+                if (item.legal_user_visible) {
+                    return buildListItem(item);
+                }
 
-        if (!response?.statuses) {
-            throw new Error('获取用户动态数据失败');
-        }
+                try {
+                    const detail = await ofetch(`${apiUrl}/statuses/show.json`, {
+                        query: {
+                            id: item.id,
+                        },
+                        headers: {
+                            Cookie: cookie,
+                            Referer: link,
+                        },
+                    });
 
-        const data = response.statuses.filter((s) => s.mark !== 1);
+                    return {
+                        title: buildTitle(item, detail),
+                        description: buildDescription(detail),
+                        pubDate: parseDate(item.created_at),
+                        link: rootUrl + item.target,
+                    };
+                } catch {
+                    return buildListItem(item);
+                }
+            })
+        )
+    );
 
-        if (!data.length) {
-            throw new Error('未找到有效的动态数据');
-        }
+    const user = data[0]?.user;
 
-        const items = await Promise.all(
-            data.map((item) =>
-                cache.tryGet(item.target, async () => {
-                    const detailUrl = rootUrl + item.target;
-                    try {
-                        await mainPage.goto(detailUrl, {
-                            waitUntil: 'domcontentloaded',
-                        });
-                        await mainPage.waitForFunction(() => document.readyState === 'complete');
-
-                        const content = await mainPage.evaluate(() => {
-                            const articleContent = document.querySelector('.article__bd')?.innerHTML || '';
-                            const statusMatch = document.documentElement.innerHTML.match(/SNOWMAN_STATUS = (.*?\});/);
-                            return {
-                                articleContent,
-                                statusData: statusMatch ? statusMatch[1] : null,
-                            };
-                        });
-
-                        if (content.statusData) {
-                            const data = JSON.parse(content.statusData);
-                            item.text = data.text;
-                        }
-
-                        const retweetedStatus = item.retweeted_status ? `<blockquote>${item.retweeted_status.user.screen_name}:&nbsp;${item.retweeted_status.description}</blockquote>` : '';
-                        const description = content.articleContent || item.description + retweetedStatus;
-
-                        return {
-                            title: item.title || sanitizeHtml(description, { allowedTags: [], allowedAttributes: {} }),
-                            description: item.text ? item.text + retweetedStatus : description,
-                            pubDate: parseDate(item.created_at),
-                            link: rootUrl + item.target,
-                        };
-                    } catch (error: unknown) {
-                        if (error instanceof Error && !error.message?.includes('ERR_ABORTED')) {
-                            throw error;
-                        }
-                        const retweetedStatus = item.retweeted_status ? `<blockquote>${item.retweeted_status.user.screen_name}:&nbsp;${item.retweeted_status.description}</blockquote>` : '';
-                        const description = item.description + retweetedStatus;
-
-                        return {
-                            title: item.title || sanitizeHtml(description, { allowedTags: [], allowedAttributes: {} }),
-                            description: item.description,
-                            pubDate: parseDate(item.created_at),
-                            link: rootUrl + item.target,
-                        };
-                    }
-                })
-            )
-        );
-
-        const extractProfileImage = (user: any): string | undefined => {
-            if (!user?.profile_image_url || !user?.photo_domain) {
-                return undefined;
-            }
-
-            const imageUrls = user.profile_image_url.split(',').filter(Boolean);
-            if (imageUrls.length === 0) {
-                return undefined;
-            }
-
-            // Priority order for image sizes
-            const sizePriority = ['!180x180.png', '!50x50.png', '!30x30.png'];
-
-            const selectedImageUrl = sizePriority.map((size) => imageUrls.find((url) => url.includes(size))).find(Boolean) || imageUrls[0];
-
-            const baseDomain = user.photo_domain.startsWith('//') ? `https:${user.photo_domain}` : user.photo_domain;
-
-            return `${baseDomain}${selectedImageUrl}`;
-        };
-
-        const profileImage = extractProfileImage(data[0].user);
-
-        return {
-            title: `${data[0].user.screen_name} 的雪球${typename[type]}动态`,
-            link,
-            description: `${data[0].user.screen_name} 的雪球${typename[type]}动态`,
-            image: profileImage,
-            item: items,
-        };
-    } finally {
-        await context.close();
-    }
+    return {
+        title: `${user?.screen_name ?? id} 的雪球${typename[type]}动态`,
+        link,
+        description: `${user?.screen_name ?? id} 的雪球${typename[type]}动态`,
+        image: extractProfileImage(user),
+        item: items,
+        allowEmpty: true,
+    };
 }


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

NOROUTE

## Example for the Proposed Route(s) / 路由地址示例

```routes
/xueqiu/user/8152922548
/xueqiu/user/8152922548/0
/xueqiu/user/8152922548/2
/xueqiu/user/8152922548/4
/xueqiu/user/8152922548/9
/xueqiu/user/8152922548/11
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Refactor of the existing `/xueqiu/user/:id/:type?` route.

The route previously drove a headless browser (Patchright) to load the profile page and navigate to each status for its full text. The user timeline is public, so once the WAF challenge cookie is obtained (via the existing `parseToken`), the data can be fetched directly from `api.xueqiu.com` — no browser navigation needed.

重构已有的 `/xueqiu/user/:id/:type?` 路由。原实现用无头浏览器（Patchright）打开主页、逐条跳转抓全文；用户动态是公开数据，拿到 WAF challenge cookie 后可直接请求 `api.xueqiu.com`，无需浏览器逐页导航。

**Changes / 改动**

- Replace browser navigation with direct `ofetch` calls to `v4/statuses/user_timeline.json` and `statuses/show.json`. / 用直接的 API 请求替代浏览器导航。
- `requirePuppeteer: false` (no longer drives a browser); `antiCrawler: true` (Xueqiu is behind Alibaba Cloud WAF). / 不再驱动浏览器，标志相应修正。
- Pass `source=买卖` for the 交易 (type `11`) tab so it filters correctly; without it the API returns the full timeline. / 交易（type 11）需传 `source=买卖` 才能正确过滤。
- Skip the `show.json` detail request when `legal_user_visible` is true (the list already contains full content). / 列表已含完整内容时跳过详情请求。
- Inline images and the retweeted status into the description; derive `screen_name` and the avatar from the timeline response. / 图片与转发内容内联进正文，用户名和头像取自列表响应。

Verified end-to-end against multiple users and all types; full text, images, retweets and the avatar are returned. / 已对多个用户和全部类型端到端验证，全文、图片、转发、头像均正常。
