### PR TITLE
fix(route/anthropic): locate research publications anywhere in flight data

### DIFF
--- a/lib/routes/anthropic/research.ts
+++ b/lib/routes/anthropic/research.ts
@@ -67,10 +67,41 @@ async function handler(ctx) {
             };
         });
 
-    const sections = fd.flatMap((d) => (Array.isArray(d.data) ? d.data : [])).flatMap((item) => item?.page?.sections ?? []);
-    const publicationSections = sections.filter((section) => section?.title === 'Publications');
+    // The publication list used to sit at a fixed `page.sections` path. It is now nested deeper in
+    // the flight payload, so walk the parsed data and pick the section up wherever it happens to be.
+    const publicationSections: any[] = [];
+    const collect = (node: any) => {
+        if (!node || typeof node !== 'object') {
+            return;
+        }
+        if (Array.isArray(node)) {
+            for (const child of node) {
+                collect(child);
+            }
+            return;
+        }
+        if (node.title === 'Publications' && Array.isArray(node.posts)) {
+            publicationSections.push(node);
+        }
+        for (const child of Object.values(node)) {
+            collect(child);
+        }
+    };
+    for (const d of fd) {
+        collect(d.data);
+    }
+
+    const seen = new Set<string>();
     const posts = publicationSections
         .flatMap((section) => section?.posts ?? [])
+        .filter((post) => {
+            const slug = post?.slug?.current;
+            if (!slug || seen.has(slug)) {
+                return false;
+            }
+            seen.add(slug);
+            return true;
+        })
         .slice(0, limit)
         .map((post): DataItem => ({
             title: post.title,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

Same symptom as the previously fixed #21581 (`Error: this route is empty`), but a different cause — the page layout changed again.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/anthropic/research
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

`/anthropic/research` currently fails with `Error: this route is empty`.

The route reads the publication list out of the Next.js flight payload at the fixed path `item.page.sections`. `www.anthropic.com/research` now nests that section deeper inside the React element tree, so `.flatMap((item) => item?.page?.sections ?? [])` resolves to an empty array, no `Publications` section is found, and the route returns no items.

This PR walks the parsed flight payload and picks up the `Publications` section wherever it sits, instead of relying on one fixed path. Posts are deduplicated by slug in case the section is embedded more than once (server payload + client hydration).

Verified against the live page on `pnpm dev`:

- `/anthropic/research` → 20 items (the route's default limit), previously 0
- `/anthropic/research?limit=3` → 3 items, `limit` still honored (as added in #23075)
- titles, links, `pubDate` and full article bodies all populate correctly

Not switching to DOM parsing like the sibling `/anthropic/news` route: the research page only server-renders ~10 publications before the "See more" button, which would silently cut the route's default of 20.
