### PR TITLE
fix(route/bilibili): guard against null emoji_details in followings dynamic

### DIFF
--- a/lib/routes/bilibili/followings-dynamic.ts
+++ b/lib/routes/bilibili/followings-dynamic.ts
@@ -174,7 +174,7 @@ async function handler(ctx) {
 
             // emoji
             let data_content = getDes(data);
-            if (item.display && item.display.emoji_info && showEmoji) {
+            if (showEmoji && item.display?.emoji_info?.emoji_details) {
                 const emoji = item.display.emoji_info.emoji_details;
                 for (const item of emoji) {
                     data_content = data_content.replaceAll(


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #21916

## Example for the Proposed Route(s) / 路由地址示例

```routes
/bilibili/followings/dynamic/109937383/showEmoji=1
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

Not a new route — a one-line fix to an existing one, so the checklist does not apply.

## Note / 说明

The emoji guard checks `emoji_info`, but the loop iterates `emoji_info.emoji_details`. For dynamics carrying an `emoji_info` object with no emoji, `emoji_details` is `null`, so `for...of` throws `TypeError: t is not iterable` and the route 503s whenever `showEmoji=1`. The reporter of #21916 pinned it to this line; #21914 and #21915 are the same crash.

The guard now checks the value that is actually iterated, and `showEmoji` moved first so the cheap check runs first.

Minimal repro of both guards (Node 26) over the shapes the API returns:

| `item.display.emoji_info` | before | after |
|---|---|---|
| `{ emoji_details: null }` | `TypeError` | skipped |
| `{}` (field absent) | `TypeError` | skipped |
| `{ emoji_details: [1 emoji] }` | 1 emoji rendered | 1 emoji rendered |
| no `display` | skipped | skipped |

Crashing shapes are handled, normal rendering is unchanged, and `emoji_details` appears nowhere else in the repo.

Replaces #23130: my first description dropped two required headings, so the route detector could not read the `routes` block and auto-closed it. Same commit, corrected description.
