### PR TITLE
fix(dev): disable moby in devcontainer for trixie base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
     "image": "mcr.microsoft.com/devcontainers/typescript-node:24-trixie",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker": {
-            "version": "latest"
+            "version": "latest",
+            "moby": false
         },
         "ghcr.io/devcontainers/features/github-cli": {
             "version": "latest"


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #22771

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Supersedes #22784 (same one-line change, closed by the route bot because the routes section was missing).

Since #21919 moved the devcontainer base image to trixie, building the devcontainer fails in the docker-in-docker feature step. The feature defaults to moby: true, and upstream devcontainers/features refuses that combination on Debian trixie because the moby packages are not available there:

```
The 'moby' option is not supported on debian 'trixie' because 'moby-cli' and related system packages are not available in that distribution.
To continue, either set the feature option '"moby": false' or use a different base image.
```

This sets moby to false so the feature installs Docker CE instead, which is the combination upstream tests for trixie. Staying on trixie keeps the devcontainer aligned with the production Dockerfile and with the t64 package names that #21919 introduced.

Verified on the same typescript-node 24-trixie image by running the upstream feature install script directly: with moby enabled it exits 1 with the error above; with moby disabled it completes and installs current Docker CE, Compose and buildx. The file still passes the oxfmt check.
