### PR TITLE
fix(route/pawchive): add enclosure support and fix media URLs

### DIFF
--- a/lib/routes/pawchive/const.ts
+++ b/lib/routes/pawchive/const.ts
@@ -1,10 +1,10 @@
-export const baseUrl = "https://pawchive.pw";
+export const baseUrl = 'https://pawchive.pw';
 export const apiBaseUrl = `${baseUrl}/api/v1`;
-export const thumbnailUrl = "https://img.pawchive.pw/thumbnail/data";
-export const fileUrl = "https://file.pawchive.pw/data";
+export const thumbnailUrl = 'https://img.pawchive.pw/thumbnail/data';
+export const fileUrl = 'https://file.pawchive.pw/data';
 
 export const MIME_TYPE_MAP = {
-    m4a: "audio/mp4",
-    mp3: "audio/mpeg",
-    mp4: "video/mp4",
+    m4a: 'audio/mp4',
+    mp3: 'audio/mpeg',
+    mp4: 'video/mp4',
 } as const;

--- a/lib/routes/pawchive/const.ts
+++ b/lib/routes/pawchive/const.ts
@@ -1,4 +1,10 @@
-export const baseUrl = 'https://pawchive.st';
+export const baseUrl = "https://pawchive.pw";
 export const apiBaseUrl = `${baseUrl}/api/v1`;
-export const thumbnailUrl = 'https://img.pawchive.st/thumbnail/data';
-export const fileUrl = 'https://file.pawchive.st/data';
+export const thumbnailUrl = "https://img.pawchive.pw/thumbnail/data";
+export const fileUrl = "https://file.pawchive.pw/data";
+
+export const MIME_TYPE_MAP = {
+    m4a: "audio/mp4",
+    mp3: "audio/mpeg",
+    mp4: "video/mp4",
+} as const;

--- a/lib/routes/pawchive/index.tsx
+++ b/lib/routes/pawchive/index.tsx
@@ -17,7 +17,9 @@ function generateEnclosureInfo(htmlContent: string): { enclosure_url?: string; e
 
     $('audio source, video source').each((_, el) => {
         const src = $(el).attr('src');
-        if (!src) {return;};
+        if (!src) {
+            return;
+        }
 
         const extension = src.replace(/.*\./, '').toLowerCase();
         const mimeType = MIME_TYPE_MAP[extension as keyof typeof MIME_TYPE_MAP];
@@ -53,11 +55,11 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['pawchive.st/'],
+            source: ['pawchive.pw/'],
             target: '',
         },
         {
-            source: ['pawchive.st/:service/user/:id'],
+            source: ['pawchive.pw/:service/user/:id'],
             target: '/:service/:id',
         },
     ],

--- a/lib/routes/pawchive/index.tsx
+++ b/lib/routes/pawchive/index.tsx
@@ -17,7 +17,7 @@ function generateEnclosureInfo(htmlContent: string): { enclosure_url?: string; e
 
     $('audio source, video source').each((_, el) => {
         const src = $(el).attr('src');
-        if (!src) return;
+        if (!src) {return};
 
         const extension = src.replace(/.*\./, '').toLowerCase();
         const mimeType = MIME_TYPE_MAP[extension as keyof typeof MIME_TYPE_MAP];

--- a/lib/routes/pawchive/index.tsx
+++ b/lib/routes/pawchive/index.tsx
@@ -8,7 +8,7 @@ import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
-import { apiBaseUrl, baseUrl, fileUrl, thumbnailUrl, MIME_TYPE_MAP } from './const';
+import { apiBaseUrl, baseUrl, fileUrl, MIME_TYPE_MAP, thumbnailUrl } from './const';
 import type { PawchiveFile, PawchivePost } from './types';
 
 function generateEnclosureInfo(htmlContent: string): { enclosure_url?: string; enclosure_type?: string } {
@@ -17,7 +17,7 @@ function generateEnclosureInfo(htmlContent: string): { enclosure_url?: string; e
 
     $('audio source, video source').each((_, el) => {
         const src = $(el).attr('src');
-        if (!src) {return};
+        if (!src) {return;};
 
         const extension = src.replace(/.*\./, '').toLowerCase();
         const mimeType = MIME_TYPE_MAP[extension as keyof typeof MIME_TYPE_MAP];

--- a/lib/routes/pawchive/index.tsx
+++ b/lib/routes/pawchive/index.tsx
@@ -1,3 +1,4 @@
+import { load } from 'cheerio';
 import type { Context } from 'hono';
 import { raw } from 'hono/html';
 import { renderToString } from 'hono/jsx/dom/server';
@@ -7,8 +8,31 @@ import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
-import { apiBaseUrl, baseUrl, fileUrl, thumbnailUrl } from './const';
+import { apiBaseUrl, baseUrl, fileUrl, thumbnailUrl, MIME_TYPE_MAP } from './const';
 import type { PawchiveFile, PawchivePost } from './types';
+
+function generateEnclosureInfo(htmlContent: string): { enclosure_url?: string; enclosure_type?: string } {
+    const $ = load(htmlContent);
+    let enclosureInfo = {};
+
+    $('audio source, video source').each((_, el) => {
+        const src = $(el).attr('src');
+        if (!src) return;
+
+        const extension = src.replace(/.*\./, '').toLowerCase();
+        const mimeType = MIME_TYPE_MAP[extension as keyof typeof MIME_TYPE_MAP];
+
+        if (mimeType) {
+            enclosureInfo = {
+                enclosure_url: src,
+                enclosure_type: mimeType,
+            };
+            return false;
+        }
+    });
+
+    return enclosureInfo;
+}
 
 export const route: Route = {
     path: '/:service/:id',
@@ -119,14 +143,18 @@ async function handler(ctx: Context) {
         return data.name || 'Unknown User';
     })) as Promise<string>;
 
-    const items = response.map((post) => ({
-        title: post.title || 'Untitled Post',
-        description: render(post, processPostFiles(post)),
-        author,
-        pubDate: parseDate(post.published),
-        link: `${baseUrl}/${post.service}/user/${post.user}/post/${post.id}`,
-        guid: `pawchive:${post.service}:${post.user}:post:${post.id}`,
-    }));
+    const items = response.map((post) => {
+        const description = render(post, processPostFiles(post));
+        return {
+            title: post.title || 'Untitled Post',
+            description,
+            author,
+            pubDate: parseDate(post.published),
+            link: `${baseUrl}/${post.service}/user/${post.user}/post/${post.id}`,
+            guid: `pawchive:${post.service}:${post.user}:post:${post.id}`,
+            ...generateEnclosureInfo(description),
+        };
+    });
 
     return {
         title: `Posts of ${author} from ${service} | Pawchive`,

--- a/lib/routes/pawchive/namespace.ts
+++ b/lib/routes/pawchive/namespace.ts
@@ -2,6 +2,6 @@ import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
     name: 'Pawchive',
-    url: 'pawchive.st',
+    url: 'pawchive.pw',
     lang: 'en',
 };


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/pawchive/patreon/167217628
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Fixes media playback issues in the pawchive route:
1. Fixed file domain: Changed file.pawchive.st → file.pawchive.pw in const.ts
2. Added enclosure support: RSS items now include enclosure_url and enclosure_type fields, enabling direct audio/video playback in RSS readers (matching kemono route behavior)