### PR TITLE
fix(route/imdb): fetch charts from GraphQL API

### DIFF
--- a/lib/routes/imdb/chart.tsx
+++ b/lib/routes/imdb/chart.tsx
@@ -1,4 +1,3 @@
-import * as cheerio from 'cheerio';
 import type { Context } from 'hono';
 import { renderToString } from 'hono/jsx/dom/server';
 
@@ -7,6 +6,48 @@ import { ViewType } from '@/types';
 import ofetch from '@/utils/ofetch';
 
 import type { ChartTitleSearchConnection } from './types';
+
+// IMDb no longer ships chart data in the page HTML (it is behind an AWS WAF JS
+// challenge). The same data is served by IMDb's public GraphQL API, which we
+// query directly.
+const GRAPHQL_ENDPOINT = 'https://api.graphql.imdb.com/';
+
+// Route chart id -> ChartTitleType GraphQL enum.
+const CHART_TYPES = {
+    top: 'TOP_RATED_MOVIES',
+    moviemeter: 'MOST_POPULAR_MOVIES',
+    toptv: 'TOP_RATED_TV_SHOWS',
+    tvmeter: 'MOST_POPULAR_TV_SHOWS',
+};
+
+const CHART_NAMES = {
+    top: 'Top 250 Movies',
+    moviemeter: 'Most Popular Movies',
+    toptv: 'Top 250 TV Shows',
+    tvmeter: 'Most Popular TV Shows',
+};
+
+const CHART_QUERY = `
+    query Chart($chartType: ChartTitleType!, $first: Int!) {
+        chartTitles(chart: { chartType: $chartType }, first: $first) {
+            edges {
+                currentRank
+                node {
+                    id
+                    titleText { text }
+                    originalTitleText { text }
+                    titleType { text }
+                    releaseYear { year endYear }
+                    primaryImage { url caption { plainText } }
+                    ratingsSummary { aggregateRating voteCount }
+                    certificate { rating }
+                    plot { plotText { plainText } }
+                    titleGenres { genres { genre { text } } }
+                }
+            }
+        }
+    }
+`;
 
 const render = ({ primaryImage, originalTitleText, certificate, ratingsSummary, plot }) =>
     renderToString(
@@ -53,7 +94,7 @@ export const route: Route = {
         },
     ],
     name: 'Charts',
-    maintainers: ['TonyRL'],
+    maintainers: ['TonyRL', 'JaggerH'],
     handler,
     url: 'www.imdb.com/chart/top/',
     description: `| Top 250 Movies | Most Popular Movies | Top 250 TV Shows | Most Popular TV Shows |
@@ -63,16 +104,24 @@ export const route: Route = {
 
 async function handler(ctx: Context) {
     const { chart = 'top' } = ctx.req.param();
-    const baseUrl = 'https://www.imdb.com';
-    const link = `${baseUrl}/chart/${chart}/`;
+    const chartType = CHART_TYPES[chart] ?? CHART_TYPES.top;
+    const link = `https://www.imdb.com/chart/${chart}/`;
 
-    const response = await ofetch(link);
-    const $ = cheerio.load(response);
-    const nextData = JSON.parse($('script#__NEXT_DATA__').text());
-    const chartTitles = nextData.props.pageProps.pageData.chartTitles as ChartTitleSearchConnection;
+    const { data } = await ofetch<{ data: { chartTitles: ChartTitleSearchConnection } }>(GRAPHQL_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            'x-imdb-user-country': 'US',
+            'x-imdb-user-language': 'en-US',
+        },
+        body: {
+            query: CHART_QUERY,
+            variables: { chartType, first: 250 },
+        },
+    });
 
