### PR TITLE
fix(hackernews): improve route docs and parameter naming

### DIFF
--- a/lib/routes/hackernews/index.ts
+++ b/lib/routes/hackernews/index.ts
@@ -7,19 +7,19 @@ import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
-    path: '/:section?/:type?/:user?',
+    path: '/:section?/:type?/:value?',
     categories: ['programming'],
     view: ViewType.Articles,
     example: '/hackernews/threads/comments_list/dang',
     parameters: {
         section: {
-            description: 'Content section, default to `index`',
+            description: 'Content section, default to `index`. Common sections: `index`, `newest`, `ask`, `show`, `jobs`, `over`, `threads`, `submitted`. Any valid HN section (e.g. `best`, `front`, `active`) is also accepted',
         },
         type: {
-            description: 'Link type, default to `sources`',
+            description: 'Content format, default to `sources`. `sources` links to original articles, `comments` fetches full comment threads, `comments_list` shows parent story with single comment',
         },
-        user: {
-            description: 'Set user, only valid in `threads` and `submitted` sections',
+        value: {
+            description: 'For `threads`/`submitted` sections, set user ID. For `over` section, set minimum points threshold (default 100). For other sections, appended as `?id=<value>` (e.g. `value=dang` → `?id=dang`)',
         },
     },
     features: {
@@ -35,23 +35,29 @@ export const route: Route = {
             source: ['news.ycombinator.com/:section', 'news.ycombinator.com/'],
         },
     ],
-    name: 'User',
+    name: 'Stories',
     maintainers: ['nczitzk', 'xie-dongping'],
     handler,
-    description: 'Subscribe to the content of a specific user',
+    description: `Subscribe to Hacker News content by section, user, or minimum points
+
+Examples:
+
+| HN100 | User submitted | User threads | Comments list |
+| ----- | -------------- | ------------ | ------------- |
+| \`/hackernews/over\` | \`/hackernews/submitted/sources/dang\` | \`/hackernews/threads/sources/dang\` | \`/hackernews/threads/comments_list/dang\` |`,
 };
 
 async function handler(ctx) {
     const section = ctx.req.param('section') ?? 'index';
     const type = ctx.req.param('type') ?? 'sources';
-    const user = ctx.req.param('user') ?? '';
+    const value = ctx.req.param('value') ?? '';
 
     const rootUrl = 'https://news.ycombinator.com';
     const sectionUrl = section === 'index' ? '' : `/${section}`;
-    let optUrl = user === '' ? '' : '?id=' + user;
+    let optUrl = value === '' ? '' : '?id=' + value;
 
     if (section === 'over') {
-        optUrl = user === '' ? '?points=100' : '?points=' + user;
+        optUrl = value === '' ? '?points=100' : '?points=' + value;
     }
 
     const currentUrl = `${rootUrl}${sectionUrl}${optUrl}`;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/hackernews/over
/hackernews/submitted/sources/dang
/hackernews/threads/sources/dang
/hackernews/threads/comments_list/dang
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Improved Hacker News route documentation and renamed the optional path parameter from `:user` to `:value` to better reflect its dual use: user ID for `threads` and `submitted` sections, and minimum points threshold for the `over` section.

This updates route metadata and documentation for an existing route. The effective route behavior remains unchanged.

- Update route name from `User` to `Stories`
- Rename the internal optional parameter from `user` to `value`
- Document common sections and accepted content formats
- Clarify the `over` section's minimum-points behavior
- Add concrete usage examples for HN100, submitted stories, user threads, and comment-list output