### PR TITLE
fix(route/xueqiu): avoid caching transient detail failures

### DIFF
--- a/lib/routes/xueqiu/user.ts
+++ b/lib/routes/xueqiu/user.ts
@@ -4,6 +4,7 @@ import sanitizeHtml from 'sanitize-html';
 import { parseToken } from '@/routes/xueqiu/cookies';
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
+import logger from '@/utils/logger';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
 
@@ -41,45 +42,102 @@ interface Status {
     id: number;
     target: string;
     created_at: number;
+    title?: string;
+    text?: string;
+    description?: string;
     mark?: number;
     legal_user_visible?: boolean;
     user?: { screen_name?: string; profile_image_url?: string; photo_domain?: string };
 }
 
-interface ApiError {
+interface StatusDetail {
+    text?: string;
+    description?: string;
     error_code?: number | string;
+    image_info_list?: Array<{ filename?: string }>;
+    retweeted_status?: {
+        user?: { screen_name?: string };
+        text?: string;
+    };
 }
+
+interface ErrorLike {
+    data?: unknown;
+    response?: {
+        _data?: unknown;
+        status?: number;
+        statusCode?: number;
+    };
+    status?: number;
+    statusCode?: number;
+}
+
+const permanentErrorCodes = new Set(['20210']);
 
 const stripHtml = (html: string): string => sanitizeHtml(html, { allowedTags: [], allowedAttributes: {} });
 
 // Build a feed item from the timeline list data alone (no detail request).
-const buildListItem = (item: any) => ({
-    title: item.title || stripHtml(item.description || ''),
-    description: item.description || '',
-    pubDate: parseDate(item.created_at),
-    link: rootUrl + item.target,
-});
+const buildListItem = (item: Status) => {
+    const description = item.text || item.description || '';
+    return {
+        title: item.title || stripHtml(description),
+        description,
+        pubDate: parseDate(item.created_at),
+        link: rootUrl + item.target,
+    };
+};
 
-const buildTitle = (item: any, detail: any): string => {
+const buildTitle = (item: Status, detail: StatusDetail): string => {
     if (item.title) {
         return item.title;
     }
-    return stripHtml(item.text || item.description || detail.text || '');
+    return stripHtml(item.text || item.description || detail.text || detail.description || '');
 };
 
-const buildDescription = (detail: any): string => {
-    let text = detail.text ?? detail.description;
+const buildDescription = (detail: StatusDetail): string => {
+    let text = detail.text?.trim() ? detail.text : detail.description || '';
     const images = detail.image_info_list ?? [];
     for (const img of images) {
         if (img?.filename) {
             text += `<br><img src="https://xqimg.imedao.com/${img.filename}">`;
         }
     }
-    if (detail.retweeted_status) {
-        text += `<blockquote>${detail.retweeted_status.user.screen_name}:&nbsp;${detail.retweeted_status.text}</blockquote>`;
+    if (detail.retweeted_status?.text) {
+        text += `<blockquote>${detail.retweeted_status.user?.screen_name ?? ''}:&nbsp;${detail.retweeted_status.text}</blockquote>`;
     }
     return text;
 };
+
+const getErrorCode = (value: unknown): number | string | undefined => {
+    if (!value || typeof value !== 'object') {
+        return;
+    }
+    const errorCode = (value as StatusDetail).error_code;
+    return typeof errorCode === 'number' || typeof errorCode === 'string' ? errorCode : undefined;
+};
+
+const getFailureContext = (error: unknown) => {
+    if (!error || typeof error !== 'object') {
+        return {};
+    }
+    const errorLike = error as ErrorLike;
+    return {
+        status: errorLike.response?.status ?? errorLike.response?.statusCode ?? errorLike.status ?? errorLike.statusCode,
+        errorCode: getErrorCode(errorLike.response?._data) ?? getErrorCode(errorLike.data),
+    };
+};
+
+const isPermanentError = (errorCode?: number | string): boolean => errorCode !== undefined && permanentErrorCodes.has(String(errorCode));
+
+const logDetailFallback = (item: Status, classification: 'empty-detail' | 'permanent' | 'transient', status?: number, errorCode?: number | string) =>
+    logger.debug(`xueqiu user detail fallback: item=${item.id} target=${item.target} status=${status ?? 'unknown'} errorCode=${errorCode ?? 'none'} classification=${classification}`);
+
+const buildDetailItem = (item: Status, detail: StatusDetail) => ({
+    title: buildTitle(item, detail),
+    description: buildDescription(detail),
+    pubDate: parseDate(item.created_at),
+    link: rootUrl + item.target,
+});
 
 const extractProfileImage = (user: any): string | undefined => {
     if (!user?.profile_image_url || !user?.photo_domain) {
@@ -140,30 +198,41 @@ async function handler(ctx) {
                         return buildListItem(item);
                     }
 
+                    let detail: StatusDetail;
                     try {
-                        const detail = await ofetch(`${apiUrl}/statuses/show.json`, {
+                        detail = await ofetch(`${apiUrl}/statuses/show.json`, {
                             query: { id: item.id },
                             headers: { Cookie: cookie, Referer: link },
+                            retry: 0,
                         });
-
-                        return {
-                            title: buildTitle(item, detail),
-                            description: buildDescription(detail),
-                            pubDate: parseDate(item.created_at),
-                            link: rootUrl + item.target,
-                        };
-                    } catch (error: any) {
-                        // Permanent failures (post deleted / not found): cache the fallback.
-                        const data: ApiError | undefined = error.response?._data || error.data;
-                        if (data?.error_code) {
+                    } catch (error) {
+                        const { status, errorCode } = getFailureContext(error);
+                        if (isPermanentError(errorCode)) {
+                            logDetailFallback(item, 'permanent', status, errorCode);
                             return buildListItem(item);
                         }
-                        // Transient failures (rate limit / WAF): throw to skip caching, retry next request.
+                        logDetailFallback(item, 'transient', status, errorCode);
                         throw error;
                     }
+
+                    const errorCode = getErrorCode(detail);
+                    if (isPermanentError(errorCode)) {
+                        logDetailFallback(item, 'permanent', 200, errorCode);
+                        return buildListItem(item);
+                    }
+                    if (errorCode !== undefined) {
+                        logDetailFallback(item, 'transient', 200, errorCode);
+                        throw new Error(`Xueqiu detail returned error code ${errorCode}`);
+                    }
+
+                    const detailItem = buildDetailItem(item, detail);
+                    if (!detailItem.description.trim()) {
+                        logDetailFallback(item, 'empty-detail', 200);
+                        throw new Error('Xueqiu detail response is empty');
+                    }
+                    return detailItem;
                 });
             } catch {
-                // Transient failure: provide a fallback item without caching, retry next request.
                 return buildListItem(item);
             }
         },


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

NOROUTE

## Example for the Proposed Route(s) / 路由地址示例

```routes
/xueqiu/user/1505944393
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Follow-up fix for the existing `/xueqiu/user/:id/:type?` route after #22708.

The route fetches each status detail through `statuses/show.json` inside `cache.tryGet`. The current implementation treats every response containing an `error_code` as a permanent failure and returns the timeline fallback from inside the cache callback. Authentication or other transient business errors are therefore cached as incomplete items. HTTP 200 responses with an empty detail body are also cached. A single transient upstream failure can consequently leave only some items in the same feed without their details until the content cache expires.

修复已有 `/xueqiu/user` 路由在 #22708 后仍存在的详情缓存污染问题。当前实现将任意带 `error_code` 的响应都视为永久失败，并在 `cache.tryGet` 回调内返回列表摘要，因此鉴权等瞬态业务错误也会被缓存；HTTP 200 但详情正文为空时同样会缓存空详情。这会让同一 feed 中部分 item 长期缺少详情。

**Changes / 改动**

- Cache the timeline fallback only for the explicitly known permanent error `20210`; authentication, WAF, rate-limit, network, unknown business errors, and empty HTTP 200 details fall back for the current feed without entering the detail cache. / 仅明确的永久错误 `20210` 缓存摘要；鉴权、WAF、限流、网络、未知业务错误和 HTTP 200 空详情仅在当次 feed 回退，不写详情缓存。
- Validate the assembled detail after including text, images, and repost content, and use `detail.description` when `detail.text` is empty. / 组合文字、图片和转发内容后再校验详情，并在 `detail.text` 为空时使用 `detail.description`。
- Use `item.text || item.description` for the timeline fallback and keep the item even when both are empty. / 摘要回退优先使用 `item.text`，其次使用 `item.description`；二者为空时仍保留 item。
- Disable automatic retries for `show.json` so an HTTP 400 is not amplified into three requests, while retaining the existing per-handler concurrency of 3. / 对 `show.json` 设置 `retry: 0`，避免一次 HTTP 400 放大为三次请求，同时保留现有单 handler 并发 3。
- Add debug diagnostics with the item id, target, HTTP status, business error code, and failure classification, without logging cookies or content. / 增加 debug 诊断日志，只记录 item id、target、HTTP 状态、业务错误码和失败分类，不记录 Cookie 或正文。

The existing cache key is intentionally unchanged, so this PR prevents new transient failures from being cached but does not migrate previously cached incomplete items.

Local cold-cache validation for `/xueqiu/user/1505944393` completed twice: both requests returned HTTP 200 with 20 items and 0 empty descriptions in 6.97 s and 6.36 s respectively. Type checking, linting, formatting, and route generation pass.
