### PR TITLE
feat(route): add Daily Mirror Sri Lanka news

### DIFF
--- a/lib/routes/dailymirrorlk/index.ts
+++ b/lib/routes/dailymirrorlk/index.ts
@@ -1,0 +1,77 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+const rootUrl = 'https://www.dailymirror.lk';
+const rootHost = 'dailymirror.lk';
+const hrefPattern = /\/\d+-\d+/;
+
+const registrable = (h: string) => h.split('.').slice(-2).join('.');
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/dailymirrorlk',
+    radar: [{ source: ['dailymirror.lk/', 'dailymirror.lk/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'dailymirror.lk/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const html = await ofetch(rootUrl);
+    const $ = load(html);
+    const seen = new Set<string>();
+    const items: Array<{ title: string; link: string }> = [];
+
+    for (const el of $('a[href]').toArray()) {
+        const a = $(el);
+        const href = a.attr('href') || '';
+        if (!href || href.startsWith('#') || href.startsWith('javascript')) {
+            continue;
+        }
+        let link: string;
+        try {
+            link = new URL(href, rootUrl).href;
+        } catch {
+            continue;
+        }
+        try {
+            const hostName = new URL(link).hostname.replace(/^www\./, '');
+            if (hostName !== rootHost && !hostName.endsWith('.' + rootHost) && registrable(hostName) !== registrable(rootHost)) {
+                continue;
+            }
+        } catch {
+            continue;
+        }
+        const path = new URL(link).pathname;
+        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+            continue;
+        }
+        if (seen.has(link)) {
+            continue;
+        }
+        let title = a.attr('title')?.trim() || a.text().replaceAll(/\s+/g, ' ').trim();
+        if (!title || title.length < 10) {
+            title = a.closest('article, li, div').find('h1, h2, h3, h4').first().text().replaceAll(/\s+/g, ' ').trim() || title;
+        }
+        if (!title || title.length < 10) {
+            continue;
+        }
+        seen.add(link);
+        items.push({ title, link });
+        if (items.length >= limit) {
+            break;
+        }
+    }
+
+    return {
+        title: 'Daily Mirror Sri Lanka',
+        link: rootUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/dailymirrorlk/index.ts
+++ b/lib/routes/dailymirrorlk/index.ts
@@ -5,9 +5,8 @@ import ofetch from '@/utils/ofetch';
 
 const rootUrl = 'https://www.dailymirror.lk';
 const rootHost = 'dailymirror.lk';
-const hrefPattern = /\/\d+-\d+/;
-
-const registrable = (h: string) => h.split('.').slice(-2).join('.');
+// /breaking-news/Article-Title/108-345280
+const hrefPattern = /^\/[a-z0-9-]+\/[^/]+\/\d+-\d+\/?$/i;
 
 export const route: Route = {
     path: '/',
@@ -40,15 +39,15 @@ async function handler(ctx) {
             continue;
         }
         try {
-            const hostName = new URL(link).hostname.replace(/^www\./, '');
-            if (hostName !== rootHost && !hostName.endsWith('.' + rootHost) && registrable(hostName) !== registrable(rootHost)) {
+            const host = new URL(link).hostname.replace(/^www\./, '');
+            if (host !== rootHost && !host.endsWith('.' + rootHost)) {
                 continue;
             }
         } catch {
             continue;
         }
         const path = new URL(link).pathname;
-        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+        if (!hrefPattern.test(path)) {
             continue;
         }
         if (seen.has(link)) {

--- a/lib/routes/dailymirrorlk/namespace.ts
+++ b/lib/routes/dailymirrorlk/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Daily Mirror Sri Lanka',
+    url: 'dailymirror.lk',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add news list route for [Daily Mirror Sri Lanka](https://www.dailymirror.lk/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/dailymirrorlk
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Maintainer: @lisyer
- Homepage HTML list scrape for article URLs like `/breaking-news/{slug}/{cat}-{id}`
- Official `/rss` returns HTML, not a usable feed
- Replaces auto-closed #22561 (PR body format / route detection)