### PR TITLE
fix(route/latepost): include cover image and abstract in description

### DIFF
--- a/lib/routes/latepost/index.ts
+++ b/lib/routes/latepost/index.ts
@@ -94,7 +94,21 @@ async function handler(ctx): Promise<Data> {
                 const content = load(detailResponse);
 
                 item.title ??= content('div.article-header-title').text();
-                item.description = content('#select-main').html()!.replaceAll('<p><br></p>', '');
+
+                // The cover image lives outside of the article body (#select-main), in either the
+                // `.abstract` block (exclusives / long reads) or `.interview-pic` (interviews).
+                // Fall back to the share image embedded in the page script, which covers both layouts.
+                let cover = content('#abstract_img').attr('src') || content('img.interview-pic').attr('src');
+                if (!cover) {
+                    cover = /var\s+imgUrl\s*=\s*'([^']+)'/.exec(detailResponse)?.[1];
+                }
+                // The site serves the cover over plain http, which readers may refuse to load.
+                const coverHtml = cover ? `<img src="${new URL(cover, rootUrl).href.replace(/^http:/, 'https:')}">` : '';
+
+                const abstract = content('div.abstract-pic-left').text().trim();
+                const abstractHtml = abstract ? `<blockquote>${abstract}</blockquote>` : '';
+
+                item.description = coverHtml + abstractHtml + content('#select-main').html()!.replaceAll('<p><br></p>', '');
                 item.author = content('div.article-header-author div.author-link a.label').first().text();
                 item.category = item.category.filter(Boolean);
                 item.guid = `latepost-${item.guid}`;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/latepost
/latepost/1
/latepost/2
/latepost/3
/latepost/4
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This is a fix to an existing route, not a new one — the checklist above is left blank on purpose.

### What was wrong

`item.description` is built from `#select-main`, which is the article body only. The cover image sits *outside* it, in a sibling block, so feed items never included it even though nearly every recent article has one.

### The two layouts

The site uses different markup depending on the column:

| Column | Cover markup |
| --- | --- |
| 晚点独家 / 长报道 (`proma` 1, 4) | `<img id="abstract_img">` inside `.abstract` |
| 人物访谈 (`proma` 2) | `<img class="interview-pic">` |
| 晚点早知道 (`proma` 3) | no cover at all |

Handling only the first selector would have missed every interview, so the patch tries both and then falls back to the `var imgUrl` share image declared in the page script, which is present exactly when a cover exists and absent otherwise.

### Scheme upgrade

The cover is served as `http://www.latepost.com/uploads/cover/...` while the body images use https. Readers rendering the item over https may refuse the mixed content, so the scheme is upgraded. The body images are unaffected.

### Abstract

The one-line abstract shown next to the cover (`.abstract-pic-left`) was dropped as well; it is now prepended as a `<blockquote>`.

### Verification

Checked against saved copies of 11 real articles spanning all four columns:

- 晚点独家 / 长报道 — cover found via `#abstract_img`
- 人物访谈 — cover found via `img.interview-pic`
- 晚点早知道 — no cover in the source, correctly left empty rather than emitting a broken `<img>`

Articles that genuinely have no cover produce the same description as before.
