### PR TITLE
fix(route/secretsanfrancisco): parse WordPress dates as UTC

### DIFF
--- a/lib/routes/secretsanfrancisco/rss.tsx
+++ b/lib/routes/secretsanfrancisco/rss.tsx
@@ -93,8 +93,9 @@ async function handler(ctx) {
                     </>
                 ),
                 link: item.link,
-                pubDate: parseDate(item.date_gmt),
-                updated: parseDate(item.modified_gmt),
+                // WordPress returns *_gmt without a timezone designator
+                pubDate: parseDate(`${item.date_gmt}Z`),
+                updated: parseDate(`${item.modified_gmt}Z`),
                 image,
                 author: item._embedded.author[0].name,
             };


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/secretsanfrancisco
/secretsanfrancisco/top-news
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

WordPress returns `date_gmt` / `modified_gmt` without a timezone designator (`2026-08-22T02:55:00`), so `parseDate` interprets them in the host's local timezone. Measured with this repo's own `parseDate`:

| `TZ` | `parseDate(date_gmt)` | `parseDate(`date_gmt` + `Z`)` |
| --- | --- | --- |
| `UTC` | `2026-08-22T02:55:00.000Z` | `2026-08-22T02:55:00.000Z` |
| `America/Los_Angeles` | `2026-08-22T09:55:00.000Z` | `2026-08-22T02:55:00.000Z` |
| `Asia/Shanghai` | `2026-08-21T18:55:00.000Z` | `2026-08-22T02:55:00.000Z` |

So every item's `pubDate` is shifted by the host's UTC offset on any non-UTC deployment. `fnal/news.ts` already uses the `${...}Z` form; this brings the route in line with it.

The earlier revision of this PR also dropped `item.image`; per review feedback that change has been removed and this PR is now the timezone fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)