### PR TITLE
fix(route): resolve qstheory relative URLs and add single-article route

### DIFF
--- a/lib/routes/qstheory/magazine-article.ts
+++ b/lib/routes/qstheory/magazine-article.ts
@@ -1,0 +1,45 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+
+import { baseUrl, getItem } from './utils';
+
+export const route: Route = {
+    path: '/magazine/:magazine/article/:date/:hash',
+    categories: ['traditional-media'],
+    example: '/qstheory/magazine/qs/article/20260715/01c61f4ff2af4af8bc50757dfff4976e',
+    parameters: {
+        magazine: '刊物，`qs` 为求是，`hqwglist` 为红旗文稿',
+        date: '文章日期，格式 `YYYYMMDD`，例如 `20260715`',
+        hash: '文章链接中的一段十六进制哈希串',
+    },
+    radar: [
+        {
+            source: ['www.qstheory.cn/:date/:hash/c.html'],
+            target: '/magazine/qs/article/:date/:hash',
+        },
+    ],
+    name: '文章',
+    maintainers: ['TonyRL', 'cscnk52'],
+    handler,
+};
+
+async function handler(ctx) {
+    const { date, hash } = ctx.req.param();
+
+    const link = `${baseUrl}/${date}/${hash}/c.html`;
+    const item = await cache.tryGet(link, async () => {
+        const response = await ofetch(link);
+        const $ = load(response);
+        const data = await getItem({ title: $('h1').first().text().trim() || $('head title').text().trim(), link });
+        return data;
+    });
+
+    return {
+        title: `求是杂志 - ${item.title}`,
+        link: `${baseUrl}/${date}`,
+        item: [item],
+    };
+}

--- a/lib/routes/qstheory/magazine.ts
+++ b/lib/routes/qstheory/magazine.ts
@@ -48,7 +48,7 @@ async function handler(ctx) {
             const $item = $$(item);
             return {
                 title: $item.text(),
-                link: $item.attr('href')!,
+                link: new URL($item.attr('href')!, baseUrl).href,
             };
         })
         .toReversed()


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Fix relative article URLs in `/qstheory/magazine/:magazine` and add single-article route. No related issue.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/qstheory/magazine/qs
/qstheory/magazine/qs/article/20260715/01c61f4ff2af4af8bc50757dfff4976e
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route added (`/qstheory/magazine/:magazine/article/:date/:hash`)
- [x] `name`, `maintainers`, `example`, `description` and `path` are added
- [x] Routes added to `radar`
- [x] `Puppeteer` is not required

## Note / 说明

1. 修复 `/qstheory/magazine/:magazine` 目录路由中文章链接为相对路径导致往期文章抓取失败的问题（用 `new URL(href, baseUrl)` 解析为绝对地址）。
2. 新增单篇文章路由 `/qstheory/magazine/:magazine/article/:date/:hash`，可通过文章链接直接获取单篇文章（标题取自 `h1`，正文/作者/时间复用 `getItem`）。单篇文章路由放在独立文件 `magazine-article.ts` 中，仍属于 `qstheory` 命名空间、挂在现有 `magazine` 路径下，不新增顶层命名空间。
