### PR TITLE
fix(route/tsinghua): 修复图书馆路由的 CodeQL SSRF 警告

### DIFF
--- a/lib/routes/tsinghua/lib/tzgg.ts
+++ b/lib/routes/tsinghua/lib/tzgg.ts
@@ -69,6 +69,9 @@ async function handler(ctx) {
     const items = await Promise.all(
         list.map((item) =>
             cache.tryGet(item.link, async () => {
+                if (new URL(item.link).hostname !== 'lib.tsinghua.edu.cn') {
+                    return item;
+                }
                 const response = await ofetch(item.link);
                 const $ = load(response);
 

--- a/lib/routes/tsinghua/lib/tzgg.ts
+++ b/lib/routes/tsinghua/lib/tzgg.ts
@@ -69,7 +69,8 @@ async function handler(ctx) {
     const items = await Promise.all(
         list.map((item) =>
             cache.tryGet(item.link, async () => {
-                if (new URL(item.link).hostname !== 'lib.tsinghua.edu.cn') {
+                const hostname = new URL(item.link).hostname;
+                if (!hostname.endsWith('.tsinghua.edu.cn') && hostname !== 'tsinghua.edu.cn') {
                     return item;
                 }
                 const response = await ofetch(item.link);


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/tsinghua/lib/tzgg
/tsinghua/lib/tzgg/kgtz
/tsinghua/lib/tzgg/sgwx
/tsinghua/lib/tzgg/fwtz
/tsinghua/lib/tzgg/wgtb
/tsinghua/lib/tzgg/qtkx
/tsinghua/lib/tzgg/gjtz
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

为图书馆通知公告路由（`lib/routes/tsinghua/lib/tzgg.ts`）增加域名校验，修复 CodeQL 报出的 SSRF 安全警告，当抓取到非 `lib.tsinghua.edu.cn` 的外链时跳过发起网络请求。