### PR TITLE
feat(route/binance): add square user and copy trading lead routes.

### DIFF
--- a/lib/binance-copy-trading.test.ts
+++ b/lib/binance-copy-trading.test.ts
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ofetchMock = vi.fn();
+const tryGetMock = vi.fn();
+
+vi.mock('@/utils/ofetch', () => ({
+    default: ofetchMock,
+}));
+
+vi.mock('@/utils/cache', () => ({
+    default: {
+        tryGet: tryGetMock,
+    },
+}));
+
+vi.mock('@/config', () => ({
+    config: {
+        trueUA: 'test-user-agent',
+    },
+}));
+
+const createContext = (portfolioId: string, limit?: string) => {
+    const json: Record<string, unknown> = {};
+
+    return {
+        req: {
+            param: (name: string) => {
+                if (name === 'portfolioId') {
+                    return portfolioId;
+                }
+            },
+            query: (name: string) => {
+                if (name === 'limit') {
+                    return limit;
+                }
+            },
+        },
+        set: (_key: string, value: unknown) => {
+            Object.assign(json, value as Record<string, unknown>);
+        },
+        get jsonData() {
+            return json;
+        },
+    };
+};
+
+describe('/binance/copy-trading/lead/:portfolioId', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        ofetchMock.mockReset();
+        tryGetMock.mockReset();
+    });
+
+    it('maps orders to feed items with correct title, pubDate, and description', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: {
+                    nickname: 'TestTrader',
+                    description: 'Test description',
+                    avatarUrl: 'https://example.com/avatar.png',
+                    futuresType: 'UM',
+                },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: {
+                    indexValue: '1785420034257',
+                    total: 100,
+                    list: [
+                        {
+                            symbol: 'BTCUSDT',
+                            baseAsset: 'BTC',
+                            quoteAsset: 'USDT',
+                            side: 'BUY',
+                            type: 'MARKET',
+                            positionSide: 'LONG',
+                            executedQty: 10.848,
+                            avgPrice: 63153.5,
+                            totalPnl: 0,
+                            orderTime: 1_785_765_131_745,
+                            orderUpdateTime: 1_785_765_131_757,
+                        },
+                        {
+                            symbol: 'BTCUSDT',
+                            baseAsset: 'BTC',
+                            quoteAsset: 'USDT',
+                            side: 'SELL',
+                            type: 'MARKET',
+                            positionSide: 'LONG',
+                            executedQty: 6.99,
+                            avgPrice: 62430,
+                            totalPnl: -13589.4,
+                            orderTime: 1_785_758_904_804,
+                            orderUpdateTime: 1_785_758_904_804,
+                        },
+                    ],
+                },
+            });
+
+        const { route } = await import('@/routes/binance/copy-trading');
+        const ctx = createContext('5075281354358777856');
+        const result = (await route.handler(ctx as any)) as any;
+
+        expect(result.title).toBe('TestTrader - Binance Copy Trading');
+        expect(result.link).toBe('https://www.binance.com/zh-CN/copy-trading/lead-details/5075281354358777856');
+        expect(result.item).toHaveLength(2);
+
+        expect(result.item[0].title).toBe('Open Long BTCUSDT @ 63,153.50');
+        expect(result.item[0].category).toEqual(['Open Long']);
+        expect(result.item[0].description).toContain('BTCUSDT');
+        expect(result.item[0].description).not.toContain('Realized PnL');
+        expect(result.item[0].pubDate).toBeInstanceOf(Date);
+
+        expect(result.item[1].title).toBe('Close Long BTCUSDT @ 62,430.00');
+        expect(result.item[1].category).toEqual(['Close Long']);
+        expect(result.item[1].description).toContain('Realized PnL');
+        expect(result.item[1].description).toContain('-13,589.40');
+    });
+
+    it('shows realized PnL only for sell orders with non-zero PnL', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: { nickname: 'Trader', futuresType: 'UM' },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: {
+                    indexValue: '1',
+                    total: 2,
+                    list: [
+                        {
+                            symbol: 'ETHUSDT',
+                            baseAsset: 'ETH',
+                            quoteAsset: 'USDT',
+                            side: 'BUY',
+                            type: 'MARKET',
+                            positionSide: 'LONG',
+                            executedQty: 1,
+                            avgPrice: 3000,
+                            totalPnl: 0,
+                            orderTime: 1_700_000_000_000,
+                            orderUpdateTime: 1_700_000_000_000,
+                        },
+                        {
+                            symbol: 'ETHUSDT',
+                            baseAsset: 'ETH',
+                            quoteAsset: 'USDT',
+                            side: 'SELL',
+                            type: 'MARKET',
+                            positionSide: 'LONG',
+                            executedQty: 1,
+                            avgPrice: 3500,
+                            totalPnl: 500,
+                            orderTime: 1_700_000_001_000,
+                            orderUpdateTime: 1_700_000_001_000,
+                        },
+                    ],
+                },
+            });
+
+        const { route } = await import('@/routes/binance/copy-trading');
+        const result = (await route.handler(createContext('123') as any)) as any;
+
+        expect(result.item[0].description).not.toContain('Realized PnL');
+        expect(result.item[1].description).toContain('Realized PnL');
+        expect(result.item[1].description).toContain('500.00');
+        expect(result.item[1].description).toContain('#2EBD85');
+    });
+
+    it('respects limit query parameter', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: { nickname: 'Trader', futuresType: 'UM' },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: {
+                    indexValue: '1',
+                    total: 5,
+                    list: Array.from({ length: 5 }, (_, index) => ({
+                        symbol: 'BTCUSDT',
+                        baseAsset: 'BTC',
+                        quoteAsset: 'USDT',
+                        side: 'BUY',
+                        type: 'MARKET',
+                        positionSide: 'LONG',
+                        executedQty: 1,
+                        avgPrice: 60000,
+                        totalPnl: 0,
+                        orderTime: 1_700_000_000_000 + index,
+                        orderUpdateTime: 1_700_000_000_000 + index,
+                    })),
+                },
+            });
+
+        const { route } = await import('@/routes/binance/copy-trading');
+        const result = (await route.handler(createContext('123', '2') as any)) as any;
+
+        expect(result.item).toHaveLength(2);
+    });
+
+    it('ensures unique guid and link for orders at the same timestamp', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: { nickname: 'Trader', futuresType: 'UM' },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: {
+                    indexValue: '1',
+                    total: 3,
+                    list: [
+                        {
+                            symbol: 'BTCUSDT',
+                            baseAsset: 'BTC',
+                            quoteAsset: 'USDT',
+                            side: 'BUY',
+                            type: 'MARKET',
+                            positionSide: 'LONG',
+                            executedQty: 1,
+                            avgPrice: 60000,
+                            totalPnl: 0,
+                            orderTime: 1_700_000_000_000,
+                            orderUpdateTime: 1_700_000_000_000,
+                        },
+                        {
+                            symbol: 'ETHUSDT',
+                            baseAsset: 'ETH',
+                            quoteAsset: 'USDT',
+                            side: 'BUY',
+                            type: 'MARKET',
+                            positionSide: 'LONG',
+                            executedQty: 2,
+                            avgPrice: 3000,
+                            totalPnl: 0,
+                            orderTime: 1_700_000_000_000,
+                            orderUpdateTime: 1_700_000_000_000,
+                        },
+                        {
+                            symbol: 'ETHUSDT',
+                            baseAsset: 'ETH',
+                            quoteAsset: 'USDT',
+                            side: 'SELL',
+                            type: 'MARKET',
+                            positionSide: 'LONG',
+                            executedQty: 2,
+                            avgPrice: 3100,
+                            totalPnl: 200,
+                            orderTime: 1_700_000_000_000,
+                            orderUpdateTime: 1_700_000_000_000,
+                        },
+                    ],
+                },
+            });
+
+        const { route } = await import('@/routes/binance/copy-trading');
+        const result = (await route.handler(createContext('123') as any)) as any;
+
+        const guids = result.item.map((i) => i.guid);
+        const links = result.item.map((i) => i.link);
+        expect(new Set(guids).size).toBe(3);
+        expect(new Set(links).size).toBe(3);
+    });
+
+    it('throws when API returns failure code', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: { nickname: 'Trader', futuresType: 'UM' },
+            })
+            .mockResolvedValueOnce({
+                code: '11012005',
+                success: false,
+                message: 'The system is currently busy',
+                data: null,
+            });
+
+        const { route } = await import('@/routes/binance/copy-trading');
+
+        await expect(route.handler(createContext('123') as any)).rejects.toThrow('The system is currently busy');
+    });
+
+    it('throws when portfolio is not found', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock.mockResolvedValueOnce({
+            code: '000000',
+            success: true,
+            data: null,
+        });
+
+        const { route } = await import('@/routes/binance/copy-trading');
+
+        await expect(route.handler(createContext('invalid-id') as any)).rejects.toThrow('not found or not accessible');
+    });
+
+    it('caches profile detail via cache.tryGet', async () => {
+        tryGetMock.mockResolvedValue({ nickname: 'CachedTrader', futuresType: 'UM', description: 'cached' });
+        ofetchMock.mockResolvedValue({
+            code: '000000',
+            success: true,
+            data: { indexValue: '1', total: 0, list: [] },
+        });
+
+        const { route } = await import('@/routes/binance/copy-trading');
+        const result = (await route.handler(createContext('123') as any)) as any;
+
+        expect(tryGetMock).toHaveBeenCalledWith('binance:copy-trading:detail:123', expect.any(Function));
+        expect(result.title).toBe('CachedTrader - Binance Copy Trading');
+        expect(ofetchMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/lib/binance-copy-trading.test.ts
+++ b/lib/binance-copy-trading.test.ts
@@ -109,15 +109,15 @@ describe('/binance/copy-trading/lead/:portfolioId', () => {
         expect(result.link).toBe('https://www.binance.com/zh-CN/copy-trading/lead-details/5075281354358777856');
         expect(result.item).toHaveLength(2);
 
-        expect(result.item[0].title).toBe('Open Long BTCUSDT @ 63,153.50');
-        expect(result.item[0].category).toEqual(['Open Long']);
+        expect(result.item[0].title).toBe('开多 BTCUSDT @ 63,153.50');
+        expect(result.item[0].category).toEqual(['开多']);
         expect(result.item[0].description).toContain('BTCUSDT');
-        expect(result.item[0].description).not.toContain('Realized PnL');
+        expect(result.item[0].description).not.toContain('已实现盈亏');
         expect(result.item[0].pubDate).toBeInstanceOf(Date);
 
-        expect(result.item[1].title).toBe('Close Long BTCUSDT @ 62,430.00');
-        expect(result.item[1].category).toEqual(['Close Long']);
-        expect(result.item[1].description).toContain('Realized PnL');
+        expect(result.item[1].title).toBe('平多 BTCUSDT @ 62,430.00');
+        expect(result.item[1].category).toEqual(['平多']);
+        expect(result.item[1].description).toContain('已实现盈亏');
         expect(result.item[1].description).toContain('-13,589.40');
     });
 
@@ -169,10 +169,69 @@ describe('/binance/copy-trading/lead/:portfolioId', () => {
         const { route } = await import('@/routes/binance/copy-trading');
         const result = (await route.handler(createContext('123') as any)) as any;
 
-        expect(result.item[0].description).not.toContain('Realized PnL');
-        expect(result.item[1].description).toContain('Realized PnL');
+        expect(result.item[0].description).not.toContain('已实现盈亏');
+        expect(result.item[1].description).toContain('已实现盈亏');
         expect(result.item[1].description).toContain('500.00');
         expect(result.item[1].description).toContain('#2EBD85');
+    });
+
+    it('correctly maps SHORT position sides (SELL+SHORT=开空, BUY+SHORT=平空)', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: { nickname: 'Trader', futuresType: 'UM' },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: {
+                    indexValue: '1',
+                    total: 2,
+                    list: [
+                        {
+                            symbol: 'SNDKUSDT',
+                            baseAsset: 'SNDK',
+                            quoteAsset: 'USDT',
+                            side: 'SELL',
+                            type: 'MARKET',
+                            positionSide: 'SHORT',
+                            executedQty: 3.85,
+                            avgPrice: 1389.62,
+                            totalPnl: 0,
+                            orderTime: 1_700_000_000_000,
+                            orderUpdateTime: 1_700_000_000_000,
+                        },
+                        {
+                            symbol: 'SNDKUSDT',
+                            baseAsset: 'SNDK',
+                            quoteAsset: 'USDT',
+                            side: 'BUY',
+                            type: 'MARKET',
+                            positionSide: 'SHORT',
+                            executedQty: 3.85,
+                            avgPrice: 1389.62,
+                            totalPnl: 100,
+                            orderTime: 1_700_000_001_000,
+                            orderUpdateTime: 1_700_000_001_000,
+                        },
+                    ],
+                },
+            });
+
+        const { route } = await import('@/routes/binance/copy-trading');
+        const result = (await route.handler(createContext('123') as any)) as any;
+
+        // SELL + SHORT = 开空 (open short)
+        expect(result.item[0].title).toBe('开空 SNDKUSDT @ 1,389.62');
+        expect(result.item[0].category).toEqual(['开空']);
+        expect(result.item[0].description).toContain('卖出开空');
+
+        // BUY + SHORT = 平空 (close short)
+        expect(result.item[1].title).toBe('平空 SNDKUSDT @ 1,389.62');
+        expect(result.item[1].category).toEqual(['平空']);
+        expect(result.item[1].description).toContain('买入平空');
     });
 
     it('respects limit query parameter', async () => {

--- a/lib/binance-square-user.test.ts
+++ b/lib/binance-square-user.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ofetchMock = vi.fn();
+const tryGetMock = vi.fn();
+
+vi.mock('@/utils/ofetch', () => ({
+    default: ofetchMock,
+}));
+
+vi.mock('@/utils/cache', () => ({
+    default: {
+        tryGet: tryGetMock,
+    },
+}));
+
+vi.mock('@/config', () => ({
+    config: {
+        trueUA: 'test-user-agent',
+    },
+}));
+
+const createContext = (username: string, routeParams?: string, limit?: string) => {
+    const json: Record<string, unknown> = {};
+
+    return {
+        req: {
+            param: (name: string) => {
+                if (name === 'username') {
+                    return username;
+                }
+                if (name === 'routeParams') {
+                    return routeParams;
+                }
+            },
+            query: (name: string) => {
+                if (name === 'limit') {
+                    return limit;
+                }
+            },
+        },
+        set: (_key: string, value: unknown) => {
+            Object.assign(json, value as Record<string, unknown>);
+        },
+        get jsonData() {
+            return json;
+        },
+    };
+};
+
+describe('/binance/square/user/:username', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        ofetchMock.mockReset();
+        tryGetMock.mockReset();
+    });
+
+    it('maps posts into feed items and uses profile username from API', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                data: {
+                    squareUid: 'uid-1',
+                    displayName: 'CZ',
+                    username: 'CZ',
+                    avatar: 'https://public.bnbstatic.com/avatar.jpg',
+                },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: {
+                    contents: [
+                        {
+                            id: 1,
+                            bodyTextOnly: 'Hello Square',
+                            createTime: 1_770_000_000_000,
+                            webLink: 'https://www.binance.com/en/square/post/1',
+                            displayName: 'CZ',
+                            commentCount: 10,
+                            likeCount: 20,
+                        },
+                        {
+                            id: 2,
+                            displayName: 'CZ',
+                            imageMetaList: [{ url: 'https://public.bnbstatic.com/image.png' }],
+                            createTime: 1_770_000_000_001,
+                            webLink: 'https://www.binance.com/en/square/post/2',
+                        },
+                    ],
+                },
+            });
+
+        const { route } = await import('@/routes/binance/square-user');
+        const ctx = createContext('cz');
+        const result = await route.handler(ctx as any);
+
+        expect(result.title).toBe('CZ (@CZ) — Binance Square');
+        expect(result.link).toBe('https://www.binance.com/square/profile/CZ');
+        expect(result.item).toHaveLength(2);
+        expect(result.item?.[0]?.title).toBe('Hello Square');
+        expect(result.item?.[1]?.title).toBe("CZ's post");
+        expect(ofetchMock).toHaveBeenCalledTimes(2);
+        expect(ofetchMock.mock.calls[1]?.[0]).toContain('filterType=ALL');
+    });
+
+    it('parses filter from routeParams', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                data: {
+                    squareUid: 'uid-1',
+                    displayName: 'CZ',
+                    username: 'CZ',
+                },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: { contents: [] },
+            });
+
+        const { route } = await import('@/routes/binance/square-user');
+        await route.handler(createContext('cz', 'filter=quote') as any);
+
+        expect(ofetchMock.mock.calls[1]?.[0]).toContain('filterType=QUOTE');
+    });
+
+    it('throws when profile is not found', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock.mockResolvedValueOnce({
+            code: '000000',
+            data: { squareUid: null },
+        });
+
+        const { route } = await import('@/routes/binance/square-user');
+
+        await expect(route.handler(createContext('missing-user') as any)).rejects.toThrow('not found on Binance Square');
+    });
+
+    it('throws when posts API fails', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                data: {
+                    squareUid: 'uid-1',
+                    displayName: 'CZ',
+                    username: 'CZ',
+                },
+            })
+            .mockResolvedValueOnce({
+                code: '000002',
+                success: false,
+                message: 'illegal parameter',
+                data: null,
+            });
+
+        const { route } = await import('@/routes/binance/square-user');
+
+        await expect(route.handler(createContext('cz') as any)).rejects.toThrow('illegal parameter');
+    });
+
+    it('respects limit query parameter', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                data: {
+                    squareUid: 'uid-1',
+                    displayName: 'CZ',
+                    username: 'CZ',
+                },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: {
+                    contents: Array.from({ length: 10 }, (_, index) => ({
+                        id: index,
+                        bodyTextOnly: `Post ${index}`,
+                        createTime: 1_770_000_000_000 + index,
+                        webLink: `https://www.binance.com/en/square/post/${index}`,
+                    })),
+                },
+            });
+
+        const { route } = await import('@/routes/binance/square-user');
+        const result = await route.handler(createContext('cz', undefined, '3') as any);
+
+        expect(result.item).toHaveLength(3);
+    });
+});

