### PR TITLE
fix(router/twitter): fix twitter converstaion root post missing issue

### DIFF
--- a/lib/routes/twitter/api/mobile-api/api.ts
+++ b/lib/routes/twitter/api/mobile-api/api.ts
@@ -188,7 +188,11 @@ function gatherLegacyFromData(entries, filterNested?, userId?) {
     return tweets;
 }
 
-const getUserTweetsByID = async (id, params = {}) => gatherLegacyFromData(await timelineTweets(id, params));
+const getUserTweetsByID = async (id, params = {}) => {
+    // Keep only root posts; drop replies and self-thread continuations from profile-conversation modules
+    const tweets = gatherLegacyFromData(await timelineTweets(id, params), ['profile-conversation-'], id);
+    return tweets.filter((t) => !t.in_reply_to_status_id_str);
+};
 // TODO: show the whole conversation instead of just the reply tweet
 const getUserTweetsAndRepliesByID = async (id, params = {}) => gatherLegacyFromData(await timelineTweetsAndReplies(id, params), ['profile-conversation-'], id);
 const getUserMediaByID = async (id, params = {}) => gatherLegacyFromData(await timelineMedia(id, params));

--- a/lib/routes/twitter/api/web-api/api.ts
+++ b/lib/routes/twitter/api/web-api/api.ts
@@ -53,8 +53,8 @@ const cacheTryGet = async (_id, params, operationName, func) => {
 };
 
 const getUserTweets = (id: string, params?: Record<string, any>) =>
-    cacheTryGet(id, params, 'getUserTweets', async (id, params = {}) =>
-        gatherLegacyFromData(
+    cacheTryGet(id, params, 'getUserTweets', async (id, params = {}) => {
+        const tweets = gatherLegacyFromData(
             await paginationTweets('UserTweets', id, {
                 ...params,
                 count: 20,
@@ -62,9 +62,13 @@ const getUserTweets = (id: string, params?: Record<string, any>) =>
                 withQuickPromoteEligibilityTweetFields: true,
                 withVoice: true,
                 withV2Timeline: true,
-            })
-        )
-    );
+            }),
+            ['profile-conversation-'],
+            id
+        );
+        // Keep only root posts; drop replies and self-thread continuations from profile-conversation modules
+        return tweets.filter((t) => !t.in_reply_to_status_id_str);
+    });
 
 const getUserTweetsAndReplies = (id: string, params?: Record<string, any>) =>
     cacheTryGet(id, params, 'getUserTweetsAndReplies', async (id, params = {}) =>


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #22938

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/twitter/user/KOMODO_Games_JP
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This fix is try to contain the twitter conversation tweet post into the route /twitter/user.
As some twitter acount using the conversation to create post.
But currently the root post is filter due to not access the entries 'profile-conversation-'.

The change is adding 'profile-conversation-' to the getUserTweetsByID  and filter the none root post info.

And sorry for the misformat pull request before.