### PR TITLE
fix(route/youtube): surface quota errors instead of returning undefined

### DIFF
--- a/lib/routes/youtube/api/google.ts
+++ b/lib/routes/youtube/api/google.ts
@@ -35,18 +35,34 @@ if (config.youtube && config.youtube.key) {
     }
 }
 
+// Reasons Google attaches to a 403 when the project is out of quota. gaxios keeps the
+// raw error body under response.data; googleapis-common also copies `errors` onto the error.
+const quotaErrorReasons = new Set(['quotaExceeded', 'dailyLimitExceeded', 'rateLimitExceeded', 'userRateLimitExceeded']);
+const isQuotaError = (error) => {
+    const errors = error?.response?.data?.error?.errors ?? error?.errors;
+    return Array.isArray(errors) && errors.some((e) => quotaErrorReasons.has(e?.reason));
+};
+
 let index = -1;
 const exec = async (func) => {
     let result;
+    let lastError;
     for (let i = 0; i < count; i++) {
         index++;
         try {
             // eslint-disable-next-line no-await-in-loop
             result = await func(youtube[index % count]);
             break;
-        } catch {
-            // console.error(error);
+        } catch (error) {
+            lastError = error;
         }
+    }
+    // Every key failed. When that is because the quota is gone, returning undefined only
+    // moves the failure to the caller's `.data` access ("Cannot read properties of
+    // undefined"), which hides the actual cause. Surface it instead. Other failures keep
+    // returning undefined so callers that treat it as "not found" behave as before.
+    if (result === undefined && isQuotaError(lastError)) {
+        throw lastError;
     }
     return result;
 };


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #22971

## Example for the Proposed Route(s) / 路由地址示例

```routes
/youtube/live/@GawrGura
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

Not a new route; fixes the shared YouTube error path.

## Note / 说明

Second ask in #22971: show `quotaExceeded` instead of a `TypeError` once the quota is gone.

The `exec` helper in the Google API wrapper rotates through the keys and swallows every failure, so with all keys exhausted it returns `undefined` and the route dies reading `.data` off that with `Cannot read properties of undefined`, which says nothing about quota.

Now, when every key failed and the last error carries a Google quota reason (`quotaExceeded`, `dailyLimitExceeded`, `rateLimitExceeded`, `userRateLimitExceeded`), it is rethrown so the error page shows the real 403 message. Key rotation is untouched, and other failures still return `undefined` on purpose — `getDataByUsername` reads that as "no content".

Old vs. new `exec` against the gaxios error shape:

| keys | before | after |
|---|---|---|
| all `quotaExceeded` | `TypeError` | 403 quota message |
| all `playlistNotFound` | `TypeError` | unchanged |
| first quota, second OK | data | data |
| no keys | `TypeError` | unchanged |

Cache interval is left alone: #21853 set it deliberately. The route test will show `ConfigNotFoundError` since CI has no `YOUTUBE_KEY`.

Replaces #23132 (auto-closed for description length); same change.
