### PR TITLE
feat(route): add The New Times news

### DIFF
--- a/lib/routes/newtimes/index.ts
+++ b/lib/routes/newtimes/index.ts
@@ -1,0 +1,77 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+const rootUrl = 'https://www.newtimes.co.rw';
+const rootHost = 'newtimes.co.rw';
+const hrefPattern = /\d{5,}/;
+
+const registrable = (h: string) => h.split('.').slice(-2).join('.');
+
+export const route: Route = {
+    path: '/',
+    categories: ['traditional-media'],
+    example: '/newtimes',
+    radar: [{ source: ['newtimes.co.rw/', 'newtimes.co.rw/*'], target: '/' }],
+    name: 'News',
+    maintainers: ['lisyer'],
+    url: 'newtimes.co.rw/',
+    handler,
+};
+
+async function handler(ctx) {
+    const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
+    const html = await ofetch(rootUrl);
+    const $ = load(html);
+    const seen = new Set<string>();
+    const items: Array<{ title: string; link: string }> = [];
+
+    for (const el of $('a[href]').toArray()) {
+        const a = $(el);
+        const href = a.attr('href') || '';
+        if (!href || href.startsWith('#') || href.startsWith('javascript')) {
+            continue;
+        }
+        let link: string;
+        try {
+            link = new URL(href, rootUrl).href;
+        } catch {
+            continue;
+        }
+        try {
+            const hostName = new URL(link).hostname.replace(/^www\./, '');
+            if (hostName !== rootHost && !hostName.endsWith('.' + rootHost) && registrable(hostName) !== registrable(rootHost)) {
+                continue;
+            }
+        } catch {
+            continue;
+        }
+        const path = new URL(link).pathname;
+        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+            continue;
+        }
+        if (seen.has(link)) {
+            continue;
+        }
+        let title = a.attr('title')?.trim() || a.text().replaceAll(/\s+/g, ' ').trim();
+        if (!title || title.length < 10) {
+            title = a.closest('article, li, div').find('h1, h2, h3, h4').first().text().replaceAll(/\s+/g, ' ').trim() || title;
+        }
+        if (!title || title.length < 10) {
+            continue;
+        }
+        seen.add(link);
+        items.push({ title, link });
+        if (items.length >= limit) {
+            break;
+        }
+    }
+
+    return {
+        title: 'The New Times',
+        link: rootUrl,
+        language: 'en',
+        item: items,
+    };
+}

--- a/lib/routes/newtimes/index.ts
+++ b/lib/routes/newtimes/index.ts
@@ -4,10 +4,10 @@ import type { Route } from '@/types';
 import ofetch from '@/utils/ofetch';
 
 const rootUrl = 'https://www.newtimes.co.rw';
+const listUrl = `${rootUrl}/news`;
 const rootHost = 'newtimes.co.rw';
-const hrefPattern = /\d{5,}/;
-
-const registrable = (h: string) => h.split('.').slice(-2).join('.');
+// /article/37279/news/energy/slug
+const hrefPattern = /^\/article\/\d+(?:\/[a-z0-9-]+)*\/?$/i;
 
 export const route: Route = {
     path: '/',
@@ -22,12 +22,14 @@ export const route: Route = {
 
 async function handler(ctx) {
     const limit = ctx.req.query('limit') ? Math.trunc(Number(ctx.req.query('limit'))) : 20;
-    const html = await ofetch(rootUrl);
+    const html = await ofetch(listUrl);
     const $ = load(html);
     const seen = new Set<string>();
     const items: Array<{ title: string; link: string }> = [];
 
-    for (const el of $('a[href]').toArray()) {
+    // Prefer article title links over scanning every anchor
+    const anchors = $('.article-title a[href], a.article-title[href], .articles-list a[href*="/article/"]').toArray();
+    for (const el of anchors) {
         const a = $(el);
         const href = a.attr('href') || '';
         if (!href || href.startsWith('#') || href.startsWith('javascript')) {
@@ -40,15 +42,15 @@ async function handler(ctx) {
             continue;
         }
         try {
-            const hostName = new URL(link).hostname.replace(/^www\./, '');
-            if (hostName !== rootHost && !hostName.endsWith('.' + rootHost) && registrable(hostName) !== registrable(rootHost)) {
+            const host = new URL(link).hostname.replace(/^www\./, '');
+            if (host !== rootHost && !host.endsWith('.' + rootHost)) {
                 continue;
             }
         } catch {
             continue;
         }
         const path = new URL(link).pathname;
-        if (!hrefPattern.test(path) && !hrefPattern.test(href)) {
+        if (!hrefPattern.test(path)) {
             continue;
         }
         if (seen.has(link)) {
@@ -56,7 +58,7 @@ async function handler(ctx) {
         }
         let title = a.attr('title')?.trim() || a.text().replaceAll(/\s+/g, ' ').trim();
         if (!title || title.length < 10) {
-            title = a.closest('article, li, div').find('h1, h2, h3, h4').first().text().replaceAll(/\s+/g, ' ').trim() || title;
+            title = a.closest('.article, .second-article, li, div').find('.article-title, h1, h2, h3').first().text().replaceAll(/\s+/g, ' ').trim() || title;
         }
         if (!title || title.length < 10) {
             continue;
@@ -70,7 +72,7 @@ async function handler(ctx) {
 
     return {
         title: 'The New Times',
-        link: rootUrl,
+        link: listUrl,
         language: 'en',
         item: items,
     };

--- a/lib/routes/newtimes/namespace.ts
+++ b/lib/routes/newtimes/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'The New Times',
+    url: 'newtimes.co.rw',
+    lang: 'en',
+    categories: ['traditional-media'],
+};


### PR DESCRIPTION
Add news list route for [The New Times](https://www.newtimes.co.rw/) (Rwanda).

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/newtimes
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- Maintainer: @lisyer
- List page: `https://www.newtimes.co.rw/news`
- Selectors: `.article-title a` / article list cards
- Article URLs like `/article/{id}/news/.../slug`
- No usable official RSS (`/rss`, `/feed` are HTML/404)
- Replaces auto-closed #22576 (PR body format); addresses auto-review about brute-force `$('a[href]')`