### PR TITLE
feat(route): add SVT news

### DIFF
--- a/lib/routes/svt/index.ts
+++ b/lib/routes/svt/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.svt.se';
+const feedUrl = 'https://www.svt.se/rss.xml';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/svt',
+    radar: [{ source: ['svt.se/', 'svt.se/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'svt.se/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'SVT',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/svt/namespace.ts
+++ b/lib/routes/svt/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'SVT',
+    url: 'svt.se',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [SVT](https://www.svt.se/).

## Involved Issue

N/A

## Example for the Proposed Route(s)

```routes
/svt
```

## New RSS Route Checklist

- [x] New Route
- [x] Date and time Parsed
- [ ] Puppeteer

## Note

- Official feed: `https://www.svt.se/rss.xml`
- Route: `/svt`
