### PR TITLE
fix(route/bilibili): guard emoji_details before iterating in followings/dynamic

### DIFF
--- a/lib/routes/bilibili/followings-dynamic.ts
+++ b/lib/routes/bilibili/followings-dynamic.ts
@@ -174,7 +174,7 @@ async function handler(ctx) {
 
             // emoji
             let data_content = getDes(data);
-            if (item.display && item.display.emoji_info && showEmoji) {
+            if (item.display?.emoji_info?.emoji_details && showEmoji) {
                 const emoji = item.display.emoji_info.emoji_details;
                 for (const item of emoji) {
                     data_content = data_content.replaceAll(


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #21916

Replaces #22907 and #22908, same one-line change, on a fresh branch.

#22907 was auto-closed for the broken build described at the end of this description, and could not be reopened once the branch was corrected (`state cannot be changed. The ... branch was force-pushed or recreated`). #22908 carried the corrected branch and went green — 23 checks passed, 0 failed, including `PR - Docker build test` and `Test` — but was closed 78 seconds after opening by the `fail-build` job in `.github/workflows/docker-test-cont.yml`, reacting to the *earlier* failed run on the old commit while its own Docker build was still in progress. That job resolves which PR to close with `gh api repos/.../pulls -f head=... -f state=all --jq '.[0]'`, and with two PRs on one branch `.[0]` picked the wrong one. Hence a branch name that has only ever had this one PR.

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

N/A — no route added or changed, this is a logic fix.

## Note / 说明

`item.display.emoji_info` can be present as an empty object (`{}`) with no `emoji_details` array. This happens for any dynamic with no custom or expression emoji. The existing guard only checked `emoji_info` for truthiness, so `for (const item of emoji)` threw `TypeError: emoji is not iterable` for every such dynamic whenever `showEmoji=1`.

The fix narrows the guard to `item.display?.emoji_info?.emoji_details`. When `emoji_details` is populated the branch is entered exactly as before, so the substitution itself is unchanged, and `emoji_details: []` was and still is a no-op.

Reported three times: #21914 and #21915 were auto-closed by the route-not-found bot without a fix, and #21916 is the surviving report.

This is a logic bug reproducible offline with a fixed payload shape, not upstream HTML or selector drift, so it does not need a live fetch to confirm. Running the guard and the loop body from lines 177-185 verbatim against both payload shapes the dynamics feed returns:

| guard | `emoji_info: {}` | `emoji_details` populated |
|---|---|---|
| before | `TypeError: emoji is not iterable` | substitutes |
| after | content passes through unchanged | substitutes |

No test file is included. `scripts/workflow/build-routes.ts` imports everything under `lib/routes/` through `directoryImport` with `importPattern: /\.tsx?$/`, so a `*.test.ts` placed next to a route is loaded outside the vitest runtime and `build:routes` dies on the first `vi.*` call. That is what broke the first attempt at this PR, and there is no per-route test anywhere in the repo to follow instead.

Verified on this branch, rebased onto master:

```
pnpm build:routes            -> exit 0
oxlint --type-aware <file>   -> 0 errors
oxfmt --check <file>         -> clean
vitest run                   -> 420 passed, 7 failed
```

The 7 failures are `lib/utils/playwright*.test.ts` (no browser installed locally), `common-utils > convertDateToISO8601` and `common-config > buildData`. All 7 reproduce identically on a clean `origin/master` worktree, so they are pre-existing and unrelated to this change.

CI on this exact commit (`79b2fc527`, run under #22908): 23 checks passed, 0 failed, 7 skipped.
