### PR TITLE
fix(route): resolve relative article URLs in qstheory magazine route

### DIFF
--- a/lib/routes/qstheory/magazine.ts
+++ b/lib/routes/qstheory/magazine.ts
@@ -48,7 +48,7 @@ async function handler(ctx) {
             const $item = $$(item);
             return {
                 title: $item.text(),
-                link: $item.attr('href')!,
+                link: new URL($item.attr('href')!, baseUrl).href,
             };
         })
         .toReversed()


### PR DESCRIPTION
修复 `qstheory` 杂志路由（在线读刊）文章链接未转绝对路径的问题。

`magazine.ts` 中 `.highlight a` 的文章链接取的是原始 `href`（相对路径 `../YYYYMMDD/.../c.html`），而 `getItem` 直接 `ofetch(item.link)` 不解析相对 URL，导致除最新一期外、往期文章全部抓取失败（此前 index.ts 已修过同类问题，magazine.ts 漏了）。现改为 `new URL(href, baseUrl)` 统一转绝对路径。

```routes
/qstheory/magazine/qs
/qstheory/magazine/hqwglist
```