### PR TITLE
feat(route): add FSM News news

### DIFF
--- a/lib/routes/fsmgov/index.ts
+++ b/lib/routes/fsmgov/index.ts
@@ -1,0 +1,48 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const rootUrl = 'https://www.fsmgov.org';
+const apiUrl = `${rootUrl}/wp-json/wp/v2/posts`;
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/fsmgov',
+    radar: [{ source: ['fsmgov.org/', 'fsmgov.org/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'fsmgov.org/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const posts = await ofetch(apiUrl, { query: { per_page: limit, _embed: '1' } });
+    const items = posts.map((item) => {
+        const $ = load(item.content?.rendered ?? '');
+        const media = item._embedded?.['wp:featuredmedia']?.[0];
+        const image = media?.source_url;
+        const parts: string[] = [];
+        if (image) {
+            parts.push(`<img src="${image}" />`);
+        }
+        parts.push($.html() || item.excerpt?.rendered || '');
+        return {
+            title: load(item.title?.rendered ?? '').text(),
+            link: item.link,
+            description: parts.join('<br>') || undefined,
+            pubDate: item.date_gmt ? parseDate(item.date_gmt) : parseDate(item.date),
+            author: item._embedded?.author?.[0]?.name,
+            category: item._embedded?.['wp:term']
+                ?.flat()
+                ?.map((t) => t.name)
+                .filter(Boolean),
+            guid: String(item.id),
+            image,
+        };
+    });
+    return { title: 'FSM News', link: rootUrl, language: 'en', item: items };
+}

--- a/lib/routes/fsmgov/index.ts
+++ b/lib/routes/fsmgov/index.ts
@@ -22,14 +22,13 @@ async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
     const posts = await ofetch(apiUrl, { query: { per_page: limit, _embed: '1' } });
     const items = posts.map((item) => {
-        const $ = load(item.content?.rendered ?? '');
         const media = item._embedded?.['wp:featuredmedia']?.[0];
         const image = media?.source_url;
         const parts: string[] = [];
         if (image) {
             parts.push(`<img src="${image}" />`);
         }
-        parts.push($.html() || item.excerpt?.rendered || '');
+        parts.push(item.content?.rendered || item.excerpt?.rendered || '');
         return {
             title: load(item.title?.rendered ?? '').text(),
             link: item.link,

--- a/lib/routes/fsmgov/namespace.ts
+++ b/lib/routes/fsmgov/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'FSM News',
+    url: 'fsmgov.org',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [FSM News](https://www.fsmgov.org/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/fsmgov
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route
    - [x] Follows Script Standard
- [ ] Anti-bot or rate limit
- [x] Date and time
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added
- [ ] Puppeteer

## Note / 说明

- WordPress REST API: `https://www.fsmgov.org/wp-json/wp/v2/posts`
- Route: `/fsmgov`
