### PR TITLE
feat(route/1lou): add keyword search route

### DIFF
--- a/lib/routes/1lou/index.ts
+++ b/lib/routes/1lou/index.ts
@@ -1,12 +1,6 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
-import cache from '@/utils/cache';
-import got from '@/utils/got';
-import { parseDate } from '@/utils/parse-date';
-import timezone from '@/utils/timezone';
 
-const rootUrl = 'https://www.1lou.me';
+import { fetchThreads, rootUrl } from './util';
 
 export const handler = async (ctx) => {
     const { params } = ctx.req.param();
@@ -18,78 +12,7 @@ export const handler = async (ctx) => {
 
     const currentUrl = new URL(`${params && params.endsWith('.htm') ? params : `${params}.htm`}${queryString ? `?${queryString}` : ''}`, rootUrl).href;
 
-    const { data: response } = await got(currentUrl);
-
-    const $ = load(response);
-
-    const language = $('html').prop('lang');
-
-    let items = $('li.media.thread.tap:not(li.hidden-sm)')
-        .slice(0, limit)
-        .toArray()
-        .map((item) => {
-            item = $(item);
-
-            const subjectEl = item.find('div.subject').children('a').first();
-
-            return {
-                title: subjectEl.text(),
-                pubDate: timezone(parseDate(item.find('span.date').text()), +8),
-                link: new URL(subjectEl.prop('href'), rootUrl).href,
-                category: [
-                    item.find('a.text-secondary').text().replaceAll('[]', ''),
-                    ...item
-                        .find('a.badge')
-                        .toArray()
-                        .map((c) => $(c).text()),
-                ].filter(Boolean),
-                author: item.find('a.username').text(),
-                language,
-            };
-        });
-
-    items = await Promise.all(
-        items.map((item) =>
-            cache.tryGet(item.link, async () => {
-                const { data: detailResponse } = await got(item.link);
-
-                const $$ = load(detailResponse);
-
-                const title = $$('h4.break-all').contents().last().text();
-
-                if (title) {
-                    const description = $$('div.message.break-all').html();
-                    const image = new URL($$('img').first().prop('src'), rootUrl).href;
-
-                    item.title = title;
-                    item.description = description;
-                    item.pubDate = timezone(parseDate($$('span.date').text()), +8);
-                    item.category = $$('a.badge')
-                        .toArray()
-                        .map((c) => $$(c).text());
-                    item.content = {
-                        html: description,
-                        text: $$('div.message.break-all').text(),
-                    };
-                    item.image = image;
-                    item.banner = image;
-                    item.language = language;
-
-                    const torrents = $$('ul.attachlist li a');
-
-                    if (torrents.length > 0) {
-                        const torrent = torrents.first();
-
-                        item.enclosure_url = new URL(torrent.prop('href'), rootUrl).href;
-                        item.enclosure_type = 'application/x-bittorrent';
-                        item.enclosure_title = torrent.text();
-                    }
-                }
-
-                return item;
-            })
-        )
-    );
+    const { $, items, language } = await fetchThreads(currentUrl, limit);
 
     const author = 'BT 之家 1LOU 站';
     const image = new URL($('img.logo-2').prop('src'), rootUrl).href;
@@ -121,7 +44,7 @@ export const route: Route = {
 
 若订阅 [最新发帖电视剧](https://www.1lou.me/forum-2-1.htm?orderby=tid\\&digest=0)，网址为 \`https://www.1lou.me/forum-2-1.htm?orderby=tid&digest=0\`。截取 \`https://www.1lou.me/\` 到末尾 \`.htm\` 的部分 \`forum-2-1\` 作为参数，并补充 \`orderby\`，此时路由为 [\`/1lou/forum-2-1?orderby=tid\`](https://rsshub.app/1lou/forum-2-1?orderby=tid)。
 
-若订阅 [搜素繁花主题贴](https://www.1lou.me/search-_E7_B9_81_E8_8A_B1-1.htm)，网址为 \`https://www.1lou.me/search-_E7_B9_81_E8_8A_B1-1.htm\`。截取 \`https://www.1lou.me/\` 到末尾 \`.htm\` 的部分 \`search-_E7_B9_81_E8_8A_B1-1\` 作为参数，此时路由为 [\`/1lou/search-_E7_B9_81_E8_8A_B1-1\`](https://rsshub.app/1lou/search-_E7_B9_81_E8_8A_B1-1)。
+若搜索关键词，请使用 [\`/1lou/search/:keyword\`](https://rsshub.app/1lou/search/奥本海默) 路由。
 :::`,
     categories: ['multimedia'],
 

--- a/lib/routes/1lou/search.ts
+++ b/lib/routes/1lou/search.ts
@@ -1,0 +1,41 @@
+import type { Route } from '@/types';
+
+import { fetchThreads, rootUrl } from './util';
+
+async function handler(ctx) {
+    const keyword = ctx.req.param('keyword');
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 50;
+
+    const currentUrl = `${rootUrl}/search.htm?keyword=${encodeURIComponent(keyword)}`;
+
+    const { items, language } = await fetchThreads(currentUrl, limit);
+
+    return {
+        title: `${keyword} - BT 之家 1LOU 站搜索`,
+        link: currentUrl,
+        item: items,
+        allowEmpty: true,
+        language,
+    };
+}
+
+export const route: Route = {
+    path: '/search/:keyword',
+    name: '关键词搜索',
+    url: '1lou.me',
+    maintainers: ['falling', 'nczitzk', 'JaggerH'],
+    handler,
+    example: '/1lou/search/奥本海默',
+    parameters: { keyword: '搜索关键词' },
+    description: '1LOU 站的关键词搜索，对应站内 `https://www.1lou.me/search.htm?keyword=<关键词>`。',
+    categories: ['multimedia'],
+
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: true,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+};

--- a/lib/routes/1lou/util.ts
+++ b/lib/routes/1lou/util.ts
@@ -1,0 +1,88 @@
+import { load } from 'cheerio';
+
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+export const rootUrl = 'https://www.1lou.me';
+
+// A 1lou list page — forum listing or search results — is the same `li.media.thread.tap` markup.
+// Fetch it, take the newest `limit` threads, then hydrate each from its detail page (torrent
+// enclosure, body, cover). Returned `$` lets callers read page-level fields (title, logo).
+export async function fetchThreads(currentUrl: string, limit: number) {
+    const { data: response } = await got(currentUrl);
+
+    const $ = load(response);
+
+    const language = $('html').prop('lang');
+
+    let items = $('li.media.thread.tap:not(li.hidden-sm)')
+        .slice(0, limit)
+        .toArray()
+        .map((item) => {
+            item = $(item);
+
+            const subjectEl = item.find('div.subject').children('a').first();
+
+            return {
+                title: subjectEl.text(),
+                pubDate: timezone(parseDate(item.find('span.date').text()), +8),
+                link: new URL(subjectEl.prop('href'), rootUrl).href,
+                category: [
+                    item.find('a.text-secondary').text().replaceAll('[]', ''),
+                    ...item
+                        .find('a.badge')
+                        .toArray()
+                        .map((c) => $(c).text()),
+                ].filter(Boolean),
+                author: item.find('a.username').text(),
+                language,
+            };
+        });
+
+    items = await Promise.all(
+        items.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const { data: detailResponse } = await got(item.link);
+
+                const $$ = load(detailResponse);
+
+                const title = $$('h4.break-all').contents().last().text();
+
+                if (title) {
+                    const description = $$('div.message.break-all').html();
+                    const image = new URL($$('img').first().prop('src'), rootUrl).href;
+
+                    item.title = title;
+                    item.description = description;
+                    item.pubDate = timezone(parseDate($$('span.date').text()), +8);
+                    item.category = $$('a.badge')
+                        .toArray()
+                        .map((c) => $$(c).text());
+                    item.content = {
+                        html: description,
+                        text: $$('div.message.break-all').text(),
+                    };
+                    item.image = image;
+                    item.banner = image;
+                    item.language = language;
+
+                    const torrents = $$('ul.attachlist li a');
+
+                    if (torrents.length > 0) {
+                        const torrent = torrents.first();
+
+                        item.enclosure_url = new URL(torrent.prop('href'), rootUrl).href;
+                        item.enclosure_type = 'application/x-bittorrent';
+                        item.enclosure_title = torrent.text();
+                    }
+                }
+
+                return item;
+            })
+        )
+    );
+
+    return { $, items, language };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/1lou/search/奥本海默
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds a keyword search route for 1lou (BT 之家). The site exposes a plain GET search at `https://www.1lou.me/search.htm?keyword=<keyword>`, and its result rows use the exact same `li.media.thread.tap` markup as the forum listings that the existing `/1lou/:params` route already parses.

To avoid duplicating that listing + per-thread detail parse, I extracted it into `lib/routes/1lou/util.ts` (`fetchThreads`) and reuse it from both the existing generic route and the new `/search/:keyword` route. The keyword is a path parameter (not a custom query parameter). Detail fetches use `cache.tryGet`, dates go through `parseDate` + `timezone(+8)`, and each item carries its `.torrent` enclosure.

Verified: `/1lou/search/奥本海默` returns 20 threads, each with a `.torrent` enclosure.
