### PR TITLE
feat(route): add The New Times news

### DIFF
--- a/lib/routes/newtimes/index.ts
+++ b/lib/routes/newtimes/index.ts
@@ -1,0 +1,77 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+const rootUrl = 'https://www.newtimes.co.rw';
+const rootHost = 'newtimes.co.rw';
+const hrefPattern = /\d{5,}/;
+
+const registrable = (h: string) => h.split('.').slice(-2).join('.');
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/newtimes',
+    radar: [{ source: ['newtimes.co.rw/', 'newtimes.co.rw/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'newtimes.co.rw/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const html = await ofetch(rootUrl);
+    const $ = load(html);
+    const seen = new Set<string>();
+    const items: Array<{ title: string; link: string }> = [];
+
+    for (const el of $('a[href]').toArray()) {
+        const a = $(el);
+        const href = a.attr('href') || '';
+        if (!href || href.startsWith('#') || href.startsWith('javascript')) {
+            continue;
+        }
+        let link: string;
+        try {
+            link = new URL(href, rootUrl).href;
+        } catch {
+            continue;
+        }
+        try {
+            const hostName = new URL(link).hostname.replace(/^www\./, '');
+            if (hostName !== rootHost && !hostName.endsWith('.' + rootHost) && registrable(hostName) !== registrable(rootHost)) {
+                continue;
+            }
+        } catch {
+            continue;
+        }
+        const path = new URL(link).pathname;
+        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+            continue;
+        }
+        if (seen.has(link)) {
+            continue;
+        }
+        let title = a.attr('title')?.trim() || a.text().replaceAll(/\s+/g, ' ').trim();
+        if (!title || title.length < 10) {
+            title = a.closest('article, li, div').find('h1, h2, h3, h4').first().text().replaceAll(/\s+/g, ' ').trim() || title;
+        }
+        if (!title || title.length < 10) {
+            continue;
+        }
+        seen.add(link);
+        items.push({ title, link });
+        if (items.length >= limit) {
+            break;
+        }
+    }
+
+    return {
+        title: 'The New Times',
+        link: rootUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/newtimes/namespace.ts
+++ b/lib/routes/newtimes/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'The New Times',
+    url: 'newtimes.co.rw',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
## Route

```routes
/newtimes
```

## Description

Add news route for `newtimes` (from bookmarks news folder bulk coverage).

- Maintainer: @lisyer
