### PR TITLE
feat(route): add Jornal de Angola news routes

### DIFF
--- a/lib/routes/jornaldeangola/namespace.ts
+++ b/lib/routes/jornaldeangola/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Jornal de Angola',
+    url: 'www.jornaldeangola.ao',
+    lang: 'pt-AO',
+    description: 'Official news site of [Jornal de Angola](https://www.jornaldeangola.ao/).',
+};

--- a/lib/routes/jornaldeangola/noticias.ts
+++ b/lib/routes/jornaldeangola/noticias.ts
@@ -1,0 +1,111 @@
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { Route } from '@/types';
+
+import { categoryLabel, enrichItems, fetchNewsList, MENU_CATEGORIES, resolveCategoryId, siteUrl, slugify } from './utils';
+
+const categoryOptions = Object.entries(MENU_CATEGORIES).map(([value, label]) => ({
+    value,
+    label: `${label} (${value})`,
+}));
+
+export const route: Route = {
+    path: ['/noticias/:category?', '/:category?'],
+    categories: ['traditional-media'],
+    example: '/jornaldeangola/noticias/politica',
+    parameters: {
+        category: {
+            description: 'Category id or slug (see table). Omit for latest news. Special values: `destaque` (featured), `ultima-hora` (breaking). Full article HTML is included by default; append `?fulltext=0` for list-only.',
+            options: [{ value: 'destaque', label: 'Destaque (featured)' }, { value: 'ultima-hora', label: 'Última hora (breaking)' }, ...categoryOptions],
+        },
+    },
+    radar: [
+        {
+            source: ['www.jornaldeangola.ao/noticias/:idCategoria/:categoria', 'www.jornaldeangola.ao/noticias/:idCategoria/:categoria/:idNoticia/:titulo', 'www.jornaldeangola.ao/noticias', 'www.jornaldeangola.ao/'],
+            target: (params) => {
+                if (params.idCategoria) {
+                    return `/noticias/${params.idCategoria}`;
+                }
+                return '/noticias';
+            },
+        },
+    ],
+    name: 'Notícias',
+    maintainers: ['lisyer'],
+    url: 'www.jornaldeangola.ao/noticias',
+    description: `## Categories
+
+| Política     | Regiões     | Sociedade     | Economia     | Cultura     | Desporto     |
+| ------------ | ----------- | ------------- | ------------ | ----------- | ------------ |
+| 1 / politica | 2 / regiões | 3 / sociedade | 4 / economia | 5 / cultura | 6 / desporto |
+
+| Entrevista     | Reportagem     | Opinião     | Mundo      | Gente      | Notícias      |
+| -------------- | -------------- | ----------- | ---------- | ---------- | ------------- |
+| 7 / entrevista | 8 / reportagem | 9 / opinião | 10 / mundo | 11 / gente | 41 / noticias |
+
+Special filters (not category ids):
+
+| Destaque | Última hora | Latest (all) |
+| -------- | ----------- | ------------ |
+| destaque | ultima-hora | *(empty)*    |
+
+Examples:
+
+- Latest: [\`/jornaldeangola/noticias\`](https://rsshub.app/jornaldeangola/noticias)
+- Politics: [\`/jornaldeangola/noticias/1\`](https://rsshub.app/jornaldeangola/noticias/1) or [\`/jornaldeangola/noticias/politica\`](https://rsshub.app/jornaldeangola/noticias/politica)
+- Sport: [\`/jornaldeangola/noticias/desporto\`](https://rsshub.app/jornaldeangola/noticias/desporto)
+- Featured: [\`/jornaldeangola/noticias/destaque\`](https://rsshub.app/jornaldeangola/noticias/destaque)
+- Breaking: [\`/jornaldeangola/noticias/ultima-hora\`](https://rsshub.app/jornaldeangola/noticias/ultima-hora)
+
+Supports \`limit\` query (default 20) and \`fulltext=0\` to skip article body fetch.`,
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    handler,
+};
+
+async function handler(ctx) {
+    const raw = ctx.req.param('category');
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const fulltext = ctx.req.query('fulltext') !== '0';
+
+    let categoryId: number | undefined;
+    let destaque = false;
+    let ultimaHora = false;
+    let label = 'Últimas';
+    let link = `${siteUrl}/noticias`;
+
+    if (raw) {
+        const key = slugify(decodeURIComponent(raw));
+        if (['destaque', 'destaques'].includes(key)) {
+            destaque = true;
+            label = 'Destaque';
+        } else if (['ultima-hora', 'ultimahora', 'ultima_hora'].includes(key)) {
+            ultimaHora = true;
+            label = 'Última hora';
+        } else {
+            categoryId = resolveCategoryId(raw);
+            if (categoryId === undefined) {
+                throw new InvalidParameterError(`Unknown category: ${raw}. Use a category id (e.g. 1) or slug (e.g. politica), or destaque / ultima-hora.`);
+            }
+            label = categoryLabel(categoryId);
+            link = `${siteUrl}/noticias/${categoryId}/${encodeURIComponent(slugify(label))}`;
+        }
+    }
+
+    const list = await fetchNewsList({ categoryId, limit, destaque, ultimaHora });
+    const items = await enrichItems(list, fulltext);
+
+    return {
+        title: `Jornal de Angola - ${label}`,
+        link,
+        description: `Notícias de ${label} — Jornal de Angola`,
+        language: 'pt-ao',
+        image: `${siteUrl}/favicon.ico`,
+        item: items,
+    };
+}

