### PR TITLE
route: add 中国地质大学（北京）

### DIFF
--- a/lib/routes/cugb/jwc.ts
+++ b/lib/routes/cugb/jwc.ts
@@ -1,0 +1,78 @@
+import { load } from 'cheerio';
+
+import type { Data, DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+const rootUrl = 'https://jwc.cugb.edu.cn';
+
+const channels: Record<string, string> = {
+    xszq: '学生专区',
+};
+
+export const route: Route = {
+    path: '/jwc/:channel?',
+    categories: ['university'],
+    example: '/cugb/jwc/xszq',
+    parameters: { channel: '栏目，默认为 `xszq` 学生专区' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['jwc.cugb.edu.cn/:channel'],
+            target: '/jwc/:channel',
+        },
+    ],
+    name: '教务处',
+    maintainers: ['syncmeta'],
+    handler,
+};
+
+async function handler(ctx): Promise<Data> {
+    const channel = ctx.req.param('channel') ?? 'xszq';
+    const limit = ctx.req.query('limit') ? Number(ctx.req.query('limit')) : 20;
+    const listUrl = `${rootUrl}/${channel}/`;
+
+    const { data: response } = await got(listUrl);
+    const $ = load(response);
+
+    const list: DataItem[] = $('li a')
+        .toArray()
+        .map((el) => {
+            const item = $(el);
+            const title = item.find('.list_con_main').text().trim();
+            return {
+                title,
+                link: new URL(item.attr('href') as string, rootUrl).href,
+                pubDate: timezone(parseDate(item.find('.list_con_time').text().trim()), 8),
+            };
+        })
+        .filter((item) => item.title)
+        .slice(0, limit);
+
+    const items = (await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link as string, async () => {
+                const { data: detailResponse } = await got(item.link as string);
+                const content = load(detailResponse);
+                item.description = content('div.detail_content_box').html() ?? '';
+                return item;
+            })
+        )
+    )) as DataItem[];
+
+    return {
+        title: `中国地质大学（北京）教务处 - ${channels[channel] ?? channel}`,
+        link: listUrl,
+        item: items,
+        language: 'zh-CN',
+    };
+}

--- a/lib/routes/cugb/namespace.ts
+++ b/lib/routes/cugb/namespace.ts
@@ -1,0 +1,13 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'China University of Geosciences (Beijing)',
+    url: 'cugb.edu.cn',
+    categories: ['university'],
+    description: '',
+    lang: 'zh-CN',
+
+    zh: {
+        name: '中国地质大学（北京）',
+    },
+};

--- a/lib/routes/cugb/news.ts
+++ b/lib/routes/cugb/news.ts
@@ -1,0 +1,83 @@
+import { load } from 'cheerio';
+
+import type { Data, DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+const rootUrl = 'https://www.cugb.edu.cn';
+
+const channels: Record<string, string> = {
+    bdxw: '北地新闻',
+};
+
+export const route: Route = {
+    path: '/news/:channel?',
+    categories: ['university'],
+    example: '/cugb/news/bdxw',
+    parameters: { channel: '栏目，默认为 `bdxw` 北地新闻' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.cugb.edu.cn/:channel.jhtml'],
+            target: '/news/:channel',
+        },
+    ],
+    name: '校园新闻',
+    maintainers: ['syncmeta'],
+    handler,
+};
+
+async function handler(ctx): Promise<Data> {
+    const channel = ctx.req.param('channel') ?? 'bdxw';
+    const limit = ctx.req.query('limit') ? Number(ctx.req.query('limit')) : 20;
+    const listUrl = `${rootUrl}/${channel}.jhtml`;
+
+    const { data: response } = await got(listUrl);
+    const $ = load(response);
+
+    const list: DataItem[] = $('li a.con')
+        .toArray()
+        .slice(0, limit)
+        .map((el) => {
+            const item = $(el);
+            const [date, author] = item
+                .find('span')
+                .text()
+                .trim()
+                .split('|')
+                .map((s) => s.trim());
+            return {
+                title: item.find('h3.tit').text().trim(),
+                link: new URL(item.attr('href') as string, rootUrl).href,
+                pubDate: timezone(parseDate(date), 8),
+                author,
+            };
+        });
+
+    const items = (await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link as string, async () => {
+                const { data: detailResponse } = await got(item.link as string);
+                const content = load(detailResponse);
+                item.description = content('div.postbody').html() ?? '';
+                return item;
+            })
+        )
+    )) as DataItem[];
+
+    return {
+        title: `中国地质大学（北京） - ${channels[channel] ?? channel}`,
+        link: listUrl,
+        item: items,
+        language: 'zh-CN',
+    };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

None

## Example for the Proposed Route(s) / 路由地址示例

```routes
/cugb/news/bdxw
/cugb/jwc/xszq
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

中国地质大学（北京），命名空间 `cugb`，分类 `university`。

- `/cugb/news/:channel?` 默认 `bdxw`（北地新闻），解析 `www.cugb.edu.cn`，抓取文章页全文（`div.postbody`）
- `/cugb/jwc/:channel?` 默认 `xszq`（学生专区），解析 `jwc.cugb.edu.cn`，全文 `div.detail_content_box`
- 已配置 radar；本地 `pnpm dev` 实测两条路由 200 且含全文，ESLint 与 tsc 通过
