### PR TITLE
feat(route): add Daily Monitor news

### DIFF
--- a/lib/routes/monitor/index.ts
+++ b/lib/routes/monitor/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.monitor.co.ug';
+const feedUrl = 'https://www.monitor.co.ug/rss.xml';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/monitor',
+    radar: [{ source: ['monitor.co.ug/', 'monitor.co.ug/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'monitor.co.ug/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'Daily Monitor',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/monitor/namespace.ts
+++ b/lib/routes/monitor/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Daily Monitor',
+    url: 'monitor.co.ug',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [Daily Monitor](https://www.monitor.co.ug/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/monitor
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route
    - [x] Follows Script Standard
- [ ] Anti-bot or rate limit
- [x] Date and time
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added
- [ ] Puppeteer

## Note / 说明

- Official feed: `https://www.monitor.co.ug/rss.xml` (normalized via RSSHub)
- Route: `/monitor`
