### PR TITLE
fix(route): add browser fallback for Discourse RSS 403

### DIFF
--- a/docker-compose.linuxdo.yml
+++ b/docker-compose.linuxdo.yml
@@ -1,0 +1,67 @@
+services:
+  rsshub:
+    build:
+      context: .
+      args:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "0"
+    image: rsshub-linuxdo:local
+    container_name: rsshub
+    restart: unless-stopped
+    ports:
+      - "1200:1200"
+    environment:
+      NODE_ENV: production
+      CACHE_EXPIRE: "1800"
+      CACHE_CONTENT_EXPIRE: "3600"
+      REQUEST_TIMEOUT: "30000"
+      REQUEST_RETRY: "1"
+      CACHE_TYPE: redis
+      REDIS_URL: redis://redis:6379/
+      LOGGER_LEVEL: info
+      ACCESS_KEY: ${RSSHUB_ACCESS_KEY:-}
+      DISCOURSE_CONFIG_0: '{"link":"https://linux.do"}'
+    shm_size: "1gb"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - curl
+        - -f
+        - http://localhost:1200/healthz
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - rsshub
+
+  redis:
+    image: redis:alpine
+    container_name: rsshub-redis
+    restart: unless-stopped
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    networks:
+      - rsshub
+
+networks:
+  rsshub:
+    driver: bridge
+
+volumes:
+  redis-data:

--- a/lib/routes/discourse/official.test.ts
+++ b/lib/routes/discourse/official.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { destroyMock, getPlaywrightPageMock, gotMock, responseTextMock, gotoMock } = vi.hoisted(() => ({
+    destroyMock: vi.fn(),
+    getPlaywrightPageMock: vi.fn(),
+    gotMock: vi.fn(),
+    responseTextMock: vi.fn(),
+    gotoMock: vi.fn(),
+}));
+
+vi.mock('@/utils/got', () => ({
+    default: gotMock,
+}));
+
+vi.mock('@/utils/playwright', () => ({
+    getPlaywrightPage: getPlaywrightPageMock,
+}));
+
+import { fetchOfficialRss } from './official';
+
+describe('Discourse official RSS', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        destroyMock.mockResolvedValue(undefined);
+        responseTextMock.mockResolvedValue('<rss>browser</rss>');
+        gotoMock.mockResolvedValue({
+            ok: () => true,
+            status: () => 200,
+            text: responseTextMock,
+        });
+        getPlaywrightPageMock.mockResolvedValue({
+            destroy: destroyMock,
+            page: {
+                goto: gotoMock,
+            },
+        });
+    });
+
+    it('uses the normal HTTP response without launching Chromium', async () => {
+        gotMock.mockResolvedValue({ data: '<rss>http</rss>' });
+
+        await expect(fetchOfficialRss('https://example.com/latest.rss', 'secret')).resolves.toBe('<rss>http</rss>');
+        expect(gotMock).toHaveBeenCalledWith('https://example.com/latest.rss', {
+            headers: {
+                'User-Api-Key': 'secret',
+            },
+        });
+        expect(getPlaywrightPageMock).not.toHaveBeenCalled();
+    });
+
+    it('does not send User-Api-Key when the configured key is empty', async () => {
+        gotMock.mockResolvedValue({ data: '<rss>http</rss>' });
+
+        await fetchOfficialRss('https://example.com/latest.rss', '');
+
+        expect(gotMock).toHaveBeenCalledWith('https://example.com/latest.rss', {
+            headers: undefined,
+        });
+    });
+
+    it('falls back to Chromium when the HTTP request returns 403', async () => {
+        const forbidden = Object.assign(new Error('403 Forbidden'), {
+            response: {
+                status: 403,
+            },
+        });
+        gotMock.mockRejectedValue(forbidden);
+
+        await expect(fetchOfficialRss('https://linux.do/c/news/34.rss')).resolves.toBe('<rss>browser</rss>');
+        expect(getPlaywrightPageMock).toHaveBeenCalledWith('https://linux.do/c/news/34.rss', {
+            closeTimeout: 45_000,
+            noGoto: true,
+        });
+        expect(gotoMock).toHaveBeenCalledWith('https://linux.do/c/news/34.rss', {
+            timeout: 30_000,
+            waitUntil: 'domcontentloaded',
+        });
+        expect(destroyMock).toHaveBeenCalledOnce();
+    });
+
+    it('keeps the original 403 when the browser fallback is unavailable', async () => {
+        const forbidden = Object.assign(new Error('403 Forbidden'), {
+            response: {
+                status: 403,
+            },
+        });
+        gotMock.mockRejectedValue(forbidden);
+        getPlaywrightPageMock.mockRejectedValue(new Error('Chromium executable not found'));
+
+        await expect(fetchOfficialRss('https://example.com/latest.rss')).rejects.toBe(forbidden);
+    });
+});

