### PR TITLE
fix(route/c114): parse article publication date

### DIFF
--- a/lib/routes/c114/roll.ts
+++ b/lib/routes/c114/roll.ts
@@ -51,7 +51,7 @@ export const handler = async (ctx) => {
 
                 item.title = title;
                 item.description = description;
-                item.pubDate = timezone(parseDate($$('div.r_time').text(), 'YYYY/M/D HH:mm'), 8);
+                item.pubDate = timezone(parseDate($$('.article_top .time, div.r_time').first().text().trim(), 'YYYY/M/D HH:mm'), 8);
                 item.author = $$('div.author').first().text().trim();
                 item.content = {
                     html: description,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/c114/roll
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [x] Date and time parsed with the correct time zone / 日期和时区已正确解析
- [ ] New package added / 添加了新的包
- [ ] Puppeteer

## Note / 说明

- Parse publication dates from the current `.article_top .time` selector.
- Retain the legacy `div.r_time` selector as a fallback.
- Checks: ESLint, oxfmt, and `git diff --check`.
