### PR TITLE
feat(core): normalize fallback logic for content.text and content.html in Atom, RSS and JSON Feed

### DIFF
--- a/lib/middleware/parameter.ts
+++ b/lib/middleware/parameter.ts
@@ -86,6 +86,7 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
 
         const handleItem = (item: DataItem) => {
             item.title &&= entities.decodeXML(item.title + '');
+            item.description ||= item.content?.html;
 
             // handle pubDate
             if (item.pubDate) {

--- a/lib/views/atom.tsx
+++ b/lib/views/atom.tsx
@@ -20,13 +20,7 @@ const RSS: FC<{ data: Data }> = ({ data }) => (
         {data.item?.map((item) => (
             <entry>
                 <title>{item.title}</title>
-                {item.content?.html || item.description ? (
-                    <content type="html">{item.content?.html || item.description}</content>
-                ) : item.content?.text ? (
-                    <content type="text">{item.content.text}</content>
-                ) : (
-                    <content src={item.link} type="text/html" />
-                )}
+                {item.description ? <content type="html">{item.description}</content> : item.content?.text ? <content type="text">{item.content.text}</content> : <content src={item.link} type="text/html" />}
                 <link href={item.link} />
                 <id>{item.guid || item.link || item.title}</id>
                 {item.pubDate && <published>{new Date(item.pubDate).toISOString()}</published>}

--- a/lib/views/atom.tsx
+++ b/lib/views/atom.tsx
@@ -20,7 +20,13 @@ const RSS: FC<{ data: Data }> = ({ data }) => (
         {data.item?.map((item) => (
             <entry>
                 <title>{item.title}</title>
-                <content type="html">{item.description}</content>
+                {item.content?.html || item.description ? (
+                    <content type="html">{item.content?.html || item.description}</content>
+                ) : item.content?.text ? (
+                    <content type="text">{item.content.text}</content>
+                ) : (
+                    <content src={item.link} type="text/html" />
+                )}
                 <link href={item.link} />
                 <id>{item.guid || item.link || item.title}</id>
                 {item.pubDate && <published>{new Date(item.pubDate).toISOString()}</published>}

--- a/lib/views/json.test.ts
+++ b/lib/views/json.test.ts
@@ -18,6 +18,7 @@ describe('JSON view', () => {
                     link: 'https://example.com/one',
                     summary: 'Entry One',
                     guid: 'guid-1',
+                    description: '<p>hello</p>',
                     content: {
                         html: '<p>hello</p>',
                         text: 'hello',

--- a/lib/views/json.ts
+++ b/lib/views/json.ts
@@ -20,8 +20,8 @@ const json = (data: Data) => {
             url: item.link,
             title: item.title,
             // content_html and content_text are each optional strings — but one or both must be present
-            content_html: (item.content && item.content.html) || item.description || item.title,
-            content_text: item.content?.text ?? undefined,
+            content_html: item.content?.html || item.description,
+            content_text: item.content?.text || (item.content?.html || item.description ? undefined : item.title),
             summary: item.summary,
             image: item.image || item.itunes_item_image,
             banner_image: item.banner,

--- a/lib/views/json.ts
+++ b/lib/views/json.ts
@@ -20,8 +20,8 @@ const json = (data: Data) => {
             url: item.link,
             title: item.title,
             // content_html and content_text are each optional strings — but one or both must be present
-            content_html: item.description,
-            content_text: item.content?.text || (item.description ? undefined : item.title),
+            content_html: item.description || item.content?.html,
+            content_text: item.content?.text || (item.description || item.content?.html ? undefined : item.title),
             summary: item.summary,
             image: item.image || item.itunes_item_image,
             banner_image: item.banner,

--- a/lib/views/json.ts
+++ b/lib/views/json.ts
@@ -20,8 +20,8 @@ const json = (data: Data) => {
             url: item.link,
             title: item.title,
             // content_html and content_text are each optional strings — but one or both must be present
-            content_html: item.content?.html || item.description,
-            content_text: item.content?.text || (item.content?.html || item.description ? undefined : item.title),
+            content_html: item.description,
+            content_text: item.content?.text || (item.description ? undefined : item.title),
             summary: item.summary,
             image: item.image || item.itunes_item_image,
             banner_image: item.banner,

--- a/lib/views/json.ts
+++ b/lib/views/json.ts
@@ -20,8 +20,8 @@ const json = (data: Data) => {
             url: item.link,
             title: item.title,
             // content_html and content_text are each optional strings — but one or both must be present
-            content_html: item.description || item.content?.html,
-            content_text: item.content?.text || (item.description || item.content?.html ? undefined : item.title),
+            content_html: item.description,
+            content_text: item.content?.text || (item.description ? undefined : item.title),
             summary: item.summary,
             image: item.image || item.itunes_item_image,
             banner_image: item.banner,

--- a/lib/views/rss.tsx
+++ b/lib/views/rss.tsx
@@ -38,7 +38,7 @@ const RSS: FC<{ data: Data }> = ({ data }) => {
                 {data.item?.map((item) => (
                     <item>
                         <title>{item.title}</title>
-                        <description>{item.description || item.content?.html || item.content?.text}</description>
+                        <description>{item.description}</description>
                         <link>{item.link}</link>
                         <guid isPermaLink="false">{item.guid || item.link || item.title}</guid>
                         {item.pubDate && <pubDate>{item.pubDate}</pubDate>}

--- a/lib/views/rss.tsx
+++ b/lib/views/rss.tsx
@@ -38,7 +38,7 @@ const RSS: FC<{ data: Data }> = ({ data }) => {
                 {data.item?.map((item) => (
                     <item>
                         <title>{item.title}</title>
-                        <description>{item.description}</description>
+                        <description>{item.description || item.content?.html || item.content?.text}</description>
                         <link>{item.link}</link>
                         <guid isPermaLink="false">{item.guid || item.link || item.title}</guid>
                         {item.pubDate && <pubDate>{item.pubDate}</pubDate>}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

#### Atom

Atom, like JSON Feed, [supports](https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.2:~:text=On%20the%20atom%3Acontent%20element%2C%20the%20value%20of%20the%20%22type%22%20attribute%20MAY%20be%0A%20%20%20one%20of%20%22text%22%2C%20%22html%22) `content.text` (via the `type="text"` attribute), but [unlike](https://www.jsonfeed.org/version/1.1/#items:~:text=content%5Fhtml%20and%20content%5Ftext%20are%20each%20optional%20strings%20%E2%80%94%20but%20one%20or%20both%20must%20be%20present%2E) JSON Feed, the Atom element (`atom:entry`) [must not](https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.2:~:text=atom%3Aentry%20elements%20MUST%20NOT%20contain%20more%20than%20one%20atom%3Acontent%20element) contain more than one `content` element.

Therefore, a condition was added for Atom where `content` with the `type="text"` attribute acts as a fallback if `content.html` is missing.

If `content` is empty, it [must](https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.3.2) contain a link (`item.link`) to the content in the `src` attribute.

#### RSS

Also, `content.html` has been added as a fallback for the `description` in the middleware. This removes the need to include a `description` when creating new routes, allowing the use of clearer options like `content.html`. At the same time, this maintains backward compatibility with old routes.

#### JSON Feed

`item.title` must be rendered in `content_html` only if `content.text` is not provided, to prevent getting the text content in `content_text` and the title in `content_html`. Also, since `item.title` is text content, it must be a fallback for `content_text` instead of `content_html`.