### PR TITLE
fix(route/wikipedia): parse current events top/bottom template form

### DIFF
--- a/lib/routes/wikipedia/current-events.ts
+++ b/lib/routes/wikipedia/current-events.ts
@@ -33,7 +33,14 @@ Notes:
     - strip css and possibly class/id
   - if the result is in wikitext, it needs to be converted to html
 
-4. is the fastest and current implementation. */
+4. is the fastest and current implementation.
+
+A daily page's wikitext is shaped as:
+  {{Current events|year=YYYY|month=MM|day=D|top=yes}}
+  <!-- All news items below this line -->
+  ...items, as nested wikitext bullet lists under ''' section headings'''...
+  <!-- All news items above this line -->
+  {{Current events|year=YYYY|month=MM|day=D|bottom=yes}} */
 
 function getCurrentEventsDatePath(date: Date): string {
     const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
@@ -45,20 +52,30 @@ function getCurrentEventsDatePath(date: Date): string {
     return `Portal:Current_events/${year}_${month}_${day}`;
 }
 
+// The day's items sit between a {{Current events|...|top=yes}} and a
+// {{Current events|...|bottom=yes}} call. Neither call nests braces, so [^{}] is enough to bound them.
+const TOP_TEMPLATE = /\{\{\s*Current events\s*\|[^{}]*\btop\s*=\s*yes[^{}]*\}\}/i;
+const BOTTOM_TEMPLATE = /\{\{\s*Current events\s*\|[^{}]*\bbottom\s*=\s*yes[^{}]*\}\}/i;
+
 // Simple MediaWiki template parser for {{Current events}} template
 function parseCurrentEventsTemplate(wikitext: string): string | null {
     if (!wikitext) {
         return null;
     }
 
-    // Look for {{Current events|content=...}} template
-    // The closing }} is always at the end of wikitext
-    const contentMatch = wikitext.match(/\{\{Current events\s*\|[\s\S]*?content(?=(\s*=))\1\s*((?:\S[\s\S]*)?)\}\}$/);
-    if (!contentMatch) {
+    const top = wikitext.match(TOP_TEMPLATE);
+    if (!top) {
         return null;
     }
 
-    let content = contentMatch[2].trim();
+    let content = wikitext.slice(top.index! + top[0].length);
+
+    const bottom = content.match(BOTTOM_TEMPLATE);
+    if (bottom) {
+        content = content.slice(0, bottom.index);
+    }
+
+    content = content.trim();
 
     // Strip comments to detect empty content
     content = stripComments(content);


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

Supersedes #23120, which the route test auto-closed on a malformed body. It cannot be reopened: the branch was force-pushed while it was closed.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/wikipedia/current-events
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows Script Standard / 跟随路由规范
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] Date and time / 日期和时间
    - [x] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fix to existing route.

  - [x] the route has been failing with `this route is empty` since 2026-08-01:
    - the daily pages no longer pass the items as the `content=` argument of `{{Current events}}`, they now sit between a `{{Current events|...|top=yes}}` and a `{{Current events|...|bottom=yes}}` call
    - the parser only matched the old form, so it returned null for every day and the empty-route guard rejected the result
    - fixed by matching the top/bottom pair instead
  - [x] the `content=` form is no longer supported: only days well outside the 7 day window still use it