-    const items = chartTitles.edges.map(({ currentRank, node }) => ({
-        title: `${currentRank}. ${node.titleText.text} (${node.releaseYear.year}${node.releaseYear.endYear ? `-${node.releaseYear.endYear}` : ''})`,
+    const items = data.chartTitles.edges.map(({ currentRank, node }) => ({
+        title: `${currentRank}. ${node.titleText.text}${node.releaseYear ? ` (${node.releaseYear.year}${node.releaseYear.endYear ? `-${node.releaseYear.endYear}` : ''})` : ''}`,
         description: render({
             primaryImage: node.primaryImage,
             originalTitleText: node.originalTitleText,
@@ -80,13 +129,12 @@ async function handler(ctx: Context) {
             ratingsSummary: node.ratingsSummary,
             plot: node.plot,
         }),
-        link: `${baseUrl}/title/${node.id}`,
-        category: node.titleGenres.genres.map((g) => chartTitles.genres.find((genre) => genre.filterId === g.genre.text)?.text),
+        link: `https://www.imdb.com/title/${node.id}`,
+        category: node.titleGenres?.genres.map((g) => g.genre.text) ?? [],
     }));
 
     return {
-        title: $('head title').text(),
-        description: $('head meta[name="description"]').attr('content'),
+        title: `IMDb: ${CHART_NAMES[chart] ?? CHART_NAMES.top}`,
         link,
         item: items,
     };

--- a/lib/routes/imdb/types.ts
+++ b/lib/routes/imdb/types.ts
@@ -1,103 +1,52 @@
-interface SearchFacet {
-    filterId: string;
-    text: string;
-    total: number;
-    __typename: string;
-}
-
-interface TitleGenres {
+interface TitleGenre {
     genre: {
         text: string;
-        __typename: string;
     };
-    __typename: string;
 }
 
 interface Title {
     id: string;
     titleText: {
         text: string;
-        __typename: string;
-    };
-    titleType: {
-        id: string;
-        text: string;
-        canHaveEpisodes: boolean;
-        displayableProperty: {
-            value: {
-                plainText: string;
-                __typename: string;
-            };
-            __typename: string;
-        };
-        __typename: string;
     };
     originalTitleText: {
         text: string;
-        __typename: string;
     };
-    primaryImage: {
-        id: string;
-        width: number;
-        height: number;
-        url: string;
-        caption: {
-            plainText: string;
-            __typename: string;
-        };
-        __typename: string;
+    titleType: {
+        text: string;
     };
     releaseYear: {
         year: number;
         endYear: number | null;
-        __typename: string;
-    };
+    } | null;
+    primaryImage: {
+        url: string;
+        caption: {
+            plainText: string;
+        } | null;
+    } | null;
     ratingsSummary: {
-        aggregateRating: number;
-        voteCount: number;
-        __typename: string;
-    };
-    runtime: {
-        seconds: number;
-        __typename: string;
-    };
+        aggregateRating: number | null;
+        voteCount: number | null;
+    } | null;
     certificate: {
         rating: string;
-        __typename: string;
     } | null;
-    canRate: {
-        isRatable: boolean;
-        __typename: string;
-    };
-    titleGenres: {
-        genres: TitleGenres[];
-        __typename: string;
-    };
-    canHaveEpisodes: boolean;
     plot: {
         plotText: {
             plainText: string;
-            __typename: string;
-        };
-        __typename: string;
-    };
-    latestTrailer: {
-        id: string;
-        __typename: string;
+        } | null;
     } | null;
-    series: null;
-    __typename: string;
+    titleGenres: {
+        genres: TitleGenre[];
+    } | null;
 }
 
 interface ChartTitleEdge {
     currentRank: number;
     node: Title;
-    __typename: string;
 }
 
 export interface ChartTitleSearchConnection {
     edges: ChartTitleEdge[];
-    genres: SearchFacet[];
-    keywords: SearchFacet[];
-    __typename: string;
 }


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/imdb/chart/top
/imdb/chart/moviemeter
/imdb/chart/toptv
/imdb/chart/tvmeter
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

`/imdb/chart/:chart` currently returns HTTP 503. The route fetches
`https://www.imdb.com/chart/:chart/` and parses `script#__NEXT_DATA__`, but
IMDb no longer ships chart data in the page HTML — a plain server-side fetch
now hits an AWS WAF JavaScript challenge (HTTP 202) with no `__NEXT_DATA__`
blob, so `JSON.parse` throws (`SyntaxError: Unexpected end of JSON input`).

This PR fetches the same data from IMDb's public GraphQL API
(`https://api.graphql.imdb.com/`) via the `chartTitles` query, which is not
behind the WAF challenge and needs no auth. The four charts map to the
`ChartTitleType` enum:

| chart | ChartTitleType |
| --- | --- |
| top | `TOP_RATED_MOVIES` |
| moviemeter | `MOST_POPULAR_MOVIES` |
| toptv | `TOP_RATED_TV_SHOWS` |
| tvmeter | `MOST_POPULAR_TV_SHOWS` |

Genre display names now come directly from `titleGenres.genres[].genre.text`,
so the old connection-level facet lookup is dropped. The item shape
(title / description with poster + rating + plot / link / category) is
unchanged. No date is exposed because the charts provide no reliable per-item
timestamp. Verified locally: all four charts return items; e.g. moviemeter #1
"Obsession (2025)" with rating 8/10 and genres Horror/Romance/Thriller.
