### PR TITLE
feat(route): add BAAI official website news

### DIFF
--- a/lib/routes/baai/namespace.ts
+++ b/lib/routes/baai/namespace.ts
@@ -2,6 +2,6 @@ import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
     name: '北京智源人工智能研究院',
-    url: 'hub.baai.ac.cn',
+    url: 'baai.ac.cn',
     lang: 'zh-CN',
 };

--- a/lib/routes/baai/news.ts
+++ b/lib/routes/baai/news.ts
@@ -1,0 +1,88 @@
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const siteUrl = 'https://www.baai.ac.cn';
+const apiUrl = `${siteUrl}/api/news`;
+
+export const route: Route = {
+    path: '/news/:category?',
+    categories: ['programming'],
+    example: '/baai/news',
+    parameters: {
+        category: {
+            description: '分类，可选 `news`（新闻）或 `media`（媒体报道），默认返回全部',
+            options: [
+                { value: 'news', label: '新闻' },
+                { value: 'media', label: '媒体报道' },
+            ],
+        },
+    },
+    radar: [
+        {
+            source: ['www.baai.ac.cn/news', 'www.baai.ac.cn/'],
+            target: '/news',
+        },
+    ],
+    name: '智源官网 - 新闻',
+    maintainers: ['lisyer'],
+    url: 'www.baai.ac.cn/news',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    handler,
+};
+
+async function handler(ctx) {
+    const { category } = ctx.req.param();
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 200;
+
+    const data = await ofetch(apiUrl, {
+        query: {
+            size: limit,
+        },
+    });
+
+    let items = data.items ?? [];
+    if (category) {
+        items = items.filter((item) => item.category === category);
+    }
+
+    const feedItems = items
+        .filter((item) => item.is_published !== false)
+        .map((item) => {
+            const image = item.image_url ? new URL(item.image_url, siteUrl).href : undefined;
+            const descriptionParts: string[] = [];
+            if (image) {
+                descriptionParts.push(`<img src="${image}" />`);
+            }
+            if (item.description) {
+                descriptionParts.push(item.description);
+            }
+
+            return {
+                title: item.title,
+                link: item.source_url || `${siteUrl}/news`,
+                description: descriptionParts.join('<br>') || item.title,
+                pubDate: item.published_at ? parseDate(item.published_at) : undefined,
+                category: item.category ? [item.category] : undefined,
+                guid: item.id,
+                image,
+            };
+        });
+
+    const categoryLabel = category === 'media' ? '媒体报道' : category === 'news' ? '新闻' : '新闻';
+
+    return {
+        title: `北京智源人工智能研究院 - ${categoryLabel}`,
+        link: `${siteUrl}/news`,
+        description: '北京智源人工智能研究院官网新闻与媒体报道',
+        language: 'zh-cn',
+        item: feedItems,
+    };
+}


### PR DESCRIPTION
Add /baai/news route for 北京智源人工智能研究院 official news list via https://www.baai.ac.cn/api/news, with optional category filter (news|media).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/baai/news
/baai/news/news
/baai/news/media
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

为北京智源人工智能研究院官网新闻列表新增 RSS 路由。

- 数据源：`https://www.baai.ac.cn/api/news?size=200`（公开 JSON API）
- 路由：`/baai/news`（全部）、`/baai/news/news`、`/baai/news/media`
- 在已有 `baai` 命名空间下扩展（原有 hub 社区路由不受影响）
- 条目链接使用 API 返回的 `source_url`（多为微信公众号原文）
- 支持通用 `limit` 查询参数
- 本地已验证可返回 56 条有效条目
