### PR TITLE
fix(route/gamebase): resolve detail URLs from news IDs

### DIFF
--- a/lib/routes/gamebase/news.tsx
+++ b/lib/routes/gamebase/news.tsx
@@ -66,7 +66,7 @@ export const handler = async (ctx: Context): Promise<Data> => {
             cache.tryGet(`gamebase-news-${item.news_no}`, async (): Promise<DataItem> => {
                 const title: string = item.news_title;
                 const pubDate: number | string = item.post_time;
-                const linkUrl: string | undefined = item.news_no ? `news/detail/${item.news_no}` : undefined;
+                const link: string | undefined = item.news_no ? new URL(`news/detail/${item.news_no}`, baseUrl).href : undefined;
                 const categories: string[] = [item.system];
                 const authors: DataItem['author'] = item.nickname;
                 const guid = `gamebase-news-${item.news_no}`;
@@ -75,8 +75,8 @@ export const handler = async (ctx: Context): Promise<Data> => {
 
                 let metaDesc = item.news_meta?.meta_des;
 
-                if (!metaDesc) {
-                    const detailResponse = await ofetch(item.link);
+                if (!metaDesc && link) {
+                    const detailResponse = await ofetch(link);
 
                     metaDesc = (detailResponse.match(/(\\u003C.*?)","/)?.[1] ?? '').replaceAll(String.raw`\"`, '"').replaceAll(/\\u([\da-f]{4})/gi, (match, hex) => String.fromCodePoint(Number.parseInt(hex, 16)));
                 }
@@ -99,7 +99,7 @@ export const handler = async (ctx: Context): Promise<Data> => {
                     title,
                     description,
                     pubDate: pubDate ? timezone(parseDate(pubDate), 8) : undefined,
-                    link: linkUrl ? new URL(linkUrl, baseUrl).href : undefined,
+                    link,
                     category: categories,
                     author: authors,
                     guid,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #22937

## Example for the Proposed Route(s) / 路由地址示例

```routes
/gamebase/news
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

The Gamebase list API now returns `news_no` but not `link` or `news_meta`. The fallback therefore called `ofetch(undefined)`.

This change builds the canonical detail URL from `news_no`, guards the fallback request when no URL can be formed, and reuses the same URL for the feed item link.

Validation:
- `git diff --check`
- Live smoke test against three current API items: all generated detail URLs returned successfully and the existing parser extracted article content
- The full repository checks were not run because the repository's pinned pnpm version could not be provisioned in the execution environment
