### PR TITLE
feat(route): add Daily Monitor news

### DIFF
--- a/lib/routes/monitor/index.ts
+++ b/lib/routes/monitor/index.ts
@@ -1,5 +1,3 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
 import { parseDate } from '@/utils/parse-date';
 import parser from '@/utils/rss-parser';
@@ -21,18 +19,15 @@ export const route: Route = {
 async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
     const feed = await parser.parseURL(feedUrl);
-    const items = (feed.items || []).slice(0, limit).map((item) => {
-        const $ = load(item['content:encoded'] || item.content || item.summary || '');
-        return {
-            title: item.title,
-            link: item.link,
-            description: $.html() || item.contentSnippet || item.summary,
-            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
-            author: item.creator || item.author,
-            category: item.categories,
-            guid: item.guid || item.id || item.link,
-        };
-    });
+    const items = (feed.items || []).slice(0, limit).map((item) => ({
+        title: item.title,
+        link: item.link,
+        description: item['content:encoded'] || item.content || item.contentSnippet || item.summary,
+        pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+        author: item.creator || item.author,
+        category: item.categories,
+        guid: item.guid || item.id || item.link,
+    }));
     return {
         title: feed.title || 'Daily Monitor',
         link: feed.link || rootUrl,

--- a/lib/routes/monitor/index.ts
+++ b/lib/routes/monitor/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.monitor.co.ug';
+const feedUrl = 'https://www.monitor.co.ug/rss.xml';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/monitor',
+    radar: [{ source: ['monitor.co.ug/', 'monitor.co.ug/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'monitor.co.ug/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'Daily Monitor',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/monitor/namespace.ts
+++ b/lib/routes/monitor/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Daily Monitor',
+    url: 'monitor.co.ug',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for Daily Monitor.

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/monitor
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Maintainer: @lisyer
- Route: `/monitor`
- Source: Daily Monitor
- Replaces auto-closed #22531 with correct PR body format.
