### PR TITLE
fix(route/makerworld): bypass Cloudflare challenge and adapt to new API shape

### DIFF
--- a/lib/routes/makerworld/contest.ts
+++ b/lib/routes/makerworld/contest.ts
@@ -1,9 +1,7 @@
-import { config } from '@/config';
 import type { Route } from '@/types';
-import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
-import { baseUrl, getNextBuildId } from './utils';
+import { baseUrl, fetchJson, getNextBuildId } from './utils';
 
 export const route: Route = {
     path: '/contests',
@@ -21,11 +19,7 @@ export const route: Route = {
 
 async function handler() {
     const nextBuildId = await getNextBuildId();
-    const response = await ofetch(`${baseUrl}/_next/data/${nextBuildId}/en/contests.json`, {
-        headers: {
-            'User-Agent': config.trueUA,
-        },
-    });
+    const response = await fetchJson(`${baseUrl}/_next/data/${nextBuildId}/en/contests.json`);
     const { listConst, previewList } = response.pageProps;
 
     const items = [

--- a/lib/routes/makerworld/trending.ts
+++ b/lib/routes/makerworld/trending.ts
@@ -1,9 +1,7 @@
-import { config } from '@/config';
 import type { Route } from '@/types';
-import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
-import { baseUrl, getNextBuildId } from './utils';
+import { baseUrl, fetchJson, getNextBuildId } from './utils';
 
 export const route: Route = {
     path: '/trending',
@@ -21,20 +19,17 @@ export const route: Route = {
 
 async function handler() {
     const nextBuildId = await getNextBuildId();
-    const response = await ofetch(`${baseUrl}/_next/data/${nextBuildId}/en.json`, {
-        headers: {
-            'User-Agent': config.trueUA,
-        },
-    });
+    const response = await fetchJson(`${baseUrl}/_next/data/${nextBuildId}/en.json`);
 
-    const items = response.pageProps.popularDesignsData.map((d) => ({
-        title: d.title,
-        link: `${baseUrl}/en/models/${d.id}-${d.slug}`,
-        author: d.designCreator.name,
-        category: d.tags,
-        pubDate: parseDate(d.startTime),
-        description: d.designExtension.design_pictures.map((i) => `<figure><img src="${i.url}" alt="${d.name}"><figcaption>${i.name}</figcaption></figure>`).join(''),
-    }));
+    const items = response.pageProps.v2Props.foryouData.hits
+        .filter((hit) => hit.design?.title)
+        .map(({ design: d }) => ({
+            title: d.title,
+            link: `${baseUrl}/en/models/${d.id}-${d.slug}`,
+            author: d.designCreator.name,
+            pubDate: parseDate(d.createTime),
+            description: d.designExtension.design_pictures.map((i) => `<figure><img src="${i.url}" alt="${d.title}"><figcaption>${i.name}</figcaption></figure>`).join(''),
+        }));
 
     return {
         title: 'Trending Models - MakerWorld',

--- a/lib/routes/makerworld/user-upload.ts
+++ b/lib/routes/makerworld/user-upload.ts
@@ -1,9 +1,7 @@
-import { config } from '@/config';
 import type { Route } from '@/types';
-import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
-import { baseUrl, getNextBuildId } from './utils';
+import { baseUrl, fetchJson, getNextBuildId } from './utils';
 
 export const route: Route = {
     path: '/user/:handle/upload',
@@ -26,14 +24,7 @@ async function handler(ctx) {
     const { handle } = ctx.req.param();
 
     const nextBuildId = await getNextBuildId();
-    const response = await ofetch(`${baseUrl}/_next/data/${nextBuildId}/en/${handle}/upload.json`, {
-        headers: {
-            'User-Agent': config.trueUA,
-        },
-        query: {
-            handle,
-        },
-    });
+    const response = await fetchJson(`${baseUrl}/_next/data/${nextBuildId}/en/${handle}/upload.json`, { handle });
     const { userInfo, designs } = response.pageProps;
 
     const items = designs.map((d) => ({

--- a/lib/routes/makerworld/utils.ts
+++ b/lib/routes/makerworld/utils.ts
@@ -3,16 +3,64 @@ import { load } from 'cheerio';
 import { config } from '@/config';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
+import { getPlaywrightPage } from '@/utils/playwright';
 
 export const baseUrl = 'https://makerworld.com';
 
-export const getNextBuildId = () =>
-    cache.tryGet('makerworld:nextBuildId', async () => {
-        const response = await ofetch(`${baseUrl}/en`, {
+const isForbidden = (error: unknown) => {
+    const status = (error as { status?: number; statusCode?: number })?.status ?? (error as { status?: number; statusCode?: number })?.statusCode;
+    return status === 403;
+};
+
+const fetchViaBrowser = async (url: string, type: 'html' | 'json' = 'html') => {
+    const { page, destroy } = await getPlaywrightPage(url, {
+        onBeforeLoad: async (page) => {
+            const expectResourceTypes = new Set(['document', 'script', 'xhr', 'fetch']);
+            await page.route('**/*', (route) => {
+                const request = route.request();
+                expectResourceTypes.has(request.resourceType()) ? route.continue() : route.abort();
+            });
+        },
+    });
+    try {
+        return (await page.evaluate(type === 'html' ? () => document.documentElement.innerHTML : () => document.documentElement.textContent)) ?? '';
+    } finally {
+        await destroy();
+    }
+};
+
+export const fetchJson = async (url: string, query?: Record<string, string>) => {
+    const finalUrl = query ? `${url}?${new URLSearchParams(query).toString()}` : url;
+    try {
+        return await ofetch(finalUrl, {
             headers: {
                 'User-Agent': config.trueUA,
             },
         });
+    } catch (error) {
+        if (!isForbidden(error)) {
+            throw error;
+        }
+        const jsonStr = await fetchViaBrowser(finalUrl, 'json');
+        return JSON.parse(jsonStr);
+    }
+};
+
+export const getNextBuildId = () =>
+    cache.tryGet('makerworld:nextBuildId', async () => {
+        let response: string;
+        try {
+            response = await ofetch(`${baseUrl}/en`, {
+                headers: {
+                    'User-Agent': config.trueUA,
+                },
+            });
+        } catch (error) {
+            if (!isForbidden(error)) {
+                throw error;
+            }
+            response = await fetchViaBrowser(`${baseUrl}/en`);
+        }
         const $ = load(response);
         const nextData = JSON.parse($('script#__NEXT_DATA__').text());
         return nextData.buildId;

--- a/lib/routes/makerworld/utils.ts
+++ b/lib/routes/makerworld/utils.ts
@@ -1,17 +1,13 @@
 import { load } from 'cheerio';
 
-import { config } from '@/config';
 import cache from '@/utils/cache';
-import ofetch from '@/utils/ofetch';
 import { getPlaywrightPage } from '@/utils/playwright';
 
 export const baseUrl = 'https://makerworld.com';
 
-const isForbidden = (error: unknown) => {
-    const status = (error as { status?: number; statusCode?: number })?.status ?? (error as { status?: number; statusCode?: number })?.statusCode;
-    return status === 403;
-};
-
+// makerworld.com sits behind a Cloudflare bot-management challenge that fingerprints the
+// TLS/HTTP client itself rather than just headers, so a plain fetch always gets a 403 no
+// matter what headers are sent. A real (stealth-patched) browser is required to pass it.
 const fetchViaBrowser = async (url: string, type: 'html' | 'json' = 'html') => {
     const { page, destroy } = await getPlaywrightPage(url, {
         onBeforeLoad: async (page) => {
@@ -31,36 +27,12 @@ const fetchViaBrowser = async (url: string, type: 'html' | 'json' = 'html') => {
 
 export const fetchJson = async (url: string, query?: Record<string, string>) => {
     const finalUrl = query ? `${url}?${new URLSearchParams(query).toString()}` : url;
-    try {
-        return await ofetch(finalUrl, {
-            headers: {
-                'User-Agent': config.trueUA,
-            },
-        });
-    } catch (error) {
-        if (!isForbidden(error)) {
-            throw error;
-        }
-        const jsonStr = await fetchViaBrowser(finalUrl, 'json');
-        return JSON.parse(jsonStr);
-    }
+    return JSON.parse(await fetchViaBrowser(finalUrl, 'json'));
 };
 
 export const getNextBuildId = () =>
     cache.tryGet('makerworld:nextBuildId', async () => {
-        let response: string;
-        try {
-            response = await ofetch(`${baseUrl}/en`, {
-                headers: {
-                    'User-Agent': config.trueUA,
-                },
-            });
-        } catch (error) {
-            if (!isForbidden(error)) {
-                throw error;
-            }
-            response = await fetchViaBrowser(`${baseUrl}/en`);
-        }
+        const response = await fetchViaBrowser(`${baseUrl}/en`);
         const $ = load(response);
         const nextData = JSON.parse($('script#__NEXT_DATA__').text());
         return nextData.buildId;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/makerworld/trending
/makerworld/contests
/makerworld/user/@Wcad00/upload
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

makerworld.com is now behind a Cloudflare bot-management challenge (`cf-mitigated: challenge`) that fingerprints the TLS/HTTP client itself, not just headers — a plain `ofetch`/`curl` request can get a 403 even with a browser-like `User-Agent`. `lib/routes/makerworld/utils.ts` now falls back to a stealth Playwright page load (`getPlaywrightPage`) whenever the direct fetch returns 403, for both the build-id lookup and the `_next/data/*.json` calls used by all three routes.

Separately, the trending page's API response shape changed: designs moved from `pageProps.popularDesignsData` to `pageProps.v2Props.foryouData.hits[].design` (mixed in with non-design promo/community-post entries), `startTime` was renamed to `createTime`, and `tags` is no longer present on that endpoint's design objects. `lib/routes/makerworld/trending.ts` is updated to match. `contest.ts` and `user-upload.ts` were checked against live responses and did not need shape changes, only the shared Cloudflare-bypass fetch helper.