### PR TITLE
fix(route/163): add radar rules for NetEase Cloud Music routes

### DIFF
--- a/lib/routes/163/music/artist-songs.ts
+++ b/lib/routes/163/music/artist-songs.ts
@@ -12,10 +12,17 @@ export const route: Route = {
         requireConfig: false,
         requirePuppeteer: false,
         antiCrawler: false,
+        supportRadar: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
     },
+    radar: [
+        {
+            source: ['music.163.com/artist'],
+            target: '/music/artist/songs/:id',
+        },
+    ],
     name: '歌手歌曲',
     maintainers: ['ZhongMingKun'],
     handler,

--- a/lib/routes/163/music/artist.ts
+++ b/lib/routes/163/music/artist.ts
@@ -12,10 +12,17 @@ export const route: Route = {
         requireConfig: false,
         requirePuppeteer: false,
         antiCrawler: false,
+        supportRadar: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
     },
+    radar: [
+        {
+            source: ['music.163.com/artist/album'],
+            target: '/music/artist/:id',
+        },
+    ],
     name: '歌手专辑',
     maintainers: ['metowolf'],
     handler,

--- a/lib/routes/163/music/djradio.tsx
+++ b/lib/routes/163/music/djradio.tsx
@@ -15,10 +15,17 @@ export const route: Route = {
         requireConfig: false,
         requirePuppeteer: false,
         antiCrawler: false,
+        supportRadar: true,
         supportBT: false,
         supportPodcast: true,
         supportScihub: false,
     },
+    radar: [
+        {
+            source: ['music.163.com/djradio'],
+            target: '/music/djradio/:id',
+        },
+    ],
     name: '电台节目',
     maintainers: ['magic-akari'],
     handler,

--- a/lib/routes/163/music/playlist.ts
+++ b/lib/routes/163/music/playlist.ts
@@ -19,10 +19,17 @@ export const route: Route = {
         ],
         requirePuppeteer: false,
         antiCrawler: true,
+        supportRadar: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
     },
+    radar: [
+        {
+            source: ['music.163.com/playlist'],
+            target: '/music/playlist/:id',
+        },
+    ],
     name: '歌单歌曲',
     maintainers: ['DIYgod'],
     handler,

--- a/lib/routes/163/music/userevents.tsx
+++ b/lib/routes/163/music/userevents.tsx
@@ -23,6 +23,12 @@ const renderDescription = ({ description, pics }) => {
 export const route: Route = {
     path: '/music/user/events/:id',
     categories: ['multimedia'],
+    radar: [
+        {
+            source: ['music.163.com/user/event'],
+            target: '/music/user/events/:id',
+        },
+    ],
     name: '用户动态',
     maintainers: ['Master-Hash'],
     handler,

--- a/lib/routes/163/music/userplaylist.tsx
+++ b/lib/routes/163/music/userplaylist.tsx
@@ -31,10 +31,17 @@ export const route: Route = {
         requireConfig: false,
         requirePuppeteer: false,
         antiCrawler: false,
+        supportRadar: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
     },
+    radar: [
+        {
+            source: ['music.163.com/user/home'],
+            target: '/music/user/playlist/:id',
+        },
+    ],
     name: '用户歌单',
     maintainers: ['DIYgod'],
     handler,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/163/music/playlist/35798529
/163/music/user/playlist/45441555
/163/music/djradio/347317067
/163/music/artist/2116
/163/music/artist/songs/2116
/163/music/user/events/45441555
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Metadata only — no route logic is changed.

The `163` routes carry no `radar` rules, so RSSHub Radar cannot suggest them from a `music.163.com` page. This adds one rule per route, each pointing at the URL that route already builds in its own `link`:

- `music.163.com/playlist` → `/163/music/playlist/:id`
- `music.163.com/user/home` → `/163/music/user/playlist/:id`
- `music.163.com/djradio` → `/163/music/djradio/:id`
- `music.163.com/artist/album` → `/163/music/artist/:id`
- `music.163.com/artist` → `/163/music/artist/songs/:id`
- `music.163.com/user/event` → `/163/music/user/events/:id`

`user/playlist` declares `:uid` in its path while the page URL carries `?id=`, so its target binds `:id` — the same convention as `acfun/video.ts` (path `:uid`, source/target `:id`).

`userevents.tsx` gets `radar` but no `supportRadar`, since it has no `features` block; happy to add one if preferred.
