### PR TITLE
feat(route): add Eritrea Chat news

### DIFF
--- a/lib/routes/eritreachat/index.ts
+++ b/lib/routes/eritreachat/index.ts
@@ -33,14 +33,13 @@ async function handler(ctx) {
     });
 
     const items = posts.map((item) => {
-        const $ = load(item.content?.rendered ?? '');
         const media = item._embedded?.['wp:featuredmedia']?.[0];
         const image = media?.source_url;
         const descriptionParts: string[] = [];
         if (image) {
             descriptionParts.push(`<img src="${image}" />`);
         }
-        descriptionParts.push($.html() || item.excerpt?.rendered || '');
+        descriptionParts.push(item.content?.rendered || item.excerpt?.rendered || '');
 
         return {
             title: load(item.title?.rendered ?? '').text(),

--- a/lib/routes/eritreachat/index.ts
+++ b/lib/routes/eritreachat/index.ts
@@ -1,0 +1,66 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const rootUrl = 'https://eritrea-chat.com';
+const apiUrl = `${rootUrl}/wp-json/wp/v2/posts`;
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/eritreachat',
+    radar: [
+        {
+            source: ['eritrea-chat.com/', 'eritrea-chat.com/*'],
+            target: '/',
+        },
+    ],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'eritrea-chat.com/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const posts = await ofetch(apiUrl, {
+        query: {
+            per_page: limit,
+            _embed: '1',
+        },
+    });
+
+    const items = posts.map((item) => {
+        const $ = load(item.content?.rendered ?? '');
+        const media = item._embedded?.['wp:featuredmedia']?.[0];
+        const image = media?.source_url;
+        const descriptionParts: string[] = [];
+        if (image) {
+            descriptionParts.push(`<img src="${image}" />`);
+        }
+        descriptionParts.push($.html() || item.excerpt?.rendered || '');
+
+        return {
+            title: load(item.title?.rendered ?? '').text(),
+            link: item.link,
+            description: descriptionParts.join('<br>') || undefined,
+            pubDate: item.date_gmt ? parseDate(item.date_gmt) : parseDate(item.date),
+            author: item._embedded?.author?.[0]?.name,
+            category: item._embedded?.['wp:term']
+                ?.flat()
+                ?.map((t) => t.name)
+                .filter(Boolean),
+            guid: String(item.id),
+            image,
+        };
+    });
+
+    return {
+        title: 'Eritrea Chat',
+        link: rootUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/eritreachat/namespace.ts
+++ b/lib/routes/eritreachat/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Eritrea Chat',
+    url: 'eritrea-chat.com',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [Eritrea Chat](https://eritrea-chat.com/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/eritreachat
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route
    - [x] Follows Script Standard
- [ ] Anti-bot or rate limit
- [x] Date and time
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added
- [ ] Puppeteer

## Note / 说明

- WordPress REST API: `https://eritrea-chat.com/wp-json/wp/v2/posts`
- Route: `/eritreachat`
