### PR TITLE
fix(route/youtube): adapt to LockupView format from youtubei.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn.lock
 yarn-error.log
 
 dist-container
+run.sh

--- a/lib/routes/youtube/api/youtubei.ts
+++ b/lib/routes/youtube/api/youtubei.ts
@@ -1,6 +1,6 @@
 import { Innertube } from 'youtubei.js';
 
-import type { Data } from '@/types';
+import type { Data, DataItem } from '@/types';
 import cache from '@/utils/cache';
 import { parseRelativeDate } from '@/utils/parse-date';
 
@@ -26,6 +26,77 @@ const getInnertube = () => {
     return innertubePromise;
 };
 
+const getVideoId = (video: any) => ('video_id' in video ? video.video_id : 'content_id' in video ? video.content_id : video.id);
+const getVideoTitle = (video: any) => ('metadata' in video ? video.metadata?.title?.text : video.title?.text);
+const getVideoImage = (video: any) => ('content_image' in video ? video.content_image?.image?.[0]?.url : 'best_thumbnail' in video ? video.best_thumbnail?.url : video.thumbnails?.[0]?.url);
+const getVideoPublished = (video: any) => {
+    if ('published' in video && video.published?.text) {
+        return video.published.text;
+    }
+    const texts = (video.metadata?.metadata?.metadata_rows ?? []).flatMap((row: any) => (row.metadata_parts ?? []).map((part: any) => part.text?.text)).filter(Boolean);
+    return texts.find((t: string) => /\d+\s+\w+\s+ago/i.test(t)) ?? texts.find((t: string) => /\b(?:today|yesterday|now)\b/i.test(t));
+};
+const parseDurationText = (text: string) => {
+    if (!text || !/^\d+:\d{2}(?::\d{2})?$/.test(text)) {
+        return;
+    }
+    return text
+        .split(':')
+        .map(Number)
+        .reduce((acc, part) => acc * 60 + part, 0);
+};
+const getVideoDuration = (video: any) => {
+    if (video.duration && 'seconds' in video.duration) {
+        return video.duration.seconds;
+    }
+    const badgeText = (video.content_image?.overlays ?? [])
+        .flatMap((overlay: any) => overlay.badges ?? [])
+        .map((badge: any) => badge.text)
+        .find(Boolean);
+    return parseDurationText(badgeText);
+};
+const getVideoAuthor = (video: any) => {
+    if ('content_id' in video) {
+        return;
+    }
+    const author = video.author;
+    if (typeof author === 'string') {
+        return author;
+    }
+    if (Array.isArray(author)) {
+        return author.map((a: any) => ({ name: a.name, url: a.url, avatar: a.thumbnails?.[0]?.url }));
+    }
+    if (author) {
+        return author.name === 'N/A' ? undefined : author.name;
+    }
+    return;
+};
+
+const mapVideoToItem = (video: any, { embed, isJsonFeed, videoSubtitles }: { embed: boolean; isJsonFeed: boolean; videoSubtitles: Record<string, NonNullable<DataItem['attachments']>> }): DataItem => {
+    const videoId = getVideoId(video);
+    const img = getVideoImage(video);
+    const description = 'description_snippet' in video ? utils.renderDescription(embed, videoId, img, utils.formatDescription(video.description_snippet?.toHTML())) : utils.renderDescription(embed, videoId, img, '');
+    const srtAttachments = isJsonFeed ? videoSubtitles[videoId] || [] : [];
+    const published = getVideoPublished(video);
+
+    return {
+        title: getVideoTitle(video) || `YouTube Video ${videoId}`,
+        description,
+        link: `https://www.youtube.com/watch?v=${videoId}`,
+        author: getVideoAuthor(video),
+        image: img,
+        pubDate: published ? parseRelativeDate(published) : undefined,
+        attachments: [
+            {
+                url: getVideoUrl(videoId),
+                mime_type: 'text/html',
+                duration_in_seconds: getVideoDuration(video),
+            },
+            ...srtAttachments,
+        ],
+    };
+};
+
 export const getChannelIdByUsername = (username: string) =>
     cache.tryGet(`youtube:getChannelIdByUsername:${username}`, async () => {
         const innertube = await getInnertube();
@@ -42,7 +113,7 @@ export const getDataByChannelId = async ({ channelId, embed, isJsonFeed }: { cha
     const innertube = await getInnertube();
     const channel = await innertube.getChannel(channelId);
     const videos = await channel.getVideos();
-    const videoSubtitles = isJsonFeed ? await getSrtAttachmentBatch(videos.videos.filter((video) => 'video_id' in video).map((video) => video.video_id)) : {};
+    const videoSubtitles = isJsonFeed ? await getSrtAttachmentBatch(videos.videos.filter((video) => 'video_id' in video || 'content_id' in video).map((video) => getVideoId(video))) : {};
 
     return {
         title: `${channel.metadata.title || channelId} - YouTube`,
@@ -50,31 +121,7 @@ export const getDataByChannelId = async ({ channelId, embed, isJsonFeed }: { cha
         image: channel.metadata.avatar?.[0].url,
         description: channel.metadata.description,
 
-        item: await Promise.all(
-            videos.videos
-                .filter((video) => 'video_id' in video)
-                .map((video) => {
-                    const srtAttachments = isJsonFeed ? videoSubtitles[video.video_id] || [] : [];
-                    const img = 'best_thumbnail' in video ? video.best_thumbnail?.url : 'thumbnails' in video ? video.thumbnails?.[0]?.url : undefined;
-
-                    return {
-                        title: video.title.text || `YouTube Video ${video.video_id}`,
-                        description: 'description_snippet' in video ? utils.renderDescription(embed, video.video_id, img, utils.formatDescription(video.description_snippet?.toHTML())) : null,
-                        link: `https://www.youtube.com/watch?v=${video.video_id}`,
-                        author: typeof video.author === 'string' ? video.author : video.author.name === 'N/A' ? undefined : video.author.name,
-                        image: img,
-                        pubDate: 'published' in video && video.published?.text ? parseRelativeDate(video.published.text) : undefined,
-                        attachments: [
-                            {
-                                url: getVideoUrl(video.video_id),
-                                mime_type: 'text/html',
-                                duration_in_seconds: video.duration && 'seconds' in video.duration ? video.duration.seconds : undefined,
-                            },
-                            ...srtAttachments,
-                        ],
-                    };
-                })
-        ),
+        item: videos.videos.filter((video) => 'video_id' in video || 'content_id' in video).map((video) => mapVideoToItem(video, { embed, isJsonFeed, videoSubtitles })),
     };
 };
 
@@ -89,35 +136,6 @@ export const getDataByPlaylistId = async ({ playlistId, embed }: { playlistId: s
         image: playlist.info.thumbnails?.[0].url,
         description: playlist.info.description || `${playlist.info.title} by ${playlist.info.author.name}`,
 
-        item: videos
-            .filter((video) => 'id' in video)
-            .map((video) => {
-                const img = 'best_thumbnail' in video ? video.best_thumbnail?.url : video.thumbnails?.[0]?.url;
-
-                return {
-                    title: video.title.text || `YouTube Video ${video.id}`,
-                    description: utils.renderDescription(embed, video.id, img, ''),
-                    link: `https://www.youtube.com/watch?v=${video.id}`,
-                    pubDate: 'published' in video && video.published?.text ? parseRelativeDate(video.published.text) : undefined,
-                    author:
-                        'author' in video
-                            ? [
-                                  {
-                                      name: video.author.name,
-                                      url: video.author.url,
-                                      avatar: video.author.thumbnails?.[0]?.url,
-                                  },
-                              ]
-                            : undefined,
-                    image: img,
-                    attachments: [
-                        {
-                            url: getVideoUrl(video.id),
-                            mime_type: 'text/html',
-                            duration_in_seconds: 'duration' in video && video.duration && 'seconds' in video.duration ? video.duration.seconds : undefined,
-                        },
-                    ],
-                };
-            }),
+        item: videos.filter((video) => 'id' in video || 'video_id' in video || 'content_id' in video).map((video) => mapVideoToItem(video, { embed, isJsonFeed: false, videoSubtitles: {} })),
     };
 };


### PR DESCRIPTION
youtubei.js 17.x changed channel.getVideos() and playlist.videos to return LockupView objects (using content_id instead of video_id), which were filtered out by 'video_id' in video and resulted in empty feeds (503).

Map both legacy Video and new LockupView formats. Closes #22658.

<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #22658

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/youtube/user/:username
/youtube/channel/:id
/youtube/playlist/:id

```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
