### PR TITLE
feat(route): add Corriere della Sera news

### DIFF
--- a/lib/routes/corriere/index.ts
+++ b/lib/routes/corriere/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.corriere.it';
+const feedUrl = 'https://www.corriere.it/rss/news.xml';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/corriere',
+    radar: [{ source: ['corriere.it/', 'corriere.it/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'corriere.it/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'Corriere della Sera',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/corriere/namespace.ts
+++ b/lib/routes/corriere/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Corriere della Sera',
+    url: 'corriere.it',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [Corriere della Sera](https://www.corriere.it/).

## Involved Issue

N/A

## Example for the Proposed Route(s)

```routes
/corriere
```

## New RSS Route Checklist

- [x] New Route
- [x] Date parsed
- [ ] Puppeteer

## Note

- Feed: `https://www.corriere.it/rss/news.xml`
- Route: `/corriere`
