### PR TITLE
feat(route): enhance authenticated Bilibili and Substack feeds

### DIFF
--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -61,6 +61,15 @@ describe('config', () => {
         delete process.env.MEDIUM_COOKIE_34;
     });
 
+    it('substack cookie', async () => {
+        process.env.SUBSTACK_COOKIE = 'substack.sid=session';
+
+        const { config } = await import('./config');
+        expect(config.substack.cookie).toBe('substack.sid=session');
+
+        delete process.env.SUBSTACK_COOKIE;
+    });
+
     it('discourse config', async () => {
         process.env.DISCOURSE_CONFIG_12 = JSON.stringify({ a: 1 });
         process.env.DISCOURSE_CONFIG_34 = JSON.stringify({ b: 2 });

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -197,6 +197,7 @@ type ConfigEnvKeys =
     | 'SPOTIFY_CLIENT_SECRET'
     | 'SPOTIFY_REFRESHTOKEN'
     | 'SSPAI_BEARERTOKEN'
+    | 'SUBSTACK_COOKIE'
     | 'TELEGRAM_TOKEN'
     | 'TELEGRAM_SESSION'
     | 'TELEGRAM_API_ID'
@@ -615,6 +616,9 @@ export type Config = {
     };
     sspai: {
         bearertoken?: string;
+    };
+    substack: {
+        cookie?: string;
     };
     telegram: {
         token?: string;
@@ -1118,6 +1122,9 @@ const calculateValue = () => {
         },
         sspai: {
             bearertoken: envs.SSPAI_BEARERTOKEN,
+        },
+        substack: {
+            cookie: envs.SUBSTACK_COOKIE,
         },
         telegram: {
             token: envs.TELEGRAM_TOKEN,

--- a/lib/routes/bilibili/article.ts
+++ b/lib/routes/bilibili/article.ts
@@ -1,6 +1,8 @@
-import { load } from 'cheerio';
-
+import { config } from '@/config';
+import ConfigNotFoundError from '@/errors/types/config-not-found';
 import type { Route } from '@/types';
+import { buildBilibiliArticleFeedItem, parseBilibiliArticlePage } from '@/utils/bilibili-article';
+import { parseBilibiliOpusArticle } from '@/utils/bilibili-opus';
 import cacheGeneral from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
@@ -8,12 +10,21 @@ import { parseDate } from '@/utils/parse-date';
 import cache from './cache';
 
 export const route: Route = {
-    path: '/user/article/:uid',
+    path: '/user/article/:uid/:loginUid?',
     categories: ['social-media'],
     example: '/bilibili/user/article/334958638',
-    parameters: { uid: '用户 id, 可在 UP 主主页中找到' },
+    parameters: {
+        uid: 'UP 主用户 id，可在其主页中找到',
+        loginUid: '可选，用于选择 BILIBILI_COOKIE_{loginUid} 对应的登录用户',
+    },
     features: {
-        requireConfig: false,
+        requireConfig: [
+            {
+                name: 'BILIBILI_COOKIE_*',
+                optional: true,
+                description: '配置 BILIBILI_COOKIE_{loginUid} 后，可在路由末尾传入 loginUid，使用该登录用户已有的访问权限读取其已解锁的图文正文。',
+            },
+        ],
         requirePuppeteer: false,
         antiCrawler: false,
         supportBT: false,
@@ -23,65 +34,107 @@ export const route: Route = {
     radar: [
         {
             source: ['space.bilibili.com/:uid'],
+            target: '/user/article/:uid',
         },
     ],
     name: 'UP 主图文',
     maintainers: ['lengthmin', 'Qixingchen', 'hyoban'],
     handler,
+    description: '逐篇抓取图文正文。配置 BILIBILI\\_COOKIE\\_{loginUid} 后，可通过 loginUid 参数选择登录用户，并使用该账号已有的访问权限读取其已解锁的充电专属内容。未配置时仅返回公开内容或预览。',
 };
 
 async function handler(ctx) {
     const uid = ctx.req.param('uid');
-    const name = await cache.getUsernameFromUID(uid);
+    const loginUid = ctx.req.param('loginUid');
+    const cookie = loginUid ? config.bilibili.cookies[loginUid] : cache.getConfiguredCookie();
+
+    if (loginUid && !cookie) {
+        throw new ConfigNotFoundError(`Missing BILIBILI_COOKIE_${loginUid}`);
+    }
+
+    const referer = `https://space.bilibili.com/${uid}/article`;
+    const headers = {
+        Referer: referer,
+        'User-Agent': config.ua,
+        ...(cookie && { Cookie: cookie }),
+    };
     const response = await got({
         method: 'get',
         url: `https://api.bilibili.com/x/polymer/web-dynamic/v1/opus/feed/space?host_mid=${uid}`,
-        headers: {
-            Referer: `https://space.bilibili.com/${uid}/article`,
-        },
+        headers,
     });
+
+    if (response.data.code !== 0 || !Array.isArray(response.data.data?.items)) {
+        throw new Error(`Failed to fetch Bilibili articles: ${response.data.message || `API code ${response.data.code}`}`);
+    }
+
     const data = response.data.data;
-    const title = `${name} 的 bilibili 图文`;
     const link = `https://space.bilibili.com/${uid}/article`;
-    const description = `${name} 的 bilibili 图文`;
-    const cookie = await cache.getCookie();
+    const cacheContext = loginUid || 'default';
 
-    const item = await Promise.all(
+    const resolvedItems = await Promise.all(
         data.items.map(async (item) => {
-            const link = 'https:' + item.jump_url;
-            const data = await cacheGeneral.tryGet(
-                link,
-                async () =>
-                    (
-                        await got({
-                            method: 'get',
-                            url: link,
-                            headers: {
-                                Referer: `https://space.bilibili.com/${uid}/article`,
-                                Cookie: cookie,
-                            },
-                        })
-                    ).data
-            );
+            const link = item.jump_url.startsWith('//') ? `https:${item.jump_url}` : item.jump_url;
+            let article = {};
 
-            const $ = load(data as string);
-            const description = $('.opus-module-content').html();
-            const pubDate = $('.opus-module-author__pub__text').text().replace('编辑于 ', '');
+            try {
+                article = await cacheGeneral.tryGet(`bilibili:article:v4:${item.opus_id}:${cacheContext}`, async () => {
+                    const detail = await got({
+                        method: 'get',
+                        url: `https://api.bilibili.com/x/polymer/web-dynamic/v1/opus/detail?id=${encodeURIComponent(item.opus_id)}`,
+                        headers,
+                    });
+                    const opusArticle = parseBilibiliOpusArticle(detail.data);
+                    if (opusArticle.description) {
+                        return opusArticle;
+                    }
 
-            const single = {
-                title: item.content,
+                    const page = await got({
+                        method: 'get',
+                        url: link,
+                        headers,
+                    });
+                    const pageArticle = parseBilibiliArticlePage(page.data as string);
+                    if (!pageArticle.description) {
+                        throw new Error(`Bilibili article body is unavailable: ${link}`);
+                    }
+                    return pageArticle;
+                });
+            } catch {
+                // An authenticated title-only result must not be cached or
+                // published. Anonymous routes retain their preview fallback.
+            }
+
+            const feedItem = buildBilibiliArticleFeedItem({
+                article,
+                fallbackTitle: item.content,
                 link,
-                description: description || item.content,
-                // 2019年11月11日 08:50
-                pubDate: pubDate ? parseDate(pubDate, 'YYYY年MM月DD日 HH:mm') : undefined,
+                authenticated: Boolean(cookie),
+            });
+
+            if (!feedItem) {
+                return;
+            }
+
+            return {
+                ...feedItem,
+                pubDate: feedItem.pubDate ? parseDate(feedItem.pubDate, typeof feedItem.pubDate === 'number' ? 'X' : 'YYYY年MM月DD日 HH:mm') : undefined,
             };
-            return single;
         })
     );
+    const item = resolvedItems.filter((item) => item !== undefined);
+
+    if (cookie && item.length === 0) {
+        throw new Error('No authenticated Bilibili article bodies were returned. Verify that the configured BILIBILI_COOKIE_* account can access these articles.');
+    }
+
+    const name = item.find((article) => article.author)?.author || uid;
+    const title = `${name} 的 bilibili 图文`;
+
     return {
         title,
         link,
-        description,
+        description: title,
         item,
     };
 }

--- a/lib/routes/bilibili/dynamic.ts
+++ b/lib/routes/bilibili/dynamic.ts
@@ -4,13 +4,15 @@ import { config } from '@/config';
 import CaptchaError from '@/errors/types/captcha';
 import type { Route } from '@/types';
 import { ViewType } from '@/types';
+import { extractBilibiliOpusImages, extractBilibiliOpusImagesFromHtml, normalizeBilibiliImageUrl, renderBilibiliImages } from '@/utils/bilibili-opus';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDuration } from '@/utils/helpers';
+import logger from '@/utils/logger';
 import { parseDate } from '@/utils/parse-date';
 import { fallback, queryToBoolean } from '@/utils/readable-social';
 
-import type { BilibiliWebDynamicResponse, Item2, Modules } from './api-interface';
+import type { BilibiliWebDynamicResponse, Item2, Modules, Orig } from './api-interface';
 import cacheIn from './cache';
 import utils, { getLiveUrl, getVideoUrl } from './utils';
 
@@ -46,7 +48,7 @@ export const route: Route = {
             },
         ],
         requirePuppeteer: false,
-        antiCrawler: false,
+        antiCrawler: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
@@ -178,10 +180,55 @@ const getImgs = (data?: Modules) => {
             url: major[type]?.cover,
         });
     }
-    return imgUrls
-        .filter(Boolean)
-        .map((img) => `<img src="${img.url}" ${img.width ? `width="${img.width}"` : ''} ${img.height ? `height="${img.height}"` : ''}>`)
-        .join('');
+    return renderBilibiliImages(imgUrls);
+};
+
+const getItemImages = async (item: Item2 | Orig | undefined, cookie: string) => {
+    const images = getImgs(item?.modules);
+    const majorType = item?.modules.module_dynamic?.major?.type;
+    const isOpus = majorType === 'MAJOR_TYPE_OPUS' || item?.type === 'DYNAMIC_TYPE_DRAW' || item?.type === 'DYNAMIC_TYPE_ARTICLE';
+    const hasInlineOpusImages = Boolean(item?.modules.module_dynamic?.major?.opus?.pics?.length);
+
+    if (!item?.id_str || !isOpus || hasInlineOpusImages) {
+        return images;
+    }
+
+    const pageUrl = `https://www.bilibili.com/opus/${item.id_str}`;
+    const headers = {
+        Referer: pageUrl,
+        'User-Agent': config.ua,
+        ...(cookie && { Cookie: cookie }),
+    };
+
+    try {
+        const detail = await cache.tryGet(`bilibili:dynamic:opus:v2:${item.id_str}`, async () => {
+            try {
+                const response = await got({
+                    method: 'get',
+                    url: `https://api.bilibili.com/x/polymer/web-dynamic/v1/opus/detail?id=${encodeURIComponent(item.id_str)}`,
+                    headers,
+                });
+                if (response.data?.code === 0) {
+                    const images = extractBilibiliOpusImages(response.data);
+                    if (images.length) {
+                        return { images };
+                    }
+                }
+            } catch {
+                // Fall back to the public Opus page below.
+            }
+
+            const page = await got({ method: 'get', url: pageUrl, headers });
+            return {
+                images: extractBilibiliOpusImagesFromHtml(page.data as string),
+            };
+        });
+
+        return renderBilibiliImages(detail.images) || images;
+    } catch (error) {
+        logger.warn(`[bilibili/dynamic] Failed to fetch Opus images for ${item.id_str}: ${error instanceof Error ? error.message : String(error)}`);
+        return images;
+    }
 };
 
 const getUrl = (item?: Item2, useAvid = false) => {
@@ -347,7 +394,7 @@ async function handler(ctx) {
                             description = description.replaceAll(
                                 emoji.text,
                                 () =>
-                                    `<img alt="${emoji.text}" src="${emoji.icon_url}" style="margin: -1px 1px 0px; display: inline-block; width: 20px; height: 20px; vertical-align: text-bottom;" title="" referrerpolicy="no-referrer">`
+                                    `<img alt="${emoji.text}" src="${normalizeBilibiliImageUrl(emoji.icon_url)}" style="margin: -1px 1px 0px; display: inline-block; width: 20px; height: 20px; vertical-align: text-bottom;" title="">`
                             );
                         }
                         // 处理转发带图评论的情况
@@ -357,7 +404,7 @@ async function handler(ctx) {
                                 pics
                                     .map(
                                         (pic) =>
-                                            `<img alt="${text}" src="${pic.src}" style="margin: 0px 0px 0px; display: inline-block; width: ${pic.width}px; height: ${pic.height}px; vertical-align: text-bottom;" title="" referrerpolicy="no-referrer">`
+                                            `<img alt="${text}" src="${normalizeBilibiliImageUrl(pic.src)}" style="margin: 0px 0px 0px; display: inline-block; width: ${pic.width}px; height: ${pic.height}px; vertical-align: text-bottom;" title="">`
                                     )
                                     .join('<br>')
                             );
@@ -417,10 +464,12 @@ async function handler(ctx) {
                     originDescription += `<br>${originDes}`;
                 }
 
+                const [itemImages, originImages] = await Promise.all([getItemImages(item, cookie), getItemImages(item.orig, cookie)]);
+
                 // 换行处理
                 description = description.replaceAll('\r\n', '<br>').replaceAll('\n', '<br>');
                 originDescription = originDescription.replaceAll('\r\n', '<br>').replaceAll('\n', '<br>');
-                const descriptions = [title, description, getIframe(data, embed), getImgs(data), urlText, originDescription, getIframe(origin, embed), getImgs(origin), originUrlText]
+                const descriptions = [title, description, getIframe(data, embed), itemImages, urlText, originDescription, getIframe(origin, embed), originImages, originUrlText]
                     .map((e) => e?.trim())
                     .filter(Boolean)
                     .join('<br>');

--- a/lib/routes/substack/notes.ts
+++ b/lib/routes/substack/notes.ts
@@ -1,0 +1,112 @@
+import { config } from '@/config';
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { buildSubstackNoteItem, isSubstackNote, type SubstackActivityFeed, type SubstackPost, type SubstackPublicationResponse } from '@/utils/substack';
+import { isValidHost } from '@/utils/valid-host';
+
+export const route: Route = {
+    path: '/notes/:user',
+    categories: ['blog'],
+    view: ViewType.SocialMedia,
+    example: '/substack/notes/norsemanmarkettiming',
+    parameters: { user: 'Substack publication subdomain' },
+    features: {
+        requireConfig: [
+            {
+                name: 'SUBSTACK_COOKIE',
+                optional: true,
+                description: 'Complete Cookie header from a logged-in Substack session. Use only on a trusted self-hosted instance; protected Notes are returned only when that account already has access.',
+            },
+        ],
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Notes',
+    maintainers: ['pseudoyu'],
+    handler,
+    description: `Returns the Notes activity published by a Substack publication's author. Set SUBSTACK\\_COOKIE on a trusted RSSHub instance to use an authenticated Substack session; protected activity is returned only when that account already has access.`,
+};
+
+async function handler(ctx) {
+    const user = ctx.req.param('user');
+
+    if (!isValidHost(user)) {
+        throw new InvalidParameterError('Invalid user');
+    }
+
+    const baseUrl = `https://${user}.substack.com`;
+    const cookie = config.substack.cookie;
+    const publicationHeaders = {
+        Referer: baseUrl,
+        'User-Agent': config.ua,
+        ...(cookie && { Cookie: cookie }),
+    };
+    const readerHeaders = {
+        Referer: 'https://substack.com/',
+        'User-Agent': config.ua,
+        ...(cookie && { Cookie: cookie }),
+    };
+
+    const archive = await cache.tryGet(`substack:archive-profile:v2:${user}`, () =>
+        ofetch<SubstackPost[]>(`${baseUrl}/api/v1/archive`, {
+            headers: publicationHeaders,
+            query: {
+                sort: 'new',
+                search: '',
+                offset: 0,
+                limit: 1,
+            },
+        })
+    );
+    const publicationId = archive[0]?.publication_id;
+    if (!publicationId) {
+        throw new Error(`Unable to resolve the Substack publication for ${user}`);
+    }
+
+    const publicationResponse = await cache.tryGet(`substack:publication:v2:${publicationId}`, () =>
+        ofetch<SubstackPublicationResponse>(`https://substack.com/api/v1/publication/public/${publicationId}`, {
+            headers: readerHeaders,
+        })
+    );
+    const publication = publicationResponse.pub;
+    const profileId = publication?.author_id || publication?.primary_user_id;
+    if (!profileId || !publication?.author_handle) {
+        throw new Error(`Unable to resolve the primary Substack author for ${user}`);
+    }
+
+    const profile = {
+        id: profileId,
+        name: publication.author_name,
+        handle: publication.author_handle,
+        photo_url: publication.author_photo_url,
+        bio: publication.hero_text,
+        primaryPublication: {
+            logo_url: publication.logo_url,
+        },
+    };
+    const activity = await cache.tryGet(`substack:notes:v2:${profileId}`, () =>
+        ofetch<SubstackActivityFeed>(`https://substack.com/api/v1/reader/feed/profile/${profileId}`, {
+            query: {
+                types: 'note',
+            },
+            headers: readerHeaders,
+        })
+    );
+    const item = (activity.items ?? []).filter((activityItem) => isSubstackNote(activityItem)).map((activityItem) => buildSubstackNoteItem(activityItem.comment, profile));
+    const handle = publication.author_handle;
+    const name = publication.author_name || user;
+
+    return {
+        title: `${name} on Substack Notes`,
+        description: publication.hero_text || `${name}'s Substack Notes`,
+        link: `https://substack.com/@${handle}/notes`,
+        image: publication.author_photo_url || publication.logo_url || '',
+        item,
+    };
+}

--- a/lib/routes/substack/subscribe.ts
+++ b/lib/routes/substack/subscribe.ts
@@ -1,9 +1,14 @@
+import pMap from 'p-map';
+
+import { config } from '@/config';
 import InvalidParameterError from '@/errors/types/invalid-parameter';
 import type { Route } from '@/types';
 import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import logger from '@/utils/logger';
 import ofetch from '@/utils/ofetch';
-import { parseDate } from '@/utils/parse-date';
 import parser from '@/utils/rss-parser';
+import { buildSubstackPostItem, getSubstackPostSlug, type SubstackPost } from '@/utils/substack';
 import { isValidHost } from '@/utils/valid-host';
 
 export const route: Route = {
@@ -11,18 +16,25 @@ export const route: Route = {
     categories: ['blog'],
     view: ViewType.SocialMedia,
     example: '/substack/subscribe/mangoread',
-    parameters: { user: 'Username of the Substack' },
+    parameters: { user: 'Substack publication subdomain' },
     features: {
-        requireConfig: false,
+        requireConfig: [
+            {
+                name: 'SUBSTACK_COOKIE',
+                optional: true,
+                description: 'Complete Cookie header from a logged-in Substack session. Use only on a trusted self-hosted instance; protected posts are returned only when that account already has access.',
+            },
+        ],
         requirePuppeteer: false,
-        antiCrawler: false,
+        antiCrawler: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
     },
-    name: 'Substack Subscription',
+    name: 'Subscription',
     maintainers: ['pseudoyu'],
     handler,
+    description: `Fetches each post from Substack's post API so the feed contains the body available to the requester. Set SUBSTACK\\_COOKIE on a trusted RSSHub instance to use an authenticated Substack session; paid posts are returned only when that account already has access.`,
 };
 
 async function handler(ctx) {
@@ -32,21 +44,40 @@ async function handler(ctx) {
         throw new InvalidParameterError('Invalid user');
     }
 
-    const response = await ofetch(`https://${user}.substack.com/feed`);
+    const baseUrl = `https://${user}.substack.com`;
+    const cookie = config.substack.cookie;
+    const headers = {
+        Referer: baseUrl,
+        'User-Agent': config.ua,
+        ...(cookie && { Cookie: cookie }),
+    };
+    const response = await ofetch<string>(`${baseUrl}/feed`, { headers });
     const feed = await parser.parseString(response);
+
+    const item = await pMap(
+        feed.items,
+        async (item) => {
+            const slug = getSubstackPostSlug(item.link);
+            if (!slug) {
+                return buildSubstackPostItem(item, undefined, user);
+            }
+
+            try {
+                const post = await cache.tryGet(`substack:post:v2:${user}:${slug}`, () => ofetch<SubstackPost>(`${baseUrl}/api/v1/posts/${encodeURIComponent(slug)}`, { headers }));
+                return buildSubstackPostItem(item, post, user);
+            } catch (error) {
+                logger.warn(`[substack/subscribe] Failed to fetch post ${slug}: ${error instanceof Error ? error.message : String(error)}`);
+                return buildSubstackPostItem(item, undefined, user);
+            }
+        },
+        { concurrency: 5 }
+    );
 
     return {
         title: feed.title ?? 'Substack',
         description: feed.description ?? `${user}'s Substack`,
-        link: feed.link ?? `https://${user}.substack.com`,
+        link: feed.link ?? baseUrl,
         image: feed.image?.url ?? '',
-        item: feed.items.map((item) => ({
-            title: item.title ?? 'Untitled',
-            description: item['content:encoded'] ?? item.content ?? '',
-            link: item.link ?? '',
-            pubDate: item.pubDate ? parseDate(item.pubDate) : undefined,
-            guid: item.guid ?? '',
-            author: item.creator ?? user,
-        })),
+        item,
     };
 }

--- a/lib/utils/bilibili-article.test.ts
+++ b/lib/utils/bilibili-article.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildBilibiliArticleFeedItem, parseBilibiliArticlePage } from './bilibili-article';
+
+describe('buildBilibiliArticleFeedItem', () => {
+    it('does not publish an authenticated title-only fallback', () => {
+        const item = buildBilibiliArticleFeedItem({
+            article: {
+                title: 'Subscriber article',
+            },
+            fallbackTitle: 'Subscriber article',
+            link: 'https://www.bilibili.com/opus/123',
+            authenticated: true,
+        });
+
+        expect(item).toBeUndefined();
+    });
+
+    it('marks an authenticated full-text upgrade with a distinct stable guid', () => {
+        const item = buildBilibiliArticleFeedItem({
+            article: {
+                title: 'Subscriber article',
+                description: '<p>Full subscriber body</p>',
+            },
+            fallbackTitle: 'Subscriber article',
+            link: 'https://www.bilibili.com/opus/123',
+            authenticated: true,
+        });
+
+        expect(item).toMatchObject({
+            guid: 'https://www.bilibili.com/opus/123#rsshub-authenticated-fulltext-v1',
+            description: '<p>Full subscriber body</p>',
+        });
+    });
+
+    it('retains the title preview for anonymous feeds', () => {
+        const item = buildBilibiliArticleFeedItem({
+            article: {},
+            fallbackTitle: 'Public preview',
+            link: 'https://www.bilibili.com/opus/123',
+            authenticated: false,
+        });
+
+        expect(item).toMatchObject({
+            guid: 'https://www.bilibili.com/opus/123',
+            description: 'Public preview',
+        });
+    });
+});
+
+describe('parseBilibiliArticlePage', () => {
+    it('extracts the complete opus body and metadata', () => {
+        const article = parseBilibiliArticlePage(`
+            <html>
+                <head><title>Fallback title - 哔哩哔哩</title></head>
+                <body>
+                    <div class="opus-module-title__text">Full article title</div>
+                    <div class="opus-module-author__name">Capital_12</div>
+                    <div class="opus-module-author__pub__text">编辑于 2026年07月17日 16:38</div>
+                    <div class="opus-module-content"><h2>Heading</h2><p>Subscriber-visible body</p></div>
+                    <div class="opus-module-paywall">Paywall prompt</div>
+                </body>
+            </html>
+        `);
+
+        expect(article).toEqual({
+            title: 'Full article title',
+            description: '<h2>Heading</h2><p>Subscriber-visible body</p>',
+            author: 'Capital_12',
+            pubDate: '2026年07月17日 16:38',
+        });
+    });
+
+    it('falls back to the document title when the opus title is unavailable', () => {
+        const article = parseBilibiliArticlePage('<html><head><title>Fallback title - 哔哩哔哩</title></head><body></body></html>');
+
+        expect(article.title).toBe('Fallback title');
+        expect(article.description).toBeUndefined();
+    });
+
+    it('ignores Bilibili verification pages', () => {
+        const article = parseBilibiliArticlePage('<html><head><title>验证码_哔哩哔哩</title></head><body></body></html>');
+
+        expect(article).toEqual({});
+    });
+});

--- a/lib/utils/bilibili-article.ts
+++ b/lib/utils/bilibili-article.ts
@@ -1,0 +1,62 @@
+import { load } from 'cheerio';
+
+interface BilibiliArticleData {
+    title?: string;
+    description?: string;
+    author?: string;
+    pubDate?: number | string;
+}
+
+interface BilibiliArticleFeedItemOptions {
+    article: BilibiliArticleData;
+    fallbackTitle: string;
+    link: string;
+    authenticated: boolean;
+}
+
+const authenticatedFullTextGuidSuffix = '#rsshub-authenticated-fulltext-v1';
+
+export function buildBilibiliArticleFeedItem({ article, fallbackTitle, link, authenticated }: BilibiliArticleFeedItemOptions) {
+    const description = article.description?.trim();
+
+    // Do not let a transient authenticated fetch failure become a permanent
+    // title-only entry in feed readers. The item will be retried on the next
+    // route refresh instead.
+    if (authenticated && !description) {
+        return;
+    }
+
+    return {
+        title: article.title || fallbackTitle,
+        link,
+        guid: authenticated ? `${link}${authenticatedFullTextGuidSuffix}` : link,
+        description: description || fallbackTitle,
+        pubDate: article.pubDate,
+        author: article.author,
+    };
+}
+
+export function parseBilibiliArticlePage(data: string) {
+    const $ = load(data);
+    const documentTitle = $('title').text().trim();
+
+    if (documentTitle.startsWith('验证码_') || $('.geetest_panel').length > 0) {
+        return {};
+    }
+
+    const title = $('.opus-module-title__text').first().text().trim() || $('meta[property="og:title"]').attr('content')?.trim() || documentTitle.replace(/\s*-\s*哔哩哔哩\s*$/, '');
+    const description = $('.opus-module-content').first().html()?.trim();
+    const author = $('.opus-module-author__name').first().text().trim();
+    const pubDate = $('.opus-module-author__pub__text')
+        .first()
+        .text()
+        .trim()
+        .replace(/^编辑于\s*/, '');
+
+    return {
+        title: title || undefined,
+        description: description || undefined,
+        author: author || undefined,
+        pubDate: pubDate || undefined,
+    };
+}

--- a/lib/utils/bilibili-opus.test.ts
+++ b/lib/utils/bilibili-opus.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractBilibiliOpusImages, extractBilibiliOpusImagesFromHtml, parseBilibiliOpusArticle, renderBilibiliImages } from './bilibili-opus';
+
+describe('Bilibili Opus images', () => {
+    it('extracts the images from the current Opus content modules', () => {
+        const images = extractBilibiliOpusImages({
+            data: {
+                item: {
+                    id_str: '1223675872465125381',
+                    modules: [
+                        {
+                            module_type: 'MODULE_TYPE_CONTENT',
+                            module_content: {
+                                paragraphs: [
+                                    {
+                                        para_type: 1,
+                                        text: {
+                                            nodes: [
+                                                {
+                                                    word: {
+                                                        words: '前两天有人信誓旦旦说印度把苹果机密给泄麻了, 现在看不如 Close AI 一根.',
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                    {
+                                        para_type: 2,
+                                        pic: {
+                                            pics: [
+                                                {
+                                                    url: 'http://i0.hdslb.com/bfs/new_dyn/45b7f7a65626f65bfef1f6bd1d731287546418.png',
+                                                    width: 1376,
+                                                    height: 2640,
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        expect(images).toEqual([
+            {
+                url: 'https://i0.hdslb.com/bfs/new_dyn/45b7f7a65626f65bfef1f6bd1d731287546418.png',
+                width: 1376,
+                height: 2640,
+            },
+        ]);
+        expect(renderBilibiliImages(images)).toBe('<img src="https://i0.hdslb.com/bfs/new_dyn/45b7f7a65626f65bfef1f6bd1d731287546418.png" width="1376" height="2640">');
+    });
+
+    it('normalizes scheme-relative URLs and removes duplicate images', () => {
+        const images = extractBilibiliOpusImages({
+            data: {
+                item: {
+                    modules: [
+                        {
+                            module_type: 'MODULE_TYPE_CONTENT',
+                            module_content: {
+                                paragraphs: [
+                                    {
+                                        para_type: 2,
+                                        pic: {
+                                            pics: [
+                                                {
+                                                    url: '//i0.hdslb.com/bfs/new_dyn/example.png',
+                                                },
+                                                {
+                                                    url: 'https://i0.hdslb.com/bfs/new_dyn/example.png',
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        expect(images).toEqual([{ url: 'https://i0.hdslb.com/bfs/new_dyn/example.png' }]);
+    });
+
+    it('renders a complete article from the Opus detail API', () => {
+        const article = parseBilibiliOpusArticle({
+            code: 0,
+            data: {
+                item: {
+                    modules: [
+                        {
+                            module_type: 'MODULE_TYPE_TITLE',
+                            module_title: {
+                                text: 'Subscriber article',
+                            },
+                        },
+                        {
+                            module_type: 'MODULE_TYPE_AUTHOR',
+                            module_author: {
+                                name: 'Capital_12',
+                                pub_ts: 1_752_748_280,
+                            },
+                        },
+                        {
+                            module_type: 'MODULE_TYPE_CONTENT',
+                            module_content: {
+                                paragraphs: [
+                                    {
+                                        para_type: 1,
+                                        text: {
+                                            nodes: [
+                                                {
+                                                    word: {
+                                                        words: 'Full body',
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                    {
+                                        para_type: 2,
+                                        pic: {
+                                            pics: [
+                                                {
+                                                    url: '//i0.hdslb.com/bfs/new_dyn/article.png',
+                                                    width: 1200,
+                                                    height: 800,
+                                                },
+                                            ],
+                                        },
+                                    },
+                                    {
+                                        para_type: 5,
+                                        list: {
+                                            items: [
+                                                {
+                                                    order: 1,
+                                                    nodes: [
+                                                        {
+                                                            word: {
+                                                                words: 'First item',
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        expect(article).toEqual({
+            title: 'Subscriber article',
+            description: '<p>Full body</p><figure><img src="https://i0.hdslb.com/bfs/new_dyn/article.png" width="1200" height="800"></figure><ol><li>First item</li></ol>',
+            author: 'Capital_12',
+            pubDate: 1_752_748_280,
+        });
+    });
+
+    it('extracts current content-module images from an Opus page fallback', () => {
+        const images = extractBilibiliOpusImagesFromHtml(`
+            <html>
+                <body>
+                    <script>
+                        window.__INITIAL_STATE__={"detail":{"id_str":"1223675872465125381","modules":[{"module_type":"MODULE_TYPE_CONTENT","module_content":{"paragraphs":[{"para_type":2,"pic":{"pics":[{"url":"http://i0.hdslb.com/bfs/new_dyn/45b7f7a65626f65bfef1f6bd1d731287546418.png","width":1376,"height":2640}]}}]}}]}};(function() {})();
+                    </script>
+                </body>
+            </html>
+        `);
+
+        expect(images).toEqual([
+            {
+                url: 'https://i0.hdslb.com/bfs/new_dyn/45b7f7a65626f65bfef1f6bd1d731287546418.png',
+                width: 1376,
+                height: 2640,
+            },
+        ]);
+    });
+});

--- a/lib/utils/bilibili-opus.ts
+++ b/lib/utils/bilibili-opus.ts
@@ -1,0 +1,236 @@
+import { load } from 'cheerio';
+import { encodeXML } from 'entities';
+
+export interface BilibiliOpusImage {
+    url: string;
+    width?: number;
+    height?: number;
+}
+
+interface BilibiliOpusParagraph {
+    para_type?: number;
+    text?: {
+        nodes?: BilibiliOpusTextNode[];
+    };
+    pic?: {
+        pics?: BilibiliOpusImage[];
+    };
+    line?: {
+        pic?: BilibiliOpusImage;
+    };
+    list?: {
+        style?: number;
+        items?: Array<{
+            order?: number;
+            nodes?: BilibiliOpusTextNode[];
+        }>;
+    };
+    heading?: {
+        level?: number;
+        nodes?: BilibiliOpusTextNode[];
+    };
+    blockquote?: {
+        nodes?: BilibiliOpusTextNode[];
+    };
+    code?: {
+        content?: string;
+        lang?: string;
+    };
+}
+
+interface BilibiliOpusTextNode {
+    word?: {
+        words?: string;
+        jump_url?: string;
+    };
+    rich?: {
+        text?: string;
+        jump_url?: string;
+    };
+    formula?: {
+        latex_content?: string;
+    };
+    user?: {
+        name?: string;
+        jump_url?: string;
+    };
+}
+
+interface BilibiliOpusModule {
+    module_type?: string;
+    module_title?: {
+        text?: string;
+    };
+    module_author?: {
+        name?: string;
+        pub_ts?: number;
+    };
+    module_content?: {
+        paragraphs?: BilibiliOpusParagraph[];
+    };
+}
+
+interface BilibiliOpusItem {
+    id_str?: string;
+    modules?: BilibiliOpusModule[];
+}
+
+interface BilibiliOpusDetailResponse {
+    code?: number;
+    data?: {
+        item?: BilibiliOpusItem;
+    };
+}
+
+export const normalizeBilibiliImageUrl = (url: string) => {
+    if (url.startsWith('//')) {
+        return `https:${url}`;
+    }
+    if (url.startsWith('http://')) {
+        return `https://${url.slice('http://'.length)}`;
+    }
+    return url;
+};
+
+const normalizeBilibiliImages = (images: BilibiliOpusImage[]) => {
+    const seen = new Set<string>();
+
+    return images.flatMap((image) => {
+        if (!image.url) {
+            return [];
+        }
+        const url = normalizeBilibiliImageUrl(image.url);
+        if (seen.has(url)) {
+            return [];
+        }
+        seen.add(url);
+        return [
+            {
+                url,
+                width: image.width,
+                height: image.height,
+            },
+        ];
+    });
+};
+
+const extractBilibiliOpusItemImages = (item?: BilibiliOpusItem) => {
+    const images =
+        item?.modules
+            ?.filter((module) => module.module_type === 'MODULE_TYPE_CONTENT')
+            .flatMap((module) => (module.module_content?.paragraphs ?? []).flatMap((paragraph) => [...(paragraph.pic?.pics ?? []), ...(paragraph.line?.pic ? [paragraph.line.pic] : [])])) ?? [];
+
+    return normalizeBilibiliImages(images);
+};
+
+export const extractBilibiliOpusImages = (response: BilibiliOpusDetailResponse): BilibiliOpusImage[] => extractBilibiliOpusItemImages(response.data?.item);
+
+const renderBilibiliOpusTextNodes = (nodes: BilibiliOpusTextNode[] = []) =>
+    nodes
+        .map((node) => {
+            const text = node.word?.words || node.rich?.text || node.user?.name || node.formula?.latex_content;
+            if (!text) {
+                return '';
+            }
+
+            const content = encodeXML(text).replaceAll('\n', '<br>');
+            const url = node.word?.jump_url || node.rich?.jump_url || node.user?.jump_url;
+            return url ? `<a href="${encodeXML(normalizeBilibiliImageUrl(url))}">${content}</a>` : content;
+        })
+        .join('');
+
+const renderBilibiliOpusParagraph = (paragraph: BilibiliOpusParagraph) => {
+    if (paragraph.pic?.pics?.length) {
+        return `<figure>${renderBilibiliImages(paragraph.pic.pics)}</figure>`;
+    }
+    if (paragraph.line?.pic) {
+        return `<figure>${renderBilibiliImages([paragraph.line.pic])}</figure>`;
+    }
+    if (paragraph.list?.items?.length) {
+        const tag = paragraph.list.items.some((item) => item.order !== undefined) ? 'ol' : 'ul';
+        const items = paragraph.list.items.map((item) => `<li>${renderBilibiliOpusTextNodes(item.nodes)}</li>`).join('');
+        return `<${tag}>${items}</${tag}>`;
+    }
+    if (paragraph.heading?.nodes?.length) {
+        const level = Math.min(Math.max(paragraph.heading.level || 2, 1), 6);
+        return `<h${level}>${renderBilibiliOpusTextNodes(paragraph.heading.nodes)}</h${level}>`;
+    }
+    if (paragraph.blockquote?.nodes?.length) {
+        return `<blockquote>${renderBilibiliOpusTextNodes(paragraph.blockquote.nodes)}</blockquote>`;
+    }
+    if (paragraph.code?.content) {
+        const language = paragraph.code.lang ? ` class="language-${encodeXML(paragraph.code.lang)}"` : '';
+        return `<pre><code${language}>${encodeXML(paragraph.code.content)}</code></pre>`;
+    }
+
+    const text = renderBilibiliOpusTextNodes(paragraph.text?.nodes);
+    return text ? `<p>${text}</p>` : '';
+};
+
+export const parseBilibiliOpusArticle = (response: BilibiliOpusDetailResponse) => {
+    if (response.code !== undefined && response.code !== 0) {
+        return {};
+    }
+
+    const modules = response.data?.item?.modules ?? [];
+    const title = modules.find((module) => module.module_type === 'MODULE_TYPE_TITLE')?.module_title?.text;
+    const author = modules.find((module) => module.module_type === 'MODULE_TYPE_AUTHOR')?.module_author;
+    const description = modules
+        .filter((module) => module.module_type === 'MODULE_TYPE_CONTENT')
+        .flatMap((module) => module.module_content?.paragraphs ?? [])
+        .map((paragraph) => renderBilibiliOpusParagraph(paragraph))
+        .filter(Boolean)
+        .join('');
+
+    return {
+        title: title || undefined,
+        description: description || undefined,
+        author: author?.name || undefined,
+        pubDate: author?.pub_ts,
+    };
+};
+
+export const extractBilibiliOpusImagesFromHtml = (data: string): BilibiliOpusImage[] => {
+    const $ = load(data);
+    const script = $('script:contains("window.__INITIAL_STATE__")').first().html();
+    const initialState = script?.match(/window\.__INITIAL_STATE__\s*=\s*(\{.*?\})\s*;\s*\(function\(/s)?.[1];
+
+    if (initialState) {
+        try {
+            const state = JSON.parse(initialState) as {
+                detail?: BilibiliOpusItem;
+            };
+            const images = extractBilibiliOpusItemImages(state.detail);
+            if (images.length) {
+                return images;
+            }
+        } catch {
+            // Fall back to the server-rendered images below.
+        }
+    }
+
+    return normalizeBilibiliImages(
+        $('.opus-module-content img')
+            .toArray()
+            .flatMap((element) => {
+                const image = $(element);
+                const url = image.attr('src');
+                if (!url) {
+                    return [];
+                }
+                const width = Math.trunc(Number(image.attr('width') || '')) || undefined;
+                const height = Math.trunc(Number(image.attr('height') || '')) || undefined;
+                return [{ url, width, height }];
+            })
+    );
+};
+
+export const renderBilibiliImages = (images: BilibiliOpusImage[]) =>
+    images
+        .filter((image) => image.url)
+        .map((image) => {
+            const attributes = [`src="${encodeXML(normalizeBilibiliImageUrl(image.url))}"`, image.width ? `width="${image.width}"` : '', image.height ? `height="${image.height}"` : ''].filter(Boolean);
+
+            return `<img ${attributes.join(' ')}>`;
+        })
+        .join('');

--- a/lib/utils/substack.test.ts
+++ b/lib/utils/substack.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSubstackNoteItem, buildSubstackPostItem, getSubstackPostSlug, renderSubstackNote } from './substack';
+
+describe('Substack utilities', () => {
+    it('extracts a post slug from a canonical URL', () => {
+        expect(getSubstackPostSlug('https://example.substack.com/p/a-paid-post')).toBe('a-paid-post');
+        expect(getSubstackPostSlug('https://example.substack.com/archive')).toBeUndefined();
+    });
+
+    it('uses the post API body and metadata instead of the feed preview', () => {
+        const item = buildSubstackPostItem(
+            {
+                title: 'Feed title',
+                link: 'https://example.substack.com/p/full-post',
+                'content:encoded': '<p>Feed preview</p>',
+                creator: 'Feed author',
+            },
+            {
+                id: 42,
+                title: 'Full post',
+                slug: 'full-post',
+                canonical_url: 'https://example.substack.com/p/full-post',
+                body_html: '<p>Subscriber-visible body</p>',
+                post_date: '2026-07-17T12:00:00.000Z',
+                publishedBylines: [{ name: 'Author' }],
+                postTags: [{ name: 'Markets' }],
+                cover_image: 'https://example.com/cover.jpg',
+            },
+            'example'
+        );
+
+        expect(item).toMatchObject({
+            title: 'Full post',
+            description: '<p>Subscriber-visible body</p>',
+            link: 'https://example.substack.com/p/full-post',
+            guid: 'https://example.substack.com/p/full-post',
+            author: 'Author',
+            category: ['Markets'],
+            image: 'https://example.com/cover.jpg',
+        });
+        expect(item.pubDate).toEqual(new Date('2026-07-17T12:00:00.000Z'));
+    });
+
+    it('keeps the feed body when post detail is unavailable', () => {
+        const item = buildSubstackPostItem(
+            {
+                title: 'Feed title',
+                link: 'https://example.substack.com/p/fallback',
+                'content:encoded': '<p>Feed body</p>',
+                guid: 'post-42',
+            },
+            undefined,
+            'example'
+        );
+
+        expect(item).toMatchObject({
+            title: 'Feed title',
+            description: '<p>Feed body</p>',
+            link: 'https://example.substack.com/p/fallback',
+            guid: 'https://example.substack.com/p/fallback',
+        });
+    });
+
+    it('renders rich Notes content and attachments safely', () => {
+        const note = {
+            id: 123,
+            body: 'A complete note',
+            date: '2026-07-16T19:41:28.774Z',
+            name: 'Writer',
+            handle: 'writer',
+            body_json: {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            { type: 'text', text: 'Bold & ', marks: [{ type: 'bold' }] },
+                            { type: 'text', text: 'linked', marks: [{ type: 'link', attrs: { href: 'https://example.com/read' } }] },
+                        ],
+                    },
+                ],
+            },
+            attachments: [
+                { type: 'image' as const, imageUrl: 'https://example.com/chart.png', imageWidth: 1200, imageHeight: 800 },
+                {
+                    type: 'link' as const,
+                    linkMetadata: {
+                        url: 'https://example.com/source',
+                        title: 'Source',
+                        description: 'Details & context',
+                    },
+                },
+            ],
+        };
+
+        const description = renderSubstackNote(note);
+        expect(description).toContain('<strong>Bold &amp; </strong>');
+        expect(description).toContain('<a href="https://example.com/read">linked</a>');
+        expect(description).toContain('<img src="https://example.com/chart.png" width="1200" height="800">');
+        expect(description).toContain('<figcaption>Details &amp; context</figcaption>');
+
+        const item = buildSubstackNoteItem(note, { name: 'Writer', handle: 'writer' });
+        expect(item).toMatchObject({
+            title: 'A complete note',
+            link: 'https://substack.com/@writer/note/c-123',
+            guid: 'https://substack.com/@writer/note/c-123',
+            author: [
+                {
+                    name: 'Writer',
+                    url: 'https://substack.com/@writer',
+                },
+            ],
+        });
+        expect(item.pubDate).toEqual(new Date('2026-07-16T19:41:28.774Z'));
+    });
+
+    it('escapes a plain-text Note fallback', () => {
+        expect(renderSubstackNote({ body: '<script>alert(1)</script>\nsecond line' })).toBe('<p>&lt;script&gt;alert(1)&lt;/script&gt;<br>second line</p>');
+    });
+
+    it('handles attachment-only Notes and rejects unsafe attachment URLs', () => {
+        const note = {
+            id: 456,
+            attachments: [
+                { type: 'image' as const, imageUrl: 'https://example.com/chart.heic' },
+                { type: 'link' as const, linkMetadata: { url: 'javascript:alert(1)', title: 'Unsafe' } },
+            ],
+        };
+
+        const item = buildSubstackNoteItem(note, { name: 'Writer', handle: 'writer' });
+        expect(item.title).toBe('Note by Writer');
+        expect(item.description).toBe('<p><img src="https://example.com/chart.heic"></p>');
+    });
+});

--- a/lib/utils/substack.ts
+++ b/lib/utils/substack.ts
@@ -1,0 +1,304 @@
+import { encodeXML } from 'entities';
+
+import type { DataItem } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+
+export type SubstackAuthor = {
+    id?: number;
+    name?: string;
+    handle?: string;
+    photo_url?: string;
+    bio?: string;
+};
+
+export type SubstackPost = {
+    id?: number;
+    publication_id?: number;
+    title?: string;
+    slug?: string;
+    post_date?: string;
+    canonical_url?: string;
+    body_html?: string;
+    cover_image?: string;
+    publishedBylines?: SubstackAuthor[];
+    postTags?: Array<{ name?: string }>;
+};
+
+export type SubstackPublicationResponse = {
+    pub?: {
+        author_id?: number;
+        primary_user_id?: number;
+        author_handle?: string;
+        author_name?: string;
+        author_photo_url?: string;
+        hero_text?: string;
+        logo_url?: string;
+        base_url?: string;
+    };
+};
+
+export type SubstackProfile = SubstackAuthor & {
+    primaryPublication?: {
+        logo_url?: string;
+    };
+};
+
+type SubstackFeedItem = {
+    title?: string;
+    content?: string;
+    link?: string;
+    pubDate?: string;
+    guid?: string;
+    creator?: string;
+    'content:encoded'?: string;
+};
+
+type SubstackRichTextMark = {
+    type?: string;
+    attrs?: {
+        href?: string;
+    };
+};
+
+type SubstackRichTextNode = {
+    type?: string;
+    text?: string;
+    attrs?: {
+        level?: number;
+    };
+    marks?: SubstackRichTextMark[];
+    content?: SubstackRichTextNode[];
+};
+
+type SubstackImageAttachment = {
+    type: 'image';
+    imageUrl?: string;
+    imageWidth?: number;
+    imageHeight?: number;
+};
+
+type SubstackLinkAttachment = {
+    type: 'link';
+    linkMetadata?: {
+        url?: string;
+        host?: string;
+        title?: string;
+        description?: string;
+        image?: string;
+    };
+};
+
+export type SubstackNote = {
+    id?: number;
+    body?: string;
+    body_json?: SubstackRichTextNode;
+    date?: string;
+    name?: string;
+    handle?: string;
+    photo_url?: string;
+    attachments?: Array<SubstackImageAttachment | SubstackLinkAttachment | { type: string }>;
+};
+
+type SubstackAttachment = NonNullable<SubstackNote['attachments']>[number];
+
+export type SubstackActivityItem = {
+    type?: string;
+    context?: {
+        type?: string;
+        timestamp?: string;
+    };
+    comment?: SubstackNote;
+};
+
+export type SubstackActivityFeed = {
+    items?: SubstackActivityItem[];
+};
+
+export function getSubstackPostSlug(link?: string) {
+    if (!link) {
+        return;
+    }
+
+    try {
+        const match = new URL(link).pathname.match(/^\/p\/([^/]+)/);
+        return match?.[1];
+    } catch {
+        return;
+    }
+}
+
+export function buildSubstackPostItem(feedItem: SubstackFeedItem, post: SubstackPost | undefined, user: string): DataItem {
+    const link = post?.canonical_url || feedItem.link || (post?.slug ? `https://${user}.substack.com/p/${post.slug}` : undefined);
+    const authors = post?.publishedBylines?.map((author) => author.name).filter((name): name is string => Boolean(name));
+    const category = post?.postTags?.map((tag) => tag.name).filter((name): name is string => Boolean(name)) ?? [];
+    const pubDate = post?.post_date || feedItem.pubDate;
+
+    return {
+        title: post?.title || feedItem.title || 'Untitled',
+        description: post?.body_html || feedItem['content:encoded'] || feedItem.content || '',
+        ...(link && { link }),
+        ...(pubDate && { pubDate: parseDate(pubDate) }),
+        ...((link || feedItem.guid) && { guid: link || feedItem.guid }),
+        author: authors?.join(', ') || feedItem.creator || user,
+        ...(category.length > 0 && { category }),
+        ...(post?.cover_image && { image: post.cover_image }),
+    };
+}
+
+export function isSubstackNote(item: SubstackActivityItem): item is SubstackActivityItem & { comment: SubstackNote } {
+    return item.type === 'comment' && item.context?.type === 'note' && Boolean(item.comment?.id);
+}
+
+export function buildSubstackNoteItem(note: SubstackNote, profile: SubstackProfile): DataItem {
+    const handle = note.handle || profile.handle;
+    if (!handle || !note.id) {
+        throw new Error('Unable to build a Substack Note without an author handle and note id');
+    }
+
+    const link = `https://substack.com/@${handle}/note/c-${note.id}`;
+    const pubDate = note.date;
+    const authorName = note.name || profile.name || handle;
+    const authorAvatar = note.photo_url || profile.photo_url;
+
+    return {
+        title: note.body || `Note by ${note.name || profile.name || handle}`,
+        description: renderSubstackNote(note),
+        link,
+        guid: link,
+        ...(pubDate && { pubDate: parseDate(pubDate) }),
+        author: [
+            {
+                name: authorName,
+                url: `https://substack.com/@${handle}`,
+                ...(authorAvatar && { avatar: authorAvatar }),
+            },
+        ],
+    };
+}
+
+export function renderSubstackNote(note: SubstackNote) {
+    const body = note.body_json?.content?.length ? renderRichTextNode(note.body_json) : renderPlainText(note.body || '');
+    const attachments =
+        note.attachments
+            ?.map((attachment) => renderAttachment(attachment))
+            .filter(Boolean)
+            .join('\n') ?? '';
+
+    return [body, attachments].filter(Boolean).join('\n');
+}
+
+function renderRichTextNode(node: SubstackRichTextNode): string {
+    if (node.type === 'text') {
+        let text = encodeXML(node.text || '');
+        const marks = node.marks ?? [];
+        for (const mark of marks) {
+            switch (mark.type) {
+                case 'bold':
+                case 'strong':
+                    text = `<strong>${text}</strong>`;
+                    break;
+                case 'em':
+                case 'italic':
+                    text = `<em>${text}</em>`;
+                    break;
+                case 'code':
+                    text = `<code>${text}</code>`;
+                    break;
+                case 'strike':
+                    text = `<s>${text}</s>`;
+                    break;
+                case 'link':
+                    text = renderLinkMark(text, mark.attrs?.href);
+                    break;
+                default:
+                    break;
+            }
+        }
+        return text;
+    }
+
+    if (node.type === 'hardBreak') {
+        return '<br>';
+    }
+
+    const content = node.content?.map((child) => renderRichTextNode(child)).join('') ?? '';
+    if (node.type === 'paragraph') {
+        return `<p>${content}</p>`;
+    }
+    if (node.type === 'blockquote') {
+        return `<blockquote>${content}</blockquote>`;
+    }
+    if (node.type === 'bulletList') {
+        return `<ul>${content}</ul>`;
+    }
+    if (node.type === 'orderedList') {
+        return `<ol>${content}</ol>`;
+    }
+    if (node.type === 'listItem') {
+        return `<li>${content}</li>`;
+    }
+    if (node.type === 'heading') {
+        const level = Math.min(Math.max(node.attrs?.level ?? 2, 1), 6);
+        return `<h${level}>${content}</h${level}>`;
+    }
+
+    return content;
+}
+
+function renderLinkMark(text: string, value?: string) {
+    const href = getSafeUrl(value);
+    return href ? `<a href="${encodeXML(href)}">${text}</a>` : text;
+}
+
+function renderPlainText(text: string) {
+    if (!text) {
+        return '';
+    }
+
+    return text
+        .split(/\n{2,}/)
+        .map((paragraph) => `<p>${encodeXML(paragraph).replaceAll('\n', '<br>')}</p>`)
+        .join('');
+}
+
+function renderAttachment(attachment: SubstackAttachment) {
+    if (attachment.type === 'image' && 'imageUrl' in attachment) {
+        const imageUrl = getSafeUrl(attachment.imageUrl);
+        if (!imageUrl) {
+            return '';
+        }
+
+        const width = attachment.imageWidth ? ` width="${attachment.imageWidth}"` : '';
+        const height = attachment.imageHeight ? ` height="${attachment.imageHeight}"` : '';
+        return `<p><img src="${encodeXML(imageUrl)}"${width}${height}></p>`;
+    }
+
+    if (attachment.type === 'link' && 'linkMetadata' in attachment) {
+        const metadata = attachment.linkMetadata;
+        const url = getSafeUrl(metadata?.url);
+        if (!url) {
+            return '';
+        }
+
+        const imageUrl = getSafeUrl(metadata?.image);
+        const title = metadata?.title || metadata?.host || url;
+        const image = imageUrl ? `<img src="${encodeXML(imageUrl)}" alt="${encodeXML(title)}">` : '';
+        const description = metadata?.description ? `<figcaption>${encodeXML(metadata.description)}</figcaption>` : '';
+        return `<figure><a href="${encodeXML(url)}">${image}<strong>${encodeXML(title)}</strong></a>${description}</figure>`;
+    }
+
+    return '';
+}
+
+function getSafeUrl(value?: string) {
+    if (!value) {
+        return;
+    }
+
+    try {
+        const url = new URL(value);
+        return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : undefined;
+    } catch {
+        return;
+    }
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #22799
Close #22800

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bilibili/user/article/3653488
/bilibili/user/dynamic/2267573
/substack/subscribe/mangoread
/substack/notes/norsemanmarkettiming
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This PR adds authenticated full-content support for existing Bilibili and Substack routes while preserving anonymous behavior. Authentication is only used to retrieve content that the configured account can already access; it does not bypass either platform's authorization checks.

### Bilibili

- Extends `/bilibili/user/article/:uid/:loginUid?` so an optional `loginUid` selects `BILIBILI_COOKIE_<loginUid>`.
- Fetches article bodies from the Opus detail API, with the article page as a fallback.
- Keeps cookie values out of generic cache keys, bumps the article cache version, and rejects title-only authenticated results.
- Normalizes current Opus image payloads so image dynamics, including newer module shapes, render correctly.

### Substack

- Enriches `/substack/subscribe/:user` from the post API, using optional `SUBSTACK_COOKIE` authentication.
- Adds `/substack/notes/:user` for the publication author's Notes activity.
- Keeps cookie values in request headers only, uses versioned content cache keys, and falls back to the native feed item when a post API request fails.

### Documentation

- Declares `BILIBILI_COOKIE_*` and `SUBSTACK_COOKIE` as optional route configuration so they are included in generated official documentation.
- Preserves `mangoread` for the existing subscription route and uses `norsemanmarkettiming` for the new Notes route.
- Marks the affected routes with the observed anti-crawler behavior.

### Validation

- `vitest`: 4 files passed, 28 tests passed.
- `oxlint --type-aware .`: passed with no new warnings.
- `oxfmt . --check`: passed on 5,910 files.
- `build-routes` and `build-docs`: passed; generated route metadata contains the new parameters, configuration, and examples.
- Both commits carry verified ED25519-SK Git signatures.
