### PR TITLE
feat(route): add CAICT research routes under /caict

### DIFF
--- a/lib/routes/caict/bps.ts
+++ b/lib/routes/caict/bps.ts
@@ -1,0 +1,41 @@
+import type { Route } from '@/types';
+
+import { fetchPage, parseList } from './utils';
+
+export const route: Route = {
+    path: '/bps',
+    categories: ['government'],
+    example: '/caict/bps',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.caict.ac.cn/kxyj/qwfb/bps', 'www.caict.ac.cn/kxyj/qwfb/bps/', 'caict.ac.cn/kxyj/qwfb/bps', 'caict.ac.cn/kxyj/qwfb/bps/'],
+            target: '/bps',
+        },
+    ],
+    name: '白皮书',
+    maintainers: ['lisyer'],
+    url: 'www.caict.ac.cn/kxyj/qwfb/bps/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    // List only: detail pages are often blocked/slow by the site WAF
+    const { $, url } = await fetchPage('/kxyj/qwfb/bps/');
+    const items = parseList($, url, limit);
+
+    return {
+        title: '中国信息通信研究院 - 白皮书',
+        link: url,
+        language: 'zh-cn',
+        item: items,
+    };
+}

--- a/lib/routes/caict/caictgd.ts
+++ b/lib/routes/caict/caictgd.ts
@@ -1,0 +1,41 @@
+import type { Route } from '@/types';
+
+import { fetchPage, parseList } from './utils';
+
+export const route: Route = {
+    path: '/caictgd',
+    categories: ['government'],
+    example: '/caict/caictgd',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.caict.ac.cn/kxyj/caictgd', 'www.caict.ac.cn/kxyj/caictgd/', 'caict.ac.cn/kxyj/caictgd', 'caict.ac.cn/kxyj/caictgd/'],
+            target: '/caictgd',
+        },
+    ],
+    name: 'CAICT 观点',
+    maintainers: ['lisyer'],
+    url: 'www.caict.ac.cn/kxyj/caictgd/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    // Mostly WeChat article links — list metadata is enough
+    const { $, url } = await fetchPage('/kxyj/caictgd/');
+    const items = parseList($, url, limit);
+
+    return {
+        title: '中国信息通信研究院 - CAICT观点',
+        link: url,
+        language: 'zh-cn',
+        item: items,
+    };
+}

--- a/lib/routes/caict/kxyj.ts
+++ b/lib/routes/caict/kxyj.ts
@@ -1,0 +1,51 @@
+import type { Route } from '@/types';
+
+import { fetchPage, parseList } from './utils';
+
+export const route: Route = {
+    path: '/kxyj',
+    categories: ['government'],
+    example: '/caict/kxyj',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.caict.ac.cn/kxyj', 'www.caict.ac.cn/kxyj/', 'caict.ac.cn/kxyj', 'caict.ac.cn/kxyj/'],
+            target: '/kxyj',
+        },
+    ],
+    name: '科研能力',
+    maintainers: ['lisyer'],
+    url: 'www.caict.ac.cn/kxyj/',
+    description: `科研能力栏目首页的动态摘要（含白皮书 / 权威数据 / 观点等混排条目）。
+
+更完整的分类订阅请使用：
+
+| 白皮书                   | 权威数据                   | CAICT 观点                       |
+| ------------------------ | -------------------------- | -------------------------------- |
+| [/caict/bps](/caict/bps) | [/caict/qwsj](/caict/qwsj) | [/caict/caictgd](/caict/caictgd) |
+
+::: warning
+官网导航中的「市场研究报告」(\`/kxyj/qwfb/scbg/\`) 当前返回 404，暂无法提供对应路由。
+:::`,
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const { $, url } = await fetchPage('/kxyj/');
+    const items = parseList($, url, limit);
+
+    return {
+        title: '中国信息通信研究院 - 科研能力',
+        link: url,
+        language: 'zh-cn',
+        item: items,
+    };
+}

--- a/lib/routes/caict/namespace.ts
+++ b/lib/routes/caict/namespace.ts
@@ -1,0 +1,11 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '中国信息通信研究院',
+    url: 'www.caict.ac.cn',
+    categories: ['government'],
+    description: `::: tip
+官方站点存在 WAF，HTTPS 请求常返回 412。本路由使用 \`http://www.caict.ac.cn\` 抓取，并在遇到拦截时自动重试。
+:::`,
+    lang: 'zh-CN',
+};

--- a/lib/routes/caict/qwsj.ts
+++ b/lib/routes/caict/qwsj.ts
@@ -1,0 +1,40 @@
+import type { Route } from '@/types';
+
+import { fetchPage, parseList } from './utils';
+
+export const route: Route = {
+    path: '/qwsj',
+    categories: ['government'],
+    example: '/caict/qwsj',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.caict.ac.cn/kxyj/qwfb/qwsj', 'www.caict.ac.cn/kxyj/qwfb/qwsj/', 'caict.ac.cn/kxyj/qwfb/qwsj', 'caict.ac.cn/kxyj/qwfb/qwsj/'],
+            target: '/qwsj',
+        },
+    ],
+    name: '权威数据',
+    maintainers: ['lisyer'],
+    url: 'www.caict.ac.cn/kxyj/qwfb/qwsj/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const { $, url } = await fetchPage('/kxyj/qwfb/qwsj/');
+    const items = parseList($, url, limit);
+
+    return {
+        title: '中国信息通信研究院 - 权威数据',
+        link: url,
+        language: 'zh-cn',
+        item: items,
+    };
+}

