### PR TITLE
fix(route): comicat pass visitor_test cookie to clear anti-bot interstitial

### DIFF
--- a/lib/routes/comicat/search.ts
+++ b/lib/routes/comicat/search.ts
@@ -7,6 +7,12 @@ import { parseDate } from '@/utils/parse-date';
 
 const baseUrl = 'https://comicat.org';
 
+// comicat.org fronts every page with a fake JS "captcha" interstitial (/public/html/start/)
+// whose only effect is to POST a form that sets a `visitor_test=human` cookie. Sending that
+// cookie directly skips the interstitial; without it every request 302s to the captcha page
+// and the listing/detail selectors match nothing.
+const headers = { Cookie: 'visitor_test=human' };
+
 export const route: Route = {
     path: '/search/:keyword',
     categories: ['anime'],
@@ -27,7 +33,7 @@ export const route: Route = {
 
 async function handler(ctx) {
     const keyword = ctx.req.param('keyword');
-    const { data: response } = await got(`${baseUrl}/search.php?keyword=${encodeURIComponent(keyword)}`);
+    const { data: response } = await got(`${baseUrl}/search.php?keyword=${encodeURIComponent(keyword)}`, { headers });
     const $ = load(response);
     const list = $('#listTable tbody > tr')
         .toArray()
@@ -41,7 +47,7 @@ async function handler(ctx) {
     const items = await Promise.all(
         list.map((item) =>
             cache.tryGet(item.link, async () => {
-                const { data: response } = await got(item.link);
+                const { data: response } = await got(item.link, { headers });
                 const $ = load(response);
 
                 item.pubDate = parseDate($('div.main > div.slayout > div > div.c1 > div:nth-child(1) > div > p:nth-child(4)').text().split('发布时间: ', 2)[1]);


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/comicat/search/芙莉莲
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This fixes the existing `comicat/search` route, which currently returns an empty feed.

comicat.org now fronts every page with a fake JS "captcha" interstitial (`/public/html/start/`). It has no real challenge or token — the `new CAPTCHA({ success: true })` animation simply submits a hidden form that sets a `visitor_test=human` cookie, then lets the visitor through. A bare `got()` request therefore 302s to that interstitial, so `#listTable` and the detail-page selectors match nothing.

This PR sends `Cookie: visitor_test=human` on both the search-listing request and the per-item detail requests, which clears the interstitial. No Puppeteer, no captcha solving, no new dependency.

Verified: `/comicat/search/芙莉莲` returns 50 items, each with a valid magnet enclosure.