--- a/lib/binance-square-user.test.ts
+++ b/lib/binance-square-user.test.ts
@@ -96,7 +96,7 @@ describe('/binance/square/user/:username', () => {
         const result = await route.handler(ctx as any);
 
         expect(result.title).toBe('CZ (@CZ) — Binance Square');
-        expect(result.link).toBe('https://www.binance.com/square/profile/CZ');
+        expect(result.link).toBe('https://www.binance.com/en/square/profile/CZ');
         expect(result.item).toHaveLength(2);
         expect(result.item?.[0]?.title).toBe('Hello Square');
         expect(result.item?.[1]?.title).toBe("CZ's post");
@@ -190,5 +190,117 @@ describe('/binance/square/user/:username', () => {
         const result = await route.handler(createContext('cz', undefined, '3') as any);
 
         expect(result.item).toHaveLength(3);
+    });
+
+    it('passes language headers when lang=zh-CN', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                data: {
+                    squareUid: 'uid-1',
+                    displayName: 'CZ',
+                    username: 'CZ',
+                },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: { contents: [] },
+            });
+
+        const { route } = await import('@/routes/binance/square-user');
+        const result = await route.handler(createContext('cz', 'lang=zh-CN') as any);
+
+        expect(result.link).toBe('https://www.binance.com/zh-CN/square/profile/CZ');
+        const postsHeaders = ofetchMock.mock.calls[1]?.[1]?.headers;
+        expect(postsHeaders?.lang).toBe('zh-CN');
+        expect(postsHeaders?.['Accept-Language']).toBe('zh-CN');
+        expect(postsHeaders?.Referer).toBe('https://www.binance.com/zh-CN/square/profile/cz');
+    });
+
+    it('uses translatedData content when language is not English', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                data: {
+                    squareUid: 'uid-1',
+                    displayName: 'CZ',
+                    username: 'CZ',
+                },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: {
+                    contents: [
+                        {
+                            id: 3,
+                            bodyTextOnly: 'English body',
+                            translatedData: {
+                                content: '中文正文',
+                            },
+                            createTime: 1_770_000_000_000,
+                            webLink: 'https://www.binance.com/zh-CN/square/post/3',
+                        },
+                    ],
+                },
+            });
+
+        const { route } = await import('@/routes/binance/square-user');
+        const result = await route.handler(createContext('cz', 'lang=zh-CN') as any);
+
+        expect(result.item?.[0]?.title).toBe('中文正文');
+        expect(result.item?.[0]?.description).toContain('中文正文');
+        expect(result.item?.[0]?.description).not.toContain('English body');
+    });
+
+    it('supports combined filter and language routeParams', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                data: {
+                    squareUid: 'uid-1',
+                    displayName: 'CZ',
+                    username: 'CZ',
+                },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: { contents: [] },
+            });
+
+        const { route } = await import('@/routes/binance/square-user');
+        await route.handler(createContext('cz', 'filter=quote&lang=zh-CN') as any);
+
+        expect(ofetchMock.mock.calls[1]?.[0]).toContain('filterType=QUOTE');
+        expect(ofetchMock.mock.calls[1]?.[1]?.headers?.lang).toBe('zh-CN');
+    });
+
+    it('normalizes language aliases from routeParams', async () => {
+        tryGetMock.mockImplementation((_key, fetcher) => fetcher());
+        ofetchMock
+            .mockResolvedValueOnce({
+                code: '000000',
+                data: {
+                    squareUid: 'uid-1',
+                    displayName: 'CZ',
+                    username: 'CZ',
+                },
+            })
+            .mockResolvedValueOnce({
+                code: '000000',
+                success: true,
+                data: { contents: [] },
+            });
+
+        const { route } = await import('@/routes/binance/square-user');
+        const result = await route.handler(createContext('cz', 'lang=zh') as any);
+
+        expect(result.link).toBe('https://www.binance.com/zh-CN/square/profile/CZ');
+        expect(ofetchMock.mock.calls[1]?.[1]?.headers?.lang).toBe('zh-CN');
     });
 });

