### PR TITLE
feat(route/xmnn): fix epaper routes after site redesign and add pdf routes

### DIFF
--- a/lib/routes/xmnn/epaper-pdf.ts
+++ b/lib/routes/xmnn/epaper-pdf.ts
@@ -1,0 +1,214 @@
+import { load } from 'cheerio';
+
+import type { Data, DataItem, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+import { AMUCSITE_ROOT, paperNames, resolveHxcbNodeUrl } from './utils';
+
+export const route: Route = {
+    path: '/pdf/:id?',
+    categories: ['traditional-media'],
+    example: '/xmnn/pdf/xmrb',
+    parameters: {
+        id: {
+            description: '报纸 id，见下表，默认为 `xmrb`，即厦门日报',
+            default: 'xmrb',
+            options: [
+                { value: 'xmrb', label: '厦门日报' },
+                { value: 'xmwb', label: '厦门晚报' },
+                { value: 'csjb', label: '城市捷报' },
+                { value: 'syzk', label: '双语周刊' },
+                { value: 'hxcb', label: '海西晨报' },
+            ],
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['epaper.xmrb.com/:id/pc/col/index.html'],
+            target: '/pdf/:id',
+        },
+        {
+            source: ['dzb.sunnews.cn/'],
+            target: '/pdf/hxcb',
+        },
+    ],
+    name: '数字报 PDF',
+    maintainers: ['nczitzk'],
+    handler,
+    description: `订阅各报纸版面 PDF。每个 item 对应一个版面，\`enclosure_url\` 指向该版面 PDF 直链。
+
+| 厦门日报 | 厦门晚报 | 城市捷报 | 双语周刊 | 海西晨报 |
+| -------- | -------- | -------- | -------- | -------- |
+| xmrb     | xmwb     | csjb     | syzk     | hxcb     |`,
+};
+
+function handler(ctx): Promise<Data> {
+    const id = ctx.req.param('id') ?? 'xmrb';
+
+    if (id === 'hxcb') {
+        return fetchHxcbPdfs();
+    }
+    if (['xmrb', 'xmwb', 'csjb', 'syzk'].includes(id)) {
+        return fetchAmucsitePdfs(id);
+    }
+    throw new Error(`Unsupported paper id: ${id}. Supported ids: xmrb, xmwb, csjb, syzk, hxcb`);
+}
+
+// Amucsite PDFs: fetch each version page to get both the PDF link and the full-page preview image
+async function fetchAmucsitePdfs(id: string): Promise<Data> {
+    const listUrl = `${AMUCSITE_ROOT}/${id}/pc/col/index.html`;
+    const listHtml = await ofetch(listUrl, { responseType: 'text' });
+    const $list = load(listHtml);
+
+    // Collect all version page URLs from the list page
+    const versionUrls: string[] = [];
+    $list('ul#list > li > a').each((_, el) => {
+        const href = $list(el).attr('href');
+        if (href) {
+            versionUrls.push(new URL(href, listUrl).href);
+        }
+    });
+
+    if (versionUrls.length === 0) {
+        throw new Error(`No version links found on ${listUrl}`);
+    }
+
+    // Fetch all version pages in parallel to extract name, PDF, and preview image
+    const versionPages = await Promise.all(
+        versionUrls.map(async (url) => {
+            const html = await ofetch(url, { responseType: 'text' });
+            const $v = load(html);
+
+            const versionName = $v('span#layout')
+                .text()
+                .trim()
+                .replace(/：\s*$/, '');
+            const pdfHref = $v('a[href$=".pdf"]').first().attr('href');
+            const previewSrc = $v('img.preview').attr('src');
+
+            return {
+                versionUrl: url,
+                versionName,
+                pdfUrl: pdfHref ? new URL(pdfHref, url).href : undefined,
+                imageUrl: previewSrc ? new URL(previewSrc.replaceAll(/\.2$/g, ''), url).href : undefined,
+                pubDateText: $v('span#paperdate').text().trim(),
+            };
+        })
+    );
+
+    const pubDate = versionPages[0]?.pubDateText ? timezone(parseDate(versionPages[0].pubDateText, 'YYYY-MM-DD'), 8) : undefined;
+
+    const items: DataItem[] = [];
+    for (const page of versionPages) {
+        if (!page.versionName || !page.pdfUrl) {
+            continue;
+        }
+        const descriptionParts: string[] = [];
+        if (page.imageUrl) {
+            descriptionParts.push(`<img src="${page.imageUrl}" alt="${page.versionName}">`);
+        }
+        descriptionParts.push(`<a href="${page.pdfUrl}">下载 ${page.versionName} PDF</a>`);
+
+        const item: DataItem = {
+            title: page.versionName,
+            description: descriptionParts.join('<br>'),
+            link: page.versionUrl,
+            enclosure_url: page.pdfUrl,
+            enclosure_type: 'application/pdf',
+            enclosure_title: page.versionName,
+        };
+        if (pubDate) {
+            item.pubDate = pubDate;
+        }
+        items.push(item);
+    }
+
+    const paperName = paperNames[id] ?? id;
+    return {
+        title: `${paperName}数字报 PDF`,
+        link: listUrl,
+        item: items,
+    };
+}
+
+// Hxcb PDFs: fetch each version page to get the full-page preview image alongside the PDF link
+async function fetchHxcbPdfs(): Promise<Data> {
+    const nodeUrl = await resolveHxcbNodeUrl();
+    const nodeHtml = await ofetch(nodeUrl, { responseType: 'text' });
+    const $node = load(nodeHtml);
+
+    const todayText = $node('li.today').text().trim();
+    const dateMatch = todayText.match(/(\d{4}年\d{2}月\d{2}日)/);
+    const pubDate = dateMatch ? timezone(parseDate(dateMatch[1], 'YYYY年MM月DD日'), 8) : undefined;
+
+    // Collect version URLs from the 版面导航 table
+    const versionUrls: string[] = [];
+    const versionNames: string[] = [];
+    const pdfUrls: string[] = [];
+    $node('#bmdh table tbody tr').each((_, el) => {
+        const $row = $node(el);
+        const $link = $row.find('a#pageLink');
+        const versionName = $link.text().trim();
+        const versionHref = $link.attr('href');
+        const $pdfLink = $row.find('a[href*=".pdf"]');
+        const pdfHref = $pdfLink.attr('href');
+        if (!versionName || !versionHref || !pdfHref) {
+            return;
+        }
+        versionUrls.push(new URL(versionHref, nodeUrl).href);
+        versionNames.push(versionName);
+        pdfUrls.push(new URL(pdfHref, nodeUrl).href);
+    });
+
+    // Fetch each version page in parallel to extract the full-page preview image
+    const imageUrls = await Promise.all(
+        versionUrls.map(async (url) => {
+            try {
+                const html = await ofetch(url, { responseType: 'text' });
+                const $v = load(html);
+                const previewSrc = $v('img[usemap*="PagePicMap"]').attr('src') ?? $v('img[USEMAP*="PagePicMap"]').attr('src');
+                return previewSrc ? new URL(previewSrc, url).href : '';
+            } catch {
+                return '';
+            }
+        })
+    );
+
+    const items: DataItem[] = [];
+    for (let i = 0; i < versionUrls.length; i++) {
+        const descriptionParts: string[] = [];
+        if (imageUrls[i] !== '') {
+            descriptionParts.push(`<img src="${imageUrls[i]}" alt="${versionNames[i]}">`);
+        }
+        descriptionParts.push(`<a href="${pdfUrls[i]}">下载 ${versionNames[i]} PDF</a>`);
+
+        const item: DataItem = {
+            title: versionNames[i],
+            description: descriptionParts.join('<br>'),
+            link: versionUrls[i],
+            enclosure_url: pdfUrls[i],
+            enclosure_type: 'application/pdf',
+            enclosure_title: versionNames[i],
+        };
+        if (pubDate) {
+            item.pubDate = pubDate;
+        }
+        items.push(item);
+    }
+
+    return {
+        title: '海西晨报数字报 PDF',
+        link: nodeUrl,
+        item: items,
+    };
+}

--- a/lib/routes/xmnn/epaper.ts
+++ b/lib/routes/xmnn/epaper.ts
@@ -1,16 +1,28 @@
 import { load } from 'cheerio';
 
-import type { Route } from '@/types';
+import type { Data, Route } from '@/types';
 import cache from '@/utils/cache';
-import got from '@/utils/got';
-import { parseDate } from '@/utils/parse-date';
-import timezone from '@/utils/timezone';
+import ofetch from '@/utils/ofetch';
+
+import { AMUCSITE_ROOT, fetchAmucsiteArticle, fetchHxcbArticle, paperNames, resolveHxcbNodeUrl } from './utils';
 
 export const route: Route = {
     path: '/epaper/:id?',
     categories: ['traditional-media'],
     example: '/xmnn/epaper/xmrb',
-    parameters: { id: '报纸 id，见下表，默认为 `xmrb`，即厦门日报' },
+    parameters: {
+        id: {
+            description: '报纸 id，见下表，默认为 `xmrb`，即厦门日报',
+            default: 'xmrb',
+            options: [
+                { value: 'xmrb', label: '厦门日报' },
+                { value: 'xmwb', label: '厦门晚报' },
+                { value: 'csjb', label: '城市捷报' },
+                { value: 'syzk', label: '双语周刊' },
+                { value: 'hxcb', label: '海西晨报' },
+            ],
+        },
+    },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -21,95 +33,120 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['epaper.xmnn.cn/:id'],
+            source: ['epaper.xmrb.com/:id/pc/col/index.html'],
             target: '/epaper/:id',
         },
+        {
+            source: ['dzb.sunnews.cn/'],
+            target: '/epaper/hxcb',
+        },
     ],
