### PR TITLE
feat(route): add Malawi 24 news

### DIFF
--- a/lib/routes/malawi24/index.ts
+++ b/lib/routes/malawi24/index.ts
@@ -1,0 +1,66 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const rootUrl = 'https://www.malawi24.com';
+const apiUrl = `${rootUrl}/wp-json/wp/v2/posts`;
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/malawi24',
+    radar: [
+        {
+            source: ['malawi24.com/', 'malawi24.com/*'],
+            target: '/',
+        },
+    ],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'malawi24.com/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const posts = await ofetch(apiUrl, {
+        query: {
+            per_page: limit,
+            _embed: '1',
+        },
+    });
+
+    const items = posts.map((item) => {
+        const $ = load(item.content?.rendered ?? '');
+        const media = item._embedded?.['wp:featuredmedia']?.[0];
+        const image = media?.source_url;
+        const descriptionParts: string[] = [];
+        if (image) {
+            descriptionParts.push(`<img src="${image}" />`);
+        }
+        descriptionParts.push($.html() || item.excerpt?.rendered || '');
+
+        return {
+            title: load(item.title?.rendered ?? '').text(),
+            link: item.link,
+            description: descriptionParts.join('<br>') || undefined,
+            pubDate: item.date_gmt ? parseDate(item.date_gmt) : parseDate(item.date),
+            author: item._embedded?.author?.[0]?.name,
+            category: item._embedded?.['wp:term']
+                ?.flat()
+                ?.map((t) => t.name)
+                .filter(Boolean),
+            guid: String(item.id),
+            image,
+        };
+    });
+
+    return {
+        title: 'Malawi 24',
+        link: rootUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/malawi24/index.ts
+++ b/lib/routes/malawi24/index.ts
@@ -33,14 +33,13 @@ async function handler(ctx) {
     });
 
     const items = posts.map((item) => {
-        const $ = load(item.content?.rendered ?? '');
         const media = item._embedded?.['wp:featuredmedia']?.[0];
         const image = media?.source_url;
         const descriptionParts: string[] = [];
         if (image) {
             descriptionParts.push(`<img src="${image}" />`);
         }
-        descriptionParts.push($.html() || item.excerpt?.rendered || '');
+        descriptionParts.push(item.content?.rendered || item.excerpt?.rendered || '');
 
         return {
             title: load(item.title?.rendered ?? '').text(),

--- a/lib/routes/malawi24/namespace.ts
+++ b/lib/routes/malawi24/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Malawi 24',
+    url: 'malawi24.com',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [Malawi 24](https://www.malawi24.com/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/malawi24
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route
    - [x] Follows Script Standard
- [ ] Anti-bot or rate limit
- [x] Date and time
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added
- [ ] Puppeteer

## Note / 说明

- WordPress REST API: `https://www.malawi24.com/wp-json/wp/v2/posts`
- Route: `/malawi24`
