### PR TITLE
fix(wallstreetcn): filter paid articles from public feeds

### DIFF
--- a/lib/routes/wallstreetcn/hot.ts
+++ b/lib/routes/wallstreetcn/hot.ts
@@ -3,6 +3,8 @@ import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 
+import { isWallstreetcnPaidContent } from './utils';
+
 export const route: Route = {
     path: '/hot/:period?',
     categories: ['finance'],
@@ -39,11 +41,13 @@ async function handler(ctx) {
         url: apiUrl,
     });
 
-    let items = response.data.data[`${period}_items`].map((item) => ({
-        guid: item.id,
-        link: item.uri,
-        pubDate: parseDate(item.display_time * 1000),
-    }));
+    let items = response.data.data[`${period}_items`]
+        .filter((item) => !isWallstreetcnPaidContent(item))
+        .map((item) => ({
+            guid: item.id,
+            link: item.uri,
+            pubDate: parseDate(item.display_time * 1000),
+        }));
 
     items = await Promise.all(
         items.map((item) =>
@@ -54,6 +58,10 @@ async function handler(ctx) {
                 });
 
                 const data = detailResponse.data.data;
+
+                if (isWallstreetcnPaidContent(data)) {
+                    return null;
+                }
 
                 item.title = data.title || data.content_text;
                 item.author = data.source_name ?? data.author.display_name;

--- a/lib/routes/wallstreetcn/news.ts
+++ b/lib/routes/wallstreetcn/news.ts
@@ -3,6 +3,8 @@ import cache from '@/utils/cache';
 import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 
+import { isWallstreetcnPaidContent } from './utils';
+
 const titles = {
     global: '最新',
     shares: '股市',
@@ -62,7 +64,7 @@ async function handler(ctx) {
     });
 
     let items = response.data.data.items
-        .filter((item) => item.resource_type !== 'ad')
+        .filter((item) => item.resource_type !== 'ad' && !isWallstreetcnPaidContent(item.resource))
         .map((item) => ({
             type: item.resource_type,
             guid: item.resource.id,
@@ -86,6 +88,10 @@ async function handler(ctx) {
                 }
 
                 const data = responseData.data;
+
+                if (isWallstreetcnPaidContent(data)) {
+                    return null;
+                }
 
                 item.title = data.title || data.content_text;
                 item.author = data.source_name ?? data.author.display_name;

--- a/lib/routes/wallstreetcn/utils.test.ts
+++ b/lib/routes/wallstreetcn/utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+
+import { isWallstreetcnPaidContent } from './utils';
+
+describe('isWallstreetcnPaidContent', () => {
+    test('filters premium URLs even when is_paid is false', () => {
+        expect(
+            isWallstreetcnPaidContent({
+                uri: 'https://wallstreetcn.com/premium/articles/3780626',
+                is_paid: false,
+                is_priced: true,
+            })
+        ).toBe(true);
+    });
+
+    test('filters member articles from detail metadata', () => {
+        expect(
+            isWallstreetcnPaidContent({
+                uri: 'https://wallstreetcn.com/member/articles/3780487',
+                is_need_pay: true,
+                membership_uri: 'https://wallstreetcn.com/membership?member_type=gold',
+                vip_type: 'gold',
+            })
+        ).toBe(true);
+    });
+
+    test('keeps ordinary articles', () => {
+        expect(
+            isWallstreetcnPaidContent({
+                uri: 'https://wallstreetcn.com/articles/3780625',
+                is_paid: false,
+                is_priced: false,
+                is_trial: false,
+                is_need_pay: false,
+            })
+        ).toBe(false);
+    });
+
+    test('does not classify malformed API values as paid', () => {
+        expect(isWallstreetcnPaidContent(undefined)).toBe(false);
+        expect(isWallstreetcnPaidContent({ uri: null, product_id: null, membership_uri: '' })).toBe(false);
+    });
+});

--- a/lib/routes/wallstreetcn/utils.ts
+++ b/lib/routes/wallstreetcn/utils.ts
@@ -1,0 +1,30 @@
+type WallstreetcnContent = Record<string, unknown>;
+
+const PAID_CONTENT_PATH = /\/(?:premium|member)\//;
+
+/**
+ * Uses Wallstreetcn's access metadata to keep paid and VIP content out of public feeds.
+ * The list and detail APIs expose different subsets of these fields, so the predicate
+ * intentionally accepts both shapes.
+ */
+export const isWallstreetcnPaidContent = (content: unknown): boolean => {
+    if (!content || typeof content !== 'object') {
+        return false;
+    }
+
+    const item = content as WallstreetcnContent;
+    const uri = typeof item.uri === 'string' ? item.uri : '';
+    const membershipUri = typeof item.membership_uri === 'string' ? item.membership_uri : '';
+
+    return (
+        PAID_CONTENT_PATH.test(uri) ||
+        item.is_paid === true ||
+        item.is_priced === true ||
+        item.is_in_vip_privilege === true ||
+        item.is_trial === true ||
+        item.is_need_pay === true ||
+        item.is_vip === true ||
+        (item.product_id !== null && item.product_id !== undefined) ||
+        membershipUri.length > 0
+    );
+};


### PR DESCRIPTION
## Summary

- Filter premium, member, VIP, and trial articles from the Wallstreetcn news and hot feeds.
- Skip entries marked as paid before fetching article details, with a detail-level guard for the hot feed.
- Add unit coverage for premium, member, ordinary, and malformed API payloads.

The upstream information-flow API can return `is_paid=false` for paid content. The observed premium article has `is_priced=true` and a `/premium/` URL, while the detail API reports `is_need_pay=true`. Member articles expose `/member/`, `is_priced=true`, and `membership_uri` metadata.

## Tests

- `npx --yes pnpm@10.34.5 exec vitest run lib/routes/wallstreetcn/utils.test.ts`
- `npx --yes pnpm@10.34.5 exec oxlint --type-aware lib/routes/wallstreetcn/hot.ts lib/routes/wallstreetcn/news.ts lib/routes/wallstreetcn/utils.ts lib/routes/wallstreetcn/utils.test.ts`
- `npx --yes pnpm@10.34.5 exec oxfmt --check lib/routes/wallstreetcn/hot.ts lib/routes/wallstreetcn/news.ts lib/routes/wallstreetcn/utils.ts lib/routes/wallstreetcn/utils.test.ts`
- `npx --yes pnpm@10.34.5 exec tsc --noEmit`

The full repository lint currently reports an unrelated pre-existing error in `lib/routes/_finance/stock-card.ts:11`, which is unchanged by this PR.