### PR TITLE
feat(route): add Channel News Asia news

### DIFF
--- a/lib/routes/channelnewsasia/index.ts
+++ b/lib/routes/channelnewsasia/index.ts
@@ -1,0 +1,69 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+const rootUrl = 'https://www.channelnewsasia.com';
+const hrefPattern = /^\/[a-z0-9-]+\/[a-z0-9-]+-\d{5,}\/?$/;
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/channelnewsasia',
+    radar: [{ source: ['channelnewsasia.com/', 'channelnewsasia.com/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'channelnewsasia.com/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const html = await ofetch(rootUrl);
+    const $ = load(html);
+    const seen = new Set<string>();
+    const items: Array<{ title: string; link: string }> = [];
+
+    for (const el of $('a[href]').toArray()) {
+        const a = $(el);
+        const href = a.attr('href') || '';
+        if (!href || href.startsWith('#') || href.startsWith('javascript')) {
+            continue;
+        }
+        let link: string;
+        try {
+            link = new URL(href, rootUrl).href;
+        } catch {
+            continue;
+        }
+        if (!link.startsWith(rootUrl)) {
+            continue;
+        }
+        const path = new URL(link).pathname;
+        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+            continue;
+        }
+        if (seen.has(link)) {
+            continue;
+        }
+        let title = a.attr('title')?.trim() || a.text().replaceAll(/\s+/g, ' ').trim();
+        if (!title || title.length < 10) {
+            title = a.closest('article, li, div').find('h1, h2, h3, h4').first().text().replaceAll(/\s+/g, ' ').trim() || title;
+        }
+        if (!title || title.length < 10) {
+            continue;
+        }
+        seen.add(link);
+        items.push({ title, link });
+        if (items.length >= limit) {
+            break;
+        }
+    }
+
+    return {
+        title: 'Channel News Asia',
+        link: rootUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/channelnewsasia/namespace.ts
+++ b/lib/routes/channelnewsasia/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Channel News Asia',
+    url: 'channelnewsasia.com',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for [Channel News Asia](https://www.channelnewsasia.com/).

## Involved Issue

N/A

## Example for the Proposed Route(s)

```routes
/channelnewsasia
```

## New RSS Route Checklist

- [x] New Route
- [ ] Puppeteer

## Note

- Homepage HTML list scrape
- Route: `/channelnewsasia`
