### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [26, 24]
+                node-version: [24]
         name: Build radar and maintainer on Node ${{ matrix.node-version }}
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `22,24`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `22,24` (using `24` where a concrete pin is needed).

- `.github/workflows/test.yml`
  - `node-version: [26, 24]` → `node-version: [24]`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `22,24`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
