### PR TITLE
fix(route/picnob): return full-resolution images for all posts

### DIFF
--- a/lib/routes/picnob/user.ts
+++ b/lib/routes/picnob/user.ts
@@ -73,6 +73,8 @@ async function handler(ctx) {
 
             return {
                 title,
+                // Grid thumbnail is square-cropped (stp=c…a_…s640x640); used only as a fallback if the
+                // detail fetch below fails. On success it's swapped for the post's native-aspect image.
                 description: `<img src="${image.attr('data-src')}"><br>${content}`,
                 link: `${baseUrl}${coverLink}`,
                 guid: coverLink?.split('/', 3)?.[2],
@@ -83,16 +85,17 @@ async function handler(ctx) {
 
     const items = await Promise.all(
         list.map((item) =>
+            // Always fetch the post detail page — the profile grid only exposes square-cropped
+            // thumbnails, and its `.corner` badge (slideOrVideo) is unreliable (single photos and many
+            // videos are never badged), so gating on it left most posts square. Cached per post link.
             cache.tryGet(item.link, async () => {
-                let media = '';
+                const page = await context.newPage();
+                await page.route('**/*', (route) => {
+                    const request = route.request();
+                    request.resourceType() === 'document' ? route.continue() : route.abort();
+                });
 
-                if (item.slideOrVideo) {
-                    const page = await context.newPage();
-                    await page.route('**/*', (route) => {
-                        const request = route.request();
-                        request.resourceType() === 'document' ? route.continue() : route.abort();
-                    });
-
+                try {
                     await page.goto(item.link, {
                         waitUntil: 'domcontentloaded',
                     });
@@ -100,23 +103,48 @@ async function handler(ctx) {
                     const html = await page.content();
                     const $ = load(html);
 
-                    media = $('.slide-item').length
-                        ? $('.slide-item div:first-of-type')
-                              .toArray()
-                              .map((item) => {
-                                  const $item = $(item);
-                                  if ($item.hasClass('video')) {
-                                      return $item.find('video').prop('outerHTML');
-                                  }
-                                  // $item.hasClass('pic')
-                                  $item.find('img').attr('src', $item.find('img').attr('data-src'));
-                                  $item.find('img').removeAttr('data-src');
-                                  return $item.html() || '';
-                              })
-                              .join('')
-                        : $('.view .video').html() || '';
-
-                    item.description = `${media}<br>${item.description}`;
+                    if ($('.slide-item').length) {
+                        // Carousel: prepend every slide's native-aspect image/video (unchanged behaviour).
+                        const media = $('.slide-item div:first-of-type')
+                            .toArray()
+                            .map((slide) => {
+                                const $slide = $(slide);
+                                // Detect video by element presence — the slide wrapper is `.entry-body`, not
+                                // `.video`, so a class check misses it. Emit the native-aspect poster as an <img>
+                                // so downstream image extraction (which only reads <img>) still gets a frame.
+                                const video = $slide.find('video');
+                                if (video.length) {
+                                    const poster = video.attr('poster') || '';
+                                    return (poster ? `<img src="${poster}">` : '') + (video.prop('outerHTML') || '');
+                                }
+                                // image slide
+                                $slide.find('img').attr('src', $slide.find('img').attr('data-src'));
+                                $slide.find('img').removeAttr('data-src');
+                                return $slide.html() || '';
+                            })
+                            .join('');
+                        item.description = `${media}<br>${item.description}`;
+                    } else if ($('.view video').length) {
+                        // Single video: use the native-aspect poster as the leading image, keep the
+                        // <video> element so downstream can still detect it's a video post.
+                        const poster = $('.view video').attr('poster') || '';
+                        const videoHtml = $('.view .video').html() || '';
+                        if (poster) {
+                            item.description = item.description.replace(/<img\b[^>]*>/, `<img src="${poster}">${videoHtml}`);
+                        }
+                    } else if ($('.view img').length) {
+                        // Single photo: swap the square grid thumbnail for the detail page's native-aspect image.
+                        const $img = $('.view img').first();
+                        const full = $img.attr('data-src') || $img.attr('src');
+                        if (full) {
+                            item.description = item.description.replace(/<img\b[^>]*>/, `<img src="${full}">`);
+                        }
+                    }
+                } catch (error) {
+                    // Detail fetch failed — keep the square grid thumbnail fallback rather than dropping the post.
+                    logger.warn(`picnob: failed to fetch post detail ${item.link}: ${error}`);
+                } finally {
+                    await page.close();
                 }
 
                 return item;


### PR DESCRIPTION
### Involved Issue / 涉及的 Issue

N/A

### Example for the Proposed Route(s) / 路由地址示例

```
routes: /picnob/user/nasa
```

### New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
- [x] Bugfix / 修复 Bug
- [ ] New package added / 添加了新的包
- [x] Route tested / 路由已通过测试

### Note / 说明

**Problem.** For most Picnob posts the route returned only the **square-cropped grid thumbnail** (`stp=c…a_…s640x640`) instead of the native-aspect image. The post detail page — which carries the full-resolution, native-aspect media — was fetched **only when the grid marked a post with `.corner`** (`slideOrVideo`). That badge is unreliable: single photos are never badged, and many videos aren't either, so those posts silently fell back to the square thumbnail.

**Fix.** Always fetch the post detail page and extract the native-aspect media:

- **Photo** → `.view img` (`data-src`)
- **Single video** → `.view video[poster]` (leading `<img>`, `<video>` kept for detection)
- **Carousel** → `.slide-item` slides as before, **plus** video slides are now detected by element presence (`$slide.find('video')`) instead of `$slide.hasClass('video')`. The slide wrapper is `.entry-body`, not `.video`, so the old class check missed carousel videos and they fell through to the square thumbnail.

On any detail-fetch failure the original grid thumbnail is kept (wrapped in `try/catch/finally`), so no posts are dropped.

**Cost.** Detail is now fetched for every post (previously only `.corner`-badged posts). Results are memoised per post link via `cache.tryGet`, so steady-state cost is bounded to new posts.

**Verified.** Tested against several accounts on a self-hosted instance — native-aspect coverage went from ~6/12 to **12/12** across photos, single videos, and all-video carousels; the fallback path preserves behaviour when a detail page can't be loaded.