--- a/lib/routes/jornaldeangola/utils.ts
+++ b/lib/routes/jornaldeangola/utils.ts
@@ -1,0 +1,178 @@
+import type { DataItem } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+export const siteUrl = 'https://www.jornaldeangola.ao';
+export const apiRoot = 'https://kiami-ja-back.kiamisoft.ao/cms/api/v1';
+
+/** Main navigation categories (id → Portuguese name). */
+export const MENU_CATEGORIES: Record<number, string> = {
+    1: 'Política',
+    2: 'Regiões',
+    3: 'Sociedade',
+    4: 'Economia',
+    5: 'Cultura',
+    6: 'Desporto',
+    7: 'Entrevista',
+    8: 'Reportagem',
+    9: 'Opinião',
+    10: 'Mundo',
+    11: 'Gente',
+    41: 'Notícias',
+};
+
+const headers = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+    Referer: `${siteUrl}/`,
+};
+
+/** Same rules as the site Angular `slugify` pipe. */
+export function slugify(text: string): string {
+    return text.replaceAll(/[ ,/]/g, (ch) => (ch === ' ' ? '-' : '')).toLowerCase();
+}
+
+/** Accent-insensitive key for matching user-provided slugs like `politica` → Política. */
+export function normalizeKey(text: string): string {
+    return slugify(text).normalize('NFD').replaceAll(/\p{M}/gu, '');
+}
+
+export function resolveCategoryId(input?: string): number | undefined {
+    if (!input) {
+        return undefined;
+    }
+    if (/^\d+$/.test(input)) {
+        return Number(input);
+    }
+    const decoded = decodeURIComponent(input);
+    const needle = normalizeKey(decoded);
+    for (const [id, name] of Object.entries(MENU_CATEGORIES)) {
+        if (normalizeKey(name) === needle || name.toLowerCase() === decoded.toLowerCase() || slugify(name) === slugify(decoded)) {
+            return Number(id);
+        }
+    }
+    return undefined;
+}
+
+export function categoryLabel(id?: number): string {
+    if (id === undefined) {
+        return 'Últimas';
+    }
+    return MENU_CATEGORIES[id] ?? `Categoria ${id}`;
+}
+
+interface ApiListItem {
+    idNoticia: number;
+    titulo: string;
+    introducao?: string;
+    dataNoticia?: string;
+    imagemDeCapa?: string;
+    textoImagemDeCapa?: string;
+    autor?: string;
+    destaque?: boolean;
+    ultimaHora?: boolean;
+    categoriasNoticia?: Array<{ idCategoriaNoticia: number; categoriaNoticia: string }>;
+}
+
+interface ApiDetail extends ApiListItem {
+    noticia?: string;
+    nomeUrl?: string;
+    url?: string;
+}
+
+function articleLink(item: ApiListItem): string {
+    const cat = item.categoriasNoticia?.[0];
+    const catId = cat?.idCategoriaNoticia ?? 41;
+    const catName = cat?.categoriaNoticia ?? MENU_CATEGORIES[catId] ?? 'Notícias';
+    return `${siteUrl}/noticias/${catId}/${encodeURIComponent(slugify(catName))}/${item.idNoticia}/${encodeURIComponent(slugify(item.titulo))}`;
+}
+
+export function toDataItem(item: ApiListItem, description?: string): DataItem {
+    const image = item.imagemDeCapa || undefined;
+    const intro = item.introducao?.trim();
+    const parts: string[] = [];
+    if (image) {
+        parts.push(`<img src="${image}" />`);
+    }
+    if (description) {
+        parts.push(description);
+    } else if (intro) {
+        parts.push(intro);
+    }
+
+    return {
+        title: item.titulo,
+        link: articleLink(item),
+        description: parts.join('<br>') || undefined,
+        pubDate: item.dataNoticia ? timezone(parseDate(item.dataNoticia), 1) : undefined,
+        author: item.autor?.trim() || undefined,
+        category: item.categoriasNoticia?.map((c) => c.categoriaNoticia).filter(Boolean),
+        guid: String(item.idNoticia),
+        image,
+    };
+}
+
+export async function fetchNewsList(options: { categoryId?: number; limit?: number; destaque?: boolean; ultimaHora?: boolean }): Promise<ApiListItem[]> {
+    const { categoryId, limit = 20, destaque, ultimaHora } = options;
+    const body: Record<string, unknown> = {
+        titulo: '',
+        noticia: '',
+        idTipoNoticia: 0,
+        destaque: destaque ?? false,
+        privada: false,
+        ultimaHora: ultimaHora ?? false,
+        premium: false,
+        codIdioma: 'pt',
+        idEmpresa: 1,
+        itensPorPagina: limit,
+        pagina: 1,
+    };
+    if (categoryId !== undefined) {
+        body.idsCategorias = [categoryId];
+    }
+
+    const data = await ofetch(`${apiRoot}/noticias`, {
+        method: 'POST',
+        headers,
+        body,
+    });
+
+    return (data.objecto as ApiListItem[]) ?? [];
+}
+
+export function fetchNewsDetail(id: number): Promise<ApiDetail | null> {
+    return cache.tryGet(`jornaldeangola:detalhe:${id}`, async () => {
+        try {
+            const data = await ofetch(`${apiRoot}/noticias/detalhe/${id}`, { headers });
+            return (data.objecto as ApiDetail) ?? null;
+        } catch {
+            return null;
+        }
+    });
+}
+
+export function enrichItems(list: ApiListItem[], withFullText: boolean): Promise<DataItem[]> {
+    if (!withFullText) {
+        return Promise.resolve(list.map((item) => toDataItem(item)));
+    }
+
+    return Promise.all(
+        list.map(async (item) => {
+            const detail = await fetchNewsDetail(item.idNoticia);
+            if (!detail) {
+                return toDataItem(item);
+            }
+            return toDataItem(
+                {
+                    ...item,
+                    ...detail,
+                    categoriasNoticia: detail.categoriasNoticia?.length ? detail.categoriasNoticia : item.categoriasNoticia,
+                },
+                detail.noticia
+            );
+        })
+    );
+}

