### PR TITLE
feat(route): add Al-Ahram English news

### DIFF
--- a/lib/routes/english/index.ts
+++ b/lib/routes/english/index.ts
@@ -36,7 +36,13 @@ async function handler(ctx) {
         } catch {
             continue;
         }
-        if (!link.startsWith(rootUrl)) {
+        try {
+            const host = new URL(link).hostname.replace(/^www\./, '');
+            const rootHost = new URL(rootUrl).hostname.replace(/^www\./, '');
+            if (host !== rootHost && !host.endsWith('.' + rootHost)) {
+                continue;
+            }
+        } catch {
             continue;
         }
         const path = new URL(link).pathname;

--- a/lib/routes/english/index.ts
+++ b/lib/routes/english/index.ts
@@ -1,0 +1,66 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+const rootUrl = 'https://english.ahram.org.eg';
+const hrefPattern = /\/NewsContent\/\d+\/\d+\//;
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/english',
+    radar: [{ source: ['english.ahram.org.eg/', 'english.ahram.org.eg/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'english.ahram.org.eg/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const html = await ofetch(rootUrl);
+    const $ = load(html);
+    const seen = new Set<string>();
+    const items: Array<{ title: string; link: string }> = [];
+
+    for (const el of $('a[href]').toArray()) {
+        const a = $(el);
+        const href = a.attr('href') || '';
+        if (!href || href.startsWith('#') || href.startsWith('javascript')) {
+            continue;
+        }
+        let link: string;
+        try {
+            link = new URL(href, rootUrl).href;
+        } catch {
+            continue;
+        }
+        if (!link.startsWith(rootUrl)) {
+            continue;
+        }
+        const path = new URL(link).pathname;
+        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+            continue;
+        }
+        if (seen.has(link)) {
+            continue;
+        }
+        const title = a.text().replaceAll(/\s+/g, ' ').trim() || a.attr('title')?.trim();
+        if (!title || title.length < 8) {
+            continue;
+        }
+        seen.add(link);
+        items.push({ title, link });
+        if (items.length >= limit) {
+            break;
+        }
+    }
+
+    return {
+        title: 'Al-Ahram English',
+        link: rootUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/english/namespace.ts
+++ b/lib/routes/english/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Al-Ahram English',
+    url: 'english.ahram.org.eg',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add RSS route for Al-Ahram English.

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/english
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Maintainer: @lisyer
- Route: `/english`
- Source: Al-Ahram English
- Replaces auto-closed #22547 with correct PR body format.
