### PR TITLE
fix(bilibili): avoid unnecessary browser and jsdom loading

### DIFF
--- a/lib/bilibili-cache.test.ts
+++ b/lib/bilibili-cache.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    cacheGet: vi.fn(),
+    cacheSet: vi.fn(),
+    cacheTryGet: vi.fn(),
+    destroy: vi.fn(),
+    getPlaywrightPage: vi.fn(),
+    got: vi.fn(),
+    jsdomLoaded: vi.fn(),
+    playwrightLoaded: vi.fn(),
+}));
+
+const configMock = vi.hoisted(() => ({
+    bilibili: {
+        cookies: {} as Record<string, string>,
+    },
+}));
+
+vi.mock('@/config', () => ({ config: configMock }));
+vi.mock('@/utils/cache', () => ({
+    default: {
+        get: mocks.cacheGet,
+        set: mocks.cacheSet,
+        tryGet: mocks.cacheTryGet,
+    },
+}));
+vi.mock('@/utils/got', () => ({ default: mocks.got }));
+vi.mock('@/utils/logger', () => ({
+    default: {
+        debug: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+vi.mock('@/utils/playwright', () => {
+    mocks.playwrightLoaded();
+    return { getPlaywrightPage: mocks.getPlaywrightPage };
+});
+vi.mock('jsdom', () => {
+    mocks.jsdomLoaded();
+    return { JSDOM: class {} };
+});
+
+describe('Bilibili cache helpers', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        mocks.cacheGet.mockReset();
+        mocks.cacheSet.mockReset();
+        mocks.cacheTryGet.mockReset().mockImplementation((_key, getter) => getter());
+        mocks.destroy.mockReset();
+        mocks.getPlaywrightPage.mockReset().mockResolvedValue({ destroy: mocks.destroy });
+        mocks.got.mockReset();
+        mocks.jsdomLoaded.mockClear();
+        mocks.playwrightLoaded.mockClear();
+
+        for (const key of Object.keys(configMock.bilibili.cookies)) {
+            delete configMock.bilibili.cookies[key];
+        }
+    });
+
+    it('does not load JSDOM or Playwright when the cache module is imported', async () => {
+        await import('@/routes/bilibili/cache');
+
+        expect(mocks.jsdomLoaded).not.toHaveBeenCalled();
+        expect(mocks.playwrightLoaded).not.toHaveBeenCalled();
+    });
+
+    it('parses the access id from render data without JSDOM', async () => {
+        configMock.bilibili.cookies.account = 'SESSDATA=test';
+        const renderData = encodeURIComponent(JSON.stringify({ access_id: 'access-id' }));
+        mocks.got.mockResolvedValueOnce({
+            data: `<html><body><script id="__RENDER_DATA__">${renderData}</script></body></html>`,
+        });
+
+        const { default: bilibiliCache } = await import('@/routes/bilibili/cache');
+
+        await expect(bilibiliCache.getRenderData('1')).resolves.toBe('access-id');
+        expect(mocks.jsdomLoaded).not.toHaveBeenCalled();
+    });
+
+    it('fetches the public WBI key without a cookie or browser', async () => {
+        const permutation = Array.from({ length: 64 }, (_, index) => index);
+        mocks.got.mockImplementation((url) => {
+            if (url === 'https://api.bilibili.com/x/web-interface/nav') {
+                return {
+                    data: {
+                        data: {
+                            wbi_img: {
+                                img_url: 'https://i0.hdslb.com/bfs/wbi/abc.png',
+                                sub_url: 'https://i0.hdslb.com/bfs/wbi/def.png',
+                            },
+                        },
+                    },
+                };
+            }
+
+            return { body: `const permutation = ${JSON.stringify(permutation)};` };
+        });
+
+        const { default: bilibiliCache } = await import('@/routes/bilibili/cache');
+
+        await expect(bilibiliCache.getWbiVerifyString()).resolves.toBe('abcdef');
+        expect(mocks.getPlaywrightPage).not.toHaveBeenCalled();
+        expect(mocks.got).toHaveBeenCalledWith('https://api.bilibili.com/x/web-interface/nav', {
+            headers: {
+                Referer: 'https://www.bilibili.com/',
+            },
+        });
+    });
+});

--- a/lib/routes/bilibili/cache.ts
+++ b/lib/routes/bilibili/cache.ts
@@ -1,12 +1,10 @@
 import { load } from 'cheerio';
-import { JSDOM } from 'jsdom';
 import { RateLimiterMemory, RateLimiterQueue } from 'rate-limiter-flexible';
 
 import { config } from '@/config';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import logger from '@/utils/logger';
-import { getPlaywrightPage } from '@/utils/playwright';
 
 import utils from './utils';
 
@@ -48,6 +46,7 @@ const getCookie = (disableConfig = false) => {
         let waitForRequest = new Promise<string>((resolve) => {
             resolve('');
         });
+        const { getPlaywrightPage } = await import('@/utils/playwright');
         const { destroy } = await getPlaywrightPage('https://space.bilibili.com/1/dynamic', {
             onBeforeLoad: (page) => {
                 waitForRequest = new Promise<string>((resolve) => {
@@ -80,10 +79,8 @@ const getRenderData = (uid) => {
                 Cookie: cookie,
             },
         });
-        const dom = new JSDOM(response);
-        const document = dom.window.document;
-        const scriptElement = document.querySelector('#__RENDER_DATA__');
-        const innerText = scriptElement ? scriptElement.textContent || '{}' : '{}';
+        const $ = load(response);
+        const innerText = $('#__RENDER_DATA__').text() || '{}';
         const renderData = JSON.parse(decodeURIComponent(innerText));
         const accessId = renderData.access_id;
         return accessId;
@@ -93,11 +90,9 @@ const getRenderData = (uid) => {
 const getWbiVerifyString = () => {
     const key = 'bili-wbi-verify-string';
     return cache.tryGet(key, async () => {
-        const cookie = await getCookie();
         const { data: navResponse } = await got('https://api.bilibili.com/x/web-interface/nav', {
             headers: {
                 Referer: 'https://www.bilibili.com/',
-                Cookie: cookie,
             },
         });
         const imgUrl = navResponse.data.wbi_img.img_url;


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。
```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/bilibili/weekly
/bilibili/hot-search
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Problem

`/bilibili/weekly` uses the shared Bilibili `cache.ts` for optional JSON Feed subtitles. Because that file imported JSDOM and the browser helper at the top level, a regular RSS request loaded both even though it used neither. On Vercel, JSDOM's dependency tree hit a CommonJS/ESM error during module loading, so the route failed before it could do any work.

`/bilibili/hot-search` had a separate issue. It only needs WBI keys from Bilibili's public nav endpoint, but `getWbiVerifyString()` called `getCookie()` first. Without a configured Cookie, RSSHub fell back to Patchright to obtain one, then failed because the Vercel deployment had no Chromium executable.

## Changes

- `lib/routes/bilibili/cache.ts` now uses the existing Cheerio parser for `#__RENDER_DATA__`. The browser helper is imported inside `getCookie()`, and public WBI keys are fetched without first acquiring or sending a Cookie.

- `lib/bilibili-cache.test.ts` adds three focused checks for module loading, Render Data parsing, and anonymous WBI key retrieval.

## Result

Regular `/bilibili/weekly` RSS requests no longer touch JSDOM or the browser helper. `/bilibili/hot-search` works without a configured Cookie or Chromium. Routes that need Cookies still use `getCookie()`, and the JSON subtitle flow is unchanged.

## Verification

Ran the three new regression tests together with two existing Bilibili video route tests; all five passed. I also called the hot-search handler without a configured Cookie and got 10 items back without launching browser automation.
