### PR TITLE
feat(core): output more author data

### DIFF
--- a/lib/middleware/template.test.ts
+++ b/lib/middleware/template.test.ts
@@ -76,7 +76,7 @@ describe('template middleware', () => {
         await template(ctx, async () => {});
 
         expect(data.item[0].title).toBe('ABC...');
-        expect(data.item[0].author).toBe('Alice, Bob');
+        expect(data.item[0].author).toEqual([{ name: 'Alice' }, { name: 'Bob' }]);
         expect(data.item[0].itunes_duration).toBe('0:01:05');
 
         config.titleLengthLimit = originalLimit;

--- a/lib/middleware/template.tsx
+++ b/lib/middleware/template.tsx
@@ -68,9 +68,6 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
                     for (const a of item.author) {
                         a.name = collapseWhitespace(a.name) || '';
                     }
-                    if (outputType === 'rss') {
-                        item.author = item.author.map((a: { name: string }) => a.name).join(', ');
-                    }
                 }
 
                 if (item.itunes_duration && ((typeof item.itunes_duration === 'string' && !item.itunes_duration.includes(':')) || (typeof item.itunes_duration === 'number' && !Number.isNaN(item.itunes_duration)))) {

--- a/lib/middleware/template.tsx
+++ b/lib/middleware/template.tsx
@@ -68,7 +68,7 @@ const middleware: MiddlewareHandler = async (ctx, next) => {
                     for (const a of item.author) {
                         a.name = collapseWhitespace(a.name) || '';
                     }
-                    if (outputType !== 'json') {
+                    if (outputType === 'rss') {
                         item.author = item.author.map((a: { name: string }) => a.name).join(', ');
                     }
                 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,6 +41,7 @@ export type DataItem = {
         | Array<{
               name: string;
               url?: string;
+              email?: string;
               avatar?: string;
           }>;
     doi?: string;

--- a/lib/views/atom.test.tsx
+++ b/lib/views/atom.test.tsx
@@ -38,6 +38,24 @@ describe('Atom view', () => {
                             title: 'Item Two',
                             link: 'https://example.com/two',
                             description: 'Entry Two',
+                            author: [
+                                {
+                                    name: 'Author Two',
+                                },
+                                {
+                                    name: 'Author Three',
+                                    url: 'https://example.com/author-three',
+                                },
+                                {
+                                    name: 'Author Four',
+                                    email: 'author-four@example.com',
+                                },
+                                {
+                                    name: 'Author Five',
+                                    url: 'https://example.com/author-five',
+                                    email: 'author-five@example.com',
+                                },
+                            ],
                             category: ['Tech', 'AI'],
                             guid: 'guid-2',
                         },
@@ -54,5 +72,10 @@ describe('Atom view', () => {
         expect(html).toContain('rsshub:upvotes');
         expect(html).toContain('rsshub:downvotes');
         expect(html).toContain('rsshub:comments');
+        expect(html).toContain('<author><name>Author One</name></author>');
+        expect(html).toContain('<author><name>Author Two</name></author>');
+        expect(html).toContain('<author><name>Author Three</name><uri>https://example.com/author-three</uri></author>');
+        expect(html).toContain('<author><name>Author Four</name><email>author-four@example.com</email></author>');
+        expect(html).toContain('<author><name>Author Five</name><uri>https://example.com/author-five</uri><email>author-five@example.com</email></author>');
     });
 });

--- a/lib/views/atom.tsx
+++ b/lib/views/atom.tsx
@@ -26,19 +26,20 @@ const RSS: FC<{ data: Data }> = ({ data }) => (
                 {item.pubDate && <published>{new Date(item.pubDate).toISOString()}</published>}
                 <updated>{new Date(item.updated || item.pubDate || new Date()).toISOString()}</updated>
                 {item.summary && <summary>{item.summary}</summary>}
-                {typeof item.author === 'string' ? (
-                    <author>
-                        <name>{item.author}</name>
-                    </author>
-                ) : (
-                    item.author?.map((a) => (
+                {item.author &&
+                    (typeof item.author === 'string' ? (
                         <author>
-                            <name>{a.name}</name>
-                            {a.url && <uri>{a.url}</uri>}
-                            {a.email && <email>{a.email}</email>}
+                            <name>{item.author}</name>
                         </author>
-                    ))
-                )}
+                    ) : (
+                        item.author.map((a) => (
+                            <author>
+                                <name>{a.name}</name>
+                                {a.url && <uri>{a.url}</uri>}
+                                {a.email && <email>{a.email}</email>}
+                            </author>
+                        ))
+                    ))}
                 {typeof item.category === 'string' ? <category term={item.category}></category> : item.category?.map((c) => <category term={c}></category>)}
                 {item.media &&
                     Object.entries(item.media).map(([key, value]) => {

--- a/lib/views/atom.tsx
+++ b/lib/views/atom.tsx
@@ -35,6 +35,7 @@ const RSS: FC<{ data: Data }> = ({ data }) => (
                         <author>
                             <name>{a.name}</name>
                             {a.url && <uri>{a.url}</uri>}
+                            {a.email && <email>{a.email}</email>}
                         </author>
                     ))
                 )}

--- a/lib/views/atom.tsx
+++ b/lib/views/atom.tsx
@@ -34,6 +34,7 @@ const RSS: FC<{ data: Data }> = ({ data }) => (
                     item.author?.map((a) => (
                         <author>
                             <name>{a.name}</name>
+                            {a.url && <uri>{a.url}</uri>}
                         </author>
                     ))
                 )}

--- a/lib/views/atom.tsx
+++ b/lib/views/atom.tsx
@@ -26,10 +26,16 @@ const RSS: FC<{ data: Data }> = ({ data }) => (
                 {item.pubDate && <published>{new Date(item.pubDate).toISOString()}</published>}
                 <updated>{new Date(item.updated || item.pubDate || new Date()).toISOString()}</updated>
                 {item.summary && <summary>{item.summary}</summary>}
-                {item.author && (
+                {typeof item.author === 'string' ? (
                     <author>
                         <name>{item.author}</name>
                     </author>
+                ) : (
+                    item.author?.map((a) => (
+                        <author>
+                            <name>{a.name}</name>
+                        </author>
+                    ))
                 )}
                 {typeof item.category === 'string' ? <category term={item.category}></category> : item.category?.map((c) => <category term={c}></category>)}
                 {item.media &&

--- a/lib/views/json.test.ts
+++ b/lib/views/json.test.ts
@@ -27,7 +27,26 @@ describe('JSON view', () => {
                     banner: 'https://example.com/banner.jpg',
                     pubDate: '2024-01-01T00:00:00Z',
                     updated: '2024-01-02T00:00:00Z',
-                    author: 'Item Author',
+                    author: [
+                        {
+                            name: 'Author One',
+                        },
+                        {
+                            name: 'Author Two',
+                            avatar: 'https://example.com/author-two/avatar.jpg',
+                        },
+                        {
+                            name: 'Author Three',
+                            email: 'author-three@example.com',
+                            avatar: 'https://example.com/author-three/avatar.jpg',
+                        },
+                        {
+                            name: 'Author Four',
+                            url: 'https://example.com/author-four',
+                            email: 'author-four@example.com',
+                            avatar: 'https://example.com/author-four/avatar.jpg',
+                        },
+                    ],
                     category: ['Tech', 'AI'],
                     enclosure_url: 'https://example.com/audio.mp3',
                     enclosure_type: 'audio/mpeg',
@@ -35,6 +54,13 @@ describe('JSON view', () => {
                     enclosure_length: 123,
                     itunes_duration: 321,
                     _extra: { foo: 'bar' },
+                },
+                {
+                    title: 'Item Two',
+                    link: 'https://example.com/two',
+                    pubDate: '2024-01-02T00:00:00Z',
+                    author: 'Author Five',
+                    category: 'Software',
                 },
             ],
         });
@@ -47,7 +73,7 @@ describe('JSON view', () => {
         expect(feed.feed_url).toBe('https://example.com/feed.json');
         expect(feed.description).toBe('JSON Description - Powered by RSSHub');
         expect(feed.authors).toEqual([{ name: 'Feed Author' }]);
-        expect(feed.items).toHaveLength(1);
+        expect(feed.items).toHaveLength(2);
         expect(feed.items[0]).toMatchObject({
             id: 'guid-1',
             url: 'https://example.com/one',
@@ -59,7 +85,25 @@ describe('JSON view', () => {
             banner_image: 'https://example.com/banner.jpg',
             date_published: '2024-01-01T00:00:00Z',
             date_modified: '2024-01-02T00:00:00Z',
-            authors: [{ name: 'Item Author' }],
+            authors: [
+                {
+                    name: 'Author One',
+                },
+                {
+                    name: 'Author Two',
+                    avatar: 'https://example.com/author-two/avatar.jpg',
+                },
+                {
+                    name: 'Author Three',
+                    url: 'mailto:author-three@example.com',
+                    avatar: 'https://example.com/author-three/avatar.jpg',
+                },
+                {
+                    name: 'Author Four',
+                    url: 'https://example.com/author-four',
+                    avatar: 'https://example.com/author-four/avatar.jpg',
+                },
+            ],
             tags: ['Tech', 'AI'],
             attachments: [
                 {
@@ -70,6 +114,15 @@ describe('JSON view', () => {
                     duration_in_seconds: 321,
                 },
             ],
+        });
+        expect(feed.items[1]).toMatchObject({
+            id: 'https://example.com/two',
+            url: 'https://example.com/two',
+            title: 'Item Two',
+            content_text: 'Item Two',
+            date_published: '2024-01-02T00:00:00Z',
+            authors: [{ name: 'Author Five' }],
+            tags: ['Software'],
         });
         expect(feed.items[0]._extra).toEqual({ foo: 'bar' });
     });

--- a/lib/views/json.ts
+++ b/lib/views/json.ts
@@ -27,7 +27,14 @@ const json = (data: Data) => {
             banner_image: item.banner,
             date_published: item.pubDate,
             date_modified: item.updated,
-            authors: typeof item.author === 'string' ? [{ name: item.author }] : item.author,
+            authors:
+                typeof item.author === 'string'
+                    ? [{ name: item.author }]
+                    : item.author?.map((a) => ({
+                          name: a.name,
+                          url: a.url || (a.email ? 'mailto:' + a.email : undefined),
+                          avatar: a.avatar,
+                      })),
             tags: typeof item.category === 'string' ? [item.category] : item.category,
             language: item.language,
             attachments:

--- a/lib/views/rss.test.tsx
+++ b/lib/views/rss.test.tsx
@@ -46,6 +46,12 @@ describe('RSS view', () => {
                             description: 'Episode Two',
                             category: ['News', 'Updates'],
                         },
+                        {
+                            title: 'Episode Three',
+                            link: 'https://example.com/three',
+                            description: 'Episode Three',
+                            author: [{ name: 'Alice' }, { name: 'Bob' }],
+                        },
                     ],
                 }}
             />
@@ -63,5 +69,7 @@ describe('RSS view', () => {
         expect(html).toContain('<enclosure url="https://example.com/audio.mp3"');
         expect(html).toContain('<category>Podcast</category>');
         expect(html).toContain('<category>News</category>');
+        expect(html).toContain('<author>Host</author>');
+        expect(html).toContain('<author>Alice, Bob</author>');
     });
 });

--- a/lib/views/rss.tsx
+++ b/lib/views/rss.tsx
@@ -42,7 +42,7 @@ const RSS: FC<{ data: Data }> = ({ data }) => {
                         <link>{item.link}</link>
                         <guid isPermaLink="false">{item.guid || item.link || item.title}</guid>
                         {item.pubDate && <pubDate>{item.pubDate}</pubDate>}
-                        {item.author && <author>{item.author}</author>}
+                        {item.author && <author>{typeof item.author === 'string' ? item.author : item.author.map((a) => a.name).join(', ')}</author>}
                         {item.image && <enclosure url={item.image} type="image/jpeg" />}
                         {item.itunes_item_image && <itunes:image href={item.itunes_item_image} />}
                         {item.enclosure_url && <enclosure url={item.enclosure_url} length={item.enclosure_length} type={item.enclosure_type} />}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Previously, all authors were listed on one line with commas and placed in a single `atom:author` element. Now, each author is a separate `atom:author` element. [This matches the Atom standard](https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.1:~:text=atom%3Aentry%20elements%20MUST%20contain%20one%20or%20more%20atom%3Aauthor%20elements).

The `author` data in [Atom](https://datatracker.ietf.org/doc/html/rfc4287#section-1.1:~:text=%3Cauthor%3E%0A%20%20%20%20%20%20%20%20%20%3Cname%3EMark%20Pilgrim%3C%2Fname%3E%0A%20%20%20%20%20%20%20%20%20%3Curi%3Ehttp%3A%2F%2Fexample%2Eorg%2F%3C%2Furi%3E%0A%20%20%20%20%20%20%20%20%20%3Cemail%3Ef8dy%40example%2Ecom%3C%2Femail%3E%0A%20%20%20%20%20%20%20%3C%2Fauthor%3E) and [JSON Feed](https://www.jsonfeed.org/version/1.1/#Top-level:~:text=authors) is very similar. This helps us easily reuse the author data.

`author.url` was only used in JSON Feed before. Now it is also used for Atom elements.

Also, the `author.email` field has been added to Atom. As a fallback (if there is an `email` but no `url`), the `author.email` value [can be used](https://www.jsonfeed.org/version/1.1/#Top-level:~:text=The%20URL%20could%20be%20a%20mailto%3A%20link%2C%20though%20we%20suspect%20that%20will%20be%20rare%2E) as a mailto link for JSON Feed.