### PR TITLE
fix(route/bt0): migrate to mukaku.com API and add keyword search

### DIFF
--- a/lib/routes/bt0/mv.ts
+++ b/lib/routes/bt0/mv.ts
@@ -1,13 +1,14 @@
 import InvalidParameterError from '@/errors/types/invalid-parameter';
 import type { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
 
-import { doGot, genSize } from './util';
+import { api, genSize, host } from './util';
 
 export const route: Route = {
     path: '/mv/:number/:domain?',
     categories: ['multimedia'],
-    example: '/bt0/mv/35575567/2',
-    parameters: { number: '影视详情id, 网页路径为`/mv/{id}.html`其中的id部分, 一般为8位纯数字', domain: '数字1-9, 比如1表示请求域名为 1bt0.com, 默认为 2' },
+    example: '/bt0/mv/3158713',
+    parameters: { number: '影视详情 id, 网页详情页路径为 `/mv/{id}` 中的数字部分', domain: '镜像编号, 对应域名 web{domain}.mukaku.com, 常用 2/3/5, 默认为 2' },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -18,11 +19,11 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['2bt0.com/mv/'],
+            source: ['mukaku.com/mv/:number'],
         },
     ],
     name: '影视资源下载列表',
-    maintainers: ['miemieYaho'],
+    maintainers: ['miemieYaho', 'JaggerH'],
     handler,
 };
 
@@ -32,35 +33,27 @@ async function handler(ctx) {
     if (!/^[1-9]$/.test(domain)) {
         throw new InvalidParameterError('Invalid domain');
     }
-    const regex = /^\d{6,}$/;
-    if (!regex.test(number)) {
+    if (!/^\d{3,}$/.test(number)) {
         throw new InvalidParameterError('Invalid number');
     }
 
-    const host = `https://www.${domain}bt0.com`;
-    const _link = `${host}/prod/core/system/getVideoDetail/${number}`;
+    const data = await api(domain, 'getVideoDetail', { id: number });
 
-    const data = (await doGot(0, host, _link)).data;
-    const items = Object.values(data.ecca).flatMap((item) =>
-        item.map((i) => ({
-            title: i.zname,
-            guid: i.zname,
-            description: `${i.zname}[${i.zsize}]`,
-            link: `${host}/tr/${i.id}.html`,
-            pubDate: i.ezt,
-            enclosure_type: 'application/x-bittorrent',
-            enclosure_url: i.zlink,
-            enclosure_length: genSize(i.zsize),
-            category: strsJoin(i.zqxd, i.text_html, i.audio_html, i.new === 1 ? '新' : ''),
-        }))
-    );
+    const items = (data.all_seeds ?? []).map((i) => ({
+        title: i.zname,
+        guid: `mukaku-seed-${i.id}`,
+        description: `${i.zname}[${i.zsize}]`,
+        link: `${host(domain)}/tr/${i.id}.html`,
+        pubDate: parseDate(i.ezt),
+        enclosure_type: 'application/x-bittorrent',
+        enclosure_url: i.zlink,
+        enclosure_length: genSize(i.zsize),
+        category: [i.definition_group, i.zqxd, i.new === 1 ? '新' : ''].filter(Boolean),
+    }));
+
     return {
-        title: data.title,
-        link: `${host}/mv/${number}.html`,
+        title: `${data.title} - 不太灵影视`,
+        link: `${host(domain)}/mv/${number}`,
         item: items,
     };
-}
-
-function strsJoin(...strings) {
-    return strings.filter((str) => str !== '').join(',');
 }

--- a/lib/routes/bt0/namespace.ts
+++ b/lib/routes/bt0/namespace.ts
@@ -2,9 +2,9 @@ import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
     name: '不太灵影视',
-    url: '2bt0.com',
+    url: 'mukaku.com',
     description: `::: tip
-(1-9) bt0.com 都指向同一个
+站点由原 (1-9) bt0.com 迁至 web {domain}.mukaku.com，domain 取镜像编号（常用 2/3/5）。
 :::`,
     lang: 'zh-CN',
 };

