### PR TITLE
feat(route): add Truth Social user timeline

### DIFF
--- a/lib/routes/truthsocial/namespace.ts
+++ b/lib/routes/truthsocial/namespace.ts
@@ -1,0 +1,12 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Truth Social',
+    url: 'truthsocial.com',
+    description: `Truth Social is a Mastodon-based social network. Public posts of prominent accounts (e.g. \`realDonaldTrump\`) are readable without authentication.
+
+::: warning
+Truth Social sits behind Cloudflare and aggressively blocks data-center IPs. Self-hosted instances on cloud servers may receive \`403\`. Running from a residential IP or via a proxy is recommended.
+:::`,
+    lang: 'en',
+};

--- a/lib/routes/truthsocial/user.ts
+++ b/lib/routes/truthsocial/user.ts
@@ -57,17 +57,31 @@ async function handler(ctx: Context): Promise<Data> {
         });
 
         logger.http(`Requesting ${ORIGIN}/@${username}`);
-        await page.goto(`${ORIGIN}/@${username}`, { waitUntil: 'domcontentloaded' });
+        // `networkidle` gives Cloudflare's challenge JS time to run and set the
+        // clearance cookie before we touch the API.
+        await page.goto(`${ORIGIN}/@${username}`, { waitUntil: 'networkidle' });
 
         // Inside the page context, same-origin fetch carries the Cloudflare cookie.
-        const apiFetch = (url: string) =>
-            page.evaluate(async (u) => {
-                const res = await fetch(u, { headers: { accept: 'application/json' }, credentials: 'include' });
-                if (!res.ok) {
-                    throw new Error(`HTTP ${res.status}`);
-                }
-                return res.json();
-            }, url);
+        // A fresh challenge can take a moment to clear, so retry on 403/503.
+        const apiFetch = (url: string): Promise<any> =>
+            page.evaluate(
+                async ({ u, retries }) => {
+                    for (let i = 0; i <= retries; i++) {
+                        // eslint-disable-next-line no-await-in-loop
+                        const res = await fetch(u, { headers: { accept: 'application/json' }, credentials: 'include' });
+                        if (res.ok) {
+                            return res.json();
+                        }
+                        if ((res.status === 403 || res.status === 503) && i < retries) {
+                            // eslint-disable-next-line no-await-in-loop
+                            await new Promise((resolve) => setTimeout(resolve, 3000));
+                            continue;
+                        }
+                        throw new Error(`HTTP ${res.status}`);
+                    }
+                },
+                { u: url, retries: 3 }
+            );
 
         account = await cache.tryGet(`truthsocial:account:${username}`, () => apiFetch(`${API_BASE}/v1/accounts/lookup?acct=${encodeURIComponent(username)}`));
 
