### PR TITLE
feat(route): add OpenRouter discounted models route

### DIFF
--- a/lib/routes/openrouter/models.ts
+++ b/lib/routes/openrouter/models.ts
@@ -1,0 +1,162 @@
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+
+const baseUrl = 'https://openrouter.ai';
+
+/** Predefined ranking categories present on OpenRouter, mapping URL slug / API key to display label. */
+const categoryNames: Record<string, string> = {
+    programming: 'Programming',
+    finance: 'Finance',
+    legal: 'Legal',
+    health: 'Health',
+    marketing: 'Marketing',
+    'marketing/seo': 'SEO',
+    seo: 'SEO',
+    academia: 'Academia',
+    science: 'Science',
+    technology: 'Technology',
+    translation: 'Translation',
+    roleplay: 'Roleplay',
+    trivia: 'Trivia',
+};
+
+export const route: Route = {
+    path: '/models/:category?',
+    categories: ['programming'],
+    example: '/openrouter/models',
+    parameters: {
+        category: {
+            description:
+                'Filter discounted models by a ranking category. When omitted, all discounted models are returned in highest-to-lowest discount order. When a category is passed, models are filtered by that category and sorted by discount (high to low) with category ranking as secondary sort.',
+            default: 'All discounted models',
+            options: [
+                { value: 'programming', label: 'Programming' },
+                { value: 'finance', label: 'Finance' },
+                { value: 'legal', label: 'Legal' },
+                { value: 'health', label: 'Health' },
+                { value: 'marketing', label: 'Marketing' },
+                { value: 'seo', label: 'SEO' },
+                { value: 'academia', label: 'Academia' },
+                { value: 'science', label: 'Science' },
+                { value: 'technology', label: 'Technology' },
+                { value: 'translation', label: 'Translation' },
+                { value: 'roleplay', label: 'Roleplay' },
+                { value: 'trivia', label: 'Trivia' },
+            ],
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['openrouter.ai/models'],
+            target: '/openrouter/models',
+        },
+    ],
+    name: 'Discounted Models',
+    maintainers: ['codacy20'],
+    handler,
+};
+
+interface DiscountedModel {
+    name: string;
+    link: string;
+    description: string;
+    discount: number;
+    categories: string[];
+    rankByCategory: Record<string, number>;
+}
+
+async function handler(ctx) {
+    const { category } = ctx.req.param();
+    const rawRequested = (category ?? '').trim().toLowerCase();
+    const requested = rawRequested === 'seo' ? 'marketing/seo' : rawRequested;
+    const requestedCategory = categoryNames[rawRequested] ?? categoryNames[requested];
+    const isFiltered = requestedCategory !== undefined;
+
+    const cached = await cache.tryGet<DiscountedModel[]>('openrouter:discounted-models', fetchModels);
+
+    const models = isFiltered
+        ? [...cached].filter((model) => model.rankByCategory[requested] !== undefined).toSorted((a, b) => b.discount - a.discount || (a.rankByCategory[requested] ?? 0) - (b.rankByCategory[requested] ?? 0))
+        : [...cached];
+
+    const items = models.map((model) => ({
+        title: `${model.name} - ${Math.round(model.discount * 100)}% off`,
+        link: model.link,
+        description: model.description,
+        category: model.categories,
+    }));
+
+    return {
+        title: isFiltered ? `OpenRouter ${requestedCategory} discounted models` : 'OpenRouter discounted models',
+        link: `${baseUrl}/models?order=discount-high-to-low`,
+        item: items,
+    };
+}
+
+/** Fetches the discounted model list from OpenRouter frontend APIs. */
+async function fetchModels(): Promise<DiscountedModel[]> {
+    const [findResponse, catalogResponse] = await Promise.all([ofetch(`${baseUrl}/api/frontend/v1/models/find?active=true&fmt=cards&order=discount-high-to-low`), ofetch(`${baseUrl}/api/frontend/v1/catalog/models`)]);
+
+    const catModels = Array.isArray(catalogResponse?.data) ? catalogResponse.data : (catalogResponse?.data?.models ?? []);
+    const pricingMap = new Map<string, any>();
+    for (const cm of catModels) {
+        const pricing = cm.endpoint?.pricing;
+        if (pricing) {
+            if (cm.slug) {
+                pricingMap.set(cm.slug, pricing);
+            }
+            if (cm.permaslug) {
+                pricingMap.set(cm.permaslug, pricing);
+            }
+        }
+    }
+
+    const findModels = findResponse?.data?.models ?? [];
+    const categoriesMap = findResponse?.data?.categories ?? {};
+
+    const discountedModels: DiscountedModel[] = [];
+
+    for (const m of findModels) {
+        const slug = m.slug;
+        const permaslug = m.permaslug;
+        const pricing = pricingMap.get(slug) ?? pricingMap.get(permaslug) ?? {};
+        const discount = Number(pricing.discount ?? 0);
+
+        if (discount > 0) {
+            const rawCategories = categoriesMap[permaslug] ?? categoriesMap[slug] ?? [];
+            const rankByCategory: Record<string, number> = {};
+            const categories: string[] = [];
+
+            for (const cat of rawCategories) {
+                const catName = cat.category?.toLowerCase();
+                const rank = cat.rank;
+                if (catName) {
+                    rankByCategory[catName] = rank;
+                    const displayName = categoryNames[catName] ?? catName;
+                    if (!categories.includes(displayName)) {
+                        categories.push(displayName);
+                    }
+                }
+            }
+
+            discountedModels.push({
+                name: m.name,
+                link: `${baseUrl}/${slug}`,
+                description: m.description ?? '',
+                discount,
+                categories,
+                rankByCategory,
+            });
+        }
+    }
+
+    return discountedModels;
+}

--- a/lib/routes/openrouter/namespace.ts
+++ b/lib/routes/openrouter/namespace.ts
@@ -1,0 +1,8 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'OpenRouter',
+    url: 'openrouter.ai',
+    description: 'OpenRouter is a unified interface for hundreds of AI models, with transparent pricing, context windows, and active discounts.',
+    lang: 'en',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/openrouter/models
/openrouter/models/programming
/openrouter/models/finance
/openrouter/models/legal
/openrouter/models/health
/openrouter/models/marketing
/openrouter/models/seo
/openrouter/models/academia
/openrouter/models/science
/openrouter/models/technology
/openrouter/models/translation
/openrouter/models/roleplay
/openrouter/models/trivia
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add route for discounted models on OpenRouter (`https://openrouter.ai/models?order=discount-high-to-low`).

- **Sort Order:** Models are ordered strictly from highest discount to lowest (e.g. 90% down to 5%).
- **Category Filtering:** Supports optional ranking category filtering (e.g., `/openrouter/models/programming`, `/openrouter/models/finance`, `/openrouter/models/seo`, etc.) preserving discount priority with category ranking as secondary sort.
- **Data Source:** Uses OpenRouter frontend APIs (`/api/frontend/v1/models/find` and `/api/frontend/v1/catalog/models`) to retrieve accurate discount percentages, pricing details, and category rankings without browser automation overhead.
