### PR TITLE
fix(route/zaobao): update finance route path

### DIFF
--- a/lib/routes/zaobao/realtime.ts
+++ b/lib/routes/zaobao/realtime.ts
@@ -37,9 +37,7 @@ async function handler(ctx) {
 
         case 'zfinance':
             name = '财经';
-            // this is for HK version; for SG version, it's redirected to
-            // /realtime/finance
-            sectionLink = '/finance/realtime';
+            sectionLink = '/realtime/finance';
 
             break;
 


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #22707

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zaobao/realtime/zfinance
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

The Zaobao finance route requests `/finance/realtime`.
This URL now does not redirects to `/realtime/finance` in HK (manually verified) and returns 404 in SG.
Zaobao's current finance page is `/realtime/finance`, which works for both HK (manually verified) and SG.

This change updates the `zfinance` path to `/realtime/finance`.

Validation:

- `pnpm build:routes` with Node.js 24
- `pnpm build` with Node.js 24
- `oxfmt --check lib/routes/zaobao/realtime.ts`
- `oxlint --type-aware lib/routes/zaobao/realtime.ts`
- Built RSSHub returned `200 application/xml` for `/zaobao/realtime/zfinance`, with 18 items and `https://www.zaobao.com/realtime/finance` as the channel link