@@ -86,7 +100,7 @@ async function handler(ctx: Context): Promise<Data> {
             const media = (source.media_attachments ?? [])
                 .map((m) => {
                     if (m.type === 'image') {
-                        return `<img src="${m.url}" referrerpolicy="no-referrer">`;
+                        return `<img src="${m.url}">`;
                     }
                     if (m.type === 'video' || m.type === 'gifv') {
                         return `<video src="${m.url}" controls poster="${m.preview_url ?? ''}"></video>`;

--- a/lib/routes/truthsocial/user.ts
+++ b/lib/routes/truthsocial/user.ts
@@ -1,0 +1,131 @@
+import type { Context } from 'hono';
+
+import type { Data, DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import logger from '@/utils/logger';
+import { parseDate } from '@/utils/parse-date';
+import playwright from '@/utils/playwright';
+
+const ORIGIN = 'https://truthsocial.com';
+const API_BASE = `${ORIGIN}/api`;
+
+export const route: Route = {
+    path: '/user/:username/:routeParams?',
+    categories: ['social-media'],
+    example: '/truthsocial/user/realDonaldTrump',
+    parameters: {
+        username: 'Truth Social handle, without the leading `@`',
+        routeParams: 'Extra params: `replies=1` include replies, `reblogs=0` exclude re-Truths',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: true,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['truthsocial.com/@:username'],
+            target: '/user/:username',
+        },
+    ],
+    name: 'User Timeline',
+    maintainers: ['syncmeta'],
+    handler,
+};
+
+async function handler(ctx: Context): Promise<Data> {
+    const { username } = ctx.req.param();
+    const routeParams = new URLSearchParams(ctx.req.param('routeParams'));
+    const includeReplies = routeParams.get('replies') === '1';
+    const includeReblogs = routeParams.get('reblogs') !== '0';
+    const limit = Number(ctx.req.query('limit') ?? '20');
+
+    // Truth Social sits behind Cloudflare, which fingerprints TLS/JA3 and blocks
+    // plain HTTP clients. A real (stealth) browser session clears the challenge,
+    // gets the cf cookie, then does same-origin fetches against the JSON API.
+    const context = await playwright();
+    let account;
+    let statuses;
+    try {
+        const page = await context.newPage();
+        await page.route('**/*', (route) => {
+            // Only HTML/XHR are needed to clear Cloudflare; drop heavy assets.
+            ['image', 'media', 'font', 'stylesheet'].includes(route.request().resourceType()) ? route.abort() : route.continue();
+        });
+
+        logger.http(`Requesting ${ORIGIN}/@${username}`);
+        await page.goto(`${ORIGIN}/@${username}`, { waitUntil: 'domcontentloaded' });
+
+        // Inside the page context, same-origin fetch carries the Cloudflare cookie.
+        const apiFetch = (url: string) =>
+            page.evaluate(async (u) => {
+                const res = await fetch(u, { headers: { accept: 'application/json' }, credentials: 'include' });
+                if (!res.ok) {
+                    throw new Error(`HTTP ${res.status}`);
+                }
+                return res.json();
+            }, url);
+
+        account = await cache.tryGet(`truthsocial:account:${username}`, () => apiFetch(`${API_BASE}/v1/accounts/lookup?acct=${encodeURIComponent(username)}`));
+
+        const params = new URLSearchParams({ exclude_replies: String(!includeReplies), limit: String(limit) });
+        statuses = await apiFetch(`${API_BASE}/v1/accounts/${account.id}/statuses?${params}`);
+    } finally {
+        await context.close();
+    }
+
+    const items: DataItem[] = (statuses as any[])
+        .filter((status) => includeReblogs || !status.reblog)
+        .map((status) => {
+            const source = status.reblog ?? status;
+            const isReblog = Boolean(status.reblog);
+
+            const media = (source.media_attachments ?? [])
+                .map((m) => {
+                    if (m.type === 'image') {
+                        return `<img src="${m.url}" referrerpolicy="no-referrer">`;
+                    }
+                    if (m.type === 'video' || m.type === 'gifv') {
+                        return `<video src="${m.url}" controls poster="${m.preview_url ?? ''}"></video>`;
+                    }
+                    return '';
+                })
+                .join('');
+
+            let description = source.content || '';
+            if (source.card) {
+                description += `<br><a href="${source.card.url}">${source.card.title || source.card.url}</a>`;
+            }
+            description += media;
+
+            return {
+                title: `${isReblog ? `Re-Truth @${source.account?.username}: ` : ''}${textTitle(source.content)}`,
+                description,
+                link: source.url || status.url,
+                guid: status.uri || status.url,
+                pubDate: parseDate(status.created_at),
+                author: `@${source.account?.username ?? username}`,
+                category: source.tags?.map((t: { name: string }) => t.name),
+            };
+        });
+
+    return {
+        title: `${account.display_name || account.username} (@${account.username}) - Truth Social`,
+        link: account.url || `${ORIGIN}/@${username}`,
+        description: account.note,
+        image: account.avatar,
+        item: items,
+        allowEmpty: true,
+    };
+}
+
+function textTitle(html: string): string {
+    const text = (html || '')
+        .replaceAll(/<[^>]+>/g, ' ')
+        .replaceAll(/\s+/g, ' ')
+        .trim();
+    return text.length > 100 ? `${text.slice(0, 100)}…` : text || '(no text)';
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #17546

## Example for the Proposed Route(s) / 路由地址示例

```routes
/truthsocial/user/realDonaldTrump
/truthsocial/user/realDonaldTrump/replies=1
/truthsocial/user/realDonaldTrump/reblogs=0
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

Adds a Truth Social user-timeline route, e.g. `/truthsocial/user/realDonaldTrump`.

**Why Puppeteer / anti-bot handling:** Truth Social is a Mastodon-based network sitting behind Cloudflare, which fingerprints TLS/JA3 and blocks plain HTTP clients (verified: direct `got`/`curl` requests with full browser headers return `403`). The route therefore uses the stealth browser (`@/utils/playwright`) to clear the Cloudflare challenge and obtain the clearance cookie, then performs **same-origin `fetch`** from within the page context against Truth Social's Mastodon-compatible JSON API:

- `GET /api/v1/accounts/lookup?acct=<handle>` → resolve handle to account id (cached for a day)
- `GET /api/v1/accounts/<id>/statuses` → fetch the timeline

Public profiles/posts of prominent accounts (e.g. `realDonaldTrump`) are readable without authentication.

**Route params:** `replies=1` includes replies, `reblogs=0` excludes re-Truths; `?limit=` controls count. Images/videos in `media_attachments`, link cards, and re-Truths (`reblog`) are rendered in the item body.

**Caveat:** even with a real browser, Cloudflare may still block requests from data-center IPs; self-hosted instances may need a residential proxy.

Tested locally against `/truthsocial/user/realDonaldTrump` → `HTTP 200`, 20 items with correct titles, links, and pubDates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)