### PR TITLE
feat(route): add Il Messaggero news

### DIFF
--- a/lib/routes/ilmessaggero/index.ts
+++ b/lib/routes/ilmessaggero/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.ilmessaggero.it';
+const feedUrl = 'https://www.ilmessaggero.it/rss/src/topstories.xml';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/ilmessaggero',
+    radar: [{ source: ['ilmessaggero.it/', 'ilmessaggero.it/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'ilmessaggero.it/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'Il Messaggero',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/ilmessaggero/namespace.ts
+++ b/lib/routes/ilmessaggero/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Il Messaggero',
+    url: 'ilmessaggero.it',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [Il Messaggero](https://www.ilmessaggero.it/).

## Involved Issue

N/A

## Example for the Proposed Route(s)

```routes
/ilmessaggero
```

## New RSS Route Checklist

- [x] New Route
- [x] Date parsed
- [ ] Puppeteer

## Note

- Feed: `https://www.ilmessaggero.it/rss/src/topstories.xml`
- Route: `/ilmessaggero`