--- a/lib/binance-square-user.test.ts
+++ b/lib/binance-square-user.test.ts
@@ -93,13 +93,13 @@ describe('/binance/square/user/:username', () => {
 
         const { route } = await import('@/routes/binance/square-user');
         const ctx = createContext('cz');
-        const result = await route.handler(ctx as any);
+        const result = (await route.handler(ctx as any)) as any;
 
         expect(result.title).toBe('CZ (@CZ) — Binance Square');
         expect(result.link).toBe('https://www.binance.com/en/square/profile/CZ');
         expect(result.item).toHaveLength(2);
-        expect(result.item?.[0]?.title).toBe('Hello Square');
-        expect(result.item?.[1]?.title).toBe("CZ's post");
+        expect(result.item[0].title).toBe('Hello Square');
+        expect(result.item[1].title).toBe("CZ's post");
         expect(ofetchMock).toHaveBeenCalledTimes(2);
         expect(ofetchMock.mock.calls[1]?.[0]).toContain('filterType=ALL');
     });
@@ -187,7 +187,7 @@ describe('/binance/square/user/:username', () => {
             });
 
         const { route } = await import('@/routes/binance/square-user');
-        const result = await route.handler(createContext('cz', undefined, '3') as any);
+        const result = (await route.handler(createContext('cz', undefined, '3') as any)) as any;
 
         expect(result.item).toHaveLength(3);
     });
