### PR TITLE
fix(route/xueqiu): serialize show.json requests and skip caching transient failures

### DIFF
--- a/lib/routes/xueqiu/user.ts
+++ b/lib/routes/xueqiu/user.ts
@@ -1,4 +1,5 @@
 import sanitizeHtml from 'sanitize-html';
+import pMap from 'p-map';
 
 import { parseToken } from '@/routes/xueqiu/cookies';
 import type { Route } from '@/types';
@@ -115,36 +116,45 @@ async function handler(ctx) {
 
     const data = response.statuses.filter((s) => s.mark !== 1); // 去除置顶动态
 
-    const items = await Promise.all(
-        data.map((item) =>
-            cache.tryGet(item.target, async () => {
-                // legal_user_visible 为 true 时列表已含完整内容，无需再请求详情
-                if (item.legal_user_visible) {
-                    return buildListItem(item);
-                }
+    // Use p-map to limit concurrency and avoid triggering Xueqiu show.json rate limiting.
+    const items = await pMap(
+        data,
+        async (item) => {
+            try {
+                return await cache.tryGet(item.target, async () => {
+                    // legal_user_visible 为 true 时列表已含完整内容，无需再请求详情
+                    if (item.legal_user_visible) {
+                        return buildListItem(item);
+                    }
 
-                try {
-                    const detail = await ofetch(`${apiUrl}/statuses/show.json`, {
-                        query: {
-                            id: item.id,
-                        },
-                        headers: {
-                            Cookie: cookie,
-                            Referer: link,
-                        },
-                    });
+                    try {
+                        const detail = await ofetch(`${apiUrl}/statuses/show.json`, {
+                            query: { id: item.id },
+                            headers: { Cookie: cookie, Referer: link },
+                        });
 
-                    return {
-                        title: buildTitle(item, detail),
-                        description: buildDescription(detail),
-                        pubDate: parseDate(item.created_at),
-                        link: rootUrl + item.target,
-                    };
-                } catch {
-                    return buildListItem(item);
-                }
-            })
-        )
+                        return {
+                            title: buildTitle(item, detail),
+                            description: buildDescription(detail),
+                            pubDate: parseDate(item.created_at),
+                            link: rootUrl + item.target,
+                        };
+                    } catch (error: any) {
+                        // Permanent failures (post deleted / not found): cache the fallback.
+                        const data = error.response?._data || error.data;
+                        if (data && typeof data === 'object' && data.error_code) {
+                            return buildListItem(item);
+                        }
+                        // Transient failures (rate limit / WAF): throw to skip caching, retry next request.
+                        throw error;
+                    }
+                });
+            } catch {
+                // Transient failure: provide a fallback item without caching, retry next request.
+                return buildListItem(item);
+            }
+        },
+        { concurrency: 3 },
     );
 
     const user = data[0]?.user;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

NOROUTE

## Example for the Proposed Route(s) / 路由地址示例

```routes
/xueqiu/user/8152922548
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fix for the existing `/xueqiu/user/:id/:type?` route.

Concurrent `show.json` calls (via `Promise.all` on up to 20 items) triggered Xueqiu's rate limiting on `statuses/show.json`. Once the limit was hit, all subsequent calls in the same request were rejected. The `cache.tryGet` wrapper then cached the failed results containing empty descriptions, making the issue persist even after the rate limit cooled.

修复已有的 `/xueqiu/user` 路由。原实现用 `Promise.all` 并发请求最多 20 个 `show.json`，在雪球 `statuses/show.json` 接口上触发频率限流，同一请求内后续调用全部被拒。`cache.tryGet` 将失败结果（空 description）缓存，导致问题持续。

**Changes / 改动**

- **Serialize `show.json` calls**: replace `Promise.all(data.map(...))` with a `for...of` loop, making one `show.json` request at a time instead of firing up to 20 concurrently. / 串行请求: `Promise.all` → `for...of`，逐个请求而非 20 并发。
- **Skip caching transient failures**: when `show.json` fails with a rate limit or WAF error (no `error_code` in the response body), re-throw the error so `cache.tryGet` does not persist the result. The next request will retry. / 瞬态失败不进缓存: 限流/WAF 错误时抛异常，`cache.tryGet` 不存；下次请求重试。
- **Cache permanent failures**: when `show.json` returns a business error (e.g. deleted post with `error_code`), cache the fallback result as before. / 永久失败(已删帖等，有 `error_code`)仍缓存。
- An outer `try/catch` around each `cache.tryGet` call provides a fallback item from the list data when a transient failure occurs, keeping the feed valid while individual items retry on the next poll. / 外层 try/catch 在瞬态失败时提供兜底 item，item 在下次轮询时自动恢复。
