### PR TITLE
feat(route): add NOS news

### DIFF
--- a/lib/routes/nos/index.ts
+++ b/lib/routes/nos/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://nos.nl';
+const feedUrl = 'https://nos.nl/rss.xml';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/nos',
+    radar: [{ source: ['nos.nl/', 'nos.nl/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'nos.nl/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'NOS',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/nos/index.ts
+++ b/lib/routes/nos/index.ts
@@ -1,5 +1,3 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
 import { parseDate } from '@/utils/parse-date';
 import parser from '@/utils/rss-parser';
@@ -21,18 +19,15 @@ export const route: Route = {
 async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
     const feed = await parser.parseURL(feedUrl);
-    const items = (feed.items || []).slice(0, limit).map((item) => {
-        const $ = load(item['content:encoded'] || item.content || item.summary || '');
-        return {
-            title: item.title,
-            link: item.link,
-            description: $.html() || item.contentSnippet || item.summary,
-            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
-            author: item.creator || item.author,
-            category: item.categories,
-            guid: item.guid || item.id || item.link,
-        };
-    });
+    const items = (feed.items || []).slice(0, limit).map((item) => ({
+        title: item.title,
+        link: item.link,
+        description: item['content:encoded'] || item.content || item.contentSnippet || item.summary,
+        pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+        author: item.creator || item.author,
+        category: item.categories,
+        guid: item.guid || item.id || item.link,
+    }));
     return {
         title: feed.title || 'NOS',
         link: feed.link || rootUrl,

--- a/lib/routes/nos/namespace.ts
+++ b/lib/routes/nos/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'NOS',
+    url: 'nos.nl',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for NOS.

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/nos
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Maintainer: @lisyer
- Route: `/nos`
- Source: NOS
- Replaces auto-closed #22533 with correct PR body format.
