### PR TITLE
fix(route/secretsanfrancisco): request JSON explicitly from WP REST API

### DIFF
--- a/lib/routes/secretsanfrancisco/rss.tsx
+++ b/lib/routes/secretsanfrancisco/rss.tsx
@@ -44,6 +44,7 @@ async function handler(ctx) {
         category = await cache.tryGet(`${baseUrl}${categoryApiPath}`, async () => {
             const { data } = await got(`${baseUrl}${categoryApiPath}`, {
                 searchParams: { slug: categorySlug },
+                headers: { accept: 'application/json' },
             });
             if (!data || data.length === 0) {
                 throw new Error(`Category "${categorySlug}" not found`);
@@ -64,6 +65,7 @@ async function handler(ctx) {
             _embed: '',
             ...(categoryId && { categories: categoryId }),
         },
+        headers: { accept: 'application/json' },
     });
 
     const items = postsResponse.data


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/secretsanfrancisco
/secretsanfrancisco/top-news
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

On some deployments the route fails with `TypeError: (intermediate value).data.filter is not a function`.

RSSHub's default browser-like request headers (`Accept: text/html,...`, `sec-fetch-dest: document`, `sec-fetch-mode: navigate`) can cause the site's CloudFront/WordPress edge to serve the HTML homepage instead of the `/wp-json/wp/v2/*` JSON response, so `.data` ends up as a string. Verified inside the affected container: overriding `accept` to `application/json` restores the expected array and the route renders.

This PR sets `headers: { accept: 'application/json' }` on both REST API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)