### PR TITLE
feat(route): add Beijing Haidian District Government routes

### DIFF
--- a/lib/routes/gov/beijing/bjhd/index.ts
+++ b/lib/routes/gov/beijing/bjhd/index.ts
@@ -99,27 +99,28 @@ function parseDocumentWriteArticles(html: string) {
     const seen = new Set<string>();
     const pattern = /document\.write\('<a href="(https?:\/\/(?:zyk\.)?bjhd\.gov\.cn[^"]+\.shtml)"[^>]*>(.*)<\/a>'\)/;
 
-    return html
-        .split('\n')
-        .map((line) => line.match(pattern))
-        .filter((match): match is RegExpMatchArray => Boolean(match))
-        .map((match) => {
-            const link = match[1];
-            if (seen.has(link) || !/\/t20\d{6}_\d+\.shtml/.test(link)) {
-                return;
-            }
-            seen.add(link);
-            const title = stripHtml(match[2]);
-            if (!title) {
-                return;
-            }
-            return {
+    return html.split('\n').flatMap((line) => {
+        const match = line.match(pattern);
+        if (!match) {
+            return [];
+        }
+        const link = match[1];
+        if (seen.has(link) || !/\/t20\d{6}_\d+\.shtml/.test(link)) {
+            return [];
+        }
+        seen.add(link);
+        const title = stripHtml(match[2]);
+        if (!title) {
+            return [];
+        }
+        return [
+            {
                 title,
                 link,
                 pubDate: pubDateFromArticleUrl(link),
-            } as DataItem;
-        })
-        .filter((item): item is DataItem => Boolean(item));
+            },
+        ];
+    });
 }
 
 function parseZcjdList(html: string) {
@@ -175,23 +176,24 @@ function fetchGfxwjItems(html: string, limit: number) {
     return $('ul.yjcgkList li')
         .toArray()
         .slice(0, limit)
-        .map((element) => {
+        .flatMap((element) => {
             const item = $(element);
             const anchor = item.find('a');
             const href = anchor.attr('href');
             const title = anchor.text().trim();
             if (!href || !title) {
-                return;
+                return [];
             }
             const link = new URL(href, `${rootUrl}/zwdt/ygk/gfxwj/`).href;
             const period = item.find('p').contents().first().text().trim();
-            return {
-                title,
-                link,
-                description: period || undefined,
-            } as DataItem;
-        })
-        .filter((item): item is DataItem => Boolean(item));
+            return [
+                {
+                    title,
+                    link,
+                    description: period || undefined,
+                },
+            ];
+        });
 }
 
 async function enrichItems(items: DataItem[], referer: string) {

--- a/lib/routes/gov/beijing/bjhd/index.ts
+++ b/lib/routes/gov/beijing/bjhd/index.ts
@@ -1,8 +1,10 @@
 import { load } from 'cheerio';
+import sanitizeHtml from 'sanitize-html';
 
 import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
+import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 import timezone from '@/utils/timezone';
 
@@ -25,7 +27,7 @@ const categories = {
     },
     ywdt: {
         title: '要闻动态',
-        link: `${rootUrl}/ywdt/`,
+        link: `${apiRootUrl}/ywdt/`,
     },
 } as const;
 
@@ -64,7 +66,7 @@ export const route: Route = {
             target: '/gov/beijing/bjhd/zcjd',
         },
         {
-            source: ['zyk.bjhd.gov.cn/ywdt/'],
+            source: ['www.bjhd.gov.cn/ywdt/'],
             target: '/gov/beijing/bjhd/ywdt',
         },
     ],
@@ -84,6 +86,15 @@ function pubDateFromArticleUrl(url: string) {
     return timezone(parseDate(`${match[1]}-${match[2]}-${match[3]}`, 'YYYY-MM-DD'), 8);
 }
 
