### PR TITLE
feat(route): add Hugging Face Spaces search

### DIFF
--- a/lib/routes/huggingface/spaces.ts
+++ b/lib/routes/huggingface/spaces.ts
@@ -1,0 +1,93 @@
+import type { DataItem, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+interface SpaceCardData {
+    emoji?: string;
+    license?: string;
+    sdk?: string;
+    title?: string;
+}
+
+interface SpaceItem {
+    id: string;
+    author?: string;
+    cardData?: SpaceCardData;
+    createdAt?: string;
+    lastModified?: string;
+    likes?: number;
+    private?: boolean;
+    sdk?: string;
+    tags?: string[];
+}
+
+export const route: Route = {
+    path: '/spaces/:query',
+    categories: ['programming'],
+    example: '/huggingface/spaces/rag',
+    parameters: {
+        query: 'Search keyword',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['huggingface.co/spaces'],
+        },
+    ],
+    name: 'Spaces Search',
+    maintainers: ['JaggerH'],
+    handler,
+    url: 'huggingface.co/spaces',
+};
+
+async function handler(ctx) {
+    const { query } = ctx.req.param();
+    const link = `https://huggingface.co/spaces?search=${encodeURIComponent(query)}`;
+    const searchParams = new URLSearchParams({
+        search: query,
+        sort: 'createdAt',
+        direction: '-1',
+        limit: '25',
+        full: 'true',
+    });
+
+    const spaces = await ofetch<SpaceItem[]>(`https://huggingface.co/api/spaces?${searchParams.toString()}`);
+
+    const items: DataItem[] = spaces.map((space) => {
+        const itemLink = `https://huggingface.co/spaces/${space.id}`;
+        const title = space.cardData?.title || space.id;
+        const tags = space.tags ?? [];
+        const sdk = space.cardData?.sdk || space.sdk;
+        const metadata = [
+            space.author ? `Author: ${space.author}` : undefined,
+            sdk ? `SDK: ${sdk}` : undefined,
+            typeof space.likes === 'number' ? `Likes: ${space.likes}` : undefined,
+            space.lastModified ? `Last modified: ${space.lastModified}` : undefined,
+            space.cardData?.license ? `License: ${space.cardData.license}` : undefined,
+            tags.length ? `Tags: ${tags.join(', ')}` : undefined,
+        ].filter(Boolean);
+
+        return {
+            title: space.cardData?.emoji ? `${space.cardData.emoji} ${title}` : title,
+            link: itemLink,
+            description: metadata.join('<br>'),
+            author: space.author,
+            category: tags,
+            pubDate: space.createdAt ? parseDate(space.createdAt) : undefined,
+            updated: space.lastModified ? parseDate(space.lastModified) : undefined,
+        };
+    });
+
+    return {
+        title: `Huggingface Spaces Search: ${query}`,
+        link,
+        item: items,
+    };
+}

--- a/lib/routes/huggingface/spaces.ts
+++ b/lib/routes/huggingface/spaces.ts
@@ -1,3 +1,4 @@
+import InvalidParameterError from '@/errors/types/invalid-parameter';
 import type { DataItem, Route } from '@/types';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
