### PR TITLE
feat(route): add Shopify Engineering blog

### DIFF
--- a/lib/routes/shopify/engineering.ts
+++ b/lib/routes/shopify/engineering.ts
@@ -1,0 +1,117 @@
+import { load } from 'cheerio';
+import pMap from 'p-map';
+
+import type { Data, DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const baseUrl = 'https://shopify.engineering';
+
+export const route: Route = {
+    path: '/engineering/:topic?',
+    categories: ['programming'],
+    example: '/shopify/engineering',
+    parameters: {
+        topic: 'Topic slug from `/topics/:topic`, e.g. `mobile`, `ai-machine-learning`. Defaults to the latest listing.',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['shopify.engineering/', 'shopify.engineering/latest'],
+            target: '/engineering',
+        },
+        {
+            source: ['shopify.engineering/topics/:topic'],
+            target: '/engineering/:topic',
+        },
+    ],
+    name: 'Engineering',
+    maintainers: ['zhsama'],
+    handler,
+    url: 'shopify.engineering/latest',
+};
+
+async function handler(ctx): Promise<Data> {
+    const topic = ctx.req.param('topic');
+    const limit = ctx.req.query('limit') ? Number(ctx.req.query('limit')) : 20;
+    const link = topic ? `${baseUrl}/topics/${topic}` : `${baseUrl}/latest`;
+
+    const response = await ofetch(link);
+    const $ = load(response);
+
+    const list: DataItem[] = $('article.article--index')
+        .toArray()
+        .map((element) => {
+            const $item = $(element);
+            const $title = $item.find('a.font-aktivgroteskextended').first();
+            const href = $title.attr('href') ?? $item.find('a[href^="/"]').not('[href^="/topics/"]').first().attr('href');
+            const dateText = $item.find('.blogPost .richtext').last().text();
+            const category = $item.find('a[href^="/topics/"]').first().text();
+
+            return {
+                title: $title.text(),
+                link: href ? new URL(href, baseUrl).href : undefined,
+                pubDate: dateText ? parseDate(dateText, ['MMM D, YYYY', 'YYYY-MM-DD']) : undefined,
+                category: category ? [category] : undefined,
+            };
+        })
+        .filter((item) => item.title && item.link)
+        .slice(0, limit);
+
+    const items = await pMap(
+        list,
+        (item) =>
+            cache.tryGet(item.link!, async () => {
+                const detail = await ofetch(item.link!);
+                const $detail = load(detail);
+
+                const published = $detail('meta[itemprop="datePublished"]').attr('content');
+                if (published) {
+                    item.pubDate = parseDate(published);
+                }
+
+                const authors = $detail('[itemprop="author"] [itemprop="name"]')
+                    .toArray()
+                    .map((el) => $detail(el).text())
+                    .filter(Boolean);
+                if (authors.length > 0) {
+                    item.author = authors.join(', ');
+                }
+
+                const headline = $detail('h1[itemprop="headline"]').text();
+                if (headline) {
+                    item.title = headline;
+                }
+
+                const image = $detail('meta[property="og:image"]').attr('content');
+                if (image) {
+                    item.image = image;
+                }
+
+                const content = $detail('[itemprop="articleBody"]');
+                content.find('.hidden, .leadpage-container').remove();
+                item.description = content.html() ?? $detail('meta[property="og:description"]').attr('content');
+
+                return item;
+            }),
+        { concurrency: 5 }
+    );
+
+    return {
+        title: topic ? $('title').text() : 'Shopify Engineering',
+        link,
+        description: $('meta[name="description"]').attr('content'),
+        image: 'https://cdn.shopify.com/b/shopify-brochure2-assets/c97c60ca19c64a8b5378d9f9e971f7bd.png',
+        language: 'en-us',
+        item: items,
+    };
+}

