### PR TITLE
feat(route): add CAICT research routes under /gov/caict

### DIFF
--- a/lib/routes/gov/caict/bps.ts
+++ b/lib/routes/gov/caict/bps.ts
@@ -1,0 +1,41 @@
+import type { Route } from '@/types';
+
+import { fetchPage, parseList } from './utils';
+
+export const route: Route = {
+    path: '/bps',
+    categories: ['government'],
+    example: '/gov/caict/bps',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.caict.ac.cn/kxyj/qwfb/bps', 'www.caict.ac.cn/kxyj/qwfb/bps/', 'caict.ac.cn/kxyj/qwfb/bps', 'caict.ac.cn/kxyj/qwfb/bps/'],
+            target: '/bps',
+        },
+    ],
+    name: '白皮书',
+    maintainers: ['lisyer'],
+    url: 'www.caict.ac.cn/kxyj/qwfb/bps/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    // List only: detail pages are often blocked/slow by the site WAF
+    const { $, url } = await fetchPage('/kxyj/qwfb/bps/');
+    const items = parseList($, url, limit);
+
+    return {
+        title: '中国信息通信研究院 - 白皮书',
+        link: url,
+        language: 'zh-cn',
+        item: items,
+    };
+}

--- a/lib/routes/gov/caict/caictgd.ts
+++ b/lib/routes/gov/caict/caictgd.ts
@@ -1,0 +1,41 @@
+import type { Route } from '@/types';
+
+import { fetchPage, parseList } from './utils';
+
+export const route: Route = {
+    path: '/caictgd',
+    categories: ['government'],
+    example: '/gov/caict/caictgd',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.caict.ac.cn/kxyj/caictgd', 'www.caict.ac.cn/kxyj/caictgd/', 'caict.ac.cn/kxyj/caictgd', 'caict.ac.cn/kxyj/caictgd/'],
+            target: '/caictgd',
+        },
+    ],
+    name: 'CAICT 观点',
+    maintainers: ['lisyer'],
+    url: 'www.caict.ac.cn/kxyj/caictgd/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const { $, url } = await fetchPage('/kxyj/caictgd/');
+    // Mostly WeChat article links — list metadata is enough
+    const items = parseList($, url, limit);
+
+    return {
+        title: '中国信息通信研究院 - CAICT观点',
+        link: url,
+        language: 'zh-cn',
+        item: items,
+    };
+}

--- a/lib/routes/gov/caict/kxyj.ts
+++ b/lib/routes/gov/caict/kxyj.ts
@@ -1,0 +1,51 @@
+import type { Route } from '@/types';
+
+import { fetchPage, parseList } from './utils';
+
+export const route: Route = {
+    path: '/kxyj',
+    categories: ['government'],
+    example: '/gov/caict/kxyj',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.caict.ac.cn/kxyj', 'www.caict.ac.cn/kxyj/', 'caict.ac.cn/kxyj', 'caict.ac.cn/kxyj/'],
+            target: '/kxyj',
+        },
+    ],
+    name: '科研能力',
+    maintainers: ['lisyer'],
+    url: 'www.caict.ac.cn/kxyj/',
+    description: `科研能力栏目首页的动态摘要（含白皮书 / 权威数据 / 观点等混排条目）。
+
+更完整的分类订阅请使用：
+
+| 白皮书                           | 权威数据                           | CAICT 观点                               |
+| -------------------------------- | ---------------------------------- | ---------------------------------------- |
+| [/gov/caict/bps](/gov/caict/bps) | [/gov/caict/qwsj](/gov/caict/qwsj) | [/gov/caict/caictgd](/gov/caict/caictgd) |
+
+::: warning
+官网导航中的「市场研究报告」(\`/kxyj/qwfb/scbg/\`) 当前返回 404，暂无法提供对应路由。
+:::`,
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const { $, url } = await fetchPage('/kxyj/');
+    const items = parseList($, url, limit);
+
+    return {
+        title: '中国信息通信研究院 - 科研能力',
+        link: url,
+        language: 'zh-cn',
+        item: items,
+    };
+}

--- a/lib/routes/gov/caict/namespace.ts
+++ b/lib/routes/gov/caict/namespace.ts
@@ -1,0 +1,11 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '中国信息通信研究院',
+    url: 'www.caict.ac.cn',
+    categories: ['government'],
+    description: `::: tip
+官方站点存在 WAF，部分环境访问 \`https://\` 可能返回 412。本路由使用 \`http://www.caict.ac.cn\` 抓取。
+:::`,
+    lang: 'zh-CN',
+};

