### PR TITLE
feat(route): add Luxemburger Wort news

### DIFF
--- a/lib/routes/wort/index.ts
+++ b/lib/routes/wort/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.wort.lu';
+const feedUrl = 'https://www.wort.lu/rss';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/wort',
+    radar: [{ source: ['wort.lu/', 'wort.lu/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'wort.lu/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'Luxemburger Wort',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/wort/namespace.ts
+++ b/lib/routes/wort/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Luxemburger Wort',
+    url: 'wort.lu',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [Luxemburger Wort](https://www.wort.lu/).

## Involved Issue

N/A

## Example for the Proposed Route(s)

```routes
/wort
```

## New RSS Route Checklist

- [x] New Route
- [x] Date and time Parsed
- [ ] Puppeteer

## Note

- Official feed: `https://www.wort.lu/rss`
- Route: `/wort`