-    name: '数字媒体',
+    name: '数字报',
     maintainers: ['nczitzk'],
     handler,
-    description: `| 厦门日报 | 厦门晚报 | 海西晨报 | 城市捷报 |
-| -------- | -------- | -------- | -------- |
-| xmrb     | xmwb     | hxcb     | csjb     |`,
+    description: `| 厦门日报 | 厦门晚报 | 城市捷报 | 双语周刊 | 海西晨报 |
+| -------- | -------- | -------- | -------- | -------- |
+| xmrb     | xmwb     | csjb     | syzk     | hxcb     |
+
+::: tip
+厦门日报、厦门晚报、城市捷报、双语周刊来自 \`epaper.xmrb.com\`，海西晨报来自 \`dzb.sunnews.cn\`。
+:::`,
 };
 
-async function handler(ctx) {
+function handler(ctx): Promise<Data> {
     const id = ctx.req.param('id') ?? 'xmrb';
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit') as string) : 80;
 
-    const rootUrl = 'https://epaper.xmnn.cn';
-    let currentUrl = `${rootUrl}/${id === 'hxcb' ? '/hxcb/epaper/paperindex.htm' : `${id}/`}`;
+    if (id === 'hxcb') {
+        return fetchHxcbArticles(limit);
+    }
+    if (['xmrb', 'xmwb', 'csjb', 'syzk'].includes(id)) {
+        return fetchAmucsiteArticles(id, limit);
+    }
+    throw new Error(`Unsupported paper id: ${id}. Supported ids: xmrb, xmwb, csjb, syzk, hxcb`);
+}
 
-    let response = await got({
-        method: 'get',
-        url: currentUrl,
+// Amucsite system: xmrb / xmwb on epaper.xmrb.com
+async function fetchAmucsiteArticles(id: string, limit: number): Promise<Data> {
+    const listUrl = `${AMUCSITE_ROOT}/${id}/pc/col/index.html`;
+    const listHtml = await ofetch(listUrl, { responseType: 'text' });
+    const $list = load(listHtml);
+
+    // Collect version page URLs from the list page
+    const versionUrls: string[] = [];
+    $list('ul#list > li > a').each((_, el) => {
+        const href = $list(el).attr('href');
+        if (href) {
+            versionUrls.push(new URL(href, listUrl).href);
+        }
     });
 
-    let $ = load(response.data);
-
-    const title = id === 'hxcb' ? '海西晨报电子版_厦门网' : $('title').text();
-
-    let matches = response.data.match(/window\.location\.href = "(.*?)";/);
-
-    if (!matches) {
-        matches = response.data.match(/setTimeout\("javascript:location\.href='(.*?)'", 3000\);/);
-
-        if (!matches) {
-            matches = response.data.match(/<meta http-equiv="refresh".*?content=".*?url=(.*?)">/i);
-        }
+    if (versionUrls.length === 0) {
+        throw new Error(`No version links found on ${listUrl}`);
     }
 
-    currentUrl = new URL(matches[1], currentUrl).href;
-
-    response = await got({
-        method: 'get',
-        url: currentUrl,
-    });
-
-    $ = load(response.data);
-
-    $('#pdfsrc').remove();
-    $('.bigImg, .smallImg').remove();
-
-    $('a img').each((_, el) => {
-        $(el).parent().remove();
-    });
-
-    let items = $('.br1, .br2, .titss')
-        .find('a')
-        .slice(0, ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 80)
-        .toArray()
-        .map((item) => {
-            item = $(item);
-
-            return {
-                title: item.text(),
-                link: new URL(item.attr('href'), currentUrl).href,
-            };
-        });
-
-    items = await Promise.all(
-        items.map((item) =>
-            cache.tryGet(item.link, async () => {
-                const detailResponse = await got({
-                    method: 'get',
-                    url: item.link,
-                });
-
-                const content = load(detailResponse.data);
-
-                content('#qw').remove();
-
-                item.description = content('.cont-b, content').html();
-                item.pubDate = timezone(parseDate(content('.time').text() || content('.today').text().split()[0], ['YYYY-MM-DD HH:mm', 'YYYY年MM月DD日']), 8);
-
-                return item;
-            })
-        )
+    // Fetch all version pages in parallel to collect article links
+    const versionResponses = await Promise.all(
+        versionUrls.map(async (url) => ({
+            url,
+            html: await ofetch(url, { responseType: 'text' }),
+        }))
     );
 
+    const articleLinks: string[] = [];
+    for (const { url, html } of versionResponses) {
+        const $v = load(html);
+        $v('ul.newsList#articlelist > li > a').each((_, el) => {
+            const href = $v(el).attr('href');
+            if (href) {
+                // Resolve relative to the version page URL (hrefs like ../../../con/.../content_*.html)
+                const absolute = new URL(href, url).href;
+                if (!articleLinks.includes(absolute)) {
+                    articleLinks.push(absolute);
+                }
+            }
+        });
+    }
+
+    const paperName = paperNames[id] ?? id;
+    const items = await Promise.all(articleLinks.slice(0, limit).map((link) => cache.tryGet(`xmnn:amucsite:${link}`, () => fetchAmucsiteArticle(link))));
+
     return {
-        title,
-        link: currentUrl,
+        title: `${paperName}数字报`,
+        link: listUrl,
+        item: items,
+    };
+}
+
+// Hxcb system: 海西晨报 on dzb.sunnews.cn
+async function fetchHxcbArticles(limit: number): Promise<Data> {
+    const nodeUrl = await resolveHxcbNodeUrl();
+    const nodeHtml = await ofetch(nodeUrl, { responseType: 'text' });
+    const $node = load(nodeHtml);
+
+    // Collect article links from all ul.titss blocks (each block is one version)
+    const articleLinks: string[] = [];
+    $node('ul.titss > li > div > a').each((_, el) => {
+        const href = $node(el).attr('href');
+        if (href) {
+            // Drop the ?div=-1 query string, keep the canonical content URL
+            const path = href.split('?', 1)[0];
+            const absolute = new URL(path, nodeUrl).href;
+            if (!articleLinks.includes(absolute)) {
+                articleLinks.push(absolute);
+            }
+        }
+    });
+
+    if (articleLinks.length === 0) {
+        throw new Error(`No article links found on ${nodeUrl}`);
+    }
+
+    const items = await Promise.all(articleLinks.slice(0, limit).map((link) => cache.tryGet(`xmnn:hxcb:${link}`, () => fetchHxcbArticle(link))));
+
+    return {
+        title: '海西晨报数字报',
+        link: nodeUrl,
         item: items,
     };
 }

--- a/lib/routes/xmnn/namespace.ts
+++ b/lib/routes/xmnn/namespace.ts
@@ -2,6 +2,6 @@ import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
     name: '厦门网',
-    url: 'epaper.xmnn.cn',
+    url: 'epaper.xmnn.com',
     lang: 'zh-CN',
 };

--- a/lib/routes/xmnn/utils.ts
+++ b/lib/routes/xmnn/utils.ts
@@ -1,0 +1,100 @@
+import type { Cheerio } from 'cheerio';
+import { load } from 'cheerio';
+import type { AnyNode } from 'domhandler';
+
+import type { DataItem } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+// Common roots for the two newspaper systems
+export const AMUCSITE_ROOT = 'https://epaper.xmrb.com';
+export const HXCB_ROOT = 'https://dzb.sunnews.cn';
+
+// Paper id -> display name
+export const paperNames: Record<string, string> = {
+    xmrb: '厦门日报',
+    xmwb: '厦门晚报',
+    csjb: '城市捷报',
+    syzk: '双语周刊',
+    hxcb: '海西晨报',
+};
+
+// Resolve the latest issue URL for an amucsite paper (xmrb / xmwb)
+export const fetchAmucsiteListUrl = (id: string): string => `${AMUCSITE_ROOT}/${id}/pc/col/index.html`;
+
+// Resolve the latest issue node URL for hxcb by parsing the META REFRESH on the entry page
+export const resolveHxcbNodeUrl = async (): Promise<string> => {
+    const html = await ofetch(HXCB_ROOT, { responseType: 'text' });
+    const match = html.match(/URL=([^"'\s>]+)/i);
+    if (!match) {
+        throw new Error('Failed to resolve latest hxcb issue URL: META REFRESH not found');
+    }
+    return new URL(match[1], HXCB_ROOT).href;
+};
+
+// Strip metadata noise (founder-content/content wrappers, enpproperty comments, etc.) from a cloned cheerio fragment.
+// Also resolves relative image URLs against baseUrl, drops the ".2" thumbnail suffix, and removes non-standard attributes.
+const cleanArticleContent = ($content: Cheerio<AnyNode>, baseUrl: string): string => {
+    $content.find('founder-content, content').contents().unwrap();
+    $content.find('script, style, .art-title, .author, .subtitle, #paperdate, #layout, #copycontent, table[bgcolor]').remove();
+
+    // Resolve relative image URLs to absolute and drop the ".2" thumbnail suffix for full-resolution JPEGs.
+    // referrerpolicy is removed because RSSHub middleware handles it per AGENTS.md rule 40.
+    $content
+        .find('img')
+        .attr('src', (_i, src) => (src ? new URL(src.replaceAll(/\.2$/g, ''), baseUrl).href : src))
+        .removeAttr('_src referrerpolicy data-toggle data-original-title placement trigger html');
+
+    // Drop any HTML comments (e.g. <!--enpproperty ...-->, <!--/enpcontent-->) from serialized output
+    return ($content.html() ?? '').replaceAll(/<!--[\s\S]*?-->/g, '').trim();
+};
+
+// Fetch and parse a single amucsite article (xmrb / xmwb)
+export const fetchAmucsiteArticle = async (link: string): Promise<DataItem> => {
+    const html = await ofetch(link, { responseType: 'text' });
+    const $ = load(html);
+
+    const title = $('h2#Title').text();
+    const author = $('div#Author').text().trim();
+    const pubDateText = $('span#paperdate').text().trim();
+    const pubDate = pubDateText ? timezone(parseDate(pubDateText, 'YYYY-MM-DD'), 8) : undefined;
+
+    const description = cleanArticleContent($('div#ozoom').clone(), link);
+
+    const item: DataItem = {
+        title,
+        description,
+        link,
+    };
+    if (author) {
+        item.author = author;
+    }
+    if (pubDate) {
+        item.pubDate = pubDate;
+    }
+    return item;
+};
+
+// Fetch and parse a single hxcb article
+export const fetchHxcbArticle = async (link: string): Promise<DataItem> => {
+    const html = await ofetch(link, { responseType: 'text' });
+    const $ = load(html);
+
+    const title = $('td.title1').text().trim();
+    const metaText = $('div.new-1_01_title03').text();
+    const dateMatch = metaText.match(/(\d{4}年\d{2}月\d{2}日)/);
+    const pubDate = dateMatch ? timezone(parseDate(dateMatch[1], 'YYYY年MM月DD日'), 8) : undefined;
+
+    const description = cleanArticleContent($('div#content').clone(), link);
+
+    const item: DataItem = {
+        title,
+        description,
+        link,
+    };
+    if (pubDate) {
+        item.pubDate = pubDate;
+    }
+    return item;
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue


## Example for the Proposed Route(s) / 路由地址示例

```routes
/xmnn/epaper/xmrb
/xmnn/epaper/xmwb
/xmnn/epaper/csjb
/xmnn/epaper/syzk
/xmnn/epaper/hxcb
/xmnn/pdf/xmrb
/xmnn/pdf/xmwb
/xmnn/pdf/csjb
/xmnn/pdf/syzk
/xmnn/pdf/hxcb
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

### 背景

厦门网电子报栏目改版,原路由 `/xmnn/epaper/:id?` 失效:
- 原源站 `epaper.xmnn.cn/{id}/` 返回 404
- 厦门日报/厦门晚报/城市捷报/双语周刊已迁移至 `epaper.xmrb.com`(amucsite 系统)
- 海西晨报独立部署在 `dzb.sunnews.cn`,入口页改为 META REFRESH 跳转

### 本次改动

1. **修复 epaper 路由**:适配新域名和新页面结构,支持 5 份报纸(厦门日报、厦门晚报、城市捷报、双语周刊、海西晨报)
2. **新增 PDF 路由** `/xmnn/pdf/:id?`:提供各报纸版面 PDF 订阅,每个 item 包含全版预览图 + PDF 下载链接
3. **抽取公共工具**到 `utils.ts`:统一处理 amucsite 和 hxcb 两套系统的文章解析、日期解析、内容清理

### 技术细节

- **amucsite 系统**(xmrb/xmwb/csjb/syzk):入口 `epaper.xmrb.com/{id}/pc/col/index.html`,列表页指向最新一期,版面列表在 `ul#list`,文章内容在 `div#ozoom`
- **海西晨报**(hxcb):入口 `dzb.sunnews.cn` 通过 META REFRESH 跳转到当天版面页,文章内容在 `div#content`
- 图片 URL 从相对路径解析为绝对路径,并去掉 `.2` 缩略图后缀获取全分辨率图片
- 使用 `cache.tryGet()` 缓存文章详情
- 日期使用 `parseDate` + `timezone(..., 8)` 处理
- `description` 仅包含正文内容,标题/作者/日期/标签进入各自字段