### PR TITLE
fix(route/anthropic): honor limit in research to cap detail fetches

### DIFF
--- a/lib/routes/anthropic/research.ts
+++ b/lib/routes/anthropic/research.ts
@@ -22,10 +22,11 @@ export const route: Route = {
     url: 'www.anthropic.com/research',
 };
 
-async function handler() {
+async function handler(ctx) {
     const link = 'https://www.anthropic.com/research';
     const response = await ofetch(link);
     const $ = load(response);
+    const limit = ctx.req.query('limit') ? Number(ctx.req.query('limit')) : 20;
 
     // self.__next_f.push
     const regexp = /self\.__next_f\.push\((.+)\)/;
@@ -70,6 +71,7 @@ async function handler() {
     const publicationSections = sections.filter((section) => section?.title === 'Publications');
     const posts = publicationSections
         .flatMap((section) => section?.posts ?? [])
+        .slice(0, limit)
         .map((post): DataItem => ({
             title: post.title,
             link: `https://www.anthropic.com/research/${post.slug.current}`,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

None

## Example for the Proposed Route(s) / 路由地址示例

```routes
/anthropic/research
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This is a fix to an existing route, not a new one. Date handling is unchanged.

`/anthropic/research` reads the Publications section out of the page's Next.js flight data and then fetches the article page for **every** entry in it via `pMap(..., { concurrency: 5 })`. That section currently holds 162 entries, so a single feed request fans out to 160+ requests against anthropic.com. In practice the route does not finish: on a public instance it returns 504 after 60s.

The two sibling routes in the same namespace already guard against this by reading the common `limit` parameter and slicing before the detail fetch:

- `/anthropic/engineering` — `ctx.req.query('limit') ? Number(...) : 20`
- `/anthropic/news` — `ctx.req.query('limit') ? Number(...) : 10`

This PR does the same for `/anthropic/research`, with a default of 20 to match `engineering`. The slice is applied before `pMap`, so the cap reduces upstream requests instead of only truncating the emitted feed the way the middleware's `limit` does.

The Publications section is ordered newest-first and there is exactly one section with that title, so slicing after `flatMap` keeps the most recent entries.

### Verification

Local `tsx lib/index.ts` against the patched route:

| request | result |
| --- | --- |
| `/anthropic/research?limit=5` | 200, 5 items, 1.5s |
| `/anthropic/research` (default) | 200, 20 items, 3.1s |

Items come back newest-first with correct `pubDate` values (2026-08-18, 2026-08-13, 2026-08-12, 2026-08-10, 2026-07-28 for `limit=5`).

`oxfmt --check`, `oxlint --type-aware`, and `tsc --noEmit` all pass.

I did not run the unpatched route locally to produce a "before" number, since that means sending 160+ requests to anthropic.com purely for a measurement. The 504 above is from a public instance.
