### PR TITLE
feat(route/br-klassik): add Aktuell (News & Kritik) feed

### DIFF
--- a/lib/routes/br-klassik/aktuell.ts
+++ b/lib/routes/br-klassik/aktuell.ts
@@ -1,0 +1,54 @@
+import type { Route } from '@/types';
+
+import { getArticle, getList } from './utils';
+
+const baseUrl = 'https://www.br-klassik.de';
+
+export const route: Route = {
+    path: '/aktuell',
+    categories: ['traditional-media'],
+    example: '/br-klassik/aktuell',
+    parameters: {},
+    features: {
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+        requireConfig: false,
+    },
+    name: 'Aktuell (News & Kritik)',
+    maintainers: ['wongJG'],
+    handler,
+    description: 'News und Kritik aus der Welt der Klassischen Musik.',
+    radar: [
+        {
+            source: ['www.br-klassik.de/aktuell/index.html'],
+            target: '/aktuell',
+        },
+    ],
+};
+
+async function handler(ctx) {
+    const list = await getList('/aktuell/index.html');
+
+    const items = await Promise.all(
+        list.slice(0, ctx.limit).map(async (item) => {
+            const detail = await getArticle(item.link);
+            return {
+                title: item.title,
+                link: item.link,
+                description: detail.description || item.description,
+                pubDate: detail.pubDate,
+                author: detail.author,
+            };
+        })
+    );
+
+    return {
+        title: 'BR-Klassik | Aktuell',
+        link: `${baseUrl}/aktuell/index.html`,
+        description: 'News und Kritik aus der Welt der Klassischen Musik',
+        item: items,
+    };
+}

--- a/lib/routes/br-klassik/namespace.ts
+++ b/lib/routes/br-klassik/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'BR-Klassik',
+    url: 'br-klassik.de',
+    lang: 'de',
+    categories: ['traditional-media'],
+};

--- a/lib/routes/br-klassik/utils.ts
+++ b/lib/routes/br-klassik/utils.ts
@@ -1,0 +1,76 @@
+import { load } from 'cheerio';
+
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const baseUrl = 'https://www.br-klassik.de';
+
+interface BrListItem {
+    link: string;
+    title: string;
+    description: string;
+}
+
+export const getList = async (path: string): Promise<BrListItem[]> => {
+    const html = await ofetch(`${baseUrl}${path}`);
+    const $ = load(html);
+    const items: BrListItem[] = [];
+    const seen = new Set<string>();
+
+    $('.br-teaser a.br-internal').each((_, elem) => {
+        const $elem = $(elem);
+        const href = $elem.attr('href');
+        if (!href || !href.endsWith('-100.html')) {
+            return;
+        }
+        const link = new URL(href, baseUrl).href;
+        if (seen.has(link)) {
+            return;
+        }
+        seen.add(link);
+
+        const headline = $elem.find('h4.br-headline').text().trim();
+        const title = $elem.find('p.br-title').text().trim();
+        const description = $elem.find('p.br-text').text().trim();
+        const itemTitle = [headline, title].filter(Boolean).join(': ');
+
+        items.push({
+            link,
+            title: itemTitle,
+            description,
+        });
+    });
+
+    return items;
+};
+
+export const getArticle = (link: string) =>
+    cache.tryGet(link, async () => {
+        const html = await ofetch(link);
+        const $ = load(html);
+
+        const $article = $('.br-article').clone();
+        $article.find('.br-audio, .br-textbox, .br-social-footer, .br-comments, .br-footer, script, style, .br-info, .br-credits').remove();
+        $article
+            .find('p')
+            .filter((_, elem) => {
+                const text = $(elem).text();
+                return text.includes('Autorin des Artikels') || text.includes('Autor des Artikels');
+            })
+            .remove();
+
+        const description = $article.html()?.trim() ?? '';
+
+        const authorDate = $('.br-authordate').text().trim();
+        const dateMatch = authorDate.match(/(\d{2})\.(\d{2})\.(\d{4})/);
+        const pubDate = dateMatch ? parseDate(`${dateMatch[3]}-${dateMatch[2]}-${dateMatch[1]}`) : undefined;
+        const authorMatch = authorDate.match(/von\s+(\S.*)$/);
+        const author = authorMatch ? authorMatch[1].trim() : undefined;
+
+        return {
+            description,
+            pubDate,
+            author,
+        };
+    });


### PR DESCRIPTION
## Proposed Route(s) / 路由地址

```routes
/br-klassik/aktuell
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds a new br-klassik namespace with an Aktuell (News & Kritik) route that
scrapes https://www.br-klassik.de/aktuell/index.html. Teasers are extracted
from .br-teaser a.br-internal (deduplicated by link), and each article is
fetched once (cached via cache.tryGet) to retrieve the full body, pubDate
(br-authordate, DD.MM.YYYY) and author.