### PR TITLE
fix(route/wikipedia): escape link targets in current events

### DIFF
--- a/lib/routes/wikipedia/current-events.ts
+++ b/lib/routes/wikipedia/current-events.ts
@@ -95,17 +95,43 @@ function stripTemplates(wikitext: string): string {
     return wikitext.replaceAll(/\{\{([^}]+)\}\}/g, '$1');
 }
 
+// sanitizeHtml runs on the wikitext before any tag is built, so & and < reach this point already
+// encoded. Decode them before assembling a URL, or the entity text ends up inside the link. &amp;
+// must go last so that &amp;lt; does not decode all the way to <.
+function decodeSanitizedEntities(text: string): string {
+    return text.replaceAll('&lt;', '<').replaceAll('&gt;', '>').replaceAll('&quot;', '"').replaceAll('&amp;', '&');
+}
+
+// Link targets come from the wikitext, so they are attacker-controlled and land in an href
+// attribute. encodeURI percent-encodes the " that would otherwise close the attribute and let the
+// rest of a crafted target through as markup, and it fixes the spaces that made the URLs invalid.
+function wikiUrl(target: string): string {
+    return `https://en.wikipedia.org/wiki/${encodeURI(decodeSanitizedEntities(target).trim().replaceAll(' ', '_'))}`;
+}
+
+// Anything that is not http(s) — javascript:, data: — is left as plain text rather than linked.
+function externalUrl(url: string): string | null {
+    const decoded = decodeSanitizedEntities(url).trim();
+    return /^https?:\/\//i.test(decoded) ? encodeURI(decoded) : null;
+}
+
 function convertWikiLinks(html: string): string {
     // Convert wiki links [[Link|Text]] or [[Link]]
-    html = html.replaceAll(/\[\[([^|\]]+)\|([^\]]+)\]\]/g, '<a href="https://en.wikipedia.org/wiki/$1">$2</a>');
-    html = html.replaceAll(/\[\[([^\]]+)\]\]/g, '<a href="https://en.wikipedia.org/wiki/$1">$1</a>');
+    html = html.replaceAll(/\[\[([^|\]]+)\|([^\]]+)\]\]/g, (_match, target: string, text: string) => `<a href="${wikiUrl(target)}">${text}</a>`);
+    html = html.replaceAll(/\[\[([^\]]+)\]\]/g, (_match, target: string) => `<a href="${wikiUrl(target)}">${target}</a>`);
     return html;
 }
 
 function convertExternalLinks(html: string): string {
-    // Convert external links [URL Text] or [URL]
-    html = html.replaceAll(/\[([^\s\]]+)\s+([^\s\]][^\]]*|\s)\]/g, '<a href="$1">$2</a>');
-    html = html.replaceAll(/\[([^\s\]]+)\]/g, '<a href="$1">$1</a>');
+    // Convert external links [URL Text] or [URL], leaving non-http(s) ones as the original text
+    html = html.replaceAll(/\[([^\s\]]+)\s+([^\s\]][^\]]*|\s)\]/g, (match, url: string, text: string) => {
+        const href = externalUrl(url);
+        return href ? `<a href="${href}">${text}</a>` : match;
+    });
+    html = html.replaceAll(/\[([^\s\]]+)\]/g, (match, url: string) => {
+        const href = externalUrl(url);
+        return href ? `<a href="${href}">${url}</a>` : match;
+    });
     return html;
 }
 


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/wikipedia/current-events
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows Script Standard / 跟随路由规范
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] Date and time / 日期和时间
    - [x] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fix to existing route.

  - [x] link targets are interpolated into the `href` attribute unescaped:
    - targets come from the wikitext, so any editor controls them, and `sanitizeHtml` runs on the wikitext before the tags are built and does not escape double quotes
    - `[[foo" onmouseover="alert(1)|x]]` produced an anchor carrying an `onmouseover` handler, and `[javascript:alert(1) x]` a `javascript:` link
    - fixed by building the url through `encodeURI` and only linkifying external urls when they are `http(s)`
  - [x] wiki hrefs contained raw spaces, making them invalid: fixed by the same encoding