--- a/lib/routes/jornaldeangola/utils.ts
+++ b/lib/routes/jornaldeangola/utils.ts
@@ -1,3 +1,4 @@
+import { config } from '@/config';
 import type { DataItem } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
@@ -26,7 +27,7 @@ export const MENU_CATEGORIES: Record<number, string> = {
 const headers = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+    'User-Agent': config.trueUA,
     Referer: `${siteUrl}/`,
 };
 


### PR DESCRIPTION
Add comprehensive RSS routes for [Jornal de Angola](https://www.jornaldeangola.ao/) (Angola official newspaper), powered by its public CMS API.

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/jornaldeangola/noticias
/jornaldeangola/noticias/destaque
/jornaldeangola/noticias/ultima-hora
/jornaldeangola/noticias/1
/jornaldeangola/noticias/2
/jornaldeangola/noticias/3
/jornaldeangola/noticias/4
/jornaldeangola/noticias/5
/jornaldeangola/noticias/6
/jornaldeangola/noticias/7
/jornaldeangola/noticias/8
/jornaldeangola/noticias/9
/jornaldeangola/noticias/10
/jornaldeangola/noticias/11
/jornaldeangola/noticias/41
/jornaldeangola/noticias/politica
/jornaldeangola/noticias/desporto
/jornaldeangola/noticias/economia
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

### Routes

| Route | Description |
| ----- | ----------- |
| `/jornaldeangola/noticias` | Latest news |
| `/jornaldeangola/noticias/:category` | By category id or slug |
| `/jornaldeangola/noticias/destaque` | Featured |
| `/jornaldeangola/noticias/ultima-hora` | Breaking news |
| `/jornaldeangola/:category` | Short alias of the above |

### Categories

| Id | Name |
| -- | ---- |
| 1 | Política |
| 2 | Regiões |
| 3 | Sociedade |
| 4 | Economia |
| 5 | Cultura |
| 6 | Desporto |
| 7 | Entrevista |
| 8 | Reportagem |
| 9 | Opinião |
| 10 | Mundo |
| 11 | Gente |
| 41 | Notícias |

### Implementation

- Frontend is an Angular SPA; data comes from `https://kiami-ja-back.kiamisoft.ao/cms/api/v1/`
- List: `POST /noticias` with filters (`idsCategorias`, `destaque`, `ultimaHora`, …)
- Detail: `GET /noticias/detalhe/:id` for full HTML body
- Article links match the SPA pattern `/noticias/:catId/:catSlug/:id/:titleSlug`
- Default includes full text; `?fulltext=0` for list-only; `?limit=` supported
- Category slugs are accent-insensitive (`politica` → Política)
- Time zone: WAT (UTC+1)
- Locally verified for latest, category id/slug, destaque, ultima-hora, and fulltext