### PR TITLE
fix(route): Update MIIT policy document and public consultation

### DIFF
--- a/lib/routes/gov/miit/yjzj.ts
+++ b/lib/routes/gov/miit/yjzj.ts
@@ -34,9 +34,8 @@ export const route: Route = {
 async function handler() {
     const url = `${rootUrl}/gzcy/yjzj/index.html`;
 
-    const cookieResponse = await got(url);
-    const cookie = cookieResponse.headers?.['set-cookie']?.[0]?.split(';', 1)[0] ?? '';
-    const indexContent = load(cookieResponse.data);
+    const indexResponse = await got(url);
+    const indexContent = load(indexResponse.data);
     const dataRequestUrl = indexContent('div.clist_con > script:nth-child(2)')
         .toArray()
         .map((item) => ({
@@ -50,9 +49,6 @@ async function handler() {
     const response = await got({
         method: 'get',
         url: dataUrl,
-        headers: {
-            Cookie: cookie,
-        },
     });
     const $ = load(response.data.data.html);
     const list = $('ul > li')

--- a/lib/routes/gov/miit/yjzj.ts
+++ b/lib/routes/gov/miit/yjzj.ts
@@ -35,7 +35,7 @@ async function handler() {
     const url = `${rootUrl}/gzcy/yjzj/index.html`;
 
     const cookieResponse = await got(url);
-    const cookie = cookieResponse.headers?.['set-cookie']?.[0]?.split(';', 1)?.[0] ?? '';
+    const cookie = cookieResponse.headers?.['set-cookie']?.[0]?.split(';', 1)[0] ?? '';
     const indexContent = load(cookieResponse.data);
     const dataRequestUrl = indexContent('div.clist_con > script:nth-child(2)')
         .toArray()

--- a/lib/routes/gov/miit/yjzj.ts
+++ b/lib/routes/gov/miit/yjzj.ts
@@ -22,20 +22,20 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['miit.gov.cn/gzcy/yjzj/index.html'],
+            source: ['https://www.miit.gov.cn/gzcy/yjzj/index.html'],
         },
     ],
     name: '意见征集',
     maintainers: ['Fatpandac'],
     handler,
-    url: 'miit.gov.cn/gzcy/yjzj/index.html',
+    url: 'https://www.miit.gov.cn/gzcy/yjzj/index.html',
 };
 
 async function handler() {
     const url = `${rootUrl}/gzcy/yjzj/index.html`;
 
     const cookieResponse = await got(url);
-    const cookie = cookieResponse.headers['set-cookie'][0].split(';', 1)[0];
+    const cookie = cookieResponse.headers?.['set-cookie']?.[0]?.split(';', 1)?.[0] ?? '';
     const indexContent = load(cookieResponse.data);
     const dataRequestUrl = indexContent('div.clist_con > script:nth-child(2)')
         .toArray()

--- a/lib/routes/gov/miit/yjzj.ts
+++ b/lib/routes/gov/miit/yjzj.ts
@@ -22,13 +22,13 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['https://www.miit.gov.cn/gzcy/yjzj/index.html'],
+            source: ['miit.gov.cn/gzcy/yjzj/index.html'],
         },
     ],
     name: '意见征集',
     maintainers: ['Fatpandac'],
     handler,
-    url: 'https://www.miit.gov.cn/gzcy/yjzj/index.html',
+    url: 'miit.gov.cn/gzcy/yjzj/index.html',
 };
 
 async function handler() {

--- a/lib/routes/gov/miit/zcwj.ts
+++ b/lib/routes/gov/miit/zcwj.ts
@@ -43,20 +43,22 @@ async function handler() {
     });
 
     const result = response.data;
-    const dataList = result.data.searchResult.dataResults.filter((item: any) => item.groupData?.[0]?.data?.url);
+    const dataList = result.data.searchResult.dataResults;
 
-    const items = dataList.map((item: any) => {
-        const data = item.groupData?.[0].data ?? {};
-        const extendedInfo = data.infoextends ? JSON.parse(data.infoextends) : {};
-        const infoContent = extendedInfo.infoContent ? JSON.parse(extendedInfo.infoContent) : {};
-        return {
-            title: data.title,
-            link: new URL(data.url, rootUrl).href,
-            description: infoContent[0]?.fieldValue || '',
-            pubDate: parseDate(Number(data.deploytime || data.publishtime)),
-            author: data.publishgroupname,
-        };
-    });
+    const items = dataList
+        .map((item: any) => {
+            const data = item.groupData?.[0].data ?? {};
+            const extendedInfo = data.infoextends ? JSON.parse(data.infoextends) : {};
+            const infoContent = extendedInfo.infoContent ? JSON.parse(extendedInfo.infoContent) : {};
+            return {
+                title: data.title,
+                link: data.url ? new URL(data.url, rootUrl).href : '',
+                description: infoContent[0]?.fieldValue || '',
+                pubDate: data.deploytime ? parseDate(Number(data.deploytime)) : undefined,
+                author: data.publishgroupname,
+            };
+        })
+        .filter((item: any) => item.link);
 
     return {
         title: '中国工业和信息化部',

--- a/lib/routes/gov/miit/zcwj.ts
+++ b/lib/routes/gov/miit/zcwj.ts
@@ -52,7 +52,7 @@ async function handler() {
         return {
             title: data.title,
             link: new URL(data.url, rootUrl).href,
-            description: data.infocontent || data.title,
+            description: data.infocontent,
             pubDate: parseDate(Number(data.deploytime || data.publishtime)),
             author: data.publishgroupname,
         };

--- a/lib/routes/gov/miit/zcwj.ts
+++ b/lib/routes/gov/miit/zcwj.ts
@@ -1,8 +1,6 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
-import cache from '@/utils/cache';
 import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
     path: '/zcwj',
@@ -18,55 +16,50 @@ export const route: Route = {
         supportScihub: false,
     },
     name: '政策文件',
-    maintainers: ['Yoge-Code'],
+    maintainers: ['Yoge-Code', 'hutianyu2006'],
     handler,
 };
 
 async function handler() {
-    const base_url = 'http://www.miit.gov.cn/n1146295/n1652858/';
-    const response = await got.get(base_url);
-    const $ = load(response.data);
-    const list = $('.clist_con li').toArray();
+    const rootUrl = 'https://www.miit.gov.cn';
+    const apiUrl = `${rootUrl}/search-front-server/api/search/info`;
 
-    const ProcessFeed = (data) => {
-        const $ = load(data);
+    const response = await got(apiUrl, {
+        headers: {
+            referer: `${rootUrl}/search/zcwjk.html`,
+        },
+        searchParams: {
+            scope: 'basic',
+            pos: 'title_text,infocontent,titlepy',
+            cateid: 196, // NOTE: Not so clear about other magic ids, temporarily hardcoded
+            p: 1,
+            pg: 10,
+            level: 6,
+            dateField: 'deploytime',
+            selectFields: 'title,content,deploytime,url,columnname,publishgroupname',
+            sortFields: JSON.stringify([{ name: 'deploytime', type: 'desc' }]),
+            group: 'distinct',
+            highlightConfigs: JSON.stringify([{ field: 'infocontent', numberOfFragments: 2, fragmentOffset: 0, fragmentSize: 30, noMatchSize: 145 }]),
+            highlightFields: 'infocontent',
+        },
+    });
 
-        const content = $('p');
-        return content.text();
-    };
+    const result = response.data;
+    const dataList = result.data.searchResult.dataResults;
 
-    const items = await Promise.all(
-        list.map(async (item) => {
-            const $ = load(item);
-            const $a = $('a');
-            let link = $a.attr('href');
-            if (link!.startsWith('..')) {
-                link = base_url + link;
-            }
-
-            const cacheIn = await cache.get(link!);
-            if (cacheIn) {
-                return JSON.parse(cacheIn);
-            }
-
-            const response = await got({
-                method: 'get',
-                url: link,
-            });
-
-            const single = {
-                title: $a.text(),
-                description: ProcessFeed(response.data),
-                link,
-            };
-
-            cache.set(link!, JSON.stringify(single));
-            return single;
-        })
-    );
+    const items = dataList.map((item: any) => {
+        const data = item.groupData?.[0].data ?? {};
+        return {
+            title: data.title,
+            link: new URL(data.url, rootUrl).href,
+            description: data.infocontent || data.title,
+            pubDate: parseDate(Number(data.deploytime || data.publishtime)),
+            author: data.publishgroupname,
+        };
+    });
 
     return {
-        title: '中国工业化和信息部',
+        title: '中国工业和信息化部',
         link: 'http://www.miit.gov.cn',
         description: '政策文件',
         item: items,

--- a/lib/routes/gov/miit/zcwj.ts
+++ b/lib/routes/gov/miit/zcwj.ts
@@ -46,12 +46,12 @@ async function handler() {
     const dataList = result.data.searchResult.dataResults;
 
     const items = dataList.map((item: any) => {
-        const data = item.groupData?.[0].data ?? {};
+        const data = (item.groupData?.[0].data ?? {}).filter((data) => data?.url);
         const extendedInfo = data.infoextends ? JSON.parse(data.infoextends) : {};
         const infoContent = extendedInfo.infoContent ? JSON.parse(extendedInfo.infoContent) : {};
         return {
             title: data.title,
-            link: data.url ? new URL(data.url, rootUrl).href : '',
+            link: new URL(data.url, rootUrl).href,
             description: infoContent[0]?.fieldValue || '',
             pubDate: parseDate(Number(data.deploytime || data.publishtime)),
             author: data.publishgroupname,

--- a/lib/routes/gov/miit/zcwj.ts
+++ b/lib/routes/gov/miit/zcwj.ts
@@ -36,11 +36,9 @@ async function handler() {
             pg: 10,
             level: 6,
             dateField: 'deploytime',
-            selectFields: 'title,content,deploytime,url,columnname,publishgroupname',
+            selectFields: 'title,content,deploytime,url,columnname,publishgroupname,infoextends',
             sortFields: JSON.stringify([{ name: 'deploytime', type: 'desc' }]),
             group: 'distinct',
-            highlightConfigs: JSON.stringify([{ field: 'infocontent', numberOfFragments: 2, fragmentOffset: 0, fragmentSize: 30, noMatchSize: 145 }]),
-            highlightFields: 'infocontent',
         },
     });
 
@@ -49,10 +47,12 @@ async function handler() {
 
     const items = dataList.map((item: any) => {
         const data = item.groupData?.[0].data ?? {};
+        const extendedInfo = data.infoextends ? JSON.parse(data.infoextends) : {};
+        const infoContent = extendedInfo.infoContent ? JSON.parse(extendedInfo.infoContent) : {};
         return {
             title: data.title,
-            link: new URL(data.url, rootUrl).href,
-            description: data.infocontent,
+            link: data.url ? new URL(data.url, rootUrl).href : '',
+            description: infoContent[0]?.fieldValue || '',
             pubDate: parseDate(Number(data.deploytime || data.publishtime)),
             author: data.publishgroupname,
         };

--- a/lib/routes/gov/miit/zcwj.ts
+++ b/lib/routes/gov/miit/zcwj.ts
@@ -43,10 +43,10 @@ async function handler() {
     });
 
     const result = response.data;
-    const dataList = result.data.searchResult.dataResults;
+    const dataList = result.data.searchResult.dataResults.filter((item: any) => item.groupData?.[0]?.data?.url);
 
     const items = dataList.map((item: any) => {
-        const data = (item.groupData?.[0].data ?? {}).filter((data) => data?.url);
+        const data = item.groupData?.[0].data ?? {};
         const extendedInfo = data.infoextends ? JSON.parse(data.infoextends) : {};
         const infoContent = extendedInfo.infoContent ? JSON.parse(extendedInfo.infoContent) : {};
         return {


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

<!-- Close # -->
Related to #22969  

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/gov/miit/zcwj
/gov/miit/yjzj
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

1. This Pull Request provides a partial fix for Issue #22969. As not all problems mentioned in the issue are fixed, I assume that it is not appropriate to close this issue.

2. For the `/gov/miit/zcwj` route, the method of fetching data has been switched from scraping web pages to accessing an API endpoint. While the API offers potential extensibility—such as the `cateid` parameter, where different IDs correspond to different categories—the full mapping between Category IDs and specific categories is currently unknown; therefore, a hard-coded approach is used for the time being.

3. For the `/gov/miit/yjzj` route, the handling of cookies, which was causing errors, has been modified to default to an empty object, thereby restoring functionality.

4. Regarding the other route mentioned in the original issue, `/gov/miit/wjfb/:ministry`: following the restructuring of the MIIT homepage, its data source appears to overlap with that of the `/gov/miit/zcwj` route. Furthermore, refactoring this route would inevitably introduce behavioral changes—specifically, the previously used department abbreviation codes have been deprecated in favor of URL-encoded Chinese strings as department identifiers in the new API. Consequently, no fix is ​​being implemented for this route at this time.