--- a/lib/routes/gov/caict/qwsj.ts
+++ b/lib/routes/gov/caict/qwsj.ts
@@ -1,0 +1,40 @@
+import type { Route } from '@/types';
+
+import { fetchPage, parseList } from './utils';
+
+export const route: Route = {
+    path: '/qwsj',
+    categories: ['government'],
+    example: '/gov/caict/qwsj',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.caict.ac.cn/kxyj/qwfb/qwsj', 'www.caict.ac.cn/kxyj/qwfb/qwsj/', 'caict.ac.cn/kxyj/qwfb/qwsj', 'caict.ac.cn/kxyj/qwfb/qwsj/'],
+            target: '/qwsj',
+        },
+    ],
+    name: '权威数据',
+    maintainers: ['lisyer'],
+    url: 'www.caict.ac.cn/kxyj/qwfb/qwsj/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const { $, url } = await fetchPage('/kxyj/qwfb/qwsj/');
+    const items = parseList($, url, limit);
+
+    return {
+        title: '中国信息通信研究院 - 权威数据',
+        link: url,
+        language: 'zh-cn',
+        item: items,
+    };
+}

--- a/lib/routes/gov/caict/utils.ts
+++ b/lib/routes/gov/caict/utils.ts
@@ -1,0 +1,86 @@
+import { type CheerioAPI, load } from 'cheerio';
+
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+/** Prefer HTTP: HTTPS is frequently blocked by the site WAF (412). */
+export const rootUrl = 'http://www.caict.ac.cn';
+
+const requestHeaders = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+    Referer: `${rootUrl}/`,
+};
+
+export async function fetchPage(path: string) {
+    const url = new URL(path.startsWith('/') ? path : `/${path}`, rootUrl).href;
+    const data = await ofetch(url, { headers: requestHeaders });
+    return { $: load(data), url };
+}
+
+const skipTitle = new Set(['上一页', '下一页', '更多', '更多>>', '【更多】']);
+
+export function parseList($: CheerioAPI, baseUrl: string, limit = 20) {
+    const items: Array<{ title: string; link: string; pubDate?: Date }> = [];
+    const seen = new Set<string>();
+
+    for (const el of $('a.kxyj_text').toArray()) {
+        const a = $(el);
+        const href = a.attr('href');
+        if (!href || href.startsWith('javascript') || href.includes('_sPageName') || href.includes('_nCurrIndex')) {
+            continue;
+        }
+
+        const title = (a.attr('title') || a.text() || '')
+            .replaceAll(/\s+/g, ' ')
+            .replace(/^[\s\-–—]+/, '')
+            .trim();
+        if (!title || skipTitle.has(title) || title.includes('更多')) {
+            continue;
+        }
+
+        let link: string;
+        try {
+            link = new URL(href, baseUrl).href;
+        } catch {
+            continue;
+        }
+
+        if (seen.has(link) || link.includes('zhaopin.caict') || link.includes('service.caict')) {
+            continue;
+        }
+
+        // Keep article / PDF / weixin links; skip bare section roots
+        const isContent = /\.(?:htm|html|pdf)(?:\?|$)/i.test(link) || link.includes('mp.weixin.qq.com');
+        if (!isContent) {
+            continue;
+        }
+
+        const tr = a.closest('tr');
+        let dateText = '';
+        if (tr.length) {
+            for (const span of tr.find('span.kxyj_text').toArray()) {
+                const text = $(span).text().trim();
+                if (/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+                    dateText = text;
+                    break;
+                }
+            }
+        }
+
+        seen.add(link);
+        items.push({
+            title,
+            link,
+            pubDate: dateText ? timezone(parseDate(dateText), 8) : undefined,
+        });
+
+        if (items.length >= limit) {
+            break;
+        }
+    }
+
+    return items;
+}

--- a/lib/routes/gov/caict/utils.ts
+++ b/lib/routes/gov/caict/utils.ts
@@ -53,7 +53,14 @@ export function parseList($: CheerioAPI, baseUrl: string, limit = 20) {
         }
 
         // Keep article / PDF / weixin links; skip bare section roots
-        const isContent = /\.(?:htm|html|pdf)(?:\?|$)/i.test(link) || link.includes('mp.weixin.qq.com');
+        let isWeixin = false;
+        try {
+            const host = new URL(link).hostname;
+            isWeixin = host === 'mp.weixin.qq.com' || host.endsWith('.mp.weixin.qq.com');
+        } catch {
+            continue;
+        }
+        const isContent = /\.(?:htm|html|pdf)(?:\?|$)/i.test(link) || isWeixin;
         if (!isContent) {
             continue;
         }


### PR DESCRIPTION
Add CAICT research list routes under `/gov/caict` (白皮书 / 权威数据 / CAICT 观点 / 科研能力).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/gov/caict/bps
/gov/caict/qwsj
/gov/caict/caictgd
/gov/caict/kxyj
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Maintainer: @lisyer
- Site often returns 412 on HTTPS; fetch prefers HTTP + browser UA
- Detail pages may be WAF-blocked; list metadata only