--- a/lib/routes/bt0/search.ts
+++ b/lib/routes/bt0/search.ts
@@ -1,0 +1,47 @@
+import type { Route } from '@/types';
+
+import { api, host } from './util';
+
+export const route: Route = {
+    path: '/search/:keyword/:domain?',
+    categories: ['multimedia'],
+    example: '/bt0/search/复仇者',
+    parameters: { keyword: '搜索关键词', domain: '镜像编号, 对应域名 web{domain}.mukaku.com, 常用 2/3/5, 默认为 2' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: '关键词搜索',
+    maintainers: ['JaggerH'],
+    handler,
+};
+
+async function handler(ctx) {
+    const domain = ctx.req.param('domain') ?? '2';
+    const keyword = ctx.req.param('keyword');
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit'), 10) : 24;
+
+    // The site's own search box calls getVideoList with the keyword in `sb`; results are matched
+    // titles (not torrents). Each links to its detail page, where /bt0/mv/:number lists the seeds.
+    const data = await api(domain, 'getVideoList', { sb: keyword, page: 1, limit });
+    const list = Array.isArray(data) ? data : (data.data ?? []);
+
+    const items = list.map((v) => ({
+        title: `${v.title}${v.otitle ? ` ${v.otitle}` : ''}${v.years ? ` (${v.years})` : ''}`,
+        link: `${host(domain)}/mv/${v.idcode}`,
+        guid: `mukaku-mv-${v.idcode}`,
+        description: `${v.image ? `<img src="${v.image}"><br>` : ''}${[v.production_area, v.class, v.language].filter(Boolean).join(' / ')}${v.doub_score && v.doub_score !== '0' ? `<br>豆瓣评分：${v.doub_score}` : ''}${v.abstract ? `<br>${v.abstract.trim()}` : ''}`,
+        category: [v.class, v.production_area].filter(Boolean),
+    }));
+
+    return {
+        title: `${keyword} - 不太灵影视搜索`,
+        link: `${host(domain)}/search?sb=${encodeURIComponent(keyword)}`,
+        item: items,
+        allowEmpty: true,
+    };
+}

--- a/lib/routes/bt0/tlist.ts
+++ b/lib/routes/bt0/tlist.ts
@@ -1,8 +1,8 @@
 import InvalidParameterError from '@/errors/types/invalid-parameter';
 import type { Route } from '@/types';
-import { parseRelativeDate } from '@/utils/parse-date';
+import { parseDate, parseRelativeDate } from '@/utils/parse-date';
 
-import { doGot, genSize } from './util';
+import { api, genSize, host } from './util';
 
 const categoryDict = {
     1: '电影',
@@ -16,7 +16,7 @@ export const route: Route = {
     path: '/tlist/:sc/:domain?',
     categories: ['multimedia'],
     example: '/bt0/tlist/1',
-    parameters: { sc: '分类(1-5), 1:电影, 2:电视剧, 3:近日热门, 4:本周热门, 5:本月热门', domain: '数字1-9, 比如1表示请求域名为 1bt0.com, 默认为 2' },
+    parameters: { sc: '分类(1-5), 1:电影, 2:电视剧, 3:近日热门, 4:本周热门, 5:本月热门', domain: '镜像编号, 对应域名 web{domain}.mukaku.com, 常用 2/3/5, 默认为 2' },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -27,11 +27,11 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['2bt0.com/tlist/'],
+            source: ['mukaku.com/tlist/'],
         },
     ],
     name: '最新资源列表',
-    maintainers: ['miemieYaho'],
+    maintainers: ['miemieYaho', 'JaggerH'],
     handler,
 };
 
@@ -45,16 +45,13 @@ async function handler(ctx) {
         throw new InvalidParameterError('Invalid sc');
     }
 
