### PR TITLE
feat(route): add Radio Okapi news

### DIFF
--- a/lib/routes/radiookapi/index.ts
+++ b/lib/routes/radiookapi/index.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.radiookapi.net';
+const feedUrl = 'https://www.radiookapi.net/rss.xml';
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/radiookapi',
+    radar: [{ source: ['radiookapi.net/', 'radiookapi.net/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'radiookapi.net/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const feed = await parser.parseURL(feedUrl);
+    const items = (feed.items || []).slice(0, limit).map((item) => {
+        const $ = load(item['content:encoded'] || item.content || item.summary || '');
+        return {
+            title: item.title,
+            link: item.link,
+            description: $.html() || item.contentSnippet || item.summary,
+            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+            author: item.creator || item.author,
+            category: item.categories,
+            guid: item.guid || item.id || item.link,
+        };
+    });
+    return {
+        title: feed.title || 'Radio Okapi',
+        link: feed.link || rootUrl,
+        description: feed.description,
+        language: feed.language || 'en',
+        item: items,
+    };
+}

--- a/lib/routes/radiookapi/index.ts
+++ b/lib/routes/radiookapi/index.ts
@@ -1,5 +1,3 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
 import { parseDate } from '@/utils/parse-date';
 import parser from '@/utils/rss-parser';
@@ -21,23 +19,20 @@ export const route: Route = {
 async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
     const feed = await parser.parseURL(feedUrl);
-    const items = (feed.items || []).slice(0, limit).map((item) => {
-        const $ = load(item['content:encoded'] || item.content || item.summary || '');
-        return {
-            title: item.title,
-            link: item.link,
-            description: $.html() || item.contentSnippet || item.summary,
-            pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
-            author: item.creator || item.author,
-            category: item.categories,
-            guid: item.guid || item.id || item.link,
-        };
-    });
+    const items = (feed.items || []).slice(0, limit).map((item) => ({
+        title: item.title,
+        link: item.link,
+        description: item['content:encoded'] || item.content || item.contentSnippet || item.summary,
+        pubDate: item.isoDate ? parseDate(item.isoDate) : item.pubDate ? parseDate(item.pubDate) : undefined,
+        author: item.creator || item.author,
+        category: item.categories,
+        guid: item.guid || item.id || item.link,
+    }));
     return {
         title: feed.title || 'Radio Okapi',
         link: feed.link || rootUrl,
         description: feed.description,
-        language: feed.language || 'en',
+        language: feed.language || 'fr',
         item: items,
     };
 }

--- a/lib/routes/radiookapi/namespace.ts
+++ b/lib/routes/radiookapi/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Radio Okapi',
+    url: 'radiookapi.net',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for Radio Okapi.

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/radiookapi
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Maintainer: @lisyer
- Route: `/radiookapi`
- Source: Radio Okapi
- Replaces auto-closed #22534 with correct PR body format.
