### PR TITLE
fix(route/xueqiu): fetch today hot list via api.xueqiu.com to bypass WAF

### DIFF
--- a/lib/routes/xueqiu/today.ts
+++ b/lib/routes/xueqiu/today.ts
@@ -14,7 +14,7 @@ export const route: Route = {
     features: {
         requireConfig: false,
         requirePuppeteer: false,
-        antiCrawler: false,
+        antiCrawler: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
@@ -35,7 +35,7 @@ async function handler(ctx) {
 
     const rootUrl = 'https://xueqiu.com';
     const currentUrl = `${rootUrl}/today`;
-    const apiUrl = `${rootUrl}/statuses/hot/listV2.json?since_id=-1&size=${size}`;
+    const apiUrl = `https://api.xueqiu.com/statuses/hot/listV2.json?since_id=-1&size=${size}`;
 
     const token = await parseToken(currentUrl);
     const response = await got({


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

NOROUTE

## Example for the Proposed Route(s) / 路由地址示例

```routes
/xueqiu/today
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fix for the existing `/xueqiu/today` route.

The route requested `statuses/hot/listV2.json` on `xueqiu.com`, which the Alibaba Cloud WAF blocks (it returns a challenge page instead of JSON), so `response.data.items` was undefined and the route threw 503. Switch the endpoint to `api.xueqiu.com`, which serves the same JSON without the WAF challenge. Also mark `antiCrawler: true`.

修复已有的 `/xueqiu/today` 路由。原实现请求 `xueqiu.com` 上的 `statuses/hot/listV2.json`，该接口被阿里云 WAF 拦截（返回 challenge 页而非 JSON），导致 `response.data.items` 为 undefined、路由报 503。改用 `api.xueqiu.com` 域名即可正常返回 JSON。同时标记 `antiCrawler: true`。

Verified end-to-end: the route returns the today hot topics with titles, authors and links. / 已端到端验证：路由返回今日话题，标题、作者、链接均正常。
