### PR TITLE
feat(route): add El Comercio news

### DIFF
--- a/lib/routes/elcomercio/index.ts
+++ b/lib/routes/elcomercio/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://elcomercio.pe';
+const feedUrl = 'https://elcomercio.pe/arcio/rss/';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/elcomercio',
+    radar: [{ source: ['elcomercio.pe/', 'elcomercio.pe/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'elcomercio.pe/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'El Comercio',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/elcomercio/namespace.ts
+++ b/lib/routes/elcomercio/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'El Comercio',
+    url: 'elcomercio.pe',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [El Comercio](https://elcomercio.pe/).

## Involved Issue

N/A

## Example for the Proposed Route(s)

```routes
/elcomercio
```

## New RSS Route Checklist

- [x] New Route
- [x] Date parsed
- [ ] Puppeteer

## Note

- Feed: `https://elcomercio.pe/arcio/rss/`
- Route: `/elcomercio`