--- a/lib/routes/shopify/engineering.ts
+++ b/lib/routes/shopify/engineering.ts
@@ -47,19 +47,21 @@ async function handler(ctx): Promise<Data> {
     const response = await ofetch(link);
     const $ = load(response);
 
-    const list: DataItem[] = $('article.article--index')
+    const list: DataItem[] = $('main article')
         .toArray()
         .map((element) => {
             const $item = $(element);
-            const $title = $item.find('a.font-aktivgroteskextended');
-            const href = $title.attr('href') ?? $item.find('a[href^="/"]').not('[href^="/topics/"]').attr('href');
-            const dateText = $item.find('.blogPost .richtext').text();
+            // Reason: Semantic links survive changes to the site's presentation classes.
+            const $title = $item
+                .find('a[href^="/"]')
+                .not('[href^="/topics/"]')
+                .filter((_, link) => /\S/.test($(link).text()));
+            const href = $title.attr('href');
             const category = $item.find('a[href^="/topics/"]').text();
 
             return {
                 title: $title.text(),
                 link: href ? new URL(href, baseUrl).href : undefined,
-                pubDate: dateText ? parseDate(dateText, ['MMM D, YYYY', 'YYYY-MM-DD']) : undefined,
                 category: category ? [category] : undefined,
             };
         })
@@ -72,22 +74,23 @@ async function handler(ctx): Promise<Data> {
                 const detail = await ofetch(item.link!);
                 const $detail = load(detail);
 
-                const published = $detail('meta[itemprop="datePublished"]').attr('content');
+                const $article = $detail('article[itemtype="https://schema.org/Article"]');
+                const published = $article.find('meta[itemprop="datePublished"]').attr('content');
                 const authors = [
                     ...new Set(
-                        $detail('[itemprop="author"] [itemprop="name"]')
+                        $article
+                            .find('a[href^="/authors/"]')
                             .toArray()
                             .map((el) => $detail(el).text())
                             .filter(Boolean)
                     ),
                 ];
-
-                const content = $detail('[itemprop="articleBody"]');
+                const content = $article.find('[itemprop="articleBody"]');
                 content.find('.hidden, .leadpage-container').remove();
 
                 return {
                     ...item,
-                    title: $detail('h1[itemprop="headline"]').text() || item.title,
+                    title: $article.find('[itemprop="headline"]').text() || item.title,
                     description: content.html() ?? $detail('meta[property="og:description"]').attr('content'),
                     pubDate: published ? parseDate(published) : item.pubDate,
                     author: authors.join(', ') || undefined,

--- a/lib/routes/shopify/engineering.ts
+++ b/lib/routes/shopify/engineering.ts
@@ -1,5 +1,4 @@
 import { load } from 'cheerio';
-import pMap from 'p-map';
 
 import type { Data, DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
@@ -52,10 +51,10 @@ async function handler(ctx): Promise<Data> {
         .toArray()
         .map((element) => {
             const $item = $(element);
-            const $title = $item.find('a.font-aktivgroteskextended').first();
-            const href = $title.attr('href') ?? $item.find('a[href^="/"]').not('[href^="/topics/"]').first().attr('href');
-            const dateText = $item.find('.blogPost .richtext').last().text();
-            const category = $item.find('a[href^="/topics/"]').first().text();
+            const $title = $item.find('a.font-aktivgroteskextended');
+            const href = $title.attr('href') ?? $item.find('a[href^="/"]').not('[href^="/topics/"]').attr('href');
+            const dateText = $item.find('.blogPost .richtext').text();
+            const category = $item.find('a[href^="/topics/"]').text();
 
             return {
                 title: $title.text(),
@@ -67,43 +66,35 @@ async function handler(ctx): Promise<Data> {
         .filter((item) => item.title && item.link)
         .slice(0, limit);
 
-    const items = await pMap(
-        list,
-        (item) =>
+    const items = await Promise.all(
+        list.map((item) =>
             cache.tryGet(item.link!, async () => {
                 const detail = await ofetch(item.link!);
                 const $detail = load(detail);
 
                 const published = $detail('meta[itemprop="datePublished"]').attr('content');
-                if (published) {
-                    item.pubDate = parseDate(published);
-                }
-
-                const authors = $detail('[itemprop="author"] [itemprop="name"]')
-                    .toArray()
-                    .map((el) => $detail(el).text())
-                    .filter(Boolean);
-                if (authors.length > 0) {
-                    item.author = authors.join(', ');
-                }
-
-                const headline = $detail('h1[itemprop="headline"]').text();
-                if (headline) {
-                    item.title = headline;
-                }
-
-                const image = $detail('meta[property="og:image"]').attr('content');
-                if (image) {
-                    item.image = image;
-                }
+                const authors = [
+                    ...new Set(
+                        $detail('[itemprop="author"] [itemprop="name"]')
+                            .toArray()
+                            .map((el) => $detail(el).text())
+                            .filter(Boolean)
+                    ),
+                ];
 
                 const content = $detail('[itemprop="articleBody"]');
                 content.find('.hidden, .leadpage-container').remove();
-                item.description = content.html() ?? $detail('meta[property="og:description"]').attr('content');
 
-                return item;
-            }),
-        { concurrency: 5 }
+                return {
+                    ...item,
+                    title: $detail('h1[itemprop="headline"]').text() || item.title,
+                    description: content.html() ?? $detail('meta[property="og:description"]').attr('content'),
+                    pubDate: published ? parseDate(published) : item.pubDate,
+                    author: authors.join(', ') || undefined,
+                    image: $detail('meta[property="og:image"]').attr('content') || undefined,
+                };
+            })
+        )
     );
 
     return {


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/shopify/engineering
/shopify/engineering/mobile
/shopify/engineering/ai-machine-learning
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

`shopify.engineering` no longer exposes `/blog.atom` or other common feed paths (all 404). The listing pages are SSR HTML.

This route scrapes `/latest` (or `/topics/:topic`) and hydrates each item from `itemprop=articleBody` / `datePublished` / author.

Local verification in a Dev Container (`pnpm dev`):

- `/shopify/engineering`: 19/19 articles from `/latest`, each with title, unique link, `pubDate`, author, and full HTML body; titles match live `h1[itemprop=headline]`
- `/shopify/engineering/mobile`: 200, 20 items (default `limit`)
- `/shopify/engineering/ai-machine-learning`: 200, 18 items
- `?format=json`: 19 items