### PR TITLE
feat(tsinghua): 图书馆通知公告

### DIFF
--- a/lib/routes/tsinghua/lib/notice.ts
+++ b/lib/routes/tsinghua/lib/notice.ts
@@ -1,4 +1,4 @@
-import { Route } from '@/types';
+import type { Route, DataItem } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { load } from 'cheerio';
@@ -27,42 +27,41 @@ export const route: Route = {
     handler: async () => {
         const baseUrl = 'https://lib.tsinghua.edu.cn';
         const link = `${baseUrl}/tzgg.htm`;
-        
+
         const response = await ofetch(link);
         const $ = load(response);
 
-        // 提取列表页信息
-        let items = $('ul.notice-list li').toArray().map((item) => {
-            const $item = $(item);
-            const a = $item.find('.notice-list-tt a');
-            const title = a.text().trim();
-            const href = a.attr('href');
-            const dateStr = $item.find('.notice-date').text().trim();
-            const category = $item.find('.notice-label').text().trim();
-            
-            return {
-                title: `[${category}] ${title}`,
-                link: new URL(href, link).href,
-                pubDate: parseDate(dateStr, 'YYYY-MM-DD'),
-                category: category,
-            };
-        });
+        // Extract list page items
+        let items: DataItem[] = $('ul.notice-list li')
+            .toArray()
+            .filter((item) => $(item).find('.notice-list-tt a').attr('href'))
+            .map((item) => {
+                const $item = $(item);
+                const a = $item.find('.notice-list-tt a');
+                const title = a.text().trim();
+                const href = a.attr('href') as string;
+                const dateStr = $item.find('.notice-date').text().trim();
+                const category = $item.find('.notice-label').text().trim();
 
-        // 异步获取每个通知的正文内容，并加入 RSSHub 内置缓存机制
-        items = await Promise.all(
+                return {
+                    title,
+                    link: new URL(href, link).href,
+                    pubDate: parseDate(dateStr, 'YYYY-MM-DD'),
+                    category,
+                };
+            });
+
+        // Fetch article body with cache
+        items = (await Promise.all(
             items.map((item) =>
-                cache.tryGet(item.link, async () => {
-                    try {
-                        const itemResponse = await ofetch(item.link);
-                        const $$ = load(itemResponse);
-                        item.description = $$('.v_news_content').html() || '无正文内容';
-                    } catch {
-                        item.description = '无法获取正文内容';
-                    }
-                    return item;
+                cache.tryGet(item.link as string, async () => {
+                    const itemResponse = await ofetch(item.link as string);
+                    const $$ = load(itemResponse);
+                    item.description = $$('.v_news_content').html() || undefined;
+                    return item as DataItem;
                 })
             )
-        );
+        )) as DataItem[];
 
         return {
             title: '清华大学图书馆 - 通知公告',

--- a/lib/routes/tsinghua/lib/notice.ts
+++ b/lib/routes/tsinghua/lib/notice.ts
@@ -1,7 +1,8 @@
-import type { Route, DataItem } from '@/types';
+import { load } from 'cheerio';
+
+import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
-import { load } from 'cheerio';
 import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {

--- a/lib/routes/tsinghua/lib/notice.ts
+++ b/lib/routes/tsinghua/lib/notice.ts
@@ -1,0 +1,74 @@
+import { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { load } from 'cheerio';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/lib/notice',
+    categories: ['university'],
+    example: '/tsinghua/lib/notice',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['lib.tsinghua.edu.cn/tzgg.htm'],
+        },
+    ],
+    name: '图书馆通知公告',
+    maintainers: ['Aquarius-Situla'],
+    handler: async () => {
+        const baseUrl = 'https://lib.tsinghua.edu.cn';
+        const link = `${baseUrl}/tzgg.htm`;
+        
+        const response = await ofetch(link);
+        const $ = load(response);
+
+        // 提取列表页信息
+        let items = $('ul.notice-list li').toArray().map((item) => {
+            const $item = $(item);
+            const a = $item.find('.notice-list-tt a');
+            const title = a.text().trim();
+            const href = a.attr('href');
+            const dateStr = $item.find('.notice-date').text().trim();
+            const category = $item.find('.notice-label').text().trim();
+            
+            return {
+                title: `[${category}] ${title}`,
+                link: new URL(href, link).href,
+                pubDate: parseDate(dateStr, 'YYYY-MM-DD'),
+                category: category,
+            };
+        });
+
+        // 异步获取每个通知的正文内容，并加入 RSSHub 内置缓存机制
+        items = await Promise.all(
+            items.map((item) =>
+                cache.tryGet(item.link, async () => {
+                    try {
+                        const itemResponse = await ofetch(item.link);
+                        const $$ = load(itemResponse);
+                        item.description = $$('.v_news_content').html() || '无正文内容';
+                    } catch {
+                        item.description = '无法获取正文内容';
+                    }
+                    return item;
+                })
+            )
+        );
+
+        return {
+            title: '清华大学图书馆 - 通知公告',
+            link,
+            description: '清华大学图书馆 - 通知公告',
+            item: items,
+        };
+    },
+};


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/tsinghua/lib/notice
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
新增路由：清华大学图书馆 - 通知公告。
- 支持自动进入详情页提取正文内容（完整 HTML 格式）。
- 已接入 RSSHub 原生 cache.tryGet 缓存机制，避免频繁发起详情页请求。
- 遵循官方 V3 规范，使用 ofetch 及 parseDate 完成请求与日期解析。