### PR TITLE
fix(route/futunn): render article pages via playwright to bypass WAF

### DIFF
--- a/lib/routes/futunn/main.ts
+++ b/lib/routes/futunn/main.ts
@@ -1,11 +1,11 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import playwright from '@/utils/playwright';
 
 import { renderDescription } from './templates/description';
+import { extractArticleInfo, fetchArticleDetail } from './utils';
 
 export const route: Route = {
     path: ['/main', '/'],
@@ -13,6 +13,7 @@ export const route: Route = {
     example: '/futunn/main',
     features: {
         supportRadar: true,
+        requirePuppeteer: true,
     },
     radar: [
         {
@@ -48,37 +49,26 @@ async function handler(ctx) {
         }),
     }));
 
+    const context = await playwright();
+
     items = await Promise.all(
         items.map((item) =>
             cache.tryGet(item.link, async () => {
                 if (/news\.futunn\.com/.test(item.link)) {
-                    const detailResponse = await got({
-                        method: 'get',
-                        url: item.link,
-                    });
+                    const content = await fetchArticleDetail(context, item.link);
 
-                    const content = load(detailResponse.data);
+                    const { description, category } = extractArticleInfo(content);
 
-                    content('.futu-news-time-stamp').remove();
-                    content('.nnstock').each((_, el) => {
-                        content(el).replaceWith(`<a href="${content(el).attr('href')}">${content(el).text().replaceAll('$', '')}</a>`);
-                    });
-
-                    item.description = content('.origin_content').html();
-                    item.category = [
-                        ...content('.news__from-topic__title')
-                            .toArray()
-                            .map((a) => content(a).text().trim()),
-                        ...content('#relatedStockWeb .stock-name')
-                            .toArray()
-                            .map((s) => content(s).text().trim()),
-                    ];
+                    item.description = description;
+                    item.category = category;
                 }
 
                 return item;
             })
         )
     );