--- a/lib/routes/caict/utils.ts
+++ b/lib/routes/caict/utils.ts
@@ -1,0 +1,133 @@
+import { type CheerioAPI, load } from 'cheerio';
+
+import { config } from '@/config';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+/** Prefer HTTP: HTTPS is frequently blocked by the site WAF (412). */
+export const rootUrl = 'http://www.caict.ac.cn';
+
+const requestHeaders = () => ({
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+    Referer: `${rootUrl}/`,
+    'User-Agent': config.trueUA,
+});
+
+function isChallengePage(html: string): boolean {
+    // WAF interstitial is tiny and lacks list markup
+    if (html.length < 4000) {
+        return true;
+    }
+    // Real list pages always include these markers
+    return !html.includes('kxyj_text') && !html.includes('pagemain');
+}
+
+/**
+ * Fetch a list page with retries. Site WAF intermittently returns 412 /
+ * short challenge HTML, especially from datacenter IPs.
+ */
+export async function fetchPage(path: string, attempt = 0): Promise<{ $: CheerioAPI; url: string }> {
+    const url = new URL(path.startsWith('/') ? path : `/${path}`, rootUrl).href;
+    const headers = requestHeaders();
+    const maxAttempts = 5;
+
+    try {
+        const data = await ofetch<string>(url, {
+            headers,
+            retry: 0,
+            // Keep HTTP; do not force HTTPS
+            responseType: 'text',
+        });
+        if (typeof data === 'string' && !isChallengePage(data)) {
+            return { $: load(data), url };
+        }
+        if (attempt + 1 >= maxAttempts) {
+            throw new Error(`WAF challenge or empty page for ${url}`);
+        }
+    } catch (error) {
+        const status = (error as { statusCode?: number; status?: number }).statusCode ?? (error as { status?: number }).status;
+        // 412 is the WAF response; retry a few times
+        if (status && status !== 412 && status !== 403 && status < 500) {
+            throw error;
+        }
+        if (attempt + 1 >= maxAttempts) {
+            throw error;
+        }
+    }
+
+    await new Promise((r) => setTimeout(r, 800 * (attempt + 1)));
+    return fetchPage(path, attempt + 1);
+}
+
+const skipTitle = new Set(['上一页', '下一页', '更多', '更多>>', '【更多】']);
+
+function isWeixinHost(hostname: string): boolean {
+    return hostname === 'mp.weixin.qq.com' || hostname.endsWith('.mp.weixin.qq.com');
+}
+
+export function parseList($: CheerioAPI, baseUrl: string, limit = 20) {
+    const items: Array<{ title: string; link: string; pubDate?: Date }> = [];
+    const seen = new Set<string>();
+
+    for (const el of $('a.kxyj_text').toArray()) {
+        const a = $(el);
+        const href = a.attr('href');
+        if (!href || href.startsWith('javascript') || href.includes('_sPageName') || href.includes('_nCurrIndex')) {
+            continue;
+        }
+
+        const title = (a.attr('title') || a.text() || '')
+            .replaceAll(/\s+/g, ' ')
+            .replace(/^[\s\-–—]+/, '')
+            .trim();
+        if (!title || skipTitle.has(title) || title.includes('更多')) {
+            continue;
+        }
+
+        let link: string;
+        let hostname = '';
+        try {
+            const u = new URL(href, baseUrl);
+            link = u.href;
+            hostname = u.hostname;
+        } catch {
+            continue;
+        }
+
+        if (seen.has(link) || link.includes('zhaopin.caict') || link.includes('service.caict')) {
+            continue;
+        }
+
+        const isContent = /\.(?:htm|html|pdf)(?:\?|$)/i.test(link) || isWeixinHost(hostname);
+        if (!isContent) {
+            continue;
+        }
+
+        const tr = a.closest('tr');
+        let dateText = '';
+        if (tr.length) {
+            for (const span of tr.find('span.kxyj_text').toArray()) {
+                const text = $(span).text().trim();
+                if (/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+                    dateText = text;
+                    break;
+                }
+            }
+        }
+
+        seen.add(link);
+        items.push({
+            title,
+            link,
+            pubDate: dateText ? timezone(parseDate(dateText), 8) : undefined,
+        });
+
+        if (items.length >= limit) {
+            break;
+        }
+    }
+
+    return items;
+}


### PR DESCRIPTION
Add 中国信息通信研究院 (CAICT) research RSS routes. This supersedes #22489.

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/caict/bps
/caict/qwsj
/caict/caictgd
/caict/kxyj
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

### Why not `/gov/caict`?

Previous PR #22489 used `/gov/caict/*` (same as old deprecated paths). Auto Route Test failed **not because of the `gov` prefix**, but because the site WAF returned **412 Precondition Failed** from CI.

This PR:

1. Uses namespace `/caict/*` (no `gov` prefix) as requested
2. Retries on WAF 412 / short challenge pages (up to 5 times)
3. Uses `config.trueUA` (auto-review fix)
4. Fixes WeChat host check via `URL.hostname` (CodeQL)
5. Keeps `antiCrawler: true`; fetches over `http://www.caict.ac.cn`

### Routes

| Route | Source |
| ----- | ------ |
| `/caict/bps` | 白皮书 `/kxyj/qwfb/bps/` |
| `/caict/qwsj` | 权威数据 `/kxyj/qwfb/qwsj/` |
| `/caict/caictgd` | CAICT 观点 `/kxyj/caictgd/` |
| `/caict/kxyj` | 科研能力首页 `/kxyj/` |

Locally verified after WAF retries. Market research `/kxyj/qwfb/scbg/` is 404 on the official site and is not included.