### PR TITLE
fix(route/iwara): update API endpoints from apiq.iwara.tv to api.iwara.tv

### DIFF
--- a/lib/routes/iwara/index.ts
+++ b/lib/routes/iwara/index.ts
@@ -43,14 +43,12 @@ async function handler(ctx) {
         apiUrl,
         async () => {
             const { page, destroy } = await getPlaywrightPage(rootUrl, {
+                noGoto: true,
                 onBeforeLoad: async (page) => {
                     await page.route('**/*', (route) => {
                         const type = route.request().resourceType();
                         ['document', 'script', 'xhr', 'fetch'].includes(type) ? route.continue() : route.abort();
                     });
-                },
-                gotoConfig: {
-                    waitUntil: 'domcontentloaded',
                 },
             });
 

--- a/lib/routes/iwara/index.ts
+++ b/lib/routes/iwara/index.ts
@@ -43,6 +43,12 @@ async function handler(ctx) {
         apiUrl,
         async () => {
             const { page, destroy } = await getPlaywrightPage(rootUrl, {
+                onBeforeLoad: async (page) => {
+                    await page.route('**/*', (route) => {
+                        const type = route.request().resourceType();
+                        ['document', 'script', 'xhr', 'fetch'].includes(type) ? route.continue() : route.abort();
+                    });
+                },
                 gotoConfig: {
                     waitUntil: 'domcontentloaded',
                 },

--- a/lib/routes/iwara/index.ts
+++ b/lib/routes/iwara/index.ts
@@ -56,8 +56,8 @@ async function handler(ctx) {
     const items = list.map((item) => ({
         title: item.title,
         author: username,
-        link: `${rootUrl}/${type}/${item.id}/${item.slug}`,
-        category: item.tags.map((i) => i.id),
+        link: `${rootUrl}/${type}/${item.id}${item.slug ? `/${item.slug}` : ''}`,
+        category: item.tags?.map((i) => i.id) || [],
         description: parseThumbnail(type, item),
         pubDate: parseDate(item.createdAt),
     }));

--- a/lib/routes/iwara/index.ts
+++ b/lib/routes/iwara/index.ts
@@ -3,13 +3,9 @@ import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
+import { getPlaywrightPage } from '@/utils/playwright';
 
 import { apiRootUrl, parseThumbnail, rootUrl, typeMap } from './utils';
-
-const apiUrlMap = {
-    video: `${apiRootUrl}/videos`,
-    image: `${apiRootUrl}/images`,
-};
 
 export const route: Route = {
     path: '/users/:username/:type?',
@@ -22,6 +18,7 @@ export const route: Route = {
     maintainers: ['Fatpandac'],
     handler,
     features: {
+        requirePuppeteer: true,
         nsfw: true,
     },
 };
@@ -39,15 +36,31 @@ async function handler(ctx) {
     });
 
     const id = profile.id;
+
+    const apiUrl = `${apiRootUrl}/${type === 'video' ? 'videos' : 'images'}?user=${id}`;
+
     const list = await cache.tryGet(
-        `${apiUrlMap[type]}?user=${id}`,
+        apiUrl,
         async () => {
-            const response = await ofetch(`${apiUrlMap[type]}?user=${id}`, {
-                headers: {
-                    'user-agent': config.trueUA,
+            const { page, destroy } = await getPlaywrightPage(rootUrl, {
+                gotoConfig: {
+                    waitUntil: 'domcontentloaded',
                 },
             });
-            return response.results;
+
+            try {
+                const response = await page.evaluate(async (url) => {
+                    const res = await fetch(url);
+                    if (!res.ok) {
+                        throw new Error(`HTTP error! status: ${res.status}`);
+                    }
+                    return res.json();
+                }, apiUrl);
+
+                return response.results;
+            } finally {
+                await destroy();
+            }
         },
         config.cache.routeExpire,
         false

--- a/lib/routes/iwara/index.ts
+++ b/lib/routes/iwara/index.ts
@@ -43,12 +43,15 @@ async function handler(ctx) {
         apiUrl,
         async () => {
             const { page, destroy } = await getPlaywrightPage(rootUrl, {
-                noGoto: true,
+                closeTimeout: 90 * 1000,
                 onBeforeLoad: async (page) => {
                     await page.route('**/*', (route) => {
                         const type = route.request().resourceType();
                         ['document', 'script', 'xhr', 'fetch'].includes(type) ? route.continue() : route.abort();
                     });
+                },
+                gotoConfig: {
+                    waitUntil: 'domcontentloaded',
                 },
             });
 

--- a/lib/routes/iwara/ranking.ts
+++ b/lib/routes/iwara/ranking.ts
@@ -1,10 +1,10 @@
 import { config } from '@/config';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
-import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
+import { getPlaywrightPage } from '@/utils/playwright';
 
-import { apiRootUrl, parseThumbnail, rootUrl, typeMap } from './utils';
+import { parseThumbnail, rootUrl, typeMap } from './utils';
 
 const sortMap = {
     date: 'Latest',
@@ -32,6 +32,7 @@ export const route: Route = {
     maintainers: ['CaoMeiYouRen233'],
     handler,
     features: {
+        requirePuppeteer: true,
         nsfw: true,
     },
     radar: [
@@ -52,25 +53,37 @@ async function handler(ctx) {
     const { type = 'video', sort = 'date', rating = 'ecchi' } = ctx.req.param();
 
     const limit = ctx.req.query('limit') || 32;
-    const url = `${apiRootUrl}/${type === 'video' ? 'videos' : 'images'}?sort=${sort}&rating=${rating}&limit=${limit}`;
+    const apiUrl = `https://api.iwara.tv/${type === 'video' ? 'videos' : 'images'}?sort=${sort}&rating=${rating}&limit=${limit}`;
 
     const items = await cache.tryGet(
         `iwara:ranking:${type}:${sort}:${rating}`,
         async () => {
-            const response = await ofetch(url, {
-                headers: {
-                    'user-agent': config.trueUA,
+            const { page, destroy } = await getPlaywrightPage(rootUrl, {
+                gotoConfig: {
+                    waitUntil: 'domcontentloaded',
                 },
             });
 
-            return response.results.map((item) => ({
-                title: item.title,
-                author: item.user.name,
-                link: `${rootUrl}/${type === 'video' ? 'video' : 'image'}/${item.id}${item.slug ? `/${item.slug}` : ''}`,
-                category: item.tags?.map((i) => i.id) || [],
-                description: parseThumbnail(type, item),
-                pubDate: parseDate(item.createdAt),
-            }));
+            try {
+                const response = await page.evaluate(async (url) => {
+                    const res = await fetch(url);
+                    if (!res.ok) {
+                        throw new Error(`HTTP error! status: ${res.status}`);
+                    }
+                    return res.json();
+                }, apiUrl);
+
+                return response.results.map((item) => ({
+                    title: item.title,
+                    author: item.user.name,
+                    link: `${rootUrl}/${type === 'video' ? 'video' : 'image'}/${item.id}${item.slug ? `/${item.slug}` : ''}`,
+                    category: item.tags?.map((i) => i.id) || [],
+                    description: parseThumbnail(type, item),
+                    pubDate: parseDate(item.createdAt),
+                }));
+            } finally {
+                await destroy();
+            }
         },
         config.cache.routeExpire,
         false

--- a/lib/routes/iwara/ranking.ts
+++ b/lib/routes/iwara/ranking.ts
@@ -59,12 +59,15 @@ async function handler(ctx) {
         `iwara:ranking:${type}:${sort}:${rating}`,
         async () => {
             const { page, destroy } = await getPlaywrightPage(rootUrl, {
-                noGoto: true,
+                closeTimeout: 90 * 1000,
                 onBeforeLoad: async (page) => {
                     await page.route('**/*', (route) => {
                         const type = route.request().resourceType();
                         ['document', 'script', 'xhr', 'fetch'].includes(type) ? route.continue() : route.abort();
                     });
+                },
+                gotoConfig: {
+                    waitUntil: 'domcontentloaded',
                 },
             });
 

--- a/lib/routes/iwara/ranking.ts
+++ b/lib/routes/iwara/ranking.ts
@@ -4,7 +4,7 @@ import cache from '@/utils/cache';
 import { parseDate } from '@/utils/parse-date';
 import { getPlaywrightPage } from '@/utils/playwright';
 
-import { parseThumbnail, rootUrl, typeMap } from './utils';
+import { apiRootUrl, parseThumbnail, rootUrl, typeMap } from './utils';
 
 const sortMap = {
     date: 'Latest',
@@ -53,7 +53,7 @@ async function handler(ctx) {
     const { type = 'video', sort = 'date', rating = 'ecchi' } = ctx.req.param();
 
     const limit = ctx.req.query('limit') || 32;
-    const apiUrl = `https://api.iwara.tv/${type === 'video' ? 'videos' : 'images'}?sort=${sort}&rating=${rating}&limit=${limit}`;
+    const apiUrl = `${apiRootUrl}/${type === 'video' ? 'videos' : 'images'}?sort=${sort}&rating=${rating}&limit=${limit}`;
 
     const items = await cache.tryGet(
         `iwara:ranking:${type}:${sort}:${rating}`,

--- a/lib/routes/iwara/ranking.ts
+++ b/lib/routes/iwara/ranking.ts
@@ -59,14 +59,12 @@ async function handler(ctx) {
         `iwara:ranking:${type}:${sort}:${rating}`,
         async () => {
             const { page, destroy } = await getPlaywrightPage(rootUrl, {
+                noGoto: true,
                 onBeforeLoad: async (page) => {
                     await page.route('**/*', (route) => {
                         const type = route.request().resourceType();
                         ['document', 'script', 'xhr', 'fetch'].includes(type) ? route.continue() : route.abort();
                     });
-                },
-                gotoConfig: {
-                    waitUntil: 'domcontentloaded',
                 },
             });
 

--- a/lib/routes/iwara/ranking.ts
+++ b/lib/routes/iwara/ranking.ts
@@ -1,8 +1,8 @@
 import { config } from '@/config';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
-import { getPlaywrightPage } from '@/utils/playwright';
 
 import { apiRootUrl, parseThumbnail, rootUrl, typeMap } from './utils';
 
@@ -32,7 +32,6 @@ export const route: Route = {
     maintainers: ['CaoMeiYouRen233'],
     handler,
     features: {
-        requirePuppeteer: true,
         nsfw: true,
     },
     radar: [
@@ -58,33 +57,20 @@ async function handler(ctx) {
     const items = await cache.tryGet(
         `iwara:ranking:${type}:${sort}:${rating}`,
         async () => {
-            const { page, destroy } = await getPlaywrightPage(url, {
-                onBeforeLoad: async (page) => {
-                    await page.route('**/*', (route) => {
-                        const request = route.request();
-                        request.resourceType() === 'document' || request.resourceType() === 'script' || request.resourceType() === 'xhr' || request.resourceType() === 'fetch' ? route.continue() : route.abort();
-                    });
-                },
-                gotoConfig: {
-                    waitUntil: 'networkidle',
+            const response = await ofetch(url, {
+                headers: {
+                    'user-agent': config.trueUA,
                 },
             });
 
-            try {
-                const content = await page.evaluate(() => document.querySelector('pre')?.textContent || document.body.textContent);
-                const response = JSON.parse(content || '{}');
-
-                return response.results.map((item) => ({
-                    title: item.title,
-                    author: item.user.name,
-                    link: `${rootUrl}/${type === 'video' ? 'video' : 'image'}/${item.id}${item.slug ? `/${item.slug}` : ''}`,
-                    category: item.tags?.map((i) => i.id) || [],
-                    description: parseThumbnail(type, item),
-                    pubDate: parseDate(item.createdAt),
-                }));
-            } finally {
-                await destroy();
-            }
+            return response.results.map((item) => ({
+                title: item.title,
+                author: item.user.name,
+                link: `${rootUrl}/${type === 'video' ? 'video' : 'image'}/${item.id}${item.slug ? `/${item.slug}` : ''}`,
+                category: item.tags?.map((i) => i.id) || [],
+                description: parseThumbnail(type, item),
+                pubDate: parseDate(item.createdAt),
+            }));
         },
         config.cache.routeExpire,
         false

--- a/lib/routes/iwara/ranking.ts
+++ b/lib/routes/iwara/ranking.ts
@@ -59,6 +59,12 @@ async function handler(ctx) {
         `iwara:ranking:${type}:${sort}:${rating}`,
         async () => {
             const { page, destroy } = await getPlaywrightPage(rootUrl, {
+                onBeforeLoad: async (page) => {
+                    await page.route('**/*', (route) => {
+                        const type = route.request().resourceType();
+                        ['document', 'script', 'xhr', 'fetch'].includes(type) ? route.continue() : route.abort();
+                    });
+                },
                 gotoConfig: {
                     waitUntil: 'domcontentloaded',
                 },

--- a/lib/routes/iwara/subscriptions.ts
+++ b/lib/routes/iwara/subscriptions.ts
@@ -9,7 +9,7 @@ import { parseDate } from '@/utils/parse-date';
 import { getPlaywrightPage } from '@/utils/playwright';
 
 import { renderSubscriptionImages } from './templates/subscriptions';
-import { imageRootUrl, rootUrl } from './utils';
+import { apiRootUrl, imageRootUrl, rootUrl } from './utils';
 
 const md = MarkdownIt({
     html: true,
@@ -69,8 +69,6 @@ async function handler() {
     const username = config.iwara.username;
     const password = config.iwara.password;
 
-    const apiRoot = 'https://api.iwara.tv';
-
     const { page, destroy } = await getPlaywrightPage(rootUrl, {
         gotoConfig: {
             waitUntil: 'domcontentloaded',
@@ -98,7 +96,7 @@ async function handler() {
         const refreshHeaders = await cache.tryGet(
             'iwara:token',
             async () => {
-                const result = await fetchApi(`${apiRoot}/user/login`, {
+                const result = await fetchApi(`${apiRootUrl}/user/login`, {
                     method: 'POST',
                     headers: apiHeaders,
                     body: { email: username, password },
@@ -113,7 +111,7 @@ async function handler() {
         const authHeaders = await cache.tryGet(
             'iwara:authToken',
             async () => {
-                const result = await fetchApi(`${apiRoot}/user/token`, {
+                const result = await fetchApi(`${apiRootUrl}/user/token`, {
                     method: 'POST',
                     headers: {
                         ...apiHeaders,
@@ -133,8 +131,8 @@ async function handler() {
 
         // fetch subscriptions
         const [videoResponse, imageResponse] = await Promise.all([
-            fetchApi(`${apiRoot}/videos?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
-            fetchApi(`${apiRoot}/images?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
+            fetchApi(`${apiRootUrl}/videos?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
+            fetchApi(`${apiRootUrl}/images?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
         ]);
 
         const videoList = videoResponse.results.map((item) => {

--- a/lib/routes/iwara/subscriptions.ts
+++ b/lib/routes/iwara/subscriptions.ts
@@ -189,7 +189,8 @@ async function handler() {
 
                     // The new API returns `file` (single object) for videos and `files` (array) for images
                     const files = response.files || (response.file ? [response.file] : []);
-                    description = renderSubscriptionImages(files.filter((f) => f.type === 'image').map((f) => `${imageRootUrl}/image/original/${f.id}/${f.name}`));
+                    const imageFiles = files.filter((f) => f.type === 'image');
+                    description = imageFiles.length > 0 ? renderSubscriptionImages(imageFiles.map((f) => `${imageRootUrl}/image/original/${f.id}/${f.name}`)) : renderSubscriptionImages([item.imageUrl]);
 
                     const body = response.body ? md.render(response.body) : '';
                     description += body;

--- a/lib/routes/iwara/subscriptions.ts
+++ b/lib/routes/iwara/subscriptions.ts
@@ -5,11 +5,11 @@ import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
-import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
+import { getPlaywrightPage } from '@/utils/playwright';
 
 import { renderSubscriptionImages } from './templates/subscriptions';
-import { apiRootUrl, imageRootUrl, rootUrl } from './utils';
+import { imageRootUrl, rootUrl } from './utils';
 
 const md = MarkdownIt({
     html: true,
@@ -40,6 +40,7 @@ export const route: Route = {
                 description: '',
             },
         ],
+        requirePuppeteer: true,
         antiCrawler: false,
         supportBT: false,
         supportPodcast: false,
@@ -68,96 +69,133 @@ async function handler() {
     const username = config.iwara.username;
     const password = config.iwara.password;
 
-    const fetchJson = (url: string, options: any = {}) =>
-        ofetch(url, {
-            headers: {
-                ...apiHeaders,
-                ...options.headers,
+    const apiRoot = 'https://api.iwara.tv';
+
+    const { page, destroy } = await getPlaywrightPage(rootUrl, {
+        gotoConfig: {
+            waitUntil: 'domcontentloaded',
+        },
+    });
+
+    try {
+        const fetchApi = (url: string, options: any) =>
+            page.evaluate(
+                async (args) => {
+                    const res = await fetch(args.url, {
+                        method: args.options.method || 'GET',
+                        headers: args.options.headers,
+                        body: args.options.body ? JSON.stringify(args.options.body) : undefined,
+                    });
+                    if (!res.ok) {
+                        throw new Error(`HTTP error! status: ${res.status}`);
+                    }
+                    return res.json();
+                },
+                { url, options }
+            );
+
+        // login and get refresh token
+        const refreshHeaders = await cache.tryGet(
+            'iwara:token',
+            async () => {
+                const result = await fetchApi(`${apiRoot}/user/login`, {
+                    method: 'POST',
+                    headers: apiHeaders,
+                    body: { email: username, password },
+                });
+                return { authorization: 'Bearer ' + result.token };
             },
-            ...(options.body ? { body: JSON.stringify(options.body) } : {}),
-            ...(options.method ? { method: options.method } : {}),
+            30 * 24 * 60 * 60,
+            false
+        );
+
+        // get access token
+        const authHeaders = await cache.tryGet(
+            'iwara:authToken',
+            async () => {
+                const result = await fetchApi(`${apiRoot}/user/token`, {
+                    method: 'POST',
+                    headers: {
+                        ...apiHeaders,
+                        Authorization: refreshHeaders.authorization,
+                    },
+                });
+                return { authorization: 'Bearer ' + result.accessToken };
+            },
+            60 * 60,
+            false
+        );
+
+        const authedHeaders = {
+            ...apiHeaders,
+            Authorization: authHeaders.authorization,
+        };
+
+        // fetch subscriptions
+        const [videoResponse, imageResponse] = await Promise.all([
+            fetchApi(`${apiRoot}/videos?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
+            fetchApi(`${apiRoot}/images?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
+        ]);
+
+        const videoList = videoResponse.results.map((item) => {
+            const imageUrl = item.file ? `${imageRootUrl}/image/original/${item.file.id}/thumbnail-${item.thumbnail.toString().padStart(2, '0')}.jpg` : '';
+
+            return {
+                title: item.title,
+                author: item.user.name,
+                link: `${rootUrl}/video/${item.id}`,
+                category: ['Video', ...(item.tags ? item.tags.map((i) => i.id) : [])],
+                imageUrl,
+                pubDate: parseDate(item.createdAt),
+                private: item.private,
+            };
         });
 
-    // login and get refresh token
-    const refreshHeaders = await cache.tryGet(
-        'iwara:token',
-        async () => {
-            const result = await fetchJson(`${apiRootUrl}/user/login`, {
-                method: 'POST',
-                headers: apiHeaders,
-                body: { email: username, password },
-            });
-            return { authorization: 'Bearer ' + result.token };
-        },
-        30 * 24 * 60 * 60,
-        false
-    );
+        const imageList = imageResponse.results.map((item) => {
+            const imageUrl = item.thumbnail ? `${imageRootUrl}/image/original/${item.thumbnail.id}/${item.thumbnail.name}` : '';
+            return {
+                title: item.title,
+                author: item.user.name,
+                link: `${rootUrl}/image/${item.id}`,
+                category: ['Image', ...(item.tags ? item.tags.map((i) => i.id) : [])],
+                imageUrl,
+                pubDate: parseDate(item.createdAt),
+            };
+        });
 
-    // get access token
-    const authHeaders = await cache.tryGet(
-        'iwara:authToken',
-        async () => {
-            const result = await fetchJson(`${apiRootUrl}/user/token`, {
-                method: 'POST',
-                headers: {
-                    ...apiHeaders,
-                    Authorization: refreshHeaders.authorization,
-                },
-            });
-            return { authorization: 'Bearer ' + result.accessToken };
-        },
-        60 * 60,
-        false
-    );
+        // fulltext
+        const list = [...videoList, ...imageList];
+        // Execute fetches with limited concurrency
+        const items = await pMap(
+            list,
+            (item) =>
+                cache.tryGet(item.link, async () => {
+                    let description = renderSubscriptionImages([item.imageUrl]);
 
-    const authedHeaders = {
-        ...apiHeaders,
-        Authorization: authHeaders.authorization,
-    };
+                    if (item.private === true) {
+                        description += 'private';
+                        return {
+                            title: item.title,
+                            author: item.author,
+                            link: item.link,
+                            category: item.category,
+                            pubDate: item.pubDate,
+                            description,
+                        };
+                    }
 
-    // fetch subscriptions
-    const [videoResponse, imageResponse] = await Promise.all([
-        fetchJson(`${apiRootUrl}/videos?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
-        fetchJson(`${apiRootUrl}/images?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
-    ]);
+                    const apiUrl = item.link.replace('www.iwara.tv', 'api.iwara.tv');
+                    const response = await fetchApi(apiUrl, {
+                        headers: authedHeaders,
+                    });
 
-    const videoList = videoResponse.results.map((item) => {
-        const imageUrl = item.file ? `${imageRootUrl}/image/original/${item.file.id}/thumbnail-${item.thumbnail.toString().padStart(2, '0')}.jpg` : '';
+                    // The new API returns `file` (single object) for videos and `files` (array) for images
+                    const files = response.files || (response.file ? [response.file] : []);
+                    description = renderSubscriptionImages(files.filter((f) => f.type === 'image').map((f) => `${imageRootUrl}/image/original/${f.id}/${f.name}`));
 
-        return {
-            title: item.title,
-            author: item.user.name,
-            link: `${rootUrl}/video/${item.id}`,
-            category: ['Video', ...(item.tags ? item.tags.map((i) => i.id) : [])],
-            imageUrl,
-            pubDate: parseDate(item.createdAt),
-            private: item.private,
-        };
-    });
+                    const body = response.body ? md.render(response.body) : '';
+                    description += body;
 
-    const imageList = imageResponse.results.map((item) => {
-        const imageUrl = item.thumbnail ? `${imageRootUrl}/image/original/${item.thumbnail.id}/${item.thumbnail.name}` : '';
-        return {
-            title: item.title,
-            author: item.user.name,
-            link: `${rootUrl}/image/${item.id}`,
-            category: ['Image', ...(item.tags ? item.tags.map((i) => i.id) : [])],
-            imageUrl,
-            pubDate: parseDate(item.createdAt),
-        };
-    });
-
-    // fulltext
-    const list = [...videoList, ...imageList];
-    // Execute fetches with limited concurrency
-    const items = await pMap(
-        list,
-        (item) =>
-            cache.tryGet(item.link, async () => {
-                let description = renderSubscriptionImages([item.imageUrl]);
-
-                if (item.private === true) {
-                    description += 'private';
                     return {
                         title: item.title,
                         author: item.author,
@@ -166,35 +204,16 @@ async function handler() {
                         pubDate: item.pubDate,
                         description,
                     };
-                }
+                }),
+            { concurrency: 5 }
+        );
 
-                const apiUrl = item.link.replace('www.iwara.tv', 'api.iwara.tv');
-                const response = await fetchJson(apiUrl, {
-                    headers: authedHeaders,
-                });
-
-                // The new API returns `file` (single object) for videos and `files` (array) for images
-                const files = response.files || (response.file ? [response.file] : []);
-                description = renderSubscriptionImages(files.filter((f) => f.type === 'image').map((f) => `${imageRootUrl}/image/original/${f.id}/${f.name}`));
-
-                const body = response.body ? md.render(response.body) : '';
-                description += body;
-
-                return {
-                    title: item.title,
-                    author: item.author,
-                    link: item.link,
-                    category: item.category,
-                    pubDate: item.pubDate,
-                    description,
-                };
-            }),
-        { concurrency: 5 }
-    );
-
-    return {
-        title: 'Iwara Subscription',
-        link: rootUrl,
-        item: items,
-    };
+        return {
+            title: 'Iwara Subscription',
+            link: rootUrl,
+            item: items,
+        };
+    } finally {
+        await destroy();
+    }
 }

--- a/lib/routes/iwara/subscriptions.ts
+++ b/lib/routes/iwara/subscriptions.ts
@@ -5,11 +5,11 @@ import { config } from '@/config';
 import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
-import { getPlaywrightPage } from '@/utils/playwright';
 
 import { renderSubscriptionImages } from './templates/subscriptions';
-import { apiqRootUrl, imageRootUrl, rootUrl } from './utils';
+import { apiRootUrl, imageRootUrl, rootUrl } from './utils';
 
 const md = MarkdownIt({
     html: true,
@@ -40,7 +40,6 @@ export const route: Route = {
                 description: '',
             },
         ],
-        requirePuppeteer: true,
         antiCrawler: false,
         supportBT: false,
         supportPodcast: false,
@@ -69,129 +68,96 @@ async function handler() {
     const username = config.iwara.username;
     const password = config.iwara.password;
 
-    const { page, destroy } = await getPlaywrightPage(rootUrl, {
-        gotoConfig: {
-            waitUntil: 'domcontentloaded',
+    const fetchJson = (url: string, options: any = {}) =>
+        ofetch(url, {
+            headers: {
+                ...apiHeaders,
+                ...options.headers,
+            },
+            ...(options.body ? { body: JSON.stringify(options.body) } : {}),
+            ...(options.method ? { method: options.method } : {}),
+        });
+
+    // login and get refresh token
+    const refreshHeaders = await cache.tryGet(
+        'iwara:token',
+        async () => {
+            const result = await fetchJson(`${apiRootUrl}/user/login`, {
+                method: 'POST',
+                headers: apiHeaders,
+                body: { email: username, password },
+            });
+            return { authorization: 'Bearer ' + result.token };
         },
+        30 * 24 * 60 * 60,
+        false
+    );
+
+    // get access token
+    const authHeaders = await cache.tryGet(
+        'iwara:authToken',
+        async () => {
+            const result = await fetchJson(`${apiRootUrl}/user/token`, {
+                method: 'POST',
+                headers: {
+                    ...apiHeaders,
+                    Authorization: refreshHeaders.authorization,
+                },
+            });
+            return { authorization: 'Bearer ' + result.accessToken };
+        },
+        60 * 60,
+        false
+    );
+
+    const authedHeaders = {
+        ...apiHeaders,
+        Authorization: authHeaders.authorization,
+    };
+
+    // fetch subscriptions
+    const [videoResponse, imageResponse] = await Promise.all([
+        fetchJson(`${apiRootUrl}/videos?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
+        fetchJson(`${apiRootUrl}/images?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
+    ]);
+
+    const videoList = videoResponse.results.map((item) => {
+        const imageUrl = item.file ? `${imageRootUrl}/image/original/${item.file.id}/thumbnail-${item.thumbnail.toString().padStart(2, '0')}.jpg` : '';
+
+        return {
+            title: item.title,
+            author: item.user.name,
+            link: `${rootUrl}/video/${item.id}`,
+            category: ['Video', ...(item.tags ? item.tags.map((i) => i.id) : [])],
+            imageUrl,
+            pubDate: parseDate(item.createdAt),
+            private: item.private,
+        };
     });
 
-    try {
-        const fetchApi = (url: string, options: any) =>
-            page.evaluate(
-                async (args) => {
-                    const res = await fetch(args.url, {
-                        method: args.options.method || 'GET',
-                        headers: args.options.headers,
-                        body: args.options.body ? JSON.stringify(args.options.body) : undefined,
-                    });
-                    if (!res.ok) {
-                        throw new Error(`HTTP error! status: ${res.status}`);
-                    }
-                    return res.json();
-                },
-                { url, options }
-            );
-
-        // login and get refresh token
-        const refreshHeaders = await cache.tryGet(
-            'iwara:token',
-            async () => {
-                const result = await fetchApi(`${apiqRootUrl}/user/login`, {
-                    method: 'POST',
-                    headers: apiHeaders,
-                    body: { email: username, password },
-                });
-                return { authorization: 'Bearer ' + result.token };
-            },
-            30 * 24 * 60 * 60,
-            false
-        );
-
-        // get access token
-        const authHeaders = await cache.tryGet(
-            'iwara:authToken',
-            async () => {
-                const result = await fetchApi(`${apiqRootUrl}/user/token`, {
-                    method: 'POST',
-                    headers: {
-                        ...apiHeaders,
-                        Authorization: refreshHeaders.authorization,
-                    },
-                });
-                return { authorization: 'Bearer ' + result.accessToken };
-            },
-            60 * 60,
-            false
-        );
-
-        const authedHeaders = {
-            ...apiHeaders,
-            Authorization: authHeaders.authorization,
+    const imageList = imageResponse.results.map((item) => {
+        const imageUrl = item.thumbnail ? `${imageRootUrl}/image/original/${item.thumbnail.id}/${item.thumbnail.name}` : '';
+        return {
+            title: item.title,
+            author: item.user.name,
+            link: `${rootUrl}/image/${item.id}`,
+            category: ['Image', ...(item.tags ? item.tags.map((i) => i.id) : [])],
+            imageUrl,
+            pubDate: parseDate(item.createdAt),
         };
+    });
 
-        // fetch subscriptions
-        const [videoResponse, imageResponse] = await Promise.all([
-            fetchApi(`${apiqRootUrl}/videos?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
-            fetchApi(`${apiqRootUrl}/images?rating=all&page=0&limit=24&subscribed=true`, { headers: authedHeaders }),
-        ]);
+    // fulltext
+    const list = [...videoList, ...imageList];
+    // Execute fetches with limited concurrency
+    const items = await pMap(
+        list,
+        (item) =>
+            cache.tryGet(item.link, async () => {
+                let description = renderSubscriptionImages([item.imageUrl]);
 
-        const videoList = videoResponse.results.map((item) => {
-            const imageUrl = item.file ? `${imageRootUrl}/image/original/${item.file.id}/thumbnail-${item.thumbnail.toString().padStart(2, '0')}.jpg` : '';
-
-            return {
-                title: item.title,
-                author: item.user.name,
-                link: `${rootUrl}/video/${item.id}`,
-                category: ['Video', ...(item.tags ? item.tags.map((i) => i.id) : [])],
-                imageUrl,
-                pubDate: parseDate(item.createdAt),
-                private: item.private,
-            };
-        });
-
-        const imageList = imageResponse.results.map((item) => {
-            const imageUrl = item.thumbnail ? `${imageRootUrl}/image/original/${item.thumbnail.id}/${item.thumbnail.name}` : '';
-            return {
-                title: item.title,
-                author: item.user.name,
-                link: `${rootUrl}/image/${item.id}`,
-                category: ['Image', ...(item.tags ? item.tags.map((i) => i.id) : [])],
-                imageUrl,
-                pubDate: parseDate(item.createdAt),
-            };
-        });
-
-        // fulltext
-        const list = [...videoList, ...imageList];
-        // Execute fetches with limited concurrency
-        const items = await pMap(
-            list,
-            (item) =>
-                cache.tryGet(item.link, async () => {
-                    let description = renderSubscriptionImages([item.imageUrl]);
-
-                    if (item.private === true) {
-                        description += 'private';
-                        return {
-                            title: item.title,
-                            author: item.author,
-                            link: item.link,
-                            category: item.category,
-                            pubDate: item.pubDate,
-                            description,
-                        };
-                    }
-
-                    const apiUrl = item.link.replace('www.iwara.tv', 'apiq.iwara.tv');
-                    const response = await fetchApi(apiUrl, {
-                        headers: authedHeaders,
-                    });
-
-                    description = renderSubscriptionImages(response.files ? response.files.filter((f) => f.type === 'image').map((f) => `${imageRootUrl}/image/original/${f.id}/${f.name}`) : [item.imageUrl]);
-
-                    const body = response.body ? md.render(response.body) : '';
-                    description += body;
-
+                if (item.private === true) {
+                    description += 'private';
                     return {
                         title: item.title,
                         author: item.author,
@@ -200,16 +166,35 @@ async function handler() {
                         pubDate: item.pubDate,
                         description,
                     };
-                }),
-            { concurrency: 5 }
-        );
+                }
 
-        return {
-            title: 'Iwara Subscription',
-            link: rootUrl,
-            item: items,
-        };
-    } finally {
-        await destroy();
-    }
+                const apiUrl = item.link.replace('www.iwara.tv', 'api.iwara.tv');
+                const response = await fetchJson(apiUrl, {
+                    headers: authedHeaders,
+                });
+
+                // The new API returns `file` (single object) for videos and `files` (array) for images
+                const files = response.files || (response.file ? [response.file] : []);
+                description = renderSubscriptionImages(files.filter((f) => f.type === 'image').map((f) => `${imageRootUrl}/image/original/${f.id}/${f.name}`));
+
+                const body = response.body ? md.render(response.body) : '';
+                description += body;
+
+                return {
+                    title: item.title,
+                    author: item.author,
+                    link: item.link,
+                    category: item.category,
+                    pubDate: item.pubDate,
+                    description,
+                };
+            }),
+        { concurrency: 5 }
+    );
+
+    return {
+        title: 'Iwara Subscription',
+        link: rootUrl,
+        item: items,
+    };
 }

--- a/lib/routes/iwara/utils.ts
+++ b/lib/routes/iwara/utils.ts
@@ -1,6 +1,5 @@
 export const rootUrl = 'https://www.iwara.tv';
 export const apiRootUrl = 'https://api.iwara.tv';
-export const apiqRootUrl = 'https://apiq.iwara.tv';
 export const imageRootUrl = 'https://i.iwara.tv';
 
 export const typeMap = {


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/iwara/ranking/video/trending/ecchi
/iwara/subscriptions
/iwara/users/kelpie/video
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

Iwara 将 API 从 apiq.iwara.tv 迁移至 api.iwara.tv，旧 endpoint 返回空数据。同时新的 api.iwara.tv 有 Cloudflare 防护，必须通过浏览器（Puppeteer）调用。

改动：
- 所有 API 请求从 `apiq.iwara.tv` 改为 `api.iwara.tv`
- ranking 和 index 路由新增 Puppeteer 以绕过 Cloudflare（subscriptions 已有 Puppeteer）
- subscriptions 的视频详情适配新 API 格式（`file` 取代 `files[]`）
- 修复 `slug` 为 null 时的链接生成