### PR TITLE
fix(utils/request-rewriter): pass CONNECT proxy tunnel requests through untouched

### DIFF
--- a/lib/utils/request-rewriter/get.test.ts
+++ b/lib/utils/request-rewriter/get.test.ts
@@ -26,4 +26,35 @@ describe('request-rewriter get wrapper', () => {
         expect(result).toBe('fallback');
         expect(origin).toHaveBeenCalledWith(options, callback);
     });
+
+    it('rebuilds url from legacy options for non-CONNECT requests', () => {
+        const origin = vi.fn<(...args: any[]) => string>(() => 'ok');
+        const wrapped = getWrappedGet(origin as any);
+        const options = { protocol: 'https:', host: 'example.com', path: '/test?a=1', method: 'POST' };
+
+        wrapped(options);
+
+        expect(origin).toHaveBeenCalledTimes(1);
+        const [url, passedOptions] = origin.mock.calls[0];
+        expect(url).toBeInstanceOf(URL);
+        expect(url.href).toBe('https://example.com/test?a=1');
+        expect(passedOptions.headers['user-agent']).toBeTruthy();
+    });
+
+    it('passes CONNECT proxy tunnel requests to origin untouched', () => {
+        const origin = vi.fn<(...args: any[]) => string>(() => 'tunnel');
+        const wrapped = getWrappedGet(origin as any);
+        const callback = vi.fn();
+        // shape built by tunnel-agent: `path` is the tunnel target authority, not a URL path
+        const options = { host: '127.0.0.1', port: 10809, method: 'CONNECT', path: 'i.instagram.com:443', headers: { host: 'i.instagram.com:443' }, agent: false };
+        const snapshot = structuredClone(options);
+
+        const result = wrapped(options, callback);
+
+        expect(result).toBe('tunnel');
+        expect(origin).toHaveBeenCalledTimes(1);
+        expect(origin.mock.calls[0][0]).toBe(options);
+        expect(origin.mock.calls[0][1]).toBe(callback);
+        expect(options).toEqual(snapshot);
+    });
 });

--- a/lib/utils/request-rewriter/get.ts
+++ b/lib/utils/request-rewriter/get.ts
@@ -37,6 +37,12 @@ const getWrappedGet = <T extends Get>(origin: T): T => {
             }
         } else {
             options = args[0];
+            // CONNECT is a proxy tunnel handshake (e.g. tunnel-agent used by `request`): `path` is the
+            // `host:port` of the tunnel target, not a URL path, so hand it to node untouched
+            if (typeof options.method === 'string' && options.method.toUpperCase() === 'CONNECT') {
+                logger.debug(`Outgoing request: CONNECT ${options.path} via ${options.hostname || options.host}:${options.port}`);
+                return origin.apply(this, args);
+            }
             try {
                 url = new URL(options.href || `${options.protocol || 'http:'}//${options.hostname || options.host}${options.path}${options.search || (options.query ? `?${options.query}` : '')}`);
             } catch {


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #16970

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

With `IG_PROXY` set, instagram-private-api uses `request` + tunnel-agent, which sends a `CONNECT` to the proxy with legacy options whose `path` is the tunnel target (`i.instagram.com:443`), not a URL path. The rewriter rebuilds a URL as protocol + host + path, giving `http://127.0.0.1i.instagram.com:443/`, and node fails with `ENOTFOUND 127.0.0.1i.instagram.com`.

Fix: in the legacy options branch, hand `CONNECT` requests to node untouched. A URL cannot be rebuilt for them, and UA / referer injection is meant for the target site, not the proxy handshake. CONNECT requests thus no longer get the global proxy agent; that path has never worked since 2024-03, so nothing depends on it. Regular requests are unaffected. Unlike the workaround in the issue, this does not throw on options without a port and keeps tunnel-agent's `agent: false`.

Tests: two cases added to the get wrapper tests (a normal legacy options request and the tunnel-agent CONNECT shape). With the fix reverted the CONNECT case fails with the malformed URL above; with it the suite passes 15/15 on node 24; oxlint, oxfmt and tsc are clean. No Instagram account plus HTTP proxy here, so the end-to-end login flow was not run.