@@ -210,7 +210,7 @@ describe('/binance/square/user/:username', () => {
             });
 
         const { route } = await import('@/routes/binance/square-user');
-        const result = await route.handler(createContext('cz', 'lang=zh-CN') as any);
+        const result = (await route.handler(createContext('cz', 'lang=zh-CN') as any)) as any;
 
         expect(result.link).toBe('https://www.binance.com/zh-CN/square/profile/CZ');
         const postsHeaders = ofetchMock.mock.calls[1]?.[1]?.headers;
@@ -249,11 +249,11 @@ describe('/binance/square/user/:username', () => {
             });
 
         const { route } = await import('@/routes/binance/square-user');
-        const result = await route.handler(createContext('cz', 'lang=zh-CN') as any);
+        const result = (await route.handler(createContext('cz', 'lang=zh-CN') as any)) as any;
 
-        expect(result.item?.[0]?.title).toBe('中文正文');
-        expect(result.item?.[0]?.description).toContain('中文正文');
-        expect(result.item?.[0]?.description).not.toContain('English body');
+        expect(result.item[0].title).toBe('中文正文');
+        expect(result.item[0].description).toContain('中文正文');
+        expect(result.item[0].description).not.toContain('English body');
     });
 
     it('supports combined filter and language routeParams', async () => {
@@ -298,7 +298,7 @@ describe('/binance/square/user/:username', () => {
             });
 
         const { route } = await import('@/routes/binance/square-user');
-        const result = await route.handler(createContext('cz', 'lang=zh') as any);
+        const result = (await route.handler(createContext('cz', 'lang=zh') as any)) as any;
 
         expect(result.link).toBe('https://www.binance.com/zh-CN/square/profile/CZ');
         expect(ofetchMock.mock.calls[1]?.[1]?.headers?.lang).toBe('zh-CN');

--- a/lib/routes/binance/copy-trading.ts
+++ b/lib/routes/binance/copy-trading.ts
@@ -9,11 +9,20 @@ import type { CopyTradingDetail, CopyTradingDetailResponse, CopyTradingOrder, Co
 
 const BASE_URL = 'https://www.binance.com';
 
+// Short labels for title/category
 const SIDE_MAP: Record<string, string> = {
-    BUY_LONG: 'Open Long',
-    SELL_LONG: 'Close Long',
-    BUY_SHORT: 'Open Short',
-    SELL_SHORT: 'Close Short',
+    BUY_LONG: '开多',
+    SELL_LONG: '平多',
+    SELL_SHORT: '开空',
+    BUY_SHORT: '平空',
+};
+
+// Full action phrases for description sentences
+const ACTION_MAP: Record<string, string> = {
+    BUY_LONG: '买入开多',
+    SELL_LONG: '卖出平多',
+    SELL_SHORT: '卖出开空',
+    BUY_SHORT: '买入平空',
 };
 
 const buildHeaders = (portfolioId: string) => ({
@@ -29,25 +38,17 @@ const getActionLabel = (order: CopyTradingOrder) => SIDE_MAP[`${order.side}_${or
 const buildOrderTitle = (order: CopyTradingOrder) => `${getActionLabel(order)} ${order.symbol} @ ${formatNumber(order.avgPrice)}`;
 
 const buildOrderDescription = (order: CopyTradingOrder) => {
-    const rows = [
-        ['Symbol', order.symbol],
-        ['Side', order.side],
-        ['Position', order.positionSide],
-        ['Type', order.type],
-        ['Avg Price', `${formatNumber(order.avgPrice)} ${order.quoteAsset}`],
-        ['Executed Qty', `${formatNumber(order.executedQty)} ${order.baseAsset}`],
-        ['Total Value', `${formatNumber(order.avgPrice * order.executedQty)} ${order.quoteAsset}`],
-    ]
-        .map(([label, value]) => `<tr><td>${label}</td><td>${value}</td></tr>`)
-        .join('');
+    const action = ACTION_MAP[`${order.side}_${order.positionSide}`] ?? order.side;
+    const totalValue = formatNumber(order.avgPrice * order.executedQty);
 
-    let pnlRow = '';
+    let desc = `以均价为<strong>${formatNumber(order.avgPrice)}${order.quoteAsset}</strong> ${action}<strong>${order.symbol}永续合约</strong> ，成交数量为 <strong>${formatNumber(order.executedQty)}${order.baseAsset}</strong>，总价值为 <strong>${totalValue}${order.quoteAsset}</strong>`;
+
     if (order.side === 'SELL' && order.totalPnl !== 0) {
         const pnlColor = order.totalPnl >= 0 ? '#2EBD85' : '#F6465D';
-        pnlRow = `<tr><td>Realized PnL</td><td style="color:${pnlColor}">${formatNumber(order.totalPnl)} ${order.quoteAsset}</td></tr>`;
+        desc += ` ，已实现盈亏为<strong style="color:${pnlColor}">${formatNumber(order.totalPnl)}</strong>${order.quoteAsset}`;
     }
 
-    return `<table><tbody>${rows}${pnlRow}</tbody></table>`;
+    return `<p>${desc} 。</p>`;
 };
 
 const fetchDetail = (portfolioId: string) =>

--- a/lib/routes/binance/copy-trading.ts
+++ b/lib/routes/binance/copy-trading.ts
@@ -1,0 +1,144 @@
+import { config } from '@/config';
+import type { Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+import type { CopyTradingDetail, CopyTradingDetailResponse, CopyTradingOrder, CopyTradingOrderHistoryResponse } from './types';
+
+const BASE_URL = 'https://www.binance.com';
+
+const SIDE_MAP: Record<string, string> = {
+    BUY_LONG: 'Open Long',
+    SELL_LONG: 'Close Long',
+    BUY_SHORT: 'Open Short',
+    SELL_SHORT: 'Close Short',
+};
+
+const buildHeaders = (portfolioId: string) => ({
+    Referer: `${BASE_URL}/zh-CN/copy-trading/lead-details/${portfolioId}`,
+    'Content-Type': 'application/json',
+    'User-Agent': config.trueUA,
+});
+
+const formatNumber = (n: number) => n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 8 });
+
+const getActionLabel = (order: CopyTradingOrder) => SIDE_MAP[`${order.side}_${order.positionSide}`] ?? order.side;
+
+const buildOrderTitle = (order: CopyTradingOrder) => `${getActionLabel(order)} ${order.symbol} @ ${formatNumber(order.avgPrice)}`;
+
+const buildOrderDescription = (order: CopyTradingOrder) => {
+    const rows = [
+        ['Symbol', order.symbol],
+        ['Side', order.side],
+        ['Position', order.positionSide],
+        ['Type', order.type],
+        ['Avg Price', `${formatNumber(order.avgPrice)} ${order.quoteAsset}`],
+        ['Executed Qty', `${formatNumber(order.executedQty)} ${order.baseAsset}`],
+        ['Total Value', `${formatNumber(order.avgPrice * order.executedQty)} ${order.quoteAsset}`],
+    ]
+        .map(([label, value]) => `<tr><td>${label}</td><td>${value}</td></tr>`)
+        .join('');
+
+    let pnlRow = '';
+    if (order.side === 'SELL' && order.totalPnl !== 0) {
+        const pnlColor = order.totalPnl >= 0 ? '#2EBD85' : '#F6465D';
+        pnlRow = `<tr><td>Realized PnL</td><td style="color:${pnlColor}">${formatNumber(order.totalPnl)} ${order.quoteAsset}</td></tr>`;
+    }
+
+    return `<table><tbody>${rows}${pnlRow}</tbody></table>`;
+};
+
+const fetchDetail = (portfolioId: string) =>
+    cache.tryGet(`binance:copy-trading:detail:${portfolioId}`, async () => {
+        const response = await ofetch<CopyTradingDetailResponse>(`${BASE_URL}/bapi/futures/v1/friendly/future/copy-trade/lead-portfolio/detail?portfolioId=${portfolioId}`, {
+            headers: buildHeaders(portfolioId),
+        });
+
+        if (!response.data?.nickname) {
+            throw new Error(`Copy trading lead "${portfolioId}" not found or not accessible`);
+        }
+
+        return response.data;
+    });
+
+const fetchOrderHistory = (portfolioId: string) =>
+    ofetch<CopyTradingOrderHistoryResponse>(`${BASE_URL}/bapi/futures/v1/friendly/future/copy-trade/lead-portfolio/order-history`, {
+        method: 'POST',
+        headers: buildHeaders(portfolioId),
+        body: { portfolioId },
+    });
+
+export const route: Route = {
+    path: '/copy-trading/lead/:portfolioId',
+    categories: ['finance'],
+    view: ViewType.Notifications,
+    example: '/binance/copy-trading/lead/5075281354358777856',
+    parameters: {
+        portfolioId: 'Copy trading lead portfolio ID, from the lead-details URL',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.binance.com/:lang/copy-trading/lead-details/:portfolioId'],
+            target: '/copy-trading/lead/:portfolioId',
+        },
+    ],
+    name: 'Copy Trading Lead',
+    description: `Latest trading records from a Binance Copy Trading lead trader.
+
+The portfolio ID can be found in the lead-details URL: \`/copy-trading/lead-details/:portfolioId\``,
+    maintainers: ['enpitsulin', 'DIYgod'],
+    handler,
+};
+
+async function handler(ctx) {
+    const portfolioId = ctx.req.param('portfolioId');
+
+    const limit = Math.trunc(Number(ctx.req.query('limit') ?? '10'));
+    const pageSize = Number.isNaN(limit) || limit <= 0 ? 10 : limit;
+
+    const detail: CopyTradingDetail = await fetchDetail(portfolioId);
+
+    const orderHistoryResponse = await fetchOrderHistory(portfolioId);
+
+    if (orderHistoryResponse.code !== '000000' || orderHistoryResponse.success === false) {
+        throw new Error(orderHistoryResponse.message || 'Failed to fetch Binance Copy Trading order history');
+    }
+
+    const orders = orderHistoryResponse.data?.list ?? [];
+    const leadDetailsUrl = `${BASE_URL}/zh-CN/copy-trading/lead-details/${portfolioId}`;
+
+    const item = orders.slice(0, pageSize).map((order, index) => ({
+        title: buildOrderTitle(order),
+        link: `${leadDetailsUrl}#${order.orderTime}-${index}`,
+        guid: `${portfolioId}-${order.orderTime}-${index}`,
+        pubDate: parseDate(order.orderTime),
+        category: [getActionLabel(order)],
+        description: buildOrderDescription(order),
+    }));
+
+    ctx.set('json', {
+        detail,
+        orderHistoryResponse,
+    });
+
+    return {
+        title: `${detail.nickname} - Binance Copy Trading`,
+        link: leadDetailsUrl,
+        description: detail.description || undefined,
+        image: detail.avatarUrl || undefined,
+        icon: detail.avatarUrl || undefined,
+        logo: detail.avatarUrl || undefined,
+        item,
+        allowEmpty: true,
+    };
+}

--- a/lib/routes/binance/square-user.ts
+++ b/lib/routes/binance/square-user.ts
@@ -7,7 +7,7 @@ import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
-import type { SquareFilterType, SquarePost, SquarePostsResponse, SquareQuoteContent, SquareUserProfile, SquareUserProfileResponse } from './types';
+import type { SquareFilterType, SquarePost, SquarePostsResponse, SquareQuoteContent, SquareTranslatedData, SquareUserProfile, SquareUserProfileResponse } from './types';
 
 const BASE_URL = 'https://www.binance.com';
 
@@ -17,18 +17,47 @@ const FILTER_MAP: Record<string, SquareFilterType> = {
     live: 'LIVE',
 };
 
-const buildHeaders = (username: string) => ({
-    Referer: `${BASE_URL}/square/profile/${username}`,
+const LANGUAGE_ALIASES: Record<string, string> = {
+    'en-US': 'en',
+    zh: 'zh-CN',
+};
+
+const normalizeLanguage = (lang: string) => LANGUAGE_ALIASES[lang] ?? lang;
+
+const buildHeaders = (username: string, language: string) => ({
+    Referer: `${BASE_URL}/${language}/square/profile/${username}`,
+    'Accept-Language': language,
     'User-Agent': config.trueUA,
     clienttype: 'web',
+    lang: language,
 });
 
 const escapeHtml = (text: string) => text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#39;');
 
 const textToHtml = (text: string) => escapeHtml(text).replaceAll('\n', '<br>');
 
-const buildQuoteDescription = (quote: SquareQuoteContent) => {
-    const quoteText = quote.bodyTextOnly || quote.title;
+const getTranslatedText = (language: string, original?: string, translated?: SquareTranslatedData | null) => {
+    if (language !== 'en') {
+        const localized = translated?.content || translated?.bodyTextOnly || translated?.body || translated?.title;
+        if (localized) {
+            return localized;
+        }
+    }
+    return original || '';
+};
+
+const getQuoteText = (quote: SquareQuoteContent, language: string) => getTranslatedText(language, quote.bodyTextOnly || quote.title, quote.translatedData) || quote.title || '';
+
+const getPostBody = (post: SquarePost, language: string) => {
+    let mainText = getTranslatedText(language, post.bodyTextOnly, post.translatedData);
+    if (!mainText && post.contentType === 4) {
+        mainText = post.title || '';
+    }
+    return mainText;
+};
+
+const buildQuoteDescription = (quote: SquareQuoteContent, language: string) => {
+    const quoteText = getQuoteText(quote, language);
     if (!quoteText) {
         return '';
     }
@@ -45,11 +74,8 @@ const buildQuoteDescription = (quote: SquareQuoteContent) => {
     return html;
 };
 
-const buildPostDescription = (post: SquarePost) => {
-    let mainText = post.bodyTextOnly || '';
-    if (!mainText && post.contentType === 4) {
-        mainText = post.title || '';
-    }
+const buildPostDescription = (post: SquarePost, language: string) => {
+    const mainText = getPostBody(post, language);
 
     const parts: string[] = [];
     if (mainText) {
@@ -66,15 +92,19 @@ const buildPostDescription = (post: SquarePost) => {
     }
 
     if (post.quoteContent) {
-        parts.push(buildQuoteDescription(post.quoteContent));
+        parts.push(buildQuoteDescription(post.quoteContent, language));
     }
 
     return parts.join('');
 };
 
-const getPostTitle = (post: SquarePost) => post.title || post.bodyTextOnly || post.quoteContent?.title || post.quoteContent?.bodyTextOnly || (post.displayName ? `${post.displayName}'s post` : `Post ${post.id}`);
+const getPostTitle = (post: SquarePost, language: string) => {
+    const quoteText = post.quoteContent ? getQuoteText(post.quoteContent, language) : undefined;
 
-const parseFilter = (routeParams?: string) => {
+    return post.title || getPostBody(post, language) || quoteText || (post.displayName ? `${post.displayName}'s post` : `Post ${post.id}`);
+};
+
+const parseRouteOptions = (routeParams?: string) => {
     const parsed = querystring.parse(routeParams);
     const rawFilter = String(parsed.filter || 'all').toLowerCase();
     const filterType = FILTER_MAP[rawFilter];
@@ -83,15 +113,18 @@ const parseFilter = (routeParams?: string) => {
         throw new Error(`Filter "${rawFilter}" is not supported. Use all, quote, or live.`);
     }
 
-    return filterType;
+    return {
+        filterType,
+        language: normalizeLanguage(String(parsed.lang || 'en')),
+    };
 };
 
-const fetchUserProfile = (username: string) =>
+const fetchUserProfile = (username: string, language: string) =>
     cache.tryGet(`binance:square:profile:${username.toLowerCase()}`, async () => {
         const response = await ofetch<SquareUserProfileResponse>(`${BASE_URL}/bapi/composite/v3/friendly/pgc/user/client`, {
             method: 'POST',
             headers: {
-                ...buildHeaders(username),
+                ...buildHeaders(username, language),
                 'Content-Type': 'application/json',
             },
             body: { username },
@@ -104,14 +137,14 @@ const fetchUserProfile = (username: string) =>
         return response.data;
     });
 
-const fetchUserPosts = async (squareUid: string, username: string, filterType: SquareFilterType) => {
+const fetchUserPosts = async (squareUid: string, username: string, filterType: SquareFilterType, language: string) => {
     const postsUrl = new URL(`${BASE_URL}/bapi/composite/v2/friendly/pgc/content/queryUserProfilePageContentsWithFilter`);
     postsUrl.searchParams.set('targetSquareUid', squareUid);
     postsUrl.searchParams.set('timeOffset', String(Date.now()));
     postsUrl.searchParams.set('filterType', filterType);
 
     const response = await ofetch<SquarePostsResponse>(postsUrl.toString(), {
-        headers: buildHeaders(username),
+        headers: buildHeaders(username, language),
     });
 
     if (response.code !== '000000' || response.success === false) {
@@ -122,13 +155,13 @@ const fetchUserPosts = async (squareUid: string, username: string, filterType: S
 };
 
 export const route: Route = {
-    path: ['/square/user/:username/:routeParams?', '/square/profile/:username/:routeParams?'],
+    path: '/square/user/:username/:routeParams?',
     categories: ['social-media'],
     view: ViewType.SocialMedia,
     example: '/binance/square/user/cz',
     parameters: {
         username: 'Binance Square username, as shown in the profile URL',
-        routeParams: 'Filter parameter. Use filter to customize post types.',
+        routeParams: 'Extra parameters. Use filter and lang to customize post types and language.',
     },
     features: {
         requireConfig: false,
@@ -143,47 +176,55 @@ export const route: Route = {
             source: ['www.binance.com/square/profile/:username'],
             target: '/square/user/:username',
         },
+        {
+            source: ['www.binance.com/:lang/square/profile/:username'],
+            target: '/square/user/:username/lang=:lang',
+        },
     ],
     name: 'Square Profile',
     description: `Posts from a Binance Square user profile.
 
-| Filter Value | Description         |
-| ------------ | ------------------- |
-| all          | All posts (default) |
-| quote        | Quote posts only    |
-| live         | Live posts only     |
+| Parameter | Value | Description         |
+| --------- | ----- | ------------------- |
+| filter    | all   | All posts (default) |
+| filter    | quote | Quote posts only    |
+| filter    | live  | Live posts only     |
+| lang      | en    | English (default)   |
+| lang      | zh-CN | Simplified Chinese  |
+| lang      | zh-TW | Traditional Chinese |
+| lang      | ja    | Japanese            |
 
-Default value for filter is \`all\` if not specified.
+Examples:
 
-Example:
-
-- \`/binance/square/user/cz/filter=quote\``,
+- \`/binance/square/user/cz/filter=quote\`
+- \`/binance/square/user/cz/lang=zh-CN\`
+- \`/binance/square/user/cz/filter=quote&lang=zh-CN\``,
     maintainers: ['enpitsulin', 'DIYgod'],
     handler,
 };
 
 async function handler(ctx) {
     const username = ctx.req.param('username');
-    const filterType = parseFilter(ctx.req.param('routeParams'));
+    const { filterType, language } = parseRouteOptions(ctx.req.param('routeParams'));
 
     const limit = Number.parseInt(ctx.req.query('limit') ?? '20', 10);
     const pageSize = Number.isNaN(limit) || limit <= 0 ? 20 : limit;
 
-    const profile: SquareUserProfile = await fetchUserProfile(username);
+    const profile: SquareUserProfile = await fetchUserProfile(username, language);
     const squareUid = profile.squareUid!;
     const profileUsername = profile.username || username;
-    const profileUrl = `${BASE_URL}/square/profile/${profileUsername}`;
+    const profileUrl = `${BASE_URL}/${language}/square/profile/${profileUsername}`;
 
-    const postsResponse = await fetchUserPosts(squareUid, username, filterType);
+    const postsResponse = await fetchUserPosts(squareUid, username, filterType, language);
     const contents = postsResponse.data?.contents ?? [];
 
     const item = contents.slice(0, pageSize).map((post) => ({
-        title: getPostTitle(post),
-        link: post.webLink || `${BASE_URL}/square/post/${post.id}`,
+        title: getPostTitle(post, language),
+        link: post.webLink || `${BASE_URL}/${language}/square/post/${post.id}`,
         pubDate: post.createTime ? parseDate(post.createTime) : undefined,
         author: post.displayName,
         category: post.hashtagList?.map((tag) => tag.trim()).filter(Boolean),
-        description: buildPostDescription(post),
+        description: buildPostDescription(post, language),
         comments: post.commentCount,
         upvotes: post.likeCount,
     }));
@@ -194,6 +235,7 @@ async function handler(ctx) {
     ctx.set('json', {
         profile,
         postsResponse,
+        language,
     });
 
     return {

--- a/lib/routes/binance/square-user.ts
+++ b/lib/routes/binance/square-user.ts
@@ -1,0 +1,209 @@
+import querystring from 'node:querystring';
+
+import { config } from '@/config';
+import type { Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+import type { SquareFilterType, SquarePost, SquarePostsResponse, SquareQuoteContent, SquareUserProfile, SquareUserProfileResponse } from './types';
+
+const BASE_URL = 'https://www.binance.com';
+
+const FILTER_MAP: Record<string, SquareFilterType> = {
+    all: 'ALL',
+    quote: 'QUOTE',
+    live: 'LIVE',
+};
+
+const buildHeaders = (username: string) => ({
+    Referer: `${BASE_URL}/square/profile/${username}`,
+    'User-Agent': config.trueUA,
+    clienttype: 'web',
+});
+
+const escapeHtml = (text: string) => text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#39;');
+
+const textToHtml = (text: string) => escapeHtml(text).replaceAll('\n', '<br>');
+
+const buildQuoteDescription = (quote: SquareQuoteContent) => {
+    const quoteText = quote.bodyTextOnly || quote.title;
+    if (!quoteText) {
+        return '';
+    }
+
+    let html = `<blockquote><p>${textToHtml(quoteText)}</p>`;
+    const imageUrl = quote.coverMeta?.url || quote.imageLink;
+    if (imageUrl) {
+        html += `<p><img src="${escapeHtml(imageUrl)}"></p>`;
+    }
+    if (quote.webLink) {
+        html += `<p><a href="${escapeHtml(quote.webLink)}">View quoted post</a></p>`;
+    }
+    html += '</blockquote>';
+    return html;
+};
+
+const buildPostDescription = (post: SquarePost) => {
+    let mainText = post.bodyTextOnly || '';
+    if (!mainText && post.contentType === 4) {
+        mainText = post.title || '';
+    }
+
+    const parts: string[] = [];
+    if (mainText) {
+        parts.push(`<p>${textToHtml(mainText)}</p>`);
+    }
+
+    if (post.coverMeta?.url) {
+        parts.push(`<p><img src="${escapeHtml(post.coverMeta.url)}"></p>`);
+    }
+
+    const imageUrls = post.imageMetaList?.map((image) => image.url).filter(Boolean) ?? post.imageList?.filter(Boolean) ?? [];
+    for (const url of imageUrls) {
+        parts.push(`<p><img src="${escapeHtml(url)}"></p>`);
+    }
+
+    if (post.quoteContent) {
+        parts.push(buildQuoteDescription(post.quoteContent));
+    }
+
+    return parts.join('');
+};
+
+const getPostTitle = (post: SquarePost) => post.title || post.bodyTextOnly || post.quoteContent?.title || post.quoteContent?.bodyTextOnly || (post.displayName ? `${post.displayName}'s post` : `Post ${post.id}`);
+
+const parseFilter = (routeParams?: string) => {
+    const parsed = querystring.parse(routeParams);
+    const rawFilter = String(parsed.filter || 'all').toLowerCase();
+    const filterType = FILTER_MAP[rawFilter];
+
+    if (!filterType) {
+        throw new Error(`Filter "${rawFilter}" is not supported. Use all, quote, or live.`);
+    }
+
+    return filterType;
+};
+
+const fetchUserProfile = (username: string) =>
+    cache.tryGet(`binance:square:profile:${username.toLowerCase()}`, async () => {
+        const response = await ofetch<SquareUserProfileResponse>(`${BASE_URL}/bapi/composite/v3/friendly/pgc/user/client`, {
+            method: 'POST',
+            headers: {
+                ...buildHeaders(username),
+                'Content-Type': 'application/json',
+            },
+            body: { username },
+        });
+
+        if (!response.data?.squareUid) {
+            throw new Error(`User "${username}" not found on Binance Square`);
+        }
+
+        return response.data;
+    });
+
+const fetchUserPosts = async (squareUid: string, username: string, filterType: SquareFilterType) => {
+    const postsUrl = new URL(`${BASE_URL}/bapi/composite/v2/friendly/pgc/content/queryUserProfilePageContentsWithFilter`);
+    postsUrl.searchParams.set('targetSquareUid', squareUid);
+    postsUrl.searchParams.set('timeOffset', String(Date.now()));
+    postsUrl.searchParams.set('filterType', filterType);
+
+    const response = await ofetch<SquarePostsResponse>(postsUrl.toString(), {
+        headers: buildHeaders(username),
+    });
+
+    if (response.code !== '000000' || response.success === false) {
+        throw new Error(response.message || 'Failed to fetch Binance Square posts');
+    }
+
+    return response;
+};
+
+export const route: Route = {
+    path: ['/square/user/:username/:routeParams?', '/square/profile/:username/:routeParams?'],
+    categories: ['social-media'],
+    view: ViewType.SocialMedia,
+    example: '/binance/square/user/cz',
+    parameters: {
+        username: 'Binance Square username, as shown in the profile URL',
+        routeParams: 'Filter parameter. Use filter to customize post types.',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.binance.com/square/profile/:username'],
+            target: '/square/user/:username',
+        },
+    ],
+    name: 'Square Profile',
+    description: `Posts from a Binance Square user profile.
+
+| Filter Value | Description         |
+| ------------ | ------------------- |
+| all          | All posts (default) |
+| quote        | Quote posts only    |
+| live         | Live posts only     |
+
+Default value for filter is \`all\` if not specified.
+
+Example:
+
+- \`/binance/square/user/cz/filter=quote\``,
+    maintainers: ['enpitsulin', 'DIYgod'],
+    handler,
+};
+
+async function handler(ctx) {
+    const username = ctx.req.param('username');
+    const filterType = parseFilter(ctx.req.param('routeParams'));
+
+    const limit = Number.parseInt(ctx.req.query('limit') ?? '20', 10);
+    const pageSize = Number.isNaN(limit) || limit <= 0 ? 20 : limit;
+
+    const profile: SquareUserProfile = await fetchUserProfile(username);
+    const squareUid = profile.squareUid!;
+    const profileUsername = profile.username || username;
+    const profileUrl = `${BASE_URL}/square/profile/${profileUsername}`;
+
+    const postsResponse = await fetchUserPosts(squareUid, username, filterType);
+    const contents = postsResponse.data?.contents ?? [];
+
+    const item = contents.slice(0, pageSize).map((post) => ({
+        title: getPostTitle(post),
+        link: post.webLink || `${BASE_URL}/square/post/${post.id}`,
+        pubDate: post.createTime ? parseDate(post.createTime) : undefined,
+        author: post.displayName,
+        category: post.hashtagList?.map((tag) => tag.trim()).filter(Boolean),
+        description: buildPostDescription(post),
+        comments: post.commentCount,
+        upvotes: post.likeCount,
+    }));
+
+    const displayName = profile.displayName || profileUsername;
+    const avatar = profile.avatar || undefined;
+
+    ctx.set('json', {
+        profile,
+        postsResponse,
+    });
+
+    return {
+        title: `${displayName} (@${profileUsername}) — Binance Square`,
+        link: profileUrl,
+        description: profile.biography || undefined,
+        image: avatar,
+        icon: avatar,
+        logo: avatar,
+        item,
+        allowEmpty: true,
+    };
+}

--- a/lib/routes/binance/square-user.ts
+++ b/lib/routes/binance/square-user.ts
@@ -105,7 +105,7 @@ const getPostTitle = (post: SquarePost, language: string) => {
 };
 
 const parseRouteOptions = (routeParams?: string) => {
-    const parsed = querystring.parse(routeParams);
+    const parsed = querystring.parse(routeParams ?? '');
     const rawFilter = String(parsed.filter || 'all').toLowerCase();
     const filterType = FILTER_MAP[rawFilter];
 
@@ -143,7 +143,7 @@ const fetchUserPosts = async (squareUid: string, username: string, filterType: S
     postsUrl.searchParams.set('timeOffset', String(Date.now()));
     postsUrl.searchParams.set('filterType', filterType);
 
-    const response = await ofetch<SquarePostsResponse>(postsUrl.toString(), {
+    const response = await ofetch<SquarePostsResponse>(postsUrl.href, {
         headers: buildHeaders(username, language),
     });
 
@@ -207,7 +207,7 @@ async function handler(ctx) {
     const username = ctx.req.param('username');
     const { filterType, language } = parseRouteOptions(ctx.req.param('routeParams'));
 
-    const limit = Number.parseInt(ctx.req.query('limit') ?? '20', 10);
+    const limit = Math.trunc(Number(ctx.req.query('limit') ?? '20'));
     const pageSize = Number.isNaN(limit) || limit <= 0 ? 20 : limit;
 
     const profile: SquareUserProfile = await fetchUserProfile(username, language);

--- a/lib/routes/binance/types.ts
+++ b/lib/routes/binance/types.ts
@@ -24,3 +24,61 @@ export interface AnnouncementArticle {
     type: number;
     releaseDate: number;
 }
+
+export type SquareFilterType = 'ALL' | 'QUOTE' | 'LIVE';
+
+export interface SquareImageMeta {
+    url: string;
+    width?: number;
+    height?: number;
+}
+
+export interface SquareQuoteContent {
+    id?: string;
+    title?: string;
+    bodyTextOnly?: string;
+    webLink?: string;
+    imageLink?: string;
+    coverMeta?: SquareImageMeta | null;
+}
+
+export interface SquarePost {
+    id: number;
+    title?: string;
+    bodyTextOnly?: string;
+    contentType?: number;
+    createTime?: number;
+    webLink?: string;
+    displayName?: string;
+    imageList?: string[];
+    imageMetaList?: SquareImageMeta[];
+    coverMeta?: SquareImageMeta | null;
+    hashtagList?: string[];
+    quoteContent?: SquareQuoteContent | null;
+    commentCount?: number;
+    likeCount?: number;
+}
+
+export interface SquarePostsResponse {
+    code: string;
+    message?: string | null;
+    data: {
+        contents?: SquarePost[];
+        timeOffset?: number;
+    } | null;
+    success?: boolean;
+}
+
+export interface SquareUserProfile {
+    squareUid?: string | null;
+    avatar?: string | null;
+    displayName?: string | null;
+    biography?: string | null;
+    username?: string | null;
+}
+
+export interface SquareUserProfileResponse {
+    code: string;
+    data: SquareUserProfile | null;
+    success?: boolean;
+}

--- a/lib/routes/binance/types.ts
+++ b/lib/routes/binance/types.ts
@@ -27,6 +27,13 @@ export interface AnnouncementArticle {
 
 export type SquareFilterType = 'ALL' | 'QUOTE' | 'LIVE';
 
+export interface SquareTranslatedData {
+    title?: string | null;
+    content?: string | null;
+    body?: string | null;
+    bodyTextOnly?: string | null;
+}
+
 export interface SquareImageMeta {
     url: string;
     width?: number;
@@ -40,6 +47,7 @@ export interface SquareQuoteContent {
     webLink?: string;
     imageLink?: string;
     coverMeta?: SquareImageMeta | null;
+    translatedData?: SquareTranslatedData | null;
 }
 
 export interface SquarePost {
@@ -55,6 +63,7 @@ export interface SquarePost {
     coverMeta?: SquareImageMeta | null;
     hashtagList?: string[];
     quoteContent?: SquareQuoteContent | null;
+    translatedData?: SquareTranslatedData | null;
     commentCount?: number;
     likeCount?: number;
 }

--- a/lib/routes/binance/types.ts
+++ b/lib/routes/binance/types.ts
@@ -91,3 +91,43 @@ export interface SquareUserProfileResponse {
     data: SquareUserProfile | null;
     success?: boolean;
 }
+
+export interface CopyTradingOrder {
+    symbol: string;
+    baseAsset: string;
+    quoteAsset: string;
+    side: 'BUY' | 'SELL';
+    type: string;
+    positionSide: 'LONG' | 'SHORT' | 'BOTH';
+    executedQty: number;
+    avgPrice: number;
+    totalPnl: number;
+    orderUpdateTime: number;
+    orderTime: number;
+}
+
+export interface CopyTradingOrderHistoryResponse {
+    code: string;
+    message?: string | null;
+    data: {
+        indexValue: string;
+        total: number;
+        list: CopyTradingOrder[];
+    } | null;
+    success?: boolean;
+}
+
+export interface CopyTradingDetail {
+    nickname: string;
+    description?: string | null;
+    avatarUrl?: string | null;
+    pgcUsername?: string | null;
+    futuresType: string;
+}
+
+export interface CopyTradingDetailResponse {
+    code: string;
+    message?: string | null;
+    data: CopyTradingDetail | null;
+    success?: boolean;
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

None.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/binance/square/user/cz
/binance/square/user/cz/filter=quote&lang=zh-CN
/binance/square/user/cz/filter=live&lang=zh-TW
/binance/copy-trading/lead/5075281354358777856
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This PR adds two new Binance routes:

### `/binance/square/user/:username/:routeParams?` — Square Profile

Posts from a Binance Square user profile.

| Parameter | Value | Description         |
| --------- | ----- | ------------------- |
| filter    | all   | All posts (default) |
| filter    | quote | Quote posts only    |
| filter    | live  | Live posts only     |
| lang      | en    | English (default)   |
| lang      | zh-CN | Simplified Chinese  |
| lang      | zh-TW | Traditional Chinese |
| lang      | ja    | Japanese            |

- Sources: Binance bapi composite endpoints
  - `POST /bapi/composite/v3/friendly/pgc/user/client` (profile lookup, cached)
  - `GET /bapi/composite/v2/friendly/pgc/content/queryUserProfilePageContentsWithFilter` (posts)
- Localizes titles, quote bodies and post bodies when a non-`en` `lang` is supplied.
- Caches profile lookups via `cache.tryGet`.
- Anti-bot measures: `Referer` set to the user profile URL, `Accept-Language` / `lang` set to the requested locale, `clienttype: web`, and `config.trueUA` User-Agent.

### `/binance/copy-trading/lead/:portfolioId` — Copy Trading Lead

Latest trading records from a Binance Copy Trading lead trader. The portfolio ID is taken from the lead-details URL (`/copy-trading/lead-details/:portfolioId`).

- Sources: Binance bapi futures endpoints
  - `GET /bapi/futures/v1/friendly/future/copy-trade/lead-portfolio/detail?portfolioId=…` (lead detail, cached)
  - `POST /bapi/futures/v1/friendly/future/copy-trade/lead-portfolio/order-history` (order history)
- Each order's title uses a short label (`开多` / `平多` / `开空` / `平空`) together with the symbol and average price.
- Each order's description is a full action phrase in Simplified Chinese, with realized PnL coloured green/red for `SELL` orders.
- Order timestamps are used as `pubDate` via `parseDate`.
- Anti-bot measures: `Referer` set to the lead-details page and `config.trueUA` User-Agent.

### Tests

Both routes ship with Vitest suites (`lib/binance-square-user.test.ts`, `lib/binance-copy-trading.test.ts`). Run with:

```bash
pnpm exec vitest run lib/binance-square-user.test.ts lib/binance-copy-trading.test.ts
```

Locally all 17 cases pass, `pnpm exec oxlint` and `pnpm exec tsc --noEmit` are clean.