@@ -6,7 +7,16 @@ interface SpaceCardData {
     emoji?: string;
     license?: string;
     sdk?: string;
+    short_description?: string;
     title?: string;
+}
+
+interface SpaceRuntime {
+    hardware?: {
+        current?: string | null;
+        requested?: string | null;
+    };
+    stage?: string;
 }
 
 interface SpaceItem {
@@ -17,16 +27,44 @@ interface SpaceItem {
     lastModified?: string;
     likes?: number;
     private?: boolean;
+    runtime?: SpaceRuntime;
     sdk?: string;
+    shortDescription?: string;
     tags?: string[];
 }
 
+const apiLimit = '100';
+const sdkOptions = ['all', 'gradio', 'streamlit', 'docker', 'static'];
+const hardwareOptions = ['all', 'cpu', 'gpu'];
+const runningOptions = ['all', 'running'];
+const sortOptions = ['createdAt', 'likes', 'trendingScore'];
+
 export const route: Route = {
-    path: '/spaces/:query',
+    path: '/spaces/:query/:sdk?/:hardware?/:running?/:sort?',
     categories: ['programming'],
-    example: '/huggingface/spaces/rag',
+    example: '/huggingface/spaces/Whisper/gradio',
     parameters: {
         query: 'Search keyword',
+        sdk: {
+            description: 'SDK filter',
+            options: sdkOptions.map((value) => ({ value, label: value })),
+            default: 'all',
+        },
+        hardware: {
+            description: 'Hardware filter',
+            options: hardwareOptions.map((value) => ({ value, label: value })),
+            default: 'all',
+        },
+        running: {
+            description: 'Runtime filter',
+            options: runningOptions.map((value) => ({ value, label: value })),
+            default: 'all',
+        },
+        sort: {
+            description: 'Sort order',
+            options: sortOptions.map((value) => ({ value, label: value })),
+            default: 'createdAt',
+        },
     },
     features: {
         requireConfig: false,
@@ -48,46 +86,99 @@ export const route: Route = {
 };
 
 async function handler(ctx) {
-    const { query } = ctx.req.param();
-    const link = `https://huggingface.co/spaces?search=${encodeURIComponent(query)}`;
+    const { query, sdk = 'all', hardware = 'all', running = 'all', sort = 'createdAt' } = ctx.req.param();
+    validateParameter('sdk', sdk, sdkOptions);
+    validateParameter('hardware', hardware, hardwareOptions);
+    validateParameter('running', running, runningOptions);
+    validateParameter('sort', sort, sortOptions);
+
+    const pageSearchParams = new URLSearchParams({ search: query });
+    if (sdk !== 'all') {
+        pageSearchParams.set('sdk', sdk);
+    }
+    if (hardware !== 'all') {
+        pageSearchParams.set('hardware', hardware);
+    }
+    if (running === 'running') {
+        pageSearchParams.set('includeNonRunning', 'false');
+    }
+    const link = `https://huggingface.co/spaces?${pageSearchParams.toString()}`;
     const searchParams = new URLSearchParams({
         search: query,
-        sort: 'createdAt',
+        sort,
         direction: '-1',
-        limit: '25',
+        limit: apiLimit,
         full: 'true',
     });
 
     const spaces = await ofetch<SpaceItem[]>(`https://huggingface.co/api/spaces?${searchParams.toString()}`);
 
-    const items: DataItem[] = spaces.map((space) => {
-        const itemLink = `https://huggingface.co/spaces/${space.id}`;
-        const title = space.cardData?.title || space.id;
-        const tags = space.tags ?? [];
-        const sdk = space.cardData?.sdk || space.sdk;
-        const metadata = [
-            space.author ? `Author: ${space.author}` : undefined,
-            sdk ? `SDK: ${sdk}` : undefined,
-            typeof space.likes === 'number' ? `Likes: ${space.likes}` : undefined,
-            space.lastModified ? `Last modified: ${space.lastModified}` : undefined,
-            space.cardData?.license ? `License: ${space.cardData.license}` : undefined,
-            tags.length ? `Tags: ${tags.join(', ')}` : undefined,
-        ].filter(Boolean);
+    const items: DataItem[] = spaces
+        .filter((space) => matchesFilters(space, sdk, hardware, running))
+        .map((space) => {
+            const itemLink = `https://huggingface.co/spaces/${space.id}`;
+            const title = space.cardData?.title || space.id;
+            const tags = space.tags ?? [];
+            const sdk = space.cardData?.sdk || space.sdk;
+            const runtimeHardware = getRuntimeHardware(space);
+            const metadata = [
+                space.cardData?.short_description || space.shortDescription,
+                sdk ? `SDK: ${sdk}` : undefined,
+                runtimeHardware ? `Hardware: ${runtimeHardware}` : undefined,
+                space.runtime?.stage ? `Runtime: ${space.runtime.stage}` : undefined,
+                typeof space.likes === 'number' ? `Likes: ${space.likes}` : undefined,
+                space.cardData?.license ? `License: ${space.cardData.license}` : undefined,
+            ].filter(Boolean);
 
-        return {
-            title: space.cardData?.emoji ? `${space.cardData.emoji} ${title}` : title,
-            link: itemLink,
-            description: metadata.join('<br>'),
-            author: space.author,
-            category: tags,
-            pubDate: space.createdAt ? parseDate(space.createdAt) : undefined,
-            updated: space.lastModified ? parseDate(space.lastModified) : undefined,
-        };
-    });
+            return {
+                title: space.cardData?.emoji ? `${space.cardData.emoji} ${title}` : title,
+                link: itemLink,
+                description: metadata.join('<br>'),
+                author: space.author,
+                category: tags,
+                pubDate: space.createdAt ? parseDate(space.createdAt) : undefined,
+                updated: space.lastModified ? parseDate(space.lastModified) : undefined,
+            };
+        });
 
     return {
         title: `Huggingface Spaces Search: ${query}`,
         link,
         item: items,
     };
+}
+
+function validateParameter(name: string, value: string, options: string[]) {
+    if (!options.includes(value)) {
+        throw new InvalidParameterError(`Invalid ${name}: ${value}. Valid values are: ${options.join(', ')}`);
+    }
+}
+
+function matchesFilters(space: SpaceItem, sdk: string, hardware: string, running: string) {
+    return matchesSdk(space, sdk) && matchesHardware(space, hardware) && matchesRunning(space, running);
+}
+
+function matchesSdk(space: SpaceItem, sdk: string) {
+    return sdk === 'all' || (space.cardData?.sdk || space.sdk) === sdk;
+}
+
+function matchesHardware(space: SpaceItem, hardware: string) {
+    if (hardware === 'all') {
+        return true;
+    }
+
+    const runtimeHardware = getRuntimeHardware(space);
+    if (!runtimeHardware) {
+        return false;
+    }
+
+    return hardware === 'cpu' ? runtimeHardware.startsWith('cpu') : !runtimeHardware.startsWith('cpu');
+}
+
+function matchesRunning(space: SpaceItem, running: string) {
+    return running === 'all' || space.runtime?.stage === 'RUNNING';
+}
+
+function getRuntimeHardware(space: SpaceItem) {
+    return space.runtime?.hardware?.current || space.runtime?.hardware?.requested;
 }


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/huggingface/spaces/Whisper
/huggingface/spaces/Whisper/gradio
/huggingface/spaces/Whisper/gradio/all/all/likes
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds a Hugging Face Spaces search route using the public Spaces API.

Supported path parameters:

- `query`: search keyword
- `sdk`: `all`, `gradio`, `streamlit`, `docker`, `static`
- `hardware`: `all`, `cpu`, `gpu`
- `running`: `all`, `running`
- `sort`: `createdAt`, `likes`, `trendingScore`

Validation performed:

- `pnpm build:routes`
- `pnpm exec oxlint --type-aware lib/routes/huggingface/spaces.ts`
- `pnpm exec oxfmt lib/routes/huggingface/spaces.ts`
- Manual route requests for all routes listed above
