### PR TITLE
feat(route): add nicovideo manga route

### DIFF
--- a/lib/routes/nicovideo/manga.ts
+++ b/lib/routes/nicovideo/manga.ts
@@ -1,0 +1,115 @@
+import { load } from 'cheerio';
+
+import { config } from '@/config';
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import proxy from '@/utils/proxy';
+
+export const route: Route = {
+    path: '/manga/:id',
+    categories: ['anime'],
+    example: '/nicovideo/manga/53991',
+    parameters: { id: 'ニコニコ漫画中的作品ID，例如 53991（manga.nicovideo.jp/comic/“53991”）' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['manga.nicovideo.jp/comic/:id'],
+            target: '/manga/:id',
+        },
+        {
+            source: ['manga.nicovideo.jp/watch/:id'],
+            target: '/manga/:id',
+        },
+    ],
+    name: '漫画详情',
+    maintainers: ['xiaobailoves'],
+
+    handler: async (ctx) => {
+        const { id } = ctx.req.param();
+
+        const comicUrl = `https://manga.nicovideo.jp/comic/${id}`;
+        const rssUrl = `https://manga.nicovideo.jp/rss/manga/${id}`; // 目前现有rss源不完整，剩余アプリで読める[应用读取]部分可能需要在网页抓取
+
+        const [htmlResponse, rssResponse] = await Promise.all([
+            cache.tryGet(`nicovideo:manga:${id}:html`, () => ofetch<string>(comicUrl, { responseType: 'text', dispatcher: proxy.dispatcher ?? undefined }), config.cache.routeExpire, false),
+            cache.tryGet(`nicovideo:manga:${id}:rss`, () => ofetch<string>(rssUrl, { responseType: 'text', dispatcher: proxy.dispatcher ?? undefined }), config.cache.routeExpire, false),
+        ]);
+
+        const $ = load(htmlResponse);
+        const $rss = load(rssResponse, { xmlMode: true });
+
+        const dateMap = new Map<string, string>();
+        for (const el of $rss('channel > item').toArray()) {
+            const $item = $rss(el);
+            const link = $item.find('link').text();
+            const pubDate = $item.find('pubDate').text();
+            if (link) {
+                const match = link.match(/\/watch\/mg\d+/);
+                if (match) {
+                    dateMap.set(match[0], pubDate);
+                }
+            }
+        }
+
+        const mangaTitle = $('.main_title h1').text().trim();
+        const author = $('.author h3 span').text().trim();
+        const coverImg = $('.main_visual img').attr('src') || '';
+        const description = $('.description_text').text().trim();
+
+        const items = $('#episode_list .episode_item')
+            .toArray()
+            .map((el) => {
+                const $el = $(el);
+
+                const titleLink = $el.find('.title a');
+                const thumbLink = $el.find('.thumb a');
+                const title = titleLink.text().trim() || $el.find('.thumb img').attr('alt') || '';
+                const link = titleLink.attr('href') || thumbLink.attr('href') || '';
+                const fullLink = link.startsWith('http') ? link : `https://manga.nicovideo.jp${link}`;
+
+                const thumb = $el.find('.thumb img').attr('data-original') || $el.find('.thumb img').attr('src') || '';
+                const pageCount = $el.find('.mg_status').text().trim();
+                const counter = $el.find('.counter').text().trim();
+
+                const pubDateStr = dateMap.get(link);
+                const pubDate = pubDateStr ? parseDate(pubDateStr) : undefined;
+
+                let descHtml = '';
+                if (thumb) {
+                    descHtml += `<p><img src="${thumb}" alt="${title}" /></p>`;
+                }
+                if (pageCount) {
+                    descHtml += `<p>${pageCount}</p>`;
+                }
+                if (counter) {
+                    descHtml += `<p>${counter}</p>`;
+                }
+
+                return {
+                    title,
+                    link: fullLink,
+                    pubDate,
+                    description: descHtml,
+                };
+            })
+            .toReversed(); // 这里倒序可能有点争议，我发现后面没pubDate部分的顺序是倒着的，所以才有这里的reverse....
+
+        return {
+            title: mangaTitle ? `${mangaTitle} - ニコニコ漫画` : $rss('channel > title').text(),
+            link: comicUrl,
+            description: description || undefined,
+            image: coverImg || undefined,
+            author: author || undefined,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/nicovideo/manga.ts
+++ b/lib/routes/nicovideo/manga.ts
@@ -37,7 +37,7 @@ export const route: Route = {
         const { id } = ctx.req.param();
 
         const comicUrl = `https://manga.nicovideo.jp/comic/${id}`;
-        const rssUrl = `https://manga.nicovideo.jp/rss/manga/${id}`; // 目前现有rss源不完整，剩余アプリで読める[应用读取]部分可能需要在网页抓取
+        const rssUrl = `https://manga.nicovideo.jp/rss/manga/${id}`; // The official RSS feed is incomplete; remaining "read in app" chapters may need scraping from the web page
 
         const [htmlResponse, rssResponse] = await Promise.all([
             cache.tryGet(`nicovideo:manga:${id}:html`, () => ofetch<string>(comicUrl, { responseType: 'text', dispatcher: proxy.dispatcher ?? undefined }), config.cache.routeExpire, false),
@@ -73,14 +73,17 @@ export const route: Route = {
                 const titleLink = $el.find('.title a');
                 const thumbLink = $el.find('.thumb a');
                 const title = titleLink.text().trim() || $el.find('.thumb img').attr('alt') || '';
-                const link = titleLink.attr('href') || thumbLink.attr('href') || '';
-                const fullLink = link.startsWith('http') ? link : `https://manga.nicovideo.jp${link}`;
+                const href = titleLink.attr('href') || thumbLink.attr('href') || '';
+                if (!href) {
+                    return null;
+                }
+                const fullLink = href.startsWith('http') ? href : `https://manga.nicovideo.jp${href}`;
 
                 const thumb = $el.find('.thumb img').attr('data-original') || $el.find('.thumb img').attr('src') || '';
                 const pageCount = $el.find('.mg_status').text().trim();
                 const counter = $el.find('.counter').text().trim();
 
-                const pubDateStr = dateMap.get(link);
+                const pubDateStr = dateMap.get(href);
                 const pubDate = pubDateStr ? parseDate(pubDateStr) : undefined;
 
                 let descHtml = '';
@@ -101,7 +104,8 @@ export const route: Route = {
                     description: descHtml,
                 };
             })
-            .toReversed(); // 这里倒序可能有点争议，我发现后面没pubDate部分的顺序是倒着的，所以才有这里的reverse....
+            .filter(Boolean)
+            .toReversed(); // Reverse so items without pubDate keep chronological order
 
         return {
             title: mangaTitle ? `${mangaTitle} - ニコニコ漫画` : $rss('channel > title').text(),


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/nicovideo/manga/65280
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
新增ニコニコ漫画（manga.nicovideo.jp）的漫画详情路由。

主要的数据来源自：
HTML 页面抓取完整章节列表（标题、链接、缩略图、页数、播放/评论数）
官方 RSS（`/rss/manga/:id`）补充最近 5 话的发布日期

**说明**：官网无API，HTML页面中每话也不含发布日期，仅 RSS 提供最近 5 话的 pubDate.