### PR TITLE
fix(route/c114): parse article publication date

### DIFF
--- a/lib/routes/c114/roll.ts
+++ b/lib/routes/c114/roll.ts
@@ -51,7 +51,7 @@ export const handler = async (ctx) => {
 
                 item.title = title;
                 item.description = description;
-                item.pubDate = timezone(parseDate($$('div.r_time').text(), 'YYYY/M/D HH:mm'), 8);
+                item.pubDate = timezone(parseDate($$('.article_top .time, div.r_time').first().text().trim(), 'YYYY/M/D HH:mm'), 8);
                 item.author = $$('div.author').first().text().trim();
                 item.content = {
                     html: description,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/c114/roll
```

## Summary

- parse publication dates from the current `.article_top .time` selector
- retain the legacy `div.r_time` selector as a fallback

## Checks

- `pnpm exec eslint lib/routes/c114/roll.ts --cache --concurrency auto`
- `pnpm exec oxfmt lib/routes/c114/roll.ts --check`
- `git diff --check`
