### PR TITLE
feat(route): add Kosmo Foto

### DIFF
--- a/lib/routes/kosmofoto/index.tsx
+++ b/lib/routes/kosmofoto/index.tsx
@@ -22,7 +22,7 @@ const api = (path: string, query: Record<string, string | number>) =>
 // Images are served through Jetpack Photon with a resize query (696px wide); without the query the original is served
 const cleanContent = (html: string): string => {
     const $ = load(html, null, false);
-    $('img').each((_, el) => {
+    $('img, iframe').each((_, el) => {
         const $img = $(el);
         const src = $img.attr('src');
         // Jetpack Photon (i0.wp.com) serves a resized variant; without the query string the original is served

--- a/lib/routes/kosmofoto/index.tsx
+++ b/lib/routes/kosmofoto/index.tsx
@@ -1,0 +1,138 @@
+import { load } from 'cheerio';
+import { decodeHTML } from 'entities';
+import { raw } from 'hono/html';
+import { renderToString } from 'hono/jsx/dom/server';
+
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { DataItem, Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const baseUrl = 'https://kosmofoto.com';
+
+const api = (path: string, query: Record<string, string | number>) =>
+    ofetch(`${baseUrl}/wp-json/wp/v2/${path}`, {
+        query,
+        // the default browser-like Accept header can make WordPress serve the HTML page instead of JSON
+        headers: { accept: 'application/json' },
+    });
+
+// Images are served through Jetpack Photon with a resize query (696px wide); without the query the original is served
+const cleanContent = (html: string): string => {
+    const $ = load(html, null, false);
+    $('img').each((_, el) => {
+        const $img = $(el);
+        const src = $img.attr('src');
+        if (src?.includes('.wp.com/')) {
+            $img.attr('src', src.split('?', 1)[0]);
+        }
+        $img.removeAttr('srcset').removeAttr('sizes').removeAttr('loading').removeAttr('decoding').removeAttr('data-recalc-dims').removeAttr('width').removeAttr('height');
+    });
+    return $.html();
+};
+
+export const route: Route = {
+    path: '/:category?',
+    categories: ['picture'],
+    view: ViewType.Articles,
+    example: '/kosmofoto/news',
+    parameters: { category: 'Category slug, see the table below or the URL of a category page. All posts by default' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['kosmofoto.com/', 'kosmofoto.com/category/:category', 'kosmofoto.com/category/:parent/:category'],
+            target: '/:category',
+        },
+    ],
+    name: 'Posts',
+    maintainers: ['IvanWng97'],
+    handler,
+    description: `The official feed only carries excerpts; this route returns the full post with all images.
+
+| Category           | Slug                   |
+| ------------------ | ---------------------- |
+| News               | \`news\`                 |
+| Film               | \`film-2\`               |
+| Featured           | \`featured\`             |
+| Analogue lifestyle | \`analogue-lifestyle-2\` |
+| Analogue Culture   | \`analogue-culture\`     |
+| Analogue History   | \`analogue-history\`     |
+| Camera reviews     | \`camera-review-2\`      |
+| Classic cameras    | \`classic-cameras\`      |
+| Vintage cameras    | \`vintage-cameras\`      |
+| Soviet cameras     | \`soviet-cameras\`       |
+| Lomography         | \`lomography\`           |
+| Kosmo Foto Mono    | \`kosmo-foto-mono\`      |`,
+};
+
+async function handler(ctx) {
+    const categorySlug = ctx.req.param('category');
+    const limit = Number(ctx.req.query('limit')) || 20;
+
+    const category = categorySlug
+        ? await cache.tryGet(`kosmofoto:category:${categorySlug}`, async () => {
+              const data = await api('categories', { slug: categorySlug });
+              if (!Array.isArray(data) || data.length === 0) {
+                  throw new InvalidParameterError(`Category "${categorySlug}" not found`);
+              }
+              return { id: data[0].id, name: decodeHTML(data[0].name), link: data[0].link };
+          })
+        : undefined;
+
+    // Rendering post bodies is slow on this site, so only list ids here and fetch each post separately, cached per post
+    const list = await api('posts', {
+        per_page: limit,
+        _fields: 'id,link',
+        ...(category && { categories: category.id }),
+    });
+    if (!Array.isArray(list)) {
+        throw new TypeError(`Unexpected response from the posts API: ${JSON.stringify(list).slice(0, 200)}`);
+    }
+
+    const items = await Promise.all(
+        list.map((entry) =>
+            cache.tryGet(entry.link, async () => {
+                const post = await api(`posts/${entry.id}`, { _embed: 'wp:featuredmedia,wp:term,author' });
+                const featured = post._embedded?.['wp:featuredmedia']?.find((media) => media.id === post.featured_media);
+                const image = featured?.source_url;
+
+                return {
+                    title: decodeHTML(post.title.rendered),
+                    link: post.link,
+                    // WordPress returns *_gmt without a timezone designator
+                    pubDate: parseDate(`${post.date_gmt}Z`),
+                    updated: parseDate(`${post.modified_gmt}Z`),
+                    author: post._embedded?.author?.[0]?.name,
+                    category: (post._embedded?.['wp:term'] ?? []).flat().map((term) => decodeHTML(term.name)),
+                    description: renderToString(
+                        <>
+                            {image ? (
+                                <figure>
+                                    <img src={image} alt={featured.alt_text || undefined} />
+                                    {featured.caption?.rendered ? <figcaption>{raw(featured.caption.rendered)}</figcaption> : null}
+                                </figure>
+                            ) : null}
+                            {raw(cleanContent(post.content.rendered))}
+                        </>
+                    ),
+                } as DataItem;
+            })
+        )
+    );
+
+    return {
+        title: category ? `Kosmo Foto - ${category.name}` : 'Kosmo Foto',
+        link: category?.link ?? baseUrl,
+        description: 'Film photography news, camera reviews and analogue culture.',
+        item: items as DataItem[],
+    };
+}

--- a/lib/routes/kosmofoto/index.tsx
+++ b/lib/routes/kosmofoto/index.tsx
@@ -50,8 +50,7 @@ export const route: Route = {
     },
     radar: [
         {
-            source: ['kosmofoto.com/', 'kosmofoto.com/category/:category', 'kosmofoto.com/category/:parent/:category'],
-            target: '/:category',
+            source: ['kosmofoto.com/category/:category', 'kosmofoto.com/category/:parent/:category', 'kosmofoto.com/'],
         },
     ],
     name: 'Posts',

--- a/lib/routes/kosmofoto/index.tsx
+++ b/lib/routes/kosmofoto/index.tsx
@@ -25,7 +25,8 @@ const cleanContent = (html: string): string => {
     $('img').each((_, el) => {
         const $img = $(el);
         const src = $img.attr('src');
-        if (src?.includes('.wp.com/')) {
+        // Jetpack Photon (i0.wp.com) serves a resized variant; without the query string the original is served
+        if (src && URL.canParse(src) && new URL(src).hostname.endsWith('.wp.com')) {
             $img.attr('src', src.split('?', 1)[0]);
         }
         $img.removeAttr('srcset').removeAttr('sizes').removeAttr('loading').removeAttr('decoding').removeAttr('data-recalc-dims').removeAttr('width').removeAttr('height');

--- a/lib/routes/kosmofoto/namespace.ts
+++ b/lib/routes/kosmofoto/namespace.ts
@@ -1,0 +1,9 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Kosmo Foto',
+    url: 'kosmofoto.com',
+    categories: ['picture'],
+    description: 'Film photography news, camera reviews and analogue culture.',
+    lang: 'en',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/kosmofoto
/kosmofoto/news
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

The official feed only carries excerpts. This route reads the WordPress REST API and returns the full post with all images, author and categories, optionally filtered by category slug.

Post bodies are slow to render on this site, so ids are listed first and each post is fetched separately with `cache.tryGet`. Images are served through Jetpack Photon with a 696px resize query; the query is stripped so the original image is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)