### PR TITLE
feat(route): add Grenada Chronicle news

### DIFF
--- a/lib/routes/grenadachronicle/index.ts
+++ b/lib/routes/grenadachronicle/index.ts
@@ -33,14 +33,13 @@ async function handler(ctx) {
     });
 
     const items = posts.map((item) => {
-        const $ = load(item.content?.rendered ?? '');
         const media = item._embedded?.['wp:featuredmedia']?.[0];
         const image = media?.source_url;
         const descriptionParts: string[] = [];
         if (image) {
             descriptionParts.push(`<img src="${image}" />`);
         }
-        descriptionParts.push($.html() || item.excerpt?.rendered || '');
+        descriptionParts.push(item.content?.rendered || item.excerpt?.rendered || '');
 
         return {
             title: load(item.title?.rendered ?? '').text(),

--- a/lib/routes/grenadachronicle/index.ts
+++ b/lib/routes/grenadachronicle/index.ts
@@ -1,0 +1,66 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const rootUrl = 'https://grenadachronicle.com';
+const apiUrl = `${rootUrl}/wp-json/wp/v2/posts`;
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/grenadachronicle',
+    radar: [
+        {
+            source: ['grenadachronicle.com/', 'grenadachronicle.com/*'],
+            target: '/',
+        },
+    ],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'grenadachronicle.com/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const posts = await ofetch(apiUrl, {
+        query: {
+            per_page: limit,
+            _embed: '1',
+        },
+    });
+
+    const items = posts.map((item) => {
+        const $ = load(item.content?.rendered ?? '');
+        const media = item._embedded?.['wp:featuredmedia']?.[0];
+        const image = media?.source_url;
+        const descriptionParts: string[] = [];
+        if (image) {
+            descriptionParts.push(`<img src="${image}" />`);
+        }
+        descriptionParts.push($.html() || item.excerpt?.rendered || '');
+
+        return {
+            title: load(item.title?.rendered ?? '').text(),
+            link: item.link,
+            description: descriptionParts.join('<br>') || undefined,
+            pubDate: item.date_gmt ? parseDate(item.date_gmt) : parseDate(item.date),
+            author: item._embedded?.author?.[0]?.name,
+            category: item._embedded?.['wp:term']
+                ?.flat()
+                ?.map((t) => t.name)
+                .filter(Boolean),
+            guid: String(item.id),
+            image,
+        };
+    });
+
+    return {
+        title: 'Grenada Chronicle',
+        link: rootUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/grenadachronicle/namespace.ts
+++ b/lib/routes/grenadachronicle/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Grenada Chronicle',
+    url: 'grenadachronicle.com',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [Grenada Chronicle](https://grenadachronicle.com/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/grenadachronicle
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route
    - [x] Follows Script Standard
- [ ] Anti-bot or rate limit
- [x] Date and time
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added
- [ ] Puppeteer

## Note / 说明

- WordPress REST API: `https://grenadachronicle.com/wp-json/wp/v2/posts`
- Route: `/grenadachronicle`
