### PR TITLE
feat(route): add Slobodna Dalmacija news

### DIFF
--- a/lib/routes/slobodnadalmacija/index.ts
+++ b/lib/routes/slobodnadalmacija/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.slobodnadalmacija.hr';
+const feedUrl = 'https://www.slobodnadalmacija.hr/feed';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/slobodnadalmacija',
+    radar: [{ source: ['slobodnadalmacija.hr/', 'slobodnadalmacija.hr/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'slobodnadalmacija.hr/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'Slobodna Dalmacija',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/slobodnadalmacija/namespace.ts
+++ b/lib/routes/slobodnadalmacija/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Slobodna Dalmacija',
+    url: 'slobodnadalmacija.hr',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [Slobodna Dalmacija](https://www.slobodnadalmacija.hr/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/slobodnadalmacija
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route
    - [x] Follows Script Standard
- [ ] Anti-bot or rate limit
- [x] Date and time
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added
- [ ] Puppeteer

## Note / 说明

- Official feed: `https://www.slobodnadalmacija.hr/feed` (normalized via RSSHub)
- Route: `/slobodnadalmacija`
