### PR TITLE
feat(route): add Fraenkel Gallery

### DIFF
--- a/lib/routes/fraenkelgallery/index.tsx
+++ b/lib/routes/fraenkelgallery/index.tsx
@@ -1,0 +1,113 @@
+import { load } from 'cheerio';
+import { decodeHTML } from 'entities';
+import { raw } from 'hono/html';
+import { renderToString } from 'hono/jsx/dom/server';
+
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { DataItem, Route } from '@/types';
+import { ViewType } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const baseUrl = 'https://fraenkelgallery.com';
+
+const types = {
+    exhibitions: { endpoint: 'fraenkel_exhibition', title: 'Exhibitions', link: `${baseUrl}/exhibitions` },
+    posts: { endpoint: 'posts', title: 'Conversations', link: `${baseUrl}/conversations` },
+};
+
+// Drop the sales-enquiry buttons and use the original image behind the Jetpack Photon resize query
+const cleanContent = (html: string): string => {
+    const $ = load(html, null, false);
+    $('.block--button').remove();
+    $('img').each((_, el) => {
+        const $img = $(el);
+        const src = $img.attr('src');
+        if (src?.includes('.wp.com/')) {
+            $img.attr('src', src.split('?', 1)[0]);
+        }
+        $img.removeAttr('srcset').removeAttr('sizes').removeAttr('loading').removeAttr('decoding').removeAttr('width').removeAttr('height');
+    });
+    return $.html();
+};
+
+export const route: Route = {
+    path: '/:type?',
+    categories: ['picture'],
+    view: ViewType.Pictures,
+    example: '/fraenkelgallery/exhibitions',
+    parameters: { type: '`exhibitions` (default) or `posts` (the Conversations blog)' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['fraenkelgallery.com/exhibitions', 'fraenkelgallery.com/'],
+            target: '/exhibitions',
+        },
+        {
+            source: ['fraenkelgallery.com/conversations'],
+            target: '/posts',
+        },
+    ],
+    name: 'Exhibitions & Conversations',
+    maintainers: ['IvanWng97'],
+    handler,
+    description: 'Exhibitions come with artist, year, type and status as categories and the full exhibition page including all images.',
+};
+
+async function handler(ctx) {
+    const type = ctx.req.param('type') ?? 'exhibitions';
+    const config = types[type as keyof typeof types];
+    if (!config) {
+        throw new InvalidParameterError(`Unknown type "${type}", expected one of ${Object.keys(types).join(', ')}`);
+    }
+    const { endpoint, title, link } = config;
+    const limit = Number(ctx.req.query('limit')) || 20;
+
+    const entries = await ofetch(`${baseUrl}/wp-json/wp/v2/${endpoint}`, {
+        query: { per_page: limit, _embed: 'wp:featuredmedia,wp:term' },
+        // the default browser-like Accept header can make WordPress serve the HTML page instead of JSON
+        headers: { accept: 'application/json' },
+    });
+    if (!Array.isArray(entries)) {
+        throw new TypeError(`Unexpected response from the ${endpoint} API: ${JSON.stringify(entries).slice(0, 200)}`);
+    }
+
+    const items: DataItem[] = entries.map((entry) => {
+        const featured = entry._embedded?.['wp:featuredmedia']?.find((media) => media.id === entry.featured_media);
+        const image = featured?.source_url;
+
+        return {
+            title: decodeHTML(entry.title.rendered),
+            link: entry.link,
+            // WordPress returns *_gmt without a timezone designator
+            pubDate: parseDate(`${entry.date_gmt}Z`),
+            updated: parseDate(`${entry.modified_gmt}Z`),
+            category: (entry._embedded?.['wp:term'] ?? []).flat().map((term) => decodeHTML(term.name)),
+            description: renderToString(
+                <>
+                    {image ? (
+                        <figure>
+                            <img src={image} alt={featured.alt_text || undefined} />
+                            {featured.caption?.rendered ? <figcaption>{raw(featured.caption.rendered)}</figcaption> : null}
+                        </figure>
+                    ) : null}
+                    {raw(cleanContent(entry.content.rendered))}
+                </>
+            ),
+        };
+    });
+
+    return {
+        title: `Fraenkel Gallery - ${title}`,
+        link,
+        description: 'Photography gallery in San Francisco: exhibitions and conversations.',
+        item: items,
+    };
+}

--- a/lib/routes/fraenkelgallery/index.tsx
+++ b/lib/routes/fraenkelgallery/index.tsx
@@ -20,7 +20,7 @@ const types = {
 const cleanContent = (html: string): string => {
     const $ = load(html, null, false);
     $('.block--button').remove();
-    $('img').each((_, el) => {
+    $('img, iframe').each((_, el) => {
         const $img = $(el);
         const src = $img.attr('src');
         // Jetpack Photon (i0.wp.com) serves a resized variant; without the query string the original is served

--- a/lib/routes/fraenkelgallery/index.tsx
+++ b/lib/routes/fraenkelgallery/index.tsx
@@ -23,7 +23,8 @@ const cleanContent = (html: string): string => {
     $('img').each((_, el) => {
         const $img = $(el);
         const src = $img.attr('src');
-        if (src?.includes('.wp.com/')) {
+        // Jetpack Photon (i0.wp.com) serves a resized variant; without the query string the original is served
+        if (src && URL.canParse(src) && new URL(src).hostname.endsWith('.wp.com')) {
             $img.attr('src', src.split('?', 1)[0]);
         }
         $img.removeAttr('srcset').removeAttr('sizes').removeAttr('loading').removeAttr('decoding').removeAttr('width').removeAttr('height');

--- a/lib/routes/fraenkelgallery/namespace.ts
+++ b/lib/routes/fraenkelgallery/namespace.ts
@@ -1,0 +1,9 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Fraenkel Gallery',
+    url: 'fraenkelgallery.com',
+    categories: ['picture'],
+    description: 'Photography gallery in San Francisco: exhibitions and conversations.',
+    lang: 'en',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/fraenkelgallery
/fraenkelgallery/exhibitions
/fraenkelgallery/posts
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fraenkel Gallery (San Francisco) publishes exhibitions as a custom post type (`fraenkel_exhibition`) that is not covered by the official feed. `/fraenkelgallery/exhibitions` (default) returns them with artist, year, type and status as categories and the full exhibition page with all images (Photon resize query stripped, sales-enquiry buttons removed). `/fraenkelgallery/posts` returns the Conversations blog with its featured image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)