--- a/lib/routes/discourse/official.ts
+++ b/lib/routes/discourse/official.ts
@@ -1,5 +1,7 @@
 import type { Data, Route } from '@/types';
 import got from '@/utils/got';
+import logger from '@/utils/logger';
+import { getPlaywrightPage } from '@/utils/playwright';
 import RSSParser from '@/utils/rss-parser';
 
 import { getConfig } from './utils';
@@ -30,21 +32,67 @@ export const route: Route = {
     handler,
 };
 
+const getResponseStatus = (error: unknown) => (error as { response?: { status?: number } })?.response?.status;
+
+const fetchOfficialRssWithBrowser = async (url: string) => {
+    const { destroy, page } = await getPlaywrightPage(url, {
+        closeTimeout: 45_000,
+        noGoto: true,
+    });
+
+    try {
+        const response = await page.goto(url, {
+            timeout: 30_000,
+            waitUntil: 'domcontentloaded',
+        });
+
+        if (!response) {
+            throw new Error(`Discourse browser mode returned no response for ${url}`);
+        }
+
+        if (!response.ok()) {
+            throw new Error(`Discourse browser mode returned HTTP ${response.status()} for ${url}`);
+        }
+
+        return await response.text();
+    } finally {
+        await destroy();
+    }
+};
+
+export const fetchOfficialRss = async (url: string, key?: string) => {
+    try {
+        return (
+            await got(url, {
+                headers: key
+                    ? {
+                          'User-Api-Key': key,
+                      }
+                    : undefined,
+            })
+        ).data;
+    } catch (error) {
+        if (getResponseStatus(error) !== 403) {
+            throw error;
+        }
+
+        logger.warn(`[discourse/official] HTTP request returned 403, falling back to browser mode: ${url}`);
+
+        try {
+            return await fetchOfficialRssWithBrowser(url);
+        } catch (browserError) {
+            logger.warn(`[discourse/official] browser fallback failed for ${url}: ${browserError}`);
+            throw error;
+        }
+    }
+};
+
 async function handler(ctx) {
-    const { link, key } = getConfig(ctx) as unknown as { link: string; key: string };
+    const { link, key } = getConfig(ctx) as unknown as { link: string; key?: string };
     const path = ctx.req.param('path');
 
     const url = `${link}/${path}.rss`;
-
-    const feed = await RSSParser.parseString(
-        (
-            await got(url, {
-                headers: {
-                    'User-Api-Key': key,
-                },
-            })
-        ).data
-    );
+    const feed = await RSSParser.parseString(await fetchOfficialRss(url, key));
 
     feed.items = feed.items.map((e) => ({
         description: e.content,


### PR DESCRIPTION
## What changed

- omit `User-Api-Key` when no Discourse API key is configured
- keep normal HTTP fetching as the fast path
- retry Discourse official RSS through Patchright/Chromium only when the upstream returns HTTP 403
- preserve the original HTTP error if browser fallback is unavailable or fails
- add focused Vitest coverage for HTTP success, empty key handling, 403 fallback, and browser-unavailable behavior
- add an example `docker-compose.linuxdo.yml` that builds with bundled Chromium for LinuxDo deployments

## Reproduction

On a real RSSHub deployment using `diygod/rsshub:chromium-bundled` and the same public egress IP:

- Node `fetch("https://linux.do/c/news/34.rss")` -> 403, Cloudflare `Just a moment...`
- Patchright + bundled Chromium `page.goto("https://linux.do/c/news/34.rss")` -> 200, `application/rss+xml`, valid RSS XML

No login, cookie, API key, or homepage warm-up was required for the browser request.

## Deployment

```bash
docker compose -f docker-compose.linuxdo.yml build
docker compose -f docker-compose.linuxdo.yml up -d
```

Route:

```text
/discourse/0/official/c/news/34
```

## Validation

GitHub Actions on this PR are the authoritative CI validation.