### PR TITLE
feat(route): add People's Daily (人民日报) route under `rmrb` namespace

### DIFF
--- a/lib/routes/rmrb/index.ts
+++ b/lib/routes/rmrb/index.ts
@@ -1,0 +1,144 @@
+import { load } from 'cheerio';
+
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+import { getArticleContent, getArticles, getEditions } from './utils';
+
+export const route: Route = {
+    path: ['/:page?', '/:page?/:date?'],
+    name: '人民日报',
+    url: 'paper.people.com.cn',
+    maintainers: ['zhangsan-xyz'],
+    example: '/rmrb/05',
+    description: '抓取人民日报电子版指定版面或当日全部版面的文章。版面编号可在报纸首页查看，例如 `05` 为评论版、`09` 为理论版；`all` 表示当日全部版面。',
+    parameters: {
+        page: {
+            description: '版面编号（1-2 位数字），默认 `01`（第01版 要闻）。例如 `05` 为评论版，`09` 为理论版，`11` 为国际版。`all` 表示抓取当日全部版面。',
+            default: '01',
+        },
+        date: '指定日期，格式 `YYYYMMDD`，默认抓取最新一期。例如 `/rmrb/05/20260701` 抓取评论版、`/rmrb/all/20260701` 抓取当日全部版面。',
+    },
+    categories: ['traditional-media'],
+    zh: {
+        name: '人民日报',
+        description: '抓取人民日报电子版指定版面或当日全部版面的文章。版面编号可在报纸首页查看，例如 `05` 为评论版、`09` 为理论版；`all` 表示当日全部版面。',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['paper.people.com.cn/rmrb/pc/layout/index.html'],
+            target: '/:page',
+        },
+    ],
+    handler,
+};
+
+interface ArticleRef {
+    title: string;
+    link: string;
+}
+
+async function handler(ctx) {
+    const page = ctx.req.param('page');
+    const date = ctx.req.param('date');
+    const limit = ctx.req.query('limit') ? Number(ctx.req.query('limit')) : 30;
+
+    if (date && !/^\d{8}$/.test(date)) {
+        throw new InvalidParameterError('date 参数格式应为 YYYYMMDD');
+    }
+
+    // page 语义：undefined -> 第01版；'all' -> 全部版面；数字 -> 对应版面
+    let pageNum: string | null = null;
+    let isAll = false;
+    if (page === undefined) {
+        pageNum = '01';
+    } else if (page === 'all') {
+        isAll = true;
+    } else if (/^\d{1,2}$/.test(page)) {
+        pageNum = page;
+    } else {
+        throw new InvalidParameterError(`版面编号应为 1-2 位数字或 "all"，收到：${page}`);
+    }
+
+    const editionDate = date ? `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}` : '';
+
+    if (isAll) {
+        const editions = await getEditions(date);
+        const matched = editions[0]?.url.match(/layout\/(\d{4})(\d{2})\/(\d{2})\//);
+        const resolvedDate = matched ? `${matched[1]}-${matched[2]}-${matched[3]}` : editionDate;
+
+        const allArticles = (await Promise.all(editions.map((edition) => getArticles(edition.url)))).flat();
+        const items = await buildItems(allArticles.slice(0, limit), resolvedDate);
+        return {
+            title: '人民日报 - 全部版面',
+            link: 'http://paper.people.com.cn/rmrb/pc/layout/index.html',
+            description: `人民日报电子版 ${resolvedDate || '最新一期'} 全部版面`,
+            item: items,
+        };
+    }
+
+    // 指定版面
+    const pageToUse = pageNum ?? '01';
+    let nodeUrl: string;
+    let resolvedDate: string;
+    if (date) {
+        const y = date.slice(0, 4);
+        const m = date.slice(4, 6);
+        const d = date.slice(6, 8);
+        nodeUrl = `http://paper.people.com.cn/rmrb/pc/layout/${y}${m}/${d}/node_${pageToUse}.html`;
+        resolvedDate = editionDate;
+    } else {
+        const indexUrl = 'http://paper.people.com.cn/rmrb/pc/layout/index.html';
+        const indexHtml = await ofetch(indexUrl);
+        const $index = load(indexHtml);
+        const href = $index(`#list li a[href$="node_${pageToUse}.html"]`).attr('href');
+        if (!href) {
+            throw new InvalidParameterError(`未找到第 ${pageToUse} 版，请确认版面编号是否正确`);
+        }
+        nodeUrl = new URL(href, indexUrl).href;
+        const matched = nodeUrl.match(/layout\/(\d{4})(\d{2})\/(\d{2})\//);
+        resolvedDate = matched ? `${matched[1]}-${matched[2]}-${matched[3]}` : '';
+    }
+
+    const articles = await getArticles(nodeUrl);
+    const items = await buildItems(articles.slice(0, limit), resolvedDate);
+
+    const nodeHtml = await ofetch(nodeUrl);
+    const $node = load(nodeHtml);
+    const editionName = $node(`#list li a[href$="node_${pageToUse}.html"]`).text().replaceAll(/\s+/g, ' ').trim() || `第${pageToUse}版`;
+
+    return {
+        title: `人民日报 - ${editionName}`,
+        link: nodeUrl,
+        description: `人民日报电子版 ${resolvedDate} ${editionName}`,
+        item: items,
+    };
+}
+
+function buildItems(articles: ArticleRef[], editionDate: string) {
+    return Promise.all(
+        articles.map((article) =>
+            cache.tryGet(article.link, async () => {
+                const { description, pubDate } = await getArticleContent(article.link);
+                return {
+                    title: article.title,
+                    link: article.link,
+                    description,
+                    pubDate: pubDate ?? parseDate(editionDate || new Date()),
+                };
+            })
+        )
+    );
+}

--- a/lib/routes/rmrb/namespace.ts
+++ b/lib/routes/rmrb/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '人民日报',
+    url: 'paper.people.com.cn',
+    description: '人民日报电子版（人民网报纸）',
+    lang: 'zh-CN',
+};

--- a/lib/routes/rmrb/utils.ts
+++ b/lib/routes/rmrb/utils.ts
@@ -1,0 +1,100 @@
+import { load } from 'cheerio';
+
+import ofetch from '@/utils/ofetch';
+
+const ROOT = 'http://paper.people.com.cn/rmrb/pc/layout';
+
+export interface Edition {
+    /** 版面编号，例如 `01` */
+    page: string;
+    /** 版面名称，例如 `第01版 要闻` */
+    name: string;
+    /** 该版面的绝对链接 */
+    url: string;
+}
+
+export interface ArticleRef {
+    title: string;
+    link: string;
+}
+
+/**
+ * 获取某一天（或最新一期）人民日报的全部版面列表。
+ * @param date 格式 `YYYYMMDD`，不传则抓取最新一期
+ */
+export async function getEditions(date?: string): Promise<Edition[]> {
+    const indexUrl = date ? `${ROOT}/${date.slice(0, 4)}${date.slice(4, 6)}/${date.slice(6, 8)}/index.html` : `${ROOT}/index.html`;
+
+    const html = await ofetch(indexUrl);
+    const $ = load(html);
+
+    const editions: Edition[] = [];
+    $('#list li a').each((_, el) => {
+        const a = $(el);
+        const href = a.attr('href');
+        if (!href || !/node_\d+\.html$/.test(href)) {
+            return;
+        }
+        const pageMatch = href.match(/node_(\d+)\.html$/);
+        editions.push({
+            page: pageMatch ? pageMatch[1] : '',
+            name: a.text().replaceAll(/\s+/g, ' ').trim(),
+            url: new URL(href, indexUrl).href,
+        });
+    });
+    return editions;
+}
+
+/**
+ * 从某个版面页中提取文章链接列表（已过滤责编等非正文条目）。
+ */
+export async function getArticles(nodeUrl: string): Promise<ArticleRef[]> {
+    const html = await ofetch(nodeUrl);
+    const $ = load(html);
+
+    const articles: ArticleRef[] = [];
+    $('a[href*="content_"]').each((_, el) => {
+        const a = $(el);
+        const href = a.attr('href');
+        if (!href) {
+            return;
+        }
+        const title = a.text().replaceAll(/\s+/g, ' ').trim();
+        // 跳过「本版责编」「责任编辑」等排版说明
+        if (!title || /责编|责任编辑/.test(title)) {
+            return;
+        }
+        articles.push({
+            title,
+            link: new URL(href, nodeUrl).href,
+        });
+    });
+    return articles;
+}
+
+/**
+ * 抓取文章正文，返回经过绝对化的 HTML，以及文章自身的发布日期（若有）。
+ */
+export async function getArticleContent(articleUrl: string): Promise<{ description: string; pubDate?: Date }> {
+    const html = await ofetch(articleUrl);
+    const $ = load(html);
+
+    const $article = $('.article');
+    // 将相对图片地址改写为绝对地址
+    $article.find('img[src]').each((_, el) => {
+        const img = $(el);
+        const src = img.attr('src');
+        if (src) {
+            img.attr('src', new URL(src, articleUrl).href);
+        }
+    });
+
+    const description = $article.html()?.trim() ?? '';
+
+    // 尝试从页面日期标记解析发布时间，例如 `(2026年07月29日 01版)`
+    const dateText = $('.date').first().text();
+    const dateMatch = dateText.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
+    const pubDate = dateMatch ? new Date(Number(dateMatch[1]), Number(dateMatch[2]) - 1, Number(dateMatch[3])) : undefined;
+
+    return { description, pubDate };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
/rmrb
/rmrb/05
/rmrb/all
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

在 `rmrb` 命名空间下新增[人民日报](https://paper.people.com.cn/rmrb/pc/layout/index.html)电子版 RSS 路由（区别于已有的 `people` 人民网命名空间）。

- 路由：`/rmrb`（默认第01版）、`/rmrb/:page`（指定版面，如 `/rmrb/05` 评论版）、`/rmrb/all`（当日全部版面聚合）
- 仅抓取最新一期，不支持历史日期：人民日报电子报在 2024-12-01 之前的版面使用另一套 URL 格式，为免维护两套易变的 URL 规则，本路由刻意简化为只抓最新一期
- 抓取 `layout/index.html` → `node_XX.html` 版面 → `content_XX.html` 正文；正文图片绝对化，`pubDate` 用 `parseDate` 解析文章自身日期；正文请求走 `cache.tryGet` 缓存
- 已按 Auto Review 反馈修正：路由名改为 `版面`、radar `target` 设为 `/`、移除自定义 `limit`、HTTPS、文章链接作用域到 `.news-list a` 等
- `Category` 归为 `traditional-media`，本地已通过 oxlint 并实测各版面返回正常
