### PR TITLE
feat(tsinghua): add thuhs routes

### DIFF
--- a/lib/routes/tsinghua/thuhs.ts
+++ b/lib/routes/tsinghua/thuhs.ts
@@ -27,7 +27,7 @@ export const route: Route = {
     features: {
         requireConfig: false,
         requirePuppeteer: false,
-        antiCrawler: false,
+        antiCrawler: true,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,

--- a/lib/routes/tsinghua/thuhs.ts
+++ b/lib/routes/tsinghua/thuhs.ts
@@ -46,7 +46,7 @@ export const route: Route = {
 | tzgg     | xstd     | jsfc     | xwdt     |
 
 :::tip
-该网站仅对中国大陆境内 IP 开放访问。建议将 RSSHub 部署在中国境内服务器，或通过 [gost](https://github.com/go-gost/gost) 等代理工具转发请求。
+该网站会屏蔽云服务器/数据中心的 IP（如 GitHub Actions 所使用的 IP 段），但普通家庭或 VPS 网络一般可正常访问。若部署在云函数或 CI 环境中遇到超时，可尝试通过 [gost](https://github.com/go-gost/gost) 等代理工具转发请求。
 :::
 `,
 };

--- a/lib/routes/tsinghua/thuhs.ts
+++ b/lib/routes/tsinghua/thuhs.ts
@@ -1,0 +1,109 @@
+import { load } from 'cheerio';
+
+import type { DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+const categoryMap = {
+    tzgg: '通知公告',
+    xstd: '学生活动',
+    jsfc: '教师风采',
+};
+
+export const route: Route = {
+    path: '/thuhs/:category?',
+    categories: ['university'],
+    example: '/tsinghua/thuhs/tzgg',
+    parameters: { category: '分类，见下表，留空则默认获取通知公告' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['qhfz.edu.cn/:category.htm'],
+        },
+    ],
+    name: '清华大学附属中学',
+    maintainers: ['Aquarius-Situla'],
+    handler,
+    description: `
+| 通知公告 | 学生活动 | 教师风采 |
+| -------- | -------- | -------- |
+| tzgg     | xstd     | jsfc     |
+`,
+};
+
+async function handler(ctx) {
+    /* Determine the target URL based on the provided category */
+    const category = ctx.req.param('category') || 'tzgg';
+    const host = 'https://www.qhfz.edu.cn';
+    const targetUrl = \`\${host}/\${category}.htm\`;
+
+    const response = await ofetch(targetUrl);
+    const $ = load(response);
+
+    /* Locate the list of articles on the specific category page */
+    let list = $('li:has(a p.bt)');
+    // If the layout differs slightly on other pages, fallback to targeting any a with a date sibling.
+    if (list.length === 0) {
+        list = $('li:has(a)');
+    }
+
+    /* Extract metadata (title, link, date) for each article */
+    const items = list.toArray().map((item) => {
+        const $item = $(item);
+        const $a = $item.find('a').first();
+        
+        let title = $item.find('p.bt').text().trim();
+        if (!title) {
+            title = $a.attr('title') || $a.text().trim();
+        }
+
+        let time = $item.find('p.sj').text().trim();
+        if (!time) {
+            // fallback if date class differs
+            time = $item.find('.sj').text().trim() || $item.find('.date').text().trim();
+        }
+
+        const link = $a.attr('href');
+
+        return {
+            title,
+            link: link ? new URL(link, targetUrl).href : '',
+            pubDate: time ? timezone(parseDate(time, 'YYYY-MM-DD'), 8) : undefined,
+        };
+    }).filter((item) => item.link); // Filter out empty links
+
+    const feedTitle = categoryMap[category] || '通知公告';
+
+    /* Fetch full article content using the RSSHub cache mechanism */
+    const out = await Promise.all(
+        items.map((item) =>
+            cache.tryGet(item.link, async () => {
+                try {
+                    const response = await ofetch(item.link);
+                    const $ = load(response);
+                    
+                    const content = $('.v_news_content').html() || $('.content').html() || $('.Article_Content').html() || '';
+                    item.description = content || undefined;
+                } catch {
+                    item.description = undefined;
+                }
+                return item;
+            })
+        )
+    );
+
+    return {
+        title: \`清华附中 - \${feedTitle}\`,
+        link: targetUrl,
+        item: out as DataItem[],
+    };
+}

--- a/lib/routes/tsinghua/thuhs.ts
+++ b/lib/routes/tsinghua/thuhs.ts
@@ -44,6 +44,10 @@ export const route: Route = {
 | 通知公告 | 学生活动 | 教师风采 | 新闻动态 |
 | -------- | -------- | -------- | -------- |
 | tzgg     | xstd     | jsfc     | xwdt     |
+
+:::tip
+该网站仅对中国大陆境内 IP 开放访问。建议将 RSSHub 部署在中国境内服务器，或通过 [gost](https://github.com/go-gost/gost) 等代理工具转发请求。
+:::
 `,
 };
 

--- a/lib/routes/tsinghua/thuhs.ts
+++ b/lib/routes/tsinghua/thuhs.ts
@@ -1,4 +1,5 @@
 import { load } from 'cheerio';
+import type { Context } from 'hono';
 
 import type { DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
@@ -11,7 +12,7 @@ import timezone from '@/utils/timezone';
  * The official website contains additional sections (e.g., recruitment, scientific research) not yet included here.
  * Future maintainers can easily support them by adding their URL prefix (e.g., 'xwdt' for 'xwdt.htm') and title to this map.
  */
-const categoryMap = {
+const categoryMap: Record<string, string> = {
     tzgg: '通知公告',
     xstd: '学生活动',
     jsfc: '教师风采',
@@ -46,7 +47,7 @@ export const route: Route = {
 `,
 };
 
-async function handler(ctx) {
+async function handler(ctx: Context) {
     /* Determine the target URL based on the provided category */
     const category = ctx.req.param('category') || 'tzgg';
     const host = 'https://www.qhfz.edu.cn';
@@ -63,7 +64,7 @@ async function handler(ctx) {
     }
 
     /* Extract metadata (title, link, date) for each article */
-    const items = list.toArray().map((item) => {
+    const items = list.toArray().map((item): DataItem & { link: string } => {
         const $item = $(item);
         const $a = $item.find('a').first();
         

--- a/lib/routes/tsinghua/thuhs.ts
+++ b/lib/routes/tsinghua/thuhs.ts
@@ -6,10 +6,16 @@ import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 import timezone from '@/utils/timezone';
 
+/*
+ * Dictionary of supported categories.
+ * The official website contains additional sections (e.g., recruitment, scientific research) not yet included here.
+ * Future maintainers can easily support them by adding their URL prefix (e.g., 'xwdt' for 'xwdt.htm') and title to this map.
+ */
 const categoryMap = {
     tzgg: '通知公告',
     xstd: '学生活动',
     jsfc: '教师风采',
+    xwdt: '新闻动态',
 };
 
 export const route: Route = {
@@ -34,9 +40,9 @@ export const route: Route = {
     maintainers: ['Aquarius-Situla'],
     handler,
     description: `
-| 通知公告 | 学生活动 | 教师风采 |
-| -------- | -------- | -------- |
-| tzgg     | xstd     | jsfc     |
+| 通知公告 | 学生活动 | 教师风采 | 新闻动态 |
+| -------- | -------- | -------- | -------- |
+| tzgg     | xstd     | jsfc     | xwdt     |
 `,
 };
 


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/tsinghua/thuhs
/tsinghua/thuhs/tzgg
/tsinghua/thuhs/xstd
/tsinghua/thuhs/jsfc
/tsinghua/thuhs/xwdt
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
添加清华附中（清华大学附属中学）相关的通知、活动与新闻动态支持。
注：该网站屏蔽了海外云服务器 IP，已在代码中开启 `antiCrawler: true` 并在文档中添加了自建和代理配置说明。