### PR TITLE
fix(route/zhihu): use /members/ API for org posts instead of deprecated /org/

### DIFF
--- a/lib/routes/zhihu/posts.ts
+++ b/lib/routes/zhihu/posts.ts
@@ -59,7 +59,7 @@ async function handler(ctx) {
         return data?.initialState?.entities?.users[id] as Profile;
     });
 
-    const apiPath = `/api/v4/${usertype === 'people' ? 'members' : 'org'}/${id}/articles?${new URLSearchParams({
+    const apiPath = `/api/v4/members/${id}/articles?${new URLSearchParams({
         include:
             'data[*].comment_count,suggest_edit,is_normal,thumbnail_extra_info,thumbnail,can_comment,comment_permission,admin_closed_comment,content,voteup_count,created,updated,upvoted_followees,voting,review_info,reaction_instruction,is_labeled,label_info;data[*].vessay_info;data[*].author.badge[?(type=best_answerer)].topics;data[*].author.vip_info;',
         offset: '0',


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route
- [x] Bug fix

## Note / 说明

### Problem / 问题

`/zhihu/posts/org/:id` returns 503. Root cause: zhihu's `/api/v4/org/:id/articles` endpoint is deprecated, org articles now all use `/api/v4/members/:id/articles`.
`/zhihu/posts/org/:id` 返回 503。根因：zhihu 的 `/api/v4/org/:id/articles` 端点已废弃，现在 org 类型文章统一走 `/api/v4/members/:id/articles`。

`posts.ts` L62 previously branched by usertype:
`posts.ts` L62 原来按 usertype 分叉：

- `people` → `/api/v4/members/...` ✓
- `org` → `/api/v4/org/...` ✗ (returns 404 / 返回 404)

### Fix / 修复

Changed to always use `/api/v4/members/...`.
改为统一 `/api/v4/members/...`。

### Verification / 验证

Requires logged-in zhihu cookies (`z_c0`, `d_c0`, `__zse_ck`):
需要知乎登录后的 cookies（`z_c0`、`d_c0`、`__zse_ck`）：

```bash
ZHIHU_COOKIES='z_c0=<value>; d_c0=<value>; __zse_ck=<value>' npm run dev

# New terminal / 新终端测试
# org route (503 before, 200 after fix) / org 路由（修复前 503，修复后 200）
curl -so /dev/null -w "%{http_code}\n" http://localhost:1200/zhihu/posts/org/huo-rong-an-quan-shi-yan-shi

# people route (always 200, unaffected) / people 路由（始终 200，不受影响）
curl -so /dev/null -w "%{http_code}\n" http://localhost:1200/zhihu/posts/people/frederchen
```

people unaffected, org restored.
people 不受影响，org 恢复。