-    const host = `https://www.${domain}bt0.com`;
-    const _link = `${host}/prod/core/system/getTList?sc=${sc}`;
-
-    const data = await doGot(0, host, _link);
-    const items = data.data.list.map((item) => ({
+    const data = await api(domain, 'getTList', { sc, page: 1 });
+    const items = data.list.map((item) => ({
         title: item.zname,
         guid: item.zname,
         description: `《${item.title}》  导演: ${item.daoyan}<br>编剧: ${item.bianji}<br>演员: ${item.yanyuan}<br>简介: ${item.conta.trim()}`,
-        link: host + item.aurl,
-        pubDate: item.eztime.endsWith('前') ? parseRelativeDate(item.eztime) : item.eztime,
+        link: host(domain) + item.aurl,
+        pubDate: item.eztime.endsWith('前') ? parseRelativeDate(item.eztime) : parseDate(item.eztime),
         enclosure_type: 'application/x-bittorrent',
         enclosure_url: item.zlink,
         enclosure_length: genSize(item.zsize),
@@ -62,7 +59,7 @@ async function handler(ctx) {
     }));
     return {
         title: `不太灵-最新资源列表-${categoryDict[sc]}`,
-        link: `${host}/tlist/${sc}_1.html`,
+        link: `${host(domain)}/tlist`,
         item: items,
     };
 }

--- a/lib/routes/bt0/util.ts
+++ b/lib/routes/bt0/util.ts
@@ -1,28 +1,30 @@
-import { CookieJar } from 'tough-cookie';
-
 import got from '@/utils/got';
 
-const cookieJar = new CookieJar();
+// The site formerly at (1-9)bt0.com now serves from web{domain}.mukaku.com as a Vue SPA backed
+// by a JSON API under /prod/api/v1/. Every request must carry app_id + identity: both are
+// constants hardcoded in the site's own JS bundle (an axios interceptor appends them to every
+// call) rather than per-visitor tokens, so replaying them verbatim is exactly what the site does.
+const APP_ID = '83768d9ad4';
+const IDENTITY = '23734adac0301bccdcb107c4aa21f96c';
 
-async function doGot(num, host, link) {
-    if (num > 4) {
-        throw new Error('The number of attempts has exceeded 5 times');
-    }
-    const response = await got.get(link, {
-        cookieJar,
+const host = (domain) => `https://web${domain}.mukaku.com`;
+
+// Call a /prod/api/v1/ endpoint and return its `data` payload, throwing on the API's own error envelope.
+const api = async (domain, path, params = {}) => {
+    const { data: body } = await got(`${host(domain)}/prod/api/v1/${path}`, {
+        searchParams: {
+            ...params,
+            app_id: APP_ID,
+            identity: IDENTITY,
+        },
     });
-    const data = response.data;
-    if (typeof data === 'string') {
-        const regex = /document\.cookie\s*=\s*"([^"]*)"/;
-        const match = data.match(regex);
-        if (!match) {
-            throw new Error('api error');
-        }
-        cookieJar.setCookieSync(match[1], host);
-        return doGot(num + 1, host, link);
+
+    if (!body?.success) {
+        throw new Error(`mukaku api ${path} failed: ${body?.code} ${body?.message}`);
     }
-    return data;
-}
+
+    return body.data;
+};
 
 const genSize = (sizeStr) => {
     // 正则表达式，用于匹配数字和单位 GB 或 MB
@@ -50,4 +52,4 @@ const genSize = (sizeStr) => {
     return bytes;
 };
 
-export { doGot, genSize };
+export { api, genSize, host };


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bt0/tlist/1
/bt0/mv/3158713
/bt0/search/复仇者
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

不太灵影视 has moved from `(1-9)bt0.com` to `web{domain}.mukaku.com` and rebuilt itself as a Vue SPA backed by a JSON API under `/prod/api/v1/`. The old `/prod/core/system/*` endpoints now 404, so the existing `mv` and `tlist` routes stopped returning items. This PR repoints them at the new API and adds a keyword search route.

- **util.ts** — a small `api()` helper for the new host + `/prod/api/v1/` base. Every request must carry `app_id` + `identity`; both are constants hardcoded in the site's own JS bundle (an axios request interceptor appends them to every call), not per-visitor tokens, so the route replays them verbatim — no captcha or token solving involved.
- **tlist** — now `getTList` (the `data.list[]` shape is unchanged; only the base/params moved).
- **mv** — now `getVideoDetail?id=`, reading the flat `data.all_seeds[]` seed list.
- **search** (new, `/bt0/search/:keyword/:domain?`) — `getVideoList?sb=`, the endpoint the site's own search box uses. Results are matched titles that each link to their detail page (where `/bt0/mv/:number` lists the seeds); keyword is a path parameter and the common `limit` is honoured.

Verified against `web2.mukaku.com`: `/bt0/tlist/1` → 20 items with magnet enclosures, `/bt0/mv/3158713` → 6 seeds, `/bt0/search/复仇者` → 30 matched titles.
