### PR TITLE
feat(core): add summary field support for atom and json feed

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -50,6 +50,7 @@ export type DataItem = {
         html: string;
         text: string;
     };
+    summary?: string;
     image?: string;
     banner?: string;
     updated?: number | string | Date;

--- a/lib/views/atom.test.tsx
+++ b/lib/views/atom.test.tsx
@@ -22,6 +22,7 @@ describe('Atom view', () => {
                             description: 'Entry One',
                             pubDate: '2024-01-01T00:00:00Z',
                             updated: '2024-01-02T00:00:00Z',
+                            summary: 'Entry One',
                             author: 'Author One',
                             category: 'News',
                             media: {

--- a/lib/views/atom.tsx
+++ b/lib/views/atom.tsx
@@ -25,6 +25,7 @@ const RSS: FC<{ data: Data }> = ({ data }) => (
                 <id>{item.guid || item.link || item.title}</id>
                 {item.pubDate && <published>{new Date(item.pubDate).toISOString()}</published>}
                 <updated>{new Date(item.updated || item.pubDate || new Date()).toISOString()}</updated>
+                {item.summary && <summary>{item.summary}</summary>}
                 {item.author && (
                     <author>
                         <name>{item.author}</name>

--- a/lib/views/json.test.ts
+++ b/lib/views/json.test.ts
@@ -16,7 +16,7 @@ describe('JSON view', () => {
                 {
                     title: 'Item One',
                     link: 'https://example.com/one',
-                    description: 'Entry One',
+                    summary: 'Entry One',
                     guid: 'guid-1',
                     content: {
                         html: '<p>hello</p>',

--- a/lib/views/json.ts
+++ b/lib/views/json.ts
@@ -22,7 +22,7 @@ const json = (data: Data) => {
             // content_html and content_text are each optional strings — but one or both must be present
             content_html: (item.content && item.content.html) || item.description || item.title,
             content_text: item.content && item.content.text,
-            summary: item.description,
+            summary: item.summary,
             image: item.image || item.itunes_item_image,
             banner_image: item.banner,
             date_published: item.pubDate,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

- it is currently not possible to specify `item.summary` when creating routes
- `item.summary` is missing for the Atom format
- by default, it contains `description`, which contradicts the [JSON Feed](https://www.jsonfeed.org/version/1.1/#items:~:text=summary) and [Atom](https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.13) standards