### PR TITLE
fix(route/wikipedia): reject unrecognised includeToday values

### DIFF
--- a/lib/routes/wikipedia/current-events.ts
+++ b/lib/routes/wikipedia/current-events.ts
@@ -1,6 +1,7 @@
 import sanitizeHtml from 'sanitize-html';
 
 import { config } from '@/config';
+import InvalidParameterError from '@/errors/types/invalid-parameter';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
@@ -422,7 +423,7 @@ async function handler(ctx) {
         throw new Error(`Failed to fetch Wikipedia current events: ${message}`, { cause: error });
     }
 }
-function determineDates(includeToday: any) {
+function determineDates(includeToday: string) {
     const now = new Date();
     const currentHourUTC = now.getUTCHours();
 
@@ -445,14 +446,21 @@ function determineDates(includeToday: any) {
 
             break;
 
-        default:
-            if (/^\d+$/.test(includeToday)) {
-                // Include after specific hour (0-23)
-                const targetHour = Number(includeToday);
-                if (targetHour >= 0 && targetHour <= 23) {
-                    shouldIncludeToday = currentHourUTC >= targetHour;
-                }
+        default: {
+            // Anything else is rejected rather than ignored: silently serving the default feed
+            // makes a mistyped parameter look like it took effect.
+            if (!/^\d+$/.test(includeToday)) {
+                throw new InvalidParameterError(`Invalid includeToday: ${includeToday}. Expected 'auto', 'always', 'never', or a UTC hour 0-23.`);
             }
+
+            // Include after specific hour (0-23). The pattern above already excludes negatives.
+            const targetHour = Number(includeToday);
+            if (targetHour > 23) {
+                throw new InvalidParameterError(`Invalid includeToday hour: ${includeToday}. Expected a UTC hour 0-23.`);
+            }
+
+            shouldIncludeToday = currentHourUTC >= targetHour;
+        }
     }
 
     // Create array of dates for the past 7 days, optionally including today


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/wikipedia/current-events
/wikipedia/current-events/always
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows Script Standard / 跟随路由规范
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] Date and time / 日期和时间
    - [x] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fix to existing route.

  - [x] `includeToday` silently ignores values it does not recognise:
    - anything that is not a keyword or an hour in 0-23 falls through the switch, and the default feed is served as if the parameter had applied, so a typo is indistinguishable from success
    - #20338 listed `/wikipedia/current-events/includeToday` in its own routes section and the route test passed, because the value was swallowed
    - fixed by raising `InvalidParameterError` for non-numeric values and for hours above 23
