### PR TITLE
feat(routes): add Guardian, FT, CNA, and Africanews categories

### DIFF
--- a/lib/routes/africanews/category.ts
+++ b/lib/routes/africanews/category.ts
@@ -1,0 +1,103 @@
+import { load } from 'cheerio';
+
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { DataItem, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.africanews.com';
+const sections: Record<string, { title: string; path: string; theme?: string }> = {
+    news: { title: 'News', path: '/news/', theme: 'news' },
+    business: { title: 'Business', path: '/business/', theme: 'business' },
+    markets: { title: 'Markets', path: '/business/markets/' },
+    'science-technology': { title: 'Science & Technology', path: '/science-technology/', theme: 'science_technology' },
+};
+
+export const route: Route = {
+    path: '/category/:section',
+    categories: ['traditional-media'],
+    example: '/africanews/category/news',
+    parameters: {
+        section: {
+            description: 'Section ID',
+            options: Object.entries(sections).map(([value, section]) => ({ value, label: section.title })),
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Category',
+    maintainers: ['kargonerd'],
+    handler,
+};
+
+async function handler(ctx) {
+    const sectionId = ctx.req.param('section');
+    const section = sections[sectionId];
+    if (!section) {
+        throw new InvalidParameterError(`Unsupported Africanews section: ${sectionId}`);
+    }
+    const limit = Math.min(Number.parseInt(ctx.req.query('limit') || '50'), 100);
+    const items = section.theme ? await fetchFeed(section, limit) : await fetchListing(section, limit);
+    return {
+        title: `Africanews - ${section.title}`,
+        link: new URL(section.path, rootUrl).href,
+        language: 'en' as const,
+        item: items,
+    };
+}
+
+async function fetchFeed(section: (typeof sections)[string], limit: number): Promise<DataItem[]> {
+    const feed = await parser.parseURL(`${rootUrl}/feed/rss?themes=${section.theme}`);
+    return feed.items.slice(0, limit).flatMap((item) =>
+        item.title && item.link
+            ? [
+                  {
+                      title: item.title,
+                      link: item.link,
+                      pubDate: item.isoDate ?? item.pubDate,
+                      description: item.content,
+                      author: item.creator,
+                      category: [section.title, ...(item.categories ?? [])],
+                  },
+              ]
+            : []
+    );
+}
+
+async function fetchListing(section: (typeof sections)[string], limit: number): Promise<DataItem[]> {
+    const currentUrl = new URL(section.path, rootUrl).href;
+    const html = await ofetch(currentUrl);
+    const $ = load(html);
+    const items = new Map<string, DataItem>();
+    $('a[href]').each((_, element) => {
+        if (items.size >= limit) {
+            return;
+        }
+        const href = $(element).attr('href');
+        if (!href) {
+            return;
+        }
+        const link = new URL(href, rootUrl);
+        const date = link.pathname.match(/^\/(20\d{2})\/(\d{2})\/(\d{2})\//);
+        if (!date) {
+            return;
+        }
+        items.set(link.href, {
+            title: $(element).text().trim(),
+            link: link.href,
+            pubDate: parseDate(`${date[1]}-${date[2]}-${date[3]}`),
+            category: [section.title],
+        });
+    });
+    return items
+        .values()
+        .filter((item) => item.title)
+        .toArray();
+}

--- a/lib/routes/africanews/namespace.ts
+++ b/lib/routes/africanews/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Africanews',
+    url: 'africanews.com',
+    lang: 'en',
+};

--- a/lib/routes/channelnewsasia/category.ts
+++ b/lib/routes/channelnewsasia/category.ts
@@ -1,0 +1,111 @@
+import { load } from 'cheerio';
+import pMap from 'p-map';
+
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.channelnewsasia.com';
+const sections: Record<string, { title: string; path: string; feedCategory?: string }> = {
+    'top-stories': { title: 'Top Stories', path: '/' },
+    asia: { title: 'Asia', path: '/asia', feedCategory: '6511' },
+    'east-asia': { title: 'East Asia', path: '/east-asia' },
+    singapore: { title: 'Singapore', path: '/singapore', feedCategory: '10416' },
+    world: { title: 'World', path: '/world', feedCategory: '6311' },
+    business: { title: 'Business', path: '/business', feedCategory: '6936' },
+};
+
+export const route: Route = {
+    path: '/category/:section',
+    categories: ['traditional-media'],
+    example: '/channelnewsasia/category/asia',
+    parameters: {
+        section: {
+            description: 'Section ID',
+            options: Object.entries(sections).map(([value, section]) => ({ value, label: section.title })),
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Category',
+    maintainers: ['kargonerd'],
+    handler,
+};
+
+async function handler(ctx) {
+    const sectionId = ctx.req.param('section');
+    const section = sections[sectionId];
+    if (!section) {
+        throw new InvalidParameterError(`Unsupported CNA section: ${sectionId}`);
+    }
+    const limit = Math.min(Number.parseInt(ctx.req.query('limit') || '20'), 50);
+    const items = sectionId === 'east-asia' ? await fetchEastAsia(section, limit) : await fetchFeed(section, limit);
+
+    return {
+        title: `CNA - ${section.title}`,
+        link: new URL(section.path, rootUrl).href,
+        language: 'en' as const,
+        item: items,
+    };
+}
+
+async function fetchFeed(section: (typeof sections)[string], limit: number): Promise<DataItem[]> {
+    const feedUrl = new URL('/api/v1/rss-outbound-feed?_format=xml', rootUrl);
+    if (section.feedCategory) {
+        feedUrl.searchParams.set('category', section.feedCategory);
+    }
+    const feed = await parser.parseURL(feedUrl.href);
+    return feed.items.slice(0, limit).flatMap((item) =>
+        item.title && item.link
+            ? [
+                  {
+                      title: item.title,
+                      link: item.link,
+                      pubDate: item.isoDate ?? item.pubDate,
+                      description: item.content,
+                      author: item.creator,
+                      category: [section.title, ...(item.categories ?? [])],
+                  },
+              ]
+            : []
+    );
+}
+
+async function fetchEastAsia(section: (typeof sections)[string], limit: number): Promise<DataItem[]> {
+    const currentUrl = new URL(section.path, rootUrl).href;
+    const html = await ofetch(currentUrl);
+    const $ = load(html);
+    const links = new Map<string, string>();
+    $('a[href^="/east-asia/"]').each((_, element) => {
+        if (links.size < limit) {
+            links.set(new URL($(element).attr('href')!, rootUrl).href, $(element).text().trim());
+        }
+    });
+    return pMap(
+        [...links],
+        ([link, listingTitle]) =>
+            cache.tryGet(link, async () => {
+                const detailHtml = await ofetch(link);
+                const detail = load(detailHtml);
+                const title = detail('meta[property="og:title"]').attr('content') ?? detail('h1').first().text().trim() ?? listingTitle;
+                const published = detail('meta[property="article:published_time"]').attr('content') ?? detail('time[datetime]').first().attr('datetime');
+                return {
+                    title,
+                    link,
+                    pubDate: published ? parseDate(published) : undefined,
+                    description: detail('[itemprop="articleBody"], article').first().html() ?? undefined,
+                    category: [section.title],
+                };
+            }),
+        { concurrency: 8 }
+    );
+}

--- a/lib/routes/channelnewsasia/namespace.ts
+++ b/lib/routes/channelnewsasia/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'CNA',
+    url: 'channelnewsasia.com',
+    lang: 'en',
+};

--- a/lib/routes/ft/category.ts
+++ b/lib/routes/ft/category.ts
@@ -1,0 +1,74 @@
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { DataItem, Route } from '@/types';
+import parser from '@/utils/rss-parser';
+
+const sections: Record<string, { title: string; feedPaths: string[] }> = {
+    world: { title: 'World', feedPaths: ['world'] },
+    'global-economy': { title: 'Global Economy', feedPaths: ['global-economy'] },
+    uk: { title: 'UK', feedPaths: ['uk-politics-policy', 'uk-business-economy'] },
+    us: { title: 'US', feedPaths: ['us'] },
+    china: { title: 'China', feedPaths: ['china'] },
+    africa: { title: 'Africa', feedPaths: ['africa'] },
+    'asia-pacific': { title: 'Asia Pacific', feedPaths: ['asia-pacific'] },
+    'emerging-markets': { title: 'Emerging Markets', feedPaths: ['emerging-markets'] },
+    europe: { title: 'Europe', feedPaths: ['europe'] },
+    americas: { title: 'Americas', feedPaths: ['americas'] },
+    'middle-east-north-africa': { title: 'Middle East & North Africa', feedPaths: ['middle-east-north-africa'] },
+};
+
+export const route: Route = {
+    path: '/category/:section',
+    categories: ['traditional-media'],
+    example: '/ft/category/china',
+    parameters: {
+        section: {
+            description: 'Section ID',
+            options: Object.entries(sections).map(([value, section]) => ({ value, label: section.title })),
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Category',
+    maintainers: ['kargonerd'],
+    handler,
+    description: 'Financial Times section feeds. Article pages are not fetched because they can require a subscription.',
+};
+
+async function handler(ctx) {
+    const sectionId = ctx.req.param('section');
+    const section = sections[sectionId];
+    if (!section) {
+        throw new InvalidParameterError(`Unsupported Financial Times section: ${sectionId}`);
+    }
+
+    const feeds = await Promise.all(section.feedPaths.map((path) => parser.parseURL(`https://www.ft.com/rss/${path}`)));
+    const items = new Map<string, DataItem>();
+    for (const feed of feeds) {
+        for (const item of feed.items) {
+            if (!item.title || !item.link || items.has(item.link)) {
+                continue;
+            }
+            items.set(item.link, {
+                title: item.title,
+                link: item.link,
+                pubDate: item.isoDate ?? item.pubDate,
+                description: item.content,
+                author: item.creator,
+                category: [...new Set([section.title, ...(item.categories ?? [])])],
+            });
+        }
+    }
+
+    return {
+        title: `Financial Times - ${section.title}`,
+        link: `https://www.ft.com/${sectionId}`,
+        language: 'en' as const,
+        item: items.values().toArray(),
+    };
+}

--- a/lib/routes/scmp/index.ts
+++ b/lib/routes/scmp/index.ts
@@ -75,7 +75,15 @@ async function handler(ctx) {
             };
         });
 
-    const items = await Promise.all(list.map((item) => cache.tryGet(item.link, () => parseItem(item))));
+    const items = await Promise.all(
+        list.map(async (item) => {
+            try {
+                return await cache.tryGet(item.link, () => parseItem(item));
+            } catch {
+                return item;
+            }
+        })
+    );
 
     ctx.set('json', {
         items,

--- a/lib/routes/scmp/utils.ts
+++ b/lib/routes/scmp/utils.ts
@@ -74,14 +74,22 @@ export const parseItem = async (item) => {
     const $ = load(response);
 
     const nextData = JSON.parse($('script#__NEXT_DATA__').text());
-    const { article } = nextData.props.pageProps.payload.data;
+    const article = nextData.props?.pageProps?.payload?.data?.article;
+
+    // SCMP Plus and some interactive pages do not expose the regular article
+    // payload. Keep the official feed item instead of failing the whole route.
+    if (!article) {
+        return item;
+    }
 
     // item.nextData = article;
 
-    item.summary = renderHTML(article.summary.json);
-    item.description = renderHTML(article.subHeadline.json) + renderHTML(article.images.find((i) => i.type === 'leading')) + renderHTML(article.body.json);
+    item.summary = renderHTML(article.summary?.json);
+    item.description = renderHTML(article.subHeadline?.json) + renderHTML(article.images?.find((i) => i.type === 'leading')) + renderHTML(article.body?.json);
     item.updated = parseDate(article.updatedDate, 'x');
-    item.category = [...new Set([...article.topics.map((t) => t.name), ...(article.sectionsV2?.flatMap((t) => t.value.map((v) => v.name)) ?? []), ...article.keywords.map((k) => k?.split(', '))])];
+    item.category = [
+        ...new Set([...(article.topics?.map((t) => t.name) ?? []), ...(article.sectionsV2?.flatMap((t) => t.value.map((v) => v.name)) ?? []), ...(article.keywords?.flatMap((keyword) => keyword?.split(', ') ?? []) ?? [])]),
+    ];
 
     // N.B. gallery in article is not rendered
     // e.g., { type: 'div', attribs: { class: 'scmp-photo-gallery', 'data-gallery-nid': '3239409' }}

--- a/lib/routes/theguardian/section.ts
+++ b/lib/routes/theguardian/section.ts
@@ -1,0 +1,54 @@
+import InvalidParameterError from '@/errors/types/invalid-parameter';
+import type { Route } from '@/types';
+
+import { getFeed } from './utils';
+
+const sections = {
+    world: { title: 'World', path: 'world' },
+    uk: { title: 'UK', path: 'uk-news' },
+    us: { title: 'US', path: 'us-news' },
+    'us-politics': { title: 'US Politics', path: 'us-news/us-politics' },
+    australia: { title: 'Australia', path: 'australia-news' },
+    europe: { title: 'Europe', path: 'world/europe-news' },
+    'middle-east': { title: 'Middle East', path: 'world/middleeast' },
+    'uk-politics': { title: 'UK Politics', path: 'politics' },
+    business: { title: 'Business', path: 'business' },
+};
+
+export const route: Route = {
+    path: '/section/:section',
+    categories: ['traditional-media'],
+    example: '/theguardian/section/world',
+    parameters: {
+        section: {
+            description: 'Section ID',
+            options: Object.entries(sections).map(([value, section]) => ({ value, label: section.title })),
+        },
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    name: 'Section',
+    maintainers: ['kargonerd'],
+    handler,
+    description: 'Selected news sections with full article content.',
+};
+
+function handler(ctx) {
+    const sectionId = ctx.req.param('section');
+    const section = sections[sectionId];
+    if (!section) {
+        throw new InvalidParameterError(`Unsupported Guardian section: ${sectionId}`);
+    }
+    const link = `https://www.theguardian.com/${section.path}`;
+    return getFeed({
+        link,
+        title: section.title,
+        rss: `${link}/rss`,
+    });
+}

--- a/lib/routes/thepaper/channel.ts
+++ b/lib/routes/thepaper/channel.ts
@@ -42,7 +42,7 @@ async function handler(ctx) {
     const id = ctx.req.param('id');
     const channelUrl = `https://m.thepaper.cn/channel/${id}`;
     const channelUrlResp = await ofetch(channelUrl);
-    const $ = load(channelUrlResp.data);
+    const $ = load(channelUrlResp);
     const nextData = $('#__NEXT_DATA__').text();
     const channelUrlData = JSON.parse(nextData);
 

--- a/lib/routes/thepaper/utils.tsx
+++ b/lib/routes/thepaper/utils.tsx
@@ -79,7 +79,7 @@ export default {
             return rss_item;
         });
     },
-    ChannelIdToName: (nodeId, next_data) => next_data.props.appProps.menu.channelList.find((c) => c.nodeId.toString() === nodeId.toString()).name,
+    ChannelIdToName: (nodeId, next_data) => next_data.props.appProps.menu.channelList.find((c) => c.nodeId.toString() === nodeId.toString())?.name ?? nodeId,
     ListIdToName: (listId, next_data) => next_data.props.appProps.menu.channelList.flatMap((c) => c.childNodeList || []).find((l) => l.nodeId.toString() === listId.toString())?.name,
     ExtractLogo: (response) => 'https://m.thepaper.cn' + load(response)('img.imageCover').attr('src'),
 };


### PR DESCRIPTION
## Summary

- add section routes for The Guardian and Financial Times
- add new CNA and Africanews namespaces with category routes
- fix The Paper channel HTML handling after the `ofetch` migration
- make SCMP full-text enrichment tolerate Plus/interactive articles without a regular article payload

## Routes

- `/theguardian/section/:section`
- `/ft/category/:section`
- `/channelnewsasia/category/:section`
- `/africanews/category/:section`

## Validation

- `pnpm typecheck`
- type-aware Oxlint, ESLint, and Oxfmt through the repository commit hooks
- local live route checks for Guardian World, FT China, CNA Asia, CNA East Asia, Africanews News, Africanews Markets, The Paper channel 25950, and SCMP category 4