### PR TITLE
feat(route): add Listín Diario news

### DIFF
--- a/lib/routes/listindiario/index.ts
+++ b/lib/routes/listindiario/index.ts
@@ -1,0 +1,77 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+const rootUrl = 'https://www.listindiario.com';
+const rootHost = 'listindiario.com';
+const hrefPattern = /\/\d{6,}/;
+
+const registrable = (h: string) => h.split('.').slice(-2).join('.');
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/listindiario',
+    radar: [{ source: ['listindiario.com/', 'listindiario.com/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'listindiario.com/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const html = await ofetch(rootUrl);
+    const $ = load(html);
+    const seen = new Set<string>();
+    const items: Array<{ title: string; link: string }> = [];
+
+    for (const el of $('a[href]').toArray()) {
+        const a = $(el);
+        const href = a.attr('href') || '';
+        if (!href || href.startsWith('#') || href.startsWith('javascript')) {
+            continue;
+        }
+        let link: string;
+        try {
+            link = new URL(href, rootUrl).href;
+        } catch {
+            continue;
+        }
+        try {
+            const hostName = new URL(link).hostname.replace(/^www\./, '');
+            if (hostName !== rootHost && !hostName.endsWith('.' + rootHost) && registrable(hostName) !== registrable(rootHost)) {
+                continue;
+            }
+        } catch {
+            continue;
+        }
+        const path = new URL(link).pathname;
+        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+            continue;
+        }
+        if (seen.has(link)) {
+            continue;
+        }
+        let title = a.attr('title')?.trim() || a.text().replaceAll(/\s+/g, ' ').trim();
+        if (!title || title.length < 10) {
+            title = a.closest('article, li, div').find('h1, h2, h3, h4').first().text().replaceAll(/\s+/g, ' ').trim() || title;
+        }
+        if (!title || title.length < 10) {
+            continue;
+        }
+        seen.add(link);
+        items.push({ title, link });
+        if (items.length >= limit) {
+            break;
+        }
+    }
+
+    return {
+        title: 'Listín Diario',
+        link: rootUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/listindiario/index.ts
+++ b/lib/routes/listindiario/index.ts
@@ -5,9 +5,8 @@ import ofetch from '@/utils/ofetch';
 
 const rootUrl = 'https://www.listindiario.com';
 const rootHost = 'listindiario.com';
-const hrefPattern = /\/\d{6,}/;
-
-const registrable = (h: string) => h.split('.').slice(-2).join('.');
+// /section/.../20260710/slug_913293.html
+const hrefPattern = /\/\d{8}\/[^/]+_\d+\.html?$/i;
 
 export const route: Route = {
     path: '/',
@@ -27,7 +26,9 @@ async function handler(ctx) {
     const seen = new Set<string>();
     const items: Array<{ title: string; link: string }> = [];
 
-    for (const el of $('a[href]').toArray()) {
+    // Prefer article cards over scanning every anchor on the page
+    const anchors = $('.c-article a[href], a.c-article__title[href]').toArray();
+    for (const el of anchors) {
         const a = $(el);
         const href = a.attr('href') || '';
         if (!href || href.startsWith('#') || href.startsWith('javascript')) {
@@ -40,15 +41,15 @@ async function handler(ctx) {
             continue;
         }
         try {
-            const hostName = new URL(link).hostname.replace(/^www\./, '');
-            if (hostName !== rootHost && !hostName.endsWith('.' + rootHost) && registrable(hostName) !== registrable(rootHost)) {
+            const host = new URL(link).hostname.replace(/^www\./, '');
+            if (host !== rootHost && !host.endsWith('.' + rootHost)) {
                 continue;
             }
         } catch {
             continue;
         }
         const path = new URL(link).pathname;
-        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+        if (!hrefPattern.test(path)) {
             continue;
         }
         if (seen.has(link)) {
@@ -56,7 +57,7 @@ async function handler(ctx) {
         }
         let title = a.attr('title')?.trim() || a.text().replaceAll(/\s+/g, ' ').trim();
         if (!title || title.length < 10) {
-            title = a.closest('article, li, div').find('h1, h2, h3, h4').first().text().replaceAll(/\s+/g, ' ').trim() || title;
+            title = a.closest('.c-article, article, li, div').find('.c-article__title, h1, h2, h3').first().text().replaceAll(/\s+/g, ' ').trim() || title;
         }
         if (!title || title.length < 10) {
             continue;
@@ -71,7 +72,7 @@ async function handler(ctx) {
     return {
         title: 'Listín Diario',
         link: rootUrl,
-        language: 'en',
+        language: 'es',
         item: items,
     };
 }

--- a/lib/routes/listindiario/namespace.ts
+++ b/lib/routes/listindiario/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Listín Diario',
+    url: 'listindiario.com',
+    lang: 'en',
+    categories: ['traditional-media'],
+};

--- a/lib/routes/listindiario/namespace.ts
+++ b/lib/routes/listindiario/namespace.ts
@@ -3,6 +3,6 @@ import type { Namespace } from '@/types';
 export const namespace: Namespace = {
     name: 'Listín Diario',
     url: 'listindiario.com',
-    lang: 'en',
+    lang: 'es',
     categories: ['traditional-media'],
 };


### PR DESCRIPTION
Add news list route for [Listín Diario](https://www.listindiario.com/).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/listindiario
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Maintainer: @lisyer
- Homepage HTML list from `.c-article` cards
- Article URLs like `/la-republica/.../20260710/slug_913293.html`
- No usable official RSS (`/rss`, `/feed` return 404)
- Replaces auto-closed #22575 (PR body format); addresses auto-review about brute-force selectors