### PR TITLE
fix(dongqiudi): adapt routes to new __NUXT__ data structure

### DIFF
--- a/lib/routes/dongqiudi/daily.ts
+++ b/lib/routes/dongqiudi/daily.ts
@@ -19,5 +19,5 @@ export const route: Route = {
 };
 
 function handler(ctx) {
-    ctx.set('redirect', '/dongqiudi/special/48');
+    return ctx.set('redirect', '/dongqiudi/special/48');
 }

--- a/lib/routes/dongqiudi/player-news.ts
+++ b/lib/routes/dongqiudi/player-news.ts
@@ -21,5 +21,5 @@ export const route: Route = {
 async function handler(ctx) {
     const playerId = ctx.req.param('id');
 
-    await utils.ProcessFeed(ctx, 'player', playerId);
+    return await utils.ProcessFeed(ctx, 'player', playerId);
 }

--- a/lib/routes/dongqiudi/result.ts
+++ b/lib/routes/dongqiudi/result.ts
@@ -1,5 +1,3 @@
-import { JSDOM } from 'jsdom';
-
 import type { Route } from '@/types';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
@@ -24,20 +22,27 @@ async function handler(ctx) {
     const team = ctx.req.param('team');
     const link = `https://www.dongqiudi.com/team/${team}.html`;
 
-    const response = await got(link);
-    const dom = new JSDOM(response.data, {
-        runScripts: 'dangerously',
-    });
-    const data = dom.window.__NUXT__.data[0];
-    const resultData = data.teamScheduleData.filter((data) => data.fs_A && data.fs_B);
+    const { data: scheduleData } = await got(`https://api.dongqiudi.com/data/v1/team/schedule/${team}`);
+    const lastSeason = scheduleData.season_list.find((s) => !s.current);
 
-    const teamName = data.teamDetail.base_info.team_name;
+    if (!lastSeason) {
+        return {
+            title: `${team} 比赛结果`,
+            link,
+            item: [],
+        };
+    }
+
+    const { data: seasonResp } = await got(lastSeason.url);
+    const resultData = seasonResp.data.filter((match) => match.fs_A && match.fs_B);
+
+    const teamName = resultData.length ? (resultData[0].team_A_id === team ? resultData[0].team_A_name : resultData[0].team_B_name) : team;
 
     const out = resultData.map((result) => ({
         title: `${result.match_title} ${result.team_A_name} ${result.fs_A}-${result.fs_B} ${result.team_B_name}`,
         guid: result.match_id,
         link: result.scheme.replace('dongqiudi:///game/', 'https://www.dongqiudi.com/liveDetail/'),
-        pubDate: parseDate(result.start_time),
+        pubDate: parseDate(result.start_play),
     }));
 
     return {

--- a/lib/routes/dongqiudi/special.ts
+++ b/lib/routes/dongqiudi/special.ts
@@ -36,17 +36,8 @@ async function handler(ctx) {
     const out = await Promise.all(
         list.map((item) =>
             cache.tryGet(item.link, async () => {
-                try {
-                    const { data: response } = await got(item.link);
-                    const success = utils.ProcessFeedType2(item, response);
-                    if (!success) {
-                        throw new Error('No article data');
-                    }
-                } catch {
-                    const { data: mobileResponse } = await got(`https://m.dongqiudi.com/article/${item.link.match(/\d+/)[0]}.html`);
-                    utils.ProcessFeedType3(item, mobileResponse);
-                }
-
+                const { data: response } = await got(item.link);
+                utils.ProcessFeedType2(item, response);
                 return item;
             })
         )

--- a/lib/routes/dongqiudi/special.ts
+++ b/lib/routes/dongqiudi/special.ts
@@ -9,7 +9,9 @@ export const route: Route = {
     path: '/special/:id',
     categories: ['sport'],
     example: '/dongqiudi/special/41',
-    parameters: { id: '专题 id, 可自行通过 https://www.dongqiudi.com/special/+数字匹配' },
+    parameters: {
+        id: '专题 id, 可自行通过 https://www.dongqiudi.com/special/+数字匹配',
+    },
     radar: [
         {
             source: ['www.dongqiudi.com/special/:id'],
@@ -36,8 +38,15 @@ async function handler(ctx) {
     const out = await Promise.all(
         list.map((item) =>
             cache.tryGet(item.link, async () => {
-                const { data: response } = await got(item.link);
-                utils.ProcessFeedType2(item, response);
+                try {
+                    const { data: response } = await got(item.link);
+                    utils.ProcessFeedType2(item, response);
+                } catch (error) {
+                    if (!(error instanceof Error) || !['HTTPError', 'RequestError', 'FetchError'].includes(error.name)) {
+                        throw error;
+                    }
+                    // Keep the list item when the article page is gone or temporarily unavailable.
+                }
                 return item;
             })
         )

--- a/lib/routes/dongqiudi/special.ts
+++ b/lib/routes/dongqiudi/special.ts
@@ -30,16 +30,22 @@ async function handler(ctx) {
     const list = response.data.map((item) => ({
         title: item.title,
         link: `https://www.dongqiudi.com/articles/${item.aid}.html`,
-        mobileLink: `https://m.dongqiudi.com/article/${item.aid}.html`,
         pubDate: parseDate(item.show_time, 'X'),
     }));
 
     const out = await Promise.all(
         list.map((item) =>
             cache.tryGet(item.link, async () => {
-                const { data: response } = await got(item.mobileLink);
-
-                utils.ProcessFeedType3(item, response);
+                try {
+                    const { data: response } = await got(item.link);
+                    const success = utils.ProcessFeedType2(item, response);
+                    if (!success) {
+                        throw new Error('No article data');
+                    }
+                } catch {
+                    const { data: mobileResponse } = await got(`https://m.dongqiudi.com/article/${item.link.match(/\d+/)[0]}.html`);
+                    utils.ProcessFeedType3(item, mobileResponse);
+                }
 
                 return item;
             })

--- a/lib/routes/dongqiudi/top-news.ts
+++ b/lib/routes/dongqiudi/top-news.ts
@@ -42,7 +42,7 @@ async function handler(ctx) {
         title: item.title,
         link: `https://www.dongqiudi.com/articles/${item.id}.html`,
         category: [item.category, ...(item.secondary_category ?? [])],
-        pubDate: parseDate(item.show_time),
+        pubDate: parseDate(item.show_time, 'X'),
     }));
 
     const out = await Promise.all(

--- a/lib/routes/dongqiudi/utils.ts
+++ b/lib/routes/dongqiudi/utils.ts
@@ -129,7 +129,7 @@ const ProcessFeedType2 = (item, response) => {
 
     // filter out undefined item
     if (!data) {
-        return false;
+        return;
     }
 
     const body = ProcessVideo(load(data.rawBody, null, false));
@@ -137,7 +137,6 @@ const ProcessFeedType2 = (item, response) => {
     ProcessImg(body('img'));
     item.description = body.html();
     item.author = data.author;
-    return true;
 };
 
 export default { ProcessVideo, ProcessFeed, ProcessFeedType2, ProcessHref, ProcessImg };

--- a/lib/routes/dongqiudi/utils.ts
+++ b/lib/routes/dongqiudi/utils.ts
@@ -140,30 +140,4 @@ const ProcessFeedType2 = (item, response) => {
     return true;
 };
 
-const ProcessFeedType3 = (item, response) => {
-    const $ = load(response);
-    const match = $('script:contains("window.__INITIAL_STATE__")')
-        .text()
-        .match(/window\.__INITIAL_STATE__\s*=\s*((?:\S.*?)??);\(/);
-    if (!match) {
-        return;
-    }
-
-    const initialState = JSON.parse(match[1]);
-
-    // filter out undefined item
-    if (!initialState) {
-        return;
-    }
-
-    if (initialState?.articleContent && Object.keys(initialState.articleContent).length) {
-        const data = Object.values(initialState.articleContent)[0] as Record<string, string>;
-        const body = ProcessVideo(load(data.body, null, false));
-        ProcessHref(body('a'));
-        ProcessImg(body('img'));
-        item.description = body.html();
-        item.author = data.writer;
-    }
-};
-
-export default { ProcessVideo, ProcessFeed, ProcessFeedType2, ProcessFeedType3, ProcessHref, ProcessImg };
+export default { ProcessVideo, ProcessFeed, ProcessFeedType2, ProcessHref, ProcessImg };

--- a/lib/routes/dongqiudi/utils.ts
+++ b/lib/routes/dongqiudi/utils.ts
@@ -68,17 +68,19 @@ const ProcessFeed = async (ctx, type, id) => {
     const apiUrl = 'https://api.dongqiudi.com/v3/archive/app/channel/feeds';
     const { data: response } = await got(link);
 
-    let name;
-
     const { window } = new JSDOM(response, {
         runScripts: 'dangerously',
     });
 
-    const typeInfo = window.__NUXT__.data[0][`${type}Detail`].base_info;
+    const nuxtData = window.__NUXT__.data[0];
+    let name;
+    let image;
     if (type === 'team') {
-        name = typeInfo.team_name;
-    } else if (type === 'player') {
-        name = typeInfo.person_name;
+        name = nuxtData.teamInfo.name;
+        image = nuxtData.teamInfo.logo;
+    } else {
+        name = nuxtData.detail.base_info.person_name;
+        image = nuxtData.detail.base_info.person_logo;
     }
 
     const { data } = await got(apiUrl, {
@@ -95,7 +97,7 @@ const ProcessFeed = async (ctx, type, id) => {
         title: article.title,
         link: `https://www.dongqiudi.com/articles/${article.id}.html`,
         category: [article.category, ...(article.secondary_category ?? [])],
-        pubDate: parseDate(article.show_time),
+        pubDate: parseDate(article.show_time, 'X'),
     }));
 
     const out = await Promise.all(
@@ -113,7 +115,7 @@ const ProcessFeed = async (ctx, type, id) => {
     return {
         title: `${name} - 相关新闻`,
         link,
-        image: type === 'team' ? typeInfo.team_logo : typeInfo.person_logo,
+        image,
         item: out,
     };
 };
@@ -123,38 +125,39 @@ const ProcessFeedType2 = (item, response) => {
         runScripts: 'dangerously',
     });
 
-    const data = dom.window.__NUXT__.data[0].newData;
+    const data = dom.window.__NUXT__?.data?.[0]?.article;
 
     // filter out undefined item
     if (!data) {
-        return;
+        return false;
     }
 
-    if (Object.keys(data).length > 0) {
-        const body = ProcessVideo(load(data.body, null, false));
-        ProcessHref(body('a'));
-        ProcessImg(body('img'));
-        item.description = body.html();
-        item.author = data.writer;
-        item.pubDate = parseDate(data.show_time, 'X');
-    }
+    const body = ProcessVideo(load(data.rawBody, null, false));
+    ProcessHref(body('a'));
+    ProcessImg(body('img'));
+    item.description = body.html();
+    item.author = data.author;
+    return true;
 };
 
 const ProcessFeedType3 = (item, response) => {
     const $ = load(response);
-    const initialState = JSON.parse(
-        $('script:contains("window.__INITIAL_STATE__")')
-            .text()
-            .match(/window\.__INITIAL_STATE__\s*=\s*((?:\S.*?)??);\(/)[1]
-    );
+    const match = $('script:contains("window.__INITIAL_STATE__")')
+        .text()
+        .match(/window\.__INITIAL_STATE__\s*=\s*((?:\S.*?)??);\(/);
+    if (!match) {
+        return;
+    }
+
+    const initialState = JSON.parse(match[1]);
 
     // filter out undefined item
     if (!initialState) {
         return;
     }
 
-    if (Object.keys(initialState.articleContent).length) {
-        const data = Object.values(initialState.articleContent)[0];
+    if (initialState?.articleContent && Object.keys(initialState.articleContent).length) {
+        const data = Object.values(initialState.articleContent)[0] as Record<string, string>;
         const body = ProcessVideo(load(data.body, null, false));
         ProcessHref(body('a'));
         ProcessImg(body('img'));


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/dongqiudi/top_news/1
/dongqiudi/team_news/50001755
/dongqiudi/player_news/50000339
/dongqiudi/result/50001755
/dongqiudi/special/41
/dongqiudi/daily
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

The dongqiudi website restructured its server-rendered `window.__NUXT__` data, breaking multiple dongqiudi routes. This PR adapts them to the new schema.

### `lib/routes/dongqiudi/utils.ts` (shared helpers)

- **`ProcessFeed`**: Use `teamInfo.name` / `detail.base_info` instead of `teamDetail.base_info` (field renames: `team_name` -> `name`, `team_logo` -> `logo`)
- **`ProcessFeed`**: Parse `show_time` as Unix seconds via `parseDate(article.show_time, 'X')` (was being parsed as milliseconds, producing 1970 dates)
- **`ProcessFeedType2`**: Read from `data[0].article` instead of `data[0].newData` (field renames: `writer` -> `author`, `body` -> `rawBody`)
- **`ProcessFeedType3`**: Removed the mobile parser because mobile pages can have empty `articleContent`, and no reliable case was found where mobile parsing succeeds while PC parsing fails.

### `lib/routes/dongqiudi/player-news.ts`

- Add missing `return` before `utils.ProcessFeed(...)` call. The handler was returning `undefined`, causing RSSHub to emit an empty feed.

### `lib/routes/dongqiudi/top-news.ts`

- Parse `show_time` as Unix seconds via `parseDate(item.show_time, 'X')` (same millisecond bug)

### `lib/routes/dongqiudi/result.ts`

- `teamScheduleData` has been removed from the team page `__NUXT__` data. Switch to the official API `api.dongqiudi.com/data/v1/team/schedule/{id}` to fetch schedule data.
- Fetch the last completed season's matches and filter by non-null scores.
- `pubDate` field renamed from `start_time` to `start_play` in the API response.
- Guard for teams with no prior season (return empty feed instead of throwing).

### `lib/routes/dongqiudi/special.ts`

- Use PC-end `ProcessFeedType2` for article content parsing. If an old article page returns `404` or another fetch-layer error, keep the list item instead of failing the whole feed.
- Removed the mobile `ProcessFeedType3` fallback because mobile pages can have empty `articleContent`, and no reliable case was found where mobile parsing succeeds while PC parsing fails.
- Removed unused `mobileLink` field.

### `lib/routes/dongqiudi/daily.ts`

- Add missing `return` before `ctx.set('redirect', ...)` call.

### Verification

All routes verified to return valid RSS via `pnpm dev`:

| Route | Test URL | Result |
|---|---|---|
| `top_news` | `/dongqiudi/top_news/1` | RSS with titles, descriptions, authors, pubDates |
| `team_news` | `/dongqiudi/team_news/50001755` | RSS for 皇家马德里 with team logo |
| `player_news` | `/dongqiudi/player_news/50000339` | RSS for 莫德里奇 with player photo |
| `result` | `/dongqiudi/result/50001755` | RSS with completed matches |
| `special` | `/dongqiudi/special/41` | RSS for 新闻大爆炸 using PC article data and skipping unavailable old article pages |
| `daily` | `/dongqiudi/daily` | Redirects to `/dongqiudi/special/48` |
