### PR TITLE
feat(route): add El Universal Venezuela news

### DIFF
--- a/lib/routes/eluniversal/index.ts
+++ b/lib/routes/eluniversal/index.ts
@@ -3,20 +3,19 @@ import { load } from 'cheerio';
 import type { Route } from '@/types';
 import ofetch from '@/utils/ofetch';
 
-const rootUrl = 'https://www.eluniversal.com.mx';
-const rootHost = 'eluniversal.com.mx';
-const hrefPattern = /\/[a-z-]+\/[a-z0-9-]{25,}\//;
-
-const registrable = (h: string) => h.split('.').slice(-2).join('.');
+const rootUrl = 'https://www.eluniversal.com';
+const rootHost = 'eluniversal.com';
+// /politica/236999/slug-title
+const hrefPattern = /^\/[a-z-]+\/\d{5,}\/[a-z0-9-]+\/?$/;
 
 export const route: Route = {
     path: '/',
     categories: ['traditional-media'],
     example: '/eluniversal',
-    radar: [{ source: ['eluniversal.com.mx/', 'eluniversal.com.mx/*'], target: '/' }],
+    radar: [{ source: ['eluniversal.com/', 'eluniversal.com/*'], target: '/' }],
     name: 'News',
     maintainers: ['lisyer'],
-    url: 'eluniversal.com.mx/',
+    url: 'eluniversal.com/',
     handler,
 };
 
@@ -40,15 +39,15 @@ async function handler(ctx) {
             continue;
         }
         try {
-            const hostName = new URL(link).hostname.replace(/^www\./, '');
-            if (hostName !== rootHost && !hostName.endsWith('.' + rootHost) && registrable(hostName) !== registrable(rootHost)) {
+            const host = new URL(link).hostname.replace(/^www\./, '');
+            if (host !== rootHost && !host.endsWith('.' + rootHost)) {
                 continue;
             }
         } catch {
             continue;
         }
         const path = new URL(link).pathname;
-        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+        if (!hrefPattern.test(path)) {
             continue;
         }
         if (seen.has(link)) {
@@ -69,7 +68,7 @@ async function handler(ctx) {
     }
 
     return {
-        title: 'El Universal',
+        title: 'El Universal Venezuela',
         link: rootUrl,
         language: 'es',
         item: items,

--- a/lib/routes/eluniversal/index.ts
+++ b/lib/routes/eluniversal/index.ts
@@ -1,0 +1,77 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+const rootUrl = 'https://www.eluniversal.com.mx';
+const rootHost = 'eluniversal.com.mx';
+const hrefPattern = /\/[a-z-]+\/[a-z0-9-]{25,}\//;
+
+const registrable = (h: string) => h.split('.').slice(-2).join('.');
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/eluniversal',
+    radar: [{ source: ['eluniversal.com.mx/', 'eluniversal.com.mx/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'eluniversal.com.mx/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const html = await ofetch(rootUrl);
+    const $ = load(html);
+    const seen = new Set<string>();
+    const items: Array<{ title: string; link: string }> = [];
+
+    for (const el of $('a[href]').toArray()) {
+        const a = $(el);
+        const href = a.attr('href') || '';
+        if (!href || href.startsWith('#') || href.startsWith('javascript')) {
+            continue;
+        }
+        let link: string;
+        try {
+            link = new URL(href, rootUrl).href;
+        } catch {
+            continue;
+        }
+        try {
+            const hostName = new URL(link).hostname.replace(/^www\./, '');
+            if (hostName !== rootHost && !hostName.endsWith('.' + rootHost) && registrable(hostName) !== registrable(rootHost)) {
+                continue;
+            }
+        } catch {
+            continue;
+        }
+        const path = new URL(link).pathname;
+        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+            continue;
+        }
+        if (seen.has(link)) {
+            continue;
+        }
+        let title = a.attr('title')?.trim() || a.text().replaceAll(/\s+/g, ' ').trim();
+        if (!title || title.length < 10) {
+            title = a.closest('article, li, div').find('h1, h2, h3, h4').first().text().replaceAll(/\s+/g, ' ').trim() || title;
+        }
+        if (!title || title.length < 10) {
+            continue;
+        }
+        seen.add(link);
+        items.push({ title, link });
+        if (items.length >= limit) {
+            break;
+        }
+    }
+
+    return {
+        title: 'El Universal',
+        link: rootUrl,
+        language: 'es',
+        item: items,
+    };
+}

--- a/lib/routes/eluniversal/namespace.ts
+++ b/lib/routes/eluniversal/namespace.ts
@@ -1,8 +1,8 @@
 import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
-    name: 'El Universal',
-    url: 'eluniversal.com.mx',
+    name: 'El Universal Venezuela',
+    url: 'eluniversal.com',
     lang: 'es',
     categories: ['traditional-media'],
 };

--- a/lib/routes/eluniversal/namespace.ts
+++ b/lib/routes/eluniversal/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'El Universal',
+    url: 'eluniversal.com.mx',
+    lang: 'es',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add news list route for [El Universal Venezuela](https://www.eluniversal.com/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/eluniversal
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Maintainer: @lisyer
- Homepage HTML list scrape for article paths `/section/{id}/{slug}`
- No official RSS found on site
- Replaces auto-closed #22548 (wrong body format; also fixed wrong .mx domain)