### PR TITLE
fix(route/fanbox): Update PostListResponse model to conform to new API…

### DIFF
--- a/lib/routes/fanbox/index.ts
+++ b/lib/routes/fanbox/index.ts
@@ -81,7 +81,7 @@ async function handler(ctx: Context): Promise<Data> {
 
     let items: DataItem[];
     try {
-        items = await Promise.all(postListResponse.body.map((i) => parseItem(page, i)));
+        items = await Promise.all(postListResponse.body.posts.map((i) => parseItem(page, i)));
     } finally {
         await page.close();
         await context.close();

--- a/lib/routes/fanbox/types.ts
+++ b/lib/routes/fanbox/types.ts
@@ -25,7 +25,9 @@ export interface UserInfoResponse {
 }
 
 export interface PostListResponse {
-    body: PostItem[];
+    body: {
+        posts: PostItem[];
+    };
 }
 
 export interface PostDetailResponse {


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #22817

## Example for the Proposed Route(s) / 路由地址示例

```routes
/fanbox/official
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
This fixes the fanbox creator route. It does not add a new route or package.

Fanbox recently updated the response model of their 'post.listCreator' endpoint, which broke the parsing of posts.
This commit updates the model postListResponse to represent the new response and fix the parsing.