### PR TITLE
feat(route): add La Tercera news

### DIFF
--- a/lib/routes/latercera/index.ts
+++ b/lib/routes/latercera/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.latercera.com';
+const feedUrl = 'https://www.latercera.com/rss';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/latercera',
+    radar: [{ source: ['latercera.com/', 'latercera.com/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'latercera.com/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'La Tercera',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/latercera/namespace.ts
+++ b/lib/routes/latercera/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'La Tercera',
+    url: 'latercera.com',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [La Tercera](https://www.latercera.com/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/latercera
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route
    - [x] Follows Script Standard
- [ ] Anti-bot or rate limit
- [x] Date and time
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added
- [ ] Puppeteer

## Note / 说明

- Official feed: `https://www.latercera.com/rss` (normalized via RSSHub)
- Route: `/latercera`
