### PR TITLE
feat(route/huggingface): support trending papers

### DIFF
--- a/lib/routes/huggingface/daily-papers.ts
+++ b/lib/routes/huggingface/daily-papers.ts
@@ -8,7 +8,7 @@ export const route: Route = {
     path: '/daily-papers/:cycle?/:voteFliter?',
     categories: ['programming'],
     example: '/huggingface/daily-papers/week/50',
-    parameters: { cycle: 'The publication cycle you want to follow. Choose from: date, week, month. Default: date', voteFliter: 'Filter papers by vote count.' },
+    parameters: { cycle: 'The publication cycle you want to follow. Choose from: date, week, month, trending. Default: date', voteFliter: 'Filter papers by vote count.' },
     features: {
         requireConfig: false,
         requirePuppeteer: false,
@@ -49,16 +49,24 @@ interface PapersData {
 async function handler(ctx) {
     const { cycle = 'date', voteFliter = '0' } = ctx.req.param();
     let url: string;
+    let title: string;
     switch (cycle) {
         case 'date':
             url = 'https://huggingface.co/papers';
+            title = 'Huggingface Daily Papers';
             break;
         case 'week':
             // We don't actually need to get the week number, because huggingface.co/papers/week/YYYY-W52 will redirect to the latest week
             url = `https://huggingface.co/papers/week/${new Date().getFullYear()}-W52`;
+            title = 'Huggingface Weekly Papers';
             break;
         case 'month':
             url = `https://huggingface.co/papers/month/${new Date().toISOString().slice(0, 7)}`;
+            title = 'Huggingface Monthly Papers';
+            break;
+        case 'trending':
+            url = 'https://huggingface.co/papers/trending';
+            title = 'Huggingface Trending Papers';
             break;
         default:
             throw new Error(`Invalid cycle: ${cycle}`);
@@ -77,13 +85,15 @@ async function handler(ctx) {
             pubDate: parseDate(item.publishedAt),
             author: item.paper.authors.map((author) => author.name).join(', '),
             upvotes: item.paper.upvotes,
-        }))
-        .toSorted((a, b) => b.upvotes - a.upvotes);
+        }));
+
+    // The trending page is already ranked by Huggingface, the cycle listings are not
+    const sortedItems = cycle === 'trending' ? items : items.toSorted((a, b) => b.upvotes - a.upvotes);
 
     return {
         allowEmpty: true,
-        title: 'Huggingface Daily Papers',
-        link: 'https://huggingface.co/papers',
-        item: items,
+        title,
+        link: url,
+        item: sortedItems,
     };
 }


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/huggingface/daily-papers
/huggingface/daily-papers/date
/huggingface/daily-papers/week
/huggingface/daily-papers/month
/huggingface/daily-papers/trending
/huggingface/daily-papers/trending/50
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds `trending` as a fourth cycle to the existing `huggingface/daily-papers` route, covering <https://huggingface.co/papers/trending>.

That page is server-rendered from the same `div[data-target="DailyPapers"]` props blob as the date/week/month listings, with the same item shape, so it slots into the existing handler rather than needing a new route file. The existing radar rule `huggingface.co/papers/:cycle` already resolved that URL to `/huggingface/daily-papers/trending`, which previously threw `Invalid cycle` — this makes the rule actually work.

Two small related changes:

- **Trending order is preserved.** The other cycles are re-sorted by upvotes; for trending the page order *is* the ranking, so it is passed through untouched (visible with `?sorted=false`).
- **Feed `title`/`link` now follow the cycle** (`Huggingface Daily/Weekly/Monthly/Trending Papers`, linking to the page actually fetched). Previously all four cycles produced a feed titled `Huggingface Daily Papers` pointing at `/papers`, which made them indistinguishable in a reader.

Verified locally against a dev server — all four cycles return 200 with items, the vote filter still applies (`/trending/50`), an unknown cycle still errors, and `/huggingface/daily-papers/trending?sorted=false` matches the site's trending order item-for-item.