+
+    await context.close();
 
     return {
         title: '富途牛牛 - 要闻',

--- a/lib/routes/futunn/topic.ts
+++ b/lib/routes/futunn/topic.ts
@@ -1,11 +1,11 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
+import playwright from '@/utils/playwright';
 
 import { renderDescription } from './templates/description';
+import { extractArticleInfo, fetchArticleDetail } from './utils';
 
 export const route: Route = {
     path: '/topic/:id',
@@ -14,6 +14,7 @@ export const route: Route = {
     parameters: { id: 'Topic ID, can be found in URL' },
     features: {
         supportRadar: true,
+        requirePuppeteer: true,
     },
     radar: [
         {
@@ -74,37 +75,26 @@ async function handler(ctx) {
         }),
     }));
 
+    const context = await playwright();
+
     items = await Promise.all(
         items.map((item) =>
             cache.tryGet(item.link, async () => {
                 if (/news\.futunn\.com/.test(item.link)) {
-                    const detailResponse = await got({
-                        method: 'get',
-                        url: item.link,
-                    });
+                    const content = await fetchArticleDetail(context, item.link);
 
-                    const content = load(detailResponse.data);
+                    const { description, category } = extractArticleInfo(content);
 
-                    content('.futu-news-time-stamp').remove();
-                    content('.nnstock').each((_, el) => {
-                        content(el).replaceWith(`<a href="${content(el).attr('href')}">${content(el).text().replaceAll('$', '')}</a>`);
-                    });
-
-                    item.description = content('.origin_content').html();
-                    item.category = [
-                        ...content('.news__from-topic__title')
-                            .toArray()
-                            .map((a) => content(a).text().trim()),
-                        ...content('#relatedStockWeb .stock-name')
-                            .toArray()
-                            .map((s) => content(s).text().trim()),
-                    ];
+                    item.description = description;
+                    item.category = category;
                 }
 
                 return item;
             })
         )
     );
+
+    await context.close();
 
     return {
         title: `富途牛牛 - 专题 - ${topicTitle}`,

--- a/lib/routes/futunn/utils.ts
+++ b/lib/routes/futunn/utils.ts
@@ -1,0 +1,72 @@
+import type { CheerioAPI } from 'cheerio';
+import { load } from 'cheerio';
+import type { BrowserContext } from 'patchright';
+
+import got from '@/utils/got';
+import logger from '@/utils/logger';
+
+/**
+ * 富途 WAF 会拦截无浏览器指纹的请求(如 got), 返回混淆 JS 壳页面,
+ * 其中不含 `.origin_content`, 导致条目正文为空。
+ * 此函数先尝试 got, 若检测到被 WAF 拦截, 则改用 playwright 渲染页面后重新提取。
+ */
+export async function fetchArticleDetail(context: BrowserContext, link: string): Promise<CheerioAPI> {
+    let html = '';
+
+    try {
+        const response = await got({ method: 'get', url: link });
+        html = response.data;
+
+        // got 拿到正常页面时直接返回
+        if (load(html)('.origin_content').length > 0) {
+            return load(html);
+        }
+    } catch {
+        // got 抛错(如 403), 继续走 playwright
+    }
+
+    logger.warn(`futunn: got 请求可能被 WAF 拦截, 改用 playwright 渲染: ${link}`);
+
+    try {
+        const page = await context.newPage();
+        try {
+            // 只加载文档与脚本, 跳过图片/样式/字体等资源
+            await page.route('**/*', (route) => {
+                const request = route.request();
+                request.resourceType() === 'document' || request.resourceType() === 'script' ? route.continue() : route.abort();
+            });
+
+            await page.goto(link, { waitUntil: 'domcontentloaded' });
+            await page.waitForSelector('.origin_content', { timeout: 30000 });
+            html = await page.content();
+
+            return load(html);
+        } finally {
+            await page.close();
+        }
+    } catch (error) {
+        // playwright 渲染失败时返回空文档, 与 got 被 WAF 拦截时行为一致(description 为空)
+        logger.error(`futunn: playwright 渲染失败: ${link} - ${error}`);
+        return load('');
+    }
+}
+
+/** 从富途文章页提取描述与分类 */
+export function extractArticleInfo(content: CheerioAPI) {
+    content('.futu-news-time-stamp').remove();
+    content('.nnstock').each((_, el) => {
+        content(el).replaceWith(`<a href="${content(el).attr('href')}">${content(el).text().replaceAll('$', '')}</a>`);
+    });
+
+    return {
+        description: content('.origin_content').html(),
+        category: [
+            ...content('.news__from-topic__title')
+                .toArray()
+                .map((a) => content(a).text().trim()),
+            ...content('#relatedStockWeb .stock-name')
+                .toArray()
+                .map((s) => content(s).text().trim()),
+        ],
+    };
+}


### PR DESCRIPTION
<!--
Fix: Futu's WAF returns an obfuscated JS shell to non-browser requests, leaving article bodies empty in the /futunn/main and /futunn/topic feeds.
-->

## Involved Issue / 该 PR 相关 Issue

N/A — bug fix for existing routes.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/futunn/main
/futunn/topic/1267
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [x] `Puppeteer`

## Note / 说明

### Problem

Futu's WAF now returns an obfuscated JavaScript shell to requests without a browser fingerprint (e.g. plain `got` requests). As a result, article bodies in the `/futunn/main` and `/futunn/topic` feeds have been **empty** — the pages fetched by `got` contain no `.origin_content` element, so `item.description` silently falls back to the abstract (or nothing).

### Changes

- Add `lib/routes/futunn/utils.ts` with:
  - `fetchArticleDetail(context, link)`: tries `got` first; if the response lacks `.origin_content` (WAF shell), falls back to rendering the page with **playwright** (via `@/utils/playwright`), then re-extracts the body.
  - `extractArticleInfo(content)`: shared body/category extraction previously duplicated in `main.ts` and `topic.ts`.
- Update `/futunn/main` and `/futunn/topic` to use the shared helper and mark `requirePuppeteer: true`.

### Verification

- `tsc --noEmit` passes; `oxlint` and `oxfmt` clean on `lib/routes/futunn/`.
- Locally ran the modified routes (`/futunn/main?limit=2`): article bodies now come through fully (e.g. the CPI article renders ~780 chars of body text instead of empty `<p></p>`).

### Notes

- The fallback only activates when `got` is blocked, so deployments without a browser keep current behavior (empty body) rather than failing.
- If playwright also fails (e.g. page itself returns 403), the entry degrades gracefully to the existing empty-description behavior.