+function stripHtml(html: string) {
+    return sanitizeHtml(html, {
+        allowedTags: [],
+        allowedAttributes: {},
+    })
+        .replaceAll(/\s+/g, ' ')
+        .trim();
+}
+
 function parseDocumentWriteArticles(html: string) {
     const items: DataItem[] = [];
     const seen = new Set<string>();
@@ -99,10 +110,7 @@ function parseDocumentWriteArticles(html: string) {
             continue;
         }
         seen.add(link);
-        const title = match[2]
-            .replaceAll(/<[^>]+>/g, '')
-            .replaceAll(/\s+/g, ' ')
-            .trim();
+        const title = stripHtml(match[2]);
         if (!title) {
             continue;
         }
@@ -142,14 +150,7 @@ function parseZcjdList(html: string) {
 }
 
 async function fetchZcmlItems(limit: number) {
-    const { data } = await got(`${apiRootUrl}/sjkf-api/haidian/data/catalog/search`, {
-        headers: getHeaders(`${rootUrl}/zwdt/zcml/`),
-        searchParams: {
-            channelId: '76770,83277',
-            pageNum: 1,
-            pageSize: limit,
-        },
-    }).json<{
+    const data = await ofetch<{
         rows: Array<{
             title: string;
             docPubUrl: string;
@@ -159,7 +160,14 @@ async function fetchZcmlItems(limit: number) {
             yearOfPublish: string;
             serialNumberOfPublish: string;
         }>;
-    }>();
+    }>(`${apiRootUrl}/sjkf-api/haidian/data/catalog/search`, {
+        headers: getHeaders(`${rootUrl}/zwdt/zcml/`),
+        query: {
+            channelId: '76770,83277',
+            pageNum: 1,
+            pageSize: limit,
+        },
+    });
 
     return data.rows.map((item) => {
         const docNumber = item.organCodeName && item.yearOfPublish && item.serialNumberOfPublish ? `${item.organCodeName}〔${item.yearOfPublish}〕${item.serialNumberOfPublish}号` : undefined;

--- a/lib/routes/gov/beijing/bjhd/index.ts
+++ b/lib/routes/gov/beijing/bjhd/index.ts
@@ -1,0 +1,252 @@
+import { load } from 'cheerio';
+
+import type { DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+const rootUrl = 'https://zyk.bjhd.gov.cn';
+const apiRootUrl = 'https://www.bjhd.gov.cn';
+
+const categories = {
+    zcml: {
+        title: '政策文件库',
+        link: `${rootUrl}/zwdt/zcml/`,
+    },
+    gfxwj: {
+        title: '政策文件意见征集',
+        link: `${rootUrl}/zwdt/ygk/gfxwj/`,
+    },
+    zcjd: {
+        title: '政策解读',
+        link: `${rootUrl}/zwdt/zcjd/`,
+    },
+    ywdt: {
+        title: '要闻动态',
+        link: 'https://www.bjhd.gov.cn/ywdt/',
+    },
+} as const;
+
+type Category = keyof typeof categories;
+
+export const route: Route = {
+    path: '/bjhd/:category',
+    categories: ['government'],
+    example: '/gov/beijing/bjhd/zcml',
+    parameters: { category: '栏目，见下表' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['zyk.bjhd.gov.cn/zwdt/zcml/'],
+            target: '/gov/beijing/bjhd/zcml',
+        },
+        {
+            source: ['zyk.bjhd.gov.cn/zwdt/ygk/gfxwj/'],
+            target: '/gov/beijing/bjhd/gfxwj',
+        },
+        {
+            source: ['zyk.bjhd.gov.cn/zwdt/zcjd/'],
+            target: '/gov/beijing/bjhd/zcjd',
+        },
+        {
+            source: ['www.bjhd.gov.cn/ywdt/'],
+            target: '/gov/beijing/bjhd/ywdt',
+        },
+    ],
+    name: '北京市海淀区人民政府',
+    maintainers: ['zll17'],
+    handler,
+    description: `| 政策文件库 | 政策文件意见征集 | 政策解读 | 要闻动态 |
+| ---------- | ---------------- | -------- | -------- |
+| zcml       | gfxwj            | zcjd     | ywdt     |`,
+};
+
+function pubDateFromArticleUrl(url: string) {
+    const match = url.match(/\/t(\d{4})(\d{2})(\d{2})_/);
+    if (!match) {
+        return;
+    }
+    return timezone(parseDate(`${match[1]}-${match[2]}-${match[3]}`, 'YYYY-MM-DD'), 8);
+}
+
+function parseDocumentWriteArticles(html: string) {
+    const items: DataItem[] = [];
+    const seen = new Set<string>();
+    const pattern = /document\.write\('<a href="(https?:\/\/(?:zyk\.)?bjhd\.gov\.cn[^"]+\.shtml)"[^>]*>([\s\S]*?)<\/a>'\)/g;
+
+    for (const match of html.matchAll(pattern)) {
+        const link = match[1];
+        if (seen.has(link) || !/\/t20\d{6}_\d+\.shtml/.test(link)) {
+            continue;
+        }
+        seen.add(link);
+        const title = match[2]
+            .replaceAll(/<[^>]+>/g, '')
+            .replaceAll(/\s+/g, ' ')
+            .trim();
+        if (!title) {
+            continue;
+        }
+        items.push({
+            title,
+            link,
+            pubDate: pubDateFromArticleUrl(link),
+        });
+    }
+
+    return items;
+}
+
+function parseZcjdList(html: string) {
+    const items: DataItem[] = [];
+    const pattern = /document\.write\('<a href="(https:\/\/zyk\.bjhd\.gov\.cn\/zwdt\/zcjd\/[^"]+\.shtml)"[^>]*>(?:<span[^>]*>[^<]*<\/span><i[^>]*><\/i>)?([^<]+)<\/a>'\)[\s\S]*?<span class="date">\[(\d{4}-\d{2}-\d{2})\]<\/span>/g;
+
+    for (const match of html.matchAll(pattern)) {
+        items.push({
+            title: match[2].trim(),
+            link: match[1],
+            pubDate: timezone(parseDate(match[3], 'YYYY-MM-DD'), 8),
+        });
+    }
+
+    return items;
+}
+
+async function fetchZcmlItems(limit: number) {
+    const response = await ofetch<{
+        rows: Array<{
+            title: string;
+            docPubUrl: string;
+            pubDate: string;
+            youxiaoxing: string;
+            organCodeName: string;
+            yearOfPublish: string;
+            serialNumberOfPublish: string;
+        }>;
+    }>(`${apiRootUrl}/sjkf-api/haidian/data/catalog/search`, {
+        query: {
+            channelId: '76770,83277',
+            pageNum: 1,
+            pageSize: limit,
+        },
+    });
+
+    return response.rows.map((item) => {
+        const docNumber = item.organCodeName && item.yearOfPublish && item.serialNumberOfPublish ? `${item.organCodeName}〔${item.yearOfPublish}〕${item.serialNumberOfPublish}号` : undefined;
+
+        return {
+            title: item.title,
+            link: item.docPubUrl,
+            pubDate: timezone(parseDate(item.pubDate), 8),
+            description: docNumber ? `<p>${docNumber}</p><p>${item.youxiaoxing === '1' ? '现行有效' : '失效'}</p>` : undefined,
+        };
+    });
+}
+
+function fetchGfxwjItems(html: string, limit: number) {
+    const $ = load(html);
+    const items: DataItem[] = [];
+
+    $('ul.yjcgkList li').each((_, element) => {
+        if (items.length >= limit) {
+            return false;
+        }
+        const item = $(element);
+        const anchor = item.find('a').first();
+        const href = anchor.attr('href');
+        const title = anchor.text().trim();
+        if (!href || !title) {
+            return;
+        }
+        const link = new URL(href, `${rootUrl}/zwdt/ygk/gfxwj/`).href;
+        const period = item.find('p').first().text().trim();
+        items.push({
+            title,
+            link,
+            description: period || undefined,
+        });
+    });
+
+    return items;
+}
+
+async function enrichItems(items: DataItem[]) {
+    return await Promise.all(
+        items.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const detailResponse = await got(item.link);
+                const $ = load(detailResponse.data);
+
+                const pubDate = $('meta[name="PubDate"]').attr('content');
+                if (pubDate) {
+                    item.pubDate = timezone(parseDate(pubDate), 8);
+                } else if (!item.pubDate) {
+                    item.pubDate = pubDateFromArticleUrl(item.link);
+                }
+
+                item.author = $('meta[name="ContentSource"]').attr('content');
+                item.description = $('#mainText').html() ?? item.description;
+
+                return item;
+            })
+        )
+    );
+}
+
+async function handler(ctx) {
+    const category = ctx.req.param('category') as Category;
+    const config = categories[category];
+
+    if (!config) {
+        throw new Error(`Invalid category: ${category}`);
+    }
+
+    const limit = ctx.req.query('limit') ? Number(ctx.req.query('limit')) : 30;
+
+    let items: DataItem[];
+
+    switch (category) {
+        case 'zcml':
+            items = await fetchZcmlItems(limit);
+            items = await enrichItems(items);
+            break;
+        case 'gfxwj': {
+            const response = await got(config.link);
+            items = fetchGfxwjItems(response.data, limit);
+            items = await enrichItems(items);
+            break;
+        }
+        case 'zcjd': {
+            const response = await got(config.link);
+            items = parseZcjdList(response.data).slice(0, limit);
+            items = await enrichItems(items);
+            break;
+        }
+        case 'ywdt': {
+            const response = await got(config.link);
+            items = parseDocumentWriteArticles(response.data)
+                .filter((item) => item.link.includes('/ywdt/') && !item.link.includes('/ywdt/jdt/'))
+                .toSorted((a, b) => (b.pubDate?.getTime() ?? 0) - (a.pubDate?.getTime() ?? 0))
+                .slice(0, limit);
+            items = await enrichItems(items);
+            break;
+        }
+        default:
+            throw new Error(`Unsupported category: ${category}`);
+    }
+
+    return {
+        title: `北京市海淀区人民政府 - ${config.title}`,
+        link: config.link,
+        item: items,
+    };
+}

--- a/lib/routes/gov/beijing/bjhd/index.ts
+++ b/lib/routes/gov/beijing/bjhd/index.ts
@@ -3,12 +3,12 @@ import { load } from 'cheerio';
 import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
-import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 import timezone from '@/utils/timezone';
 
 const rootUrl = 'https://zyk.bjhd.gov.cn';
 const apiRootUrl = 'https://www.bjhd.gov.cn';
+const refererUrl = 'https://www.beijing.gov.cn/';
 
 const categories = {
     zcml: {
@@ -25,11 +25,17 @@ const categories = {
     },
     ywdt: {
         title: '要闻动态',
-        link: 'https://www.bjhd.gov.cn/ywdt/',
+        link: `${rootUrl}/ywdt/`,
     },
 } as const;
 
 type Category = keyof typeof categories;
+
+function getHeaders(referer = refererUrl) {
+    return {
+        Referer: referer,
+    };
+}
 
 export const route: Route = {
     path: '/bjhd/:category',
@@ -39,7 +45,7 @@ export const route: Route = {
     features: {
         requireConfig: false,
         requirePuppeteer: false,
-        antiCrawler: false,
+        antiCrawler: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
@@ -58,7 +64,7 @@ export const route: Route = {
             target: '/gov/beijing/bjhd/zcjd',
         },
         {
-            source: ['www.bjhd.gov.cn/ywdt/'],
+            source: ['zyk.bjhd.gov.cn/ywdt/'],
             target: '/gov/beijing/bjhd/ywdt',
         },
     ],
@@ -81,9 +87,13 @@ function pubDateFromArticleUrl(url: string) {
 function parseDocumentWriteArticles(html: string) {
     const items: DataItem[] = [];
     const seen = new Set<string>();
-    const pattern = /document\.write\('<a href="(https?:\/\/(?:zyk\.)?bjhd\.gov\.cn[^"]+\.shtml)"[^>]*>([\s\S]*?)<\/a>'\)/g;
+    const pattern = /document\.write\('<a href="(https?:\/\/(?:zyk\.)?bjhd\.gov\.cn[^"]+\.shtml)"[^>]*>(.*)<\/a>'\)/;
 
-    for (const match of html.matchAll(pattern)) {
+    for (const line of html.split('\n')) {
+        const match = line.match(pattern);
+        if (!match) {
+            continue;
+        }
         const link = match[1];
         if (seen.has(link) || !/\/t20\d{6}_\d+\.shtml/.test(link)) {
             continue;
@@ -108,13 +118,23 @@ function parseDocumentWriteArticles(html: string) {
 
 function parseZcjdList(html: string) {
     const items: DataItem[] = [];
-    const pattern = /document\.write\('<a href="(https:\/\/zyk\.bjhd\.gov\.cn\/zwdt\/zcjd\/[^"]+\.shtml)"[^>]*>(?:<span[^>]*>[^<]*<\/span><i[^>]*><\/i>)?([^<]+)<\/a>'\)[\s\S]*?<span class="date">\[(\d{4}-\d{2}-\d{2})\]<\/span>/g;
+    const lines = html.split('\n');
 
-    for (const match of html.matchAll(pattern)) {
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const linkMatch = line.match(/document\.write\('<a href="(https:\/\/zyk\.bjhd\.gov\.cn\/zwdt\/zcjd\/[^"]+\.shtml)"/);
+        if (!linkMatch) {
+            continue;
+        }
+        const titleMatch = line.match(/<\/i>([^<]+)<\/a>/);
+        const dateMatch = lines[i + 1]?.match(/\[(\d{4}-\d{2}-\d{2})\]/);
+        if (!titleMatch) {
+            continue;
+        }
         items.push({
-            title: match[2].trim(),
-            link: match[1],
-            pubDate: timezone(parseDate(match[3], 'YYYY-MM-DD'), 8),
+            title: titleMatch[1].trim(),
+            link: linkMatch[1],
+            pubDate: dateMatch ? timezone(parseDate(dateMatch[1], 'YYYY-MM-DD'), 8) : undefined,
         });
     }
 
@@ -122,7 +142,14 @@ function parseZcjdList(html: string) {
 }
 
 async function fetchZcmlItems(limit: number) {
-    const response = await ofetch<{
+    const { data } = await got(`${apiRootUrl}/sjkf-api/haidian/data/catalog/search`, {
+        headers: getHeaders(`${rootUrl}/zwdt/zcml/`),
+        searchParams: {
+            channelId: '76770,83277',
+            pageNum: 1,
+            pageSize: limit,
+        },
+    }).json<{
         rows: Array<{
             title: string;
             docPubUrl: string;
@@ -132,15 +159,9 @@ async function fetchZcmlItems(limit: number) {
             yearOfPublish: string;
             serialNumberOfPublish: string;
         }>;
-    }>(`${apiRootUrl}/sjkf-api/haidian/data/catalog/search`, {
-        query: {
-            channelId: '76770,83277',
-            pageNum: 1,
-            pageSize: limit,
-        },
-    });
+    }>();
 
-    return response.rows.map((item) => {
+    return data.rows.map((item) => {
         const docNumber = item.organCodeName && item.yearOfPublish && item.serialNumberOfPublish ? `${item.organCodeName}〔${item.yearOfPublish}〕${item.serialNumberOfPublish}号` : undefined;
 
         return {
@@ -179,11 +200,13 @@ function fetchGfxwjItems(html: string, limit: number) {
     return items;
 }
 
-async function enrichItems(items: DataItem[]) {
+async function enrichItems(items: DataItem[], referer: string) {
     return await Promise.all(
         items.map((item) =>
             cache.tryGet(item.link, async () => {
-                const detailResponse = await got(item.link);
+                const detailResponse = await got(item.link, {
+                    headers: getHeaders(referer),
+                });
                 const $ = load(detailResponse.data);
 
                 const pubDate = $('meta[name="PubDate"]').attr('content');
@@ -217,27 +240,33 @@ async function handler(ctx) {
     switch (category) {
         case 'zcml':
             items = await fetchZcmlItems(limit);
-            items = await enrichItems(items);
+            items = await enrichItems(items, config.link);
             break;
         case 'gfxwj': {
-            const response = await got(config.link);
+            const response = await got(config.link, {
+                headers: getHeaders(config.link),
+            });
             items = fetchGfxwjItems(response.data, limit);
-            items = await enrichItems(items);
+            items = await enrichItems(items, config.link);
             break;
         }
         case 'zcjd': {
-            const response = await got(config.link);
+            const response = await got(config.link, {
+                headers: getHeaders(config.link),
+            });
             items = parseZcjdList(response.data).slice(0, limit);
-            items = await enrichItems(items);
+            items = await enrichItems(items, config.link);
             break;
         }
         case 'ywdt': {
-            const response = await got(config.link);
+            const response = await got(config.link, {
+                headers: getHeaders(config.link),
+            });
             items = parseDocumentWriteArticles(response.data)
                 .filter((item) => item.link.includes('/ywdt/') && !item.link.includes('/ywdt/jdt/'))
                 .toSorted((a, b) => (b.pubDate?.getTime() ?? 0) - (a.pubDate?.getTime() ?? 0))
                 .slice(0, limit);
-            items = await enrichItems(items);
+            items = await enrichItems(items, config.link);
             break;
         }
         default:

--- a/lib/routes/gov/beijing/bjhd/index.ts
+++ b/lib/routes/gov/beijing/bjhd/index.ts
@@ -96,57 +96,45 @@ function stripHtml(html: string) {
 }
 
 function parseDocumentWriteArticles(html: string) {
-    const items: DataItem[] = [];
     const seen = new Set<string>();
     const pattern = /document\.write\('<a href="(https?:\/\/(?:zyk\.)?bjhd\.gov\.cn[^"]+\.shtml)"[^>]*>(.*)<\/a>'\)/;
 
-    for (const line of html.split('\n')) {
-        const match = line.match(pattern);
-        if (!match) {
-            continue;
-        }
-        const link = match[1];
-        if (seen.has(link) || !/\/t20\d{6}_\d+\.shtml/.test(link)) {
-            continue;
-        }
-        seen.add(link);
-        const title = stripHtml(match[2]);
-        if (!title) {
-            continue;
-        }
-        items.push({
-            title,
-            link,
-            pubDate: pubDateFromArticleUrl(link),
-        });
-    }
-
-    return items;
+    return html
+        .split('\n')
+        .map((line) => line.match(pattern))
+        .filter((match): match is RegExpMatchArray => Boolean(match))
+        .map((match) => {
+            const link = match[1];
+            if (seen.has(link) || !/\/t20\d{6}_\d+\.shtml/.test(link)) {
+                return;
+            }
+            seen.add(link);
+            const title = stripHtml(match[2]);
+            if (!title) {
+                return;
+            }
+            return {
+                title,
+                link,
+                pubDate: pubDateFromArticleUrl(link),
+            } as DataItem;
+        })
+        .filter((item): item is DataItem => Boolean(item));
 }
 
 function parseZcjdList(html: string) {
-    const items: DataItem[] = [];
-    const lines = html.split('\n');
+    const $ = load(html);
+    const data = JSON.parse($('abbr#json').text() || '[]') as Array<{
+        title: string;
+        time: string;
+        url: string;
+    }>;
 
-    for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        const linkMatch = line.match(/document\.write\('<a href="(https:\/\/zyk\.bjhd\.gov\.cn\/zwdt\/zcjd\/[^"]+\.shtml)"/);
-        if (!linkMatch) {
-            continue;
-        }
-        const titleMatch = line.match(/<\/i>([^<]+)<\/a>/);
-        const dateMatch = lines[i + 1]?.match(/\[(\d{4}-\d{2}-\d{2})\]/);
-        if (!titleMatch) {
-            continue;
-        }
-        items.push({
-            title: titleMatch[1].trim(),
-            link: linkMatch[1],
-            pubDate: dateMatch ? timezone(parseDate(dateMatch[1], 'YYYY-MM-DD'), 8) : undefined,
-        });
-    }
-
-    return items;
+    return data.map((item) => ({
+        title: item.title,
+        link: item.url,
+        pubDate: item.time ? timezone(parseDate(item.time, 'YYYY-MM-DD'), 8) : undefined,
+    }));
 }
 
 async function fetchZcmlItems(limit: number) {
@@ -183,29 +171,27 @@ async function fetchZcmlItems(limit: number) {
 
 function fetchGfxwjItems(html: string, limit: number) {
     const $ = load(html);
-    const items: DataItem[] = [];
 
-    $('ul.yjcgkList li').each((_, element) => {
-        if (items.length >= limit) {
-            return false;
-        }
-        const item = $(element);
-        const anchor = item.find('a').first();
-        const href = anchor.attr('href');
-        const title = anchor.text().trim();
-        if (!href || !title) {
-            return;
-        }
-        const link = new URL(href, `${rootUrl}/zwdt/ygk/gfxwj/`).href;
-        const period = item.find('p').first().text().trim();
-        items.push({
-            title,
-            link,
-            description: period || undefined,
-        });
-    });
-
-    return items;
+    return $('ul.yjcgkList li')
+        .toArray()
+        .slice(0, limit)
+        .map((element) => {
+            const item = $(element);
+            const anchor = item.find('a');
+            const href = anchor.attr('href');
+            const title = anchor.text().trim();
+            if (!href || !title) {
+                return;
+            }
+            const link = new URL(href, `${rootUrl}/zwdt/ygk/gfxwj/`).href;
+            const period = item.find('p').contents().first().text().trim();
+            return {
+                title,
+                link,
+                description: period || undefined,
+            } as DataItem;
+        })
+        .filter((item): item is DataItem => Boolean(item));
 }
 
 async function enrichItems(items: DataItem[], referer: string) {


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/gov/beijing/bjhd/zcml
/gov/beijing/bjhd/gfxwj
/gov/beijing/bjhd/zcjd
/gov/beijing/bjhd/ywdt
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add RSS routes for Beijing Haidian District Government, covering policy document library, policy opinion collection, policy interpretation, and news.
