### PR TITLE
feat(route/czechstepbystep): add kratke-ceske-zpravy

### DIFF
--- a/lib/routes/czechstepbystep/kratke-ceske-zpravy.ts
+++ b/lib/routes/czechstepbystep/kratke-ceske-zpravy.ts
@@ -1,3 +1,4 @@
+import type { CheerioAPI } from 'cheerio';
 import { load } from 'cheerio';
 
 import type { Route } from '@/types';
@@ -7,10 +8,98 @@ import { parseDate } from '@/utils/parse-date';
 
 import { renderDescription } from './templates/description';
 
-const handler: Route['handler'] = async (ctx) => {
-    const baseUrl = 'https://www.czechstepbystep.cz';
-    const targetUrl = `${baseUrl}/kategorie/kratke-ceske-zpravy`;
+const baseUrl = 'https://www.czechstepbystep.cz';
+const targetUrl = `${baseUrl}/kategorie/kratke-ceske-zpravy`;
 
+interface ArticleListItem {
+    title: string;
+    link: string;
+    pubDate?: Date;
+}
+
+interface Worksheet {
+    worksheetHref?: string;
+    worksheetExt?: string;
+    enclosureUrl?: string;
+    enclosureType?: string;
+}
+
+const extractYouTubeId = ($: CheerioAPI, link: string): string => {
+    const iframeEl = $('.entry-text iframe');
+    const iframeSrc = iframeEl.attr('data-src') || iframeEl.attr('src');
+    const videoId = iframeSrc?.match(/(?:embed\/|v=|youtu\.be\/)([^?&]+)/)?.[1];
+    if (!videoId) {
+        throw new Error(`Failed to extract YouTube video id from article: ${link}`);
+    }
+    return videoId;
+};
+
+const extractTranscript = ($: CheerioAPI): string | undefined => {
+    const paragraphs = $('.entry-text p');
+    const nodes = paragraphs.toArray();
+    const startIdx = nodes.findIndex((p) => $(p).text() === 'Text zprávy:');
+    const endIdx = nodes.findIndex((p) => $(p).text().includes('Krátké české zprávy můžete sledovat'));
+    if (startIdx === -1 || endIdx === -1) {
+        return undefined;
+    }
+    const transcript = paragraphs
+        .slice(startIdx + 1, endIdx)
+        .filter((_, p) => $(p).text().trim() !== '')
+        .toString();
+    return transcript || undefined;
+};
+
+const extractExerciseHref = ($: CheerioAPI): string | undefined => $('.entry-text a[href*="wordwall.net"]').attr('href');
+
+const extractWorksheet = ($: CheerioAPI): Worksheet => {
+    const rawHref = $('.entry-text p')
+        .filter((_, p) => $(p).text().includes('Pracovní list'))
+        .find('a[href]')
+        .attr('href');
+    if (!rawHref) {
+        return {};
+    }
+    const href = rawHref.startsWith('http') ? rawHref : `${baseUrl}${rawHref}`;
+    const ext = href.match(/\.(docx|pdf)(?:[?#]|$)/i)?.[1]?.toUpperCase();
+    return {
+        worksheetHref: href,
+        worksheetExt: ext,
+        enclosureUrl: href,
+        enclosureType: ext === 'PDF' ? 'application/pdf' : ext === 'DOCX' ? 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' : undefined,
+    };
+};
+
+const parseArticle = async (item: ArticleListItem) => {
+    const html = await ofetch(item.link);
+    const $ = load(html);
+
+    const videoId = extractYouTubeId($, item.link);
+    const transcriptHtml = extractTranscript($);
+    const exerciseHref = extractExerciseHref($);
+    const worksheet = extractWorksheet($);
+
+    const description = renderDescription({
+        videoId,
+        transcriptHtml,
+        exerciseHref,
+        worksheetHref: worksheet.worksheetHref,
+        worksheetExt: worksheet.worksheetExt,
+    });
+
+    const detailDateStr = $('.sigle-meta__date').text().trim();
+    const pubDate = detailDateStr ? parseDate(detailDateStr, 'D. M. YYYY') : item.pubDate;
+
+    return {
+        title: item.title,
+        link: item.link,
+        pubDate,
+        description,
+        enclosure_url: worksheet.enclosureUrl,
+        enclosure_type: worksheet.enclosureType,
+    };
+};
+
+const handler: Route['handler'] = async (ctx) => {
     const response = await ofetch(targetUrl);
     const $ = load(response);
 
@@ -21,8 +110,7 @@ const handler: Route['handler'] = async (ctx) => {
         .toArray()
         .map((item) => {
             const el = $(item);
-            const linkEl = el.find('a.news-item-link');
-            const rawLink = linkEl.attr('href');
+            const rawLink = el.find('a.news-item-link').attr('href');
             const link = rawLink ? (rawLink.startsWith('http') ? rawLink : `${baseUrl}${rawLink}`) : '';
             const title = el.find('.news-item-link__title').text().trim();
             const dateStr = el.find('.news-item-meta__date').text().trim();
@@ -36,95 +124,7 @@ const handler: Route['handler'] = async (ctx) => {
         })
         .filter((item) => item.link);
 
-    const items = await Promise.all(
-        list.map((item) =>
-            cache.tryGet(item.link, async () => {
-                const html = await ofetch(item.link);
-                const $detail = load(html);
-
-                // 1. Video ID
-                let videoId: string | undefined;
-                const iframeEl = $detail('.entry-text iframe[src*="youtube.com"], .entry-text iframe[src*="youtu.be"], .entry-text iframe[data-src*="youtube.com"], .entry-text iframe[data-src*="youtu.be"]');
-                const iframeSrc = iframeEl.attr('data-src') || iframeEl.attr('src');
-                if (iframeSrc) {
-                    const match = iframeSrc.match(/(?:embed\/|v=|youtu\.be\/)([^?&]+)/);
-                    if (match) {
-                        videoId = match[1];
-                    }
-                }
-                if (!videoId) {
-                    const ytLink = $detail('.entry-text a[href*="youtube.com"], .entry-text a[href*="youtu.be"]').attr('href');
-                    if (ytLink) {
-                        const match = ytLink.match(/(?:v=|youtu\.be\/)([^?&]+)/);
-                        if (match) {
-                            videoId = match[1];
-                        }
-                    }
-                }
-
-                // 2. Full transcript HTML
-                let transcriptHtml: string | undefined;
-                const allParagraphs = $detail('.entry-text p');
-                const startIdx = allParagraphs.toArray().findIndex((p) => $detail(p).text().includes('Text zprávy:'));
-                if (startIdx !== -1) {
-                    const endIdx = allParagraphs.toArray().findIndex((p, i) => {
-                        if (i <= startIdx) {
-                            return false;
-                        }
-                        const txt = $detail(p).text();
-                        return txt.includes('Online cvičení') || txt.includes('Pracovní list') || txt.includes('Krátké české zprávy můžete sledovat') || txt.includes('Toto dílo podléhá licenci');
-                    });
-                    const slice = allParagraphs.slice(startIdx + 1, endIdx === -1 ? undefined : endIdx);
-                    transcriptHtml = slice.filter((_, p) => $detail(p).text().trim() !== '').toString();
-                }
-
-                // 3. Online exercise link
-                const exerciseHref = $detail('.entry-text a[href*="wordwall.net"]').attr('href');
-
-                // 4. Worksheet link & enclosure
-                let worksheetHref: string | undefined;
-                let worksheetExt: string | undefined;
-                let enclosureUrl: string | undefined;
-                let enclosureType: string | undefined;
-
-                const rawWsHref = $detail('.entry-text a[href*="uploads"]').attr('href');
-                if (rawWsHref && (rawWsHref.includes('PL_') || rawWsHref.endsWith('.docx') || rawWsHref.endsWith('.pdf'))) {
-                    const wsHref = rawWsHref.startsWith('http') ? rawWsHref : `${baseUrl}${rawWsHref}`;
-                    worksheetHref = wsHref;
-                    enclosureUrl = wsHref;
-                    if (wsHref.endsWith('.pdf')) {
-                        enclosureType = 'application/pdf';
-                        worksheetExt = 'PDF';
-                    } else if (wsHref.endsWith('.docx')) {
-                        enclosureType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-                        worksheetExt = 'DOCX';
-                    } else {
-                        worksheetExt = 'soubor';
-                    }
-                }
-
-                const description = renderDescription({
-                    videoId,
-                    transcriptHtml,
-                    exerciseHref,
-                    worksheetHref,
-                    worksheetExt,
-                });
-
-                const detailDateStr = $detail('.sigle-meta__date').text().trim();
-                const pubDate = detailDateStr ? parseDate(detailDateStr, 'D. M. YYYY') : item.pubDate;
-
-                return {
-                    title: item.title,
-                    link: item.link,
-                    pubDate,
-                    description,
-                    enclosure_url: enclosureUrl,
-                    enclosure_type: enclosureType,
-                };
-            })
-        )
-    );
+    const items = await Promise.all(list.map((item) => cache.tryGet(item.link, () => parseArticle(item))));
 
     return {
         title: 'Krátké české zprávy - CzechStepByStep',

--- a/lib/routes/czechstepbystep/kratke-ceske-zpravy.ts
+++ b/lib/routes/czechstepbystep/kratke-ceske-zpravy.ts
@@ -1,0 +1,163 @@
+import { load } from 'cheerio';
+
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+import { renderDescription } from './templates/description';
+
+const handler: Route['handler'] = async (ctx) => {
+    const baseUrl = 'https://www.czechstepbystep.cz';
+    const targetUrl = `${baseUrl}/kategorie/kratke-ceske-zpravy`;
+
+    const response = await ofetch(targetUrl);
+    const $ = load(response);
+
+    const limit = Number(ctx.req.query('limit') || 20);
+
+    const list = $('.news-item-info')
+        .slice(0, limit)
+        .toArray()
+        .map((item) => {
+            const el = $(item);
+            const linkEl = el.find('a.news-item-link');
+            const rawLink = linkEl.attr('href');
+            const link = rawLink ? (rawLink.startsWith('http') ? rawLink : `${baseUrl}${rawLink}`) : '';
+            const title = el.find('.news-item-link__title').text().trim();
+            const dateStr = el.find('.news-item-meta__date').text().trim();
+            const pubDate = dateStr ? parseDate(dateStr, 'D. M. YYYY') : undefined;
+
+            return {
+                title,
+                link,
+                pubDate,
+            };
+        })
+        .filter((item) => item.link);
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const html = await ofetch(item.link);
+                const $detail = load(html);
+
+                // 1. Video ID
+                let videoId: string | undefined;
+                const iframeEl = $detail('.entry-text iframe[src*="youtube.com"], .entry-text iframe[src*="youtu.be"], .entry-text iframe[data-src*="youtube.com"], .entry-text iframe[data-src*="youtu.be"]');
+                const iframeSrc = iframeEl.attr('data-src') || iframeEl.attr('src');
+                if (iframeSrc) {
+                    const match = iframeSrc.match(/(?:embed\/|v=|youtu\.be\/)([^?&]+)/);
+                    if (match) {
+                        videoId = match[1];
+                    }
+                }
+                if (!videoId) {
+                    const ytLink = $detail('.entry-text a[href*="youtube.com"], .entry-text a[href*="youtu.be"]').attr('href');
+                    if (ytLink) {
+                        const match = ytLink.match(/(?:v=|youtu\.be\/)([^?&]+)/);
+                        if (match) {
+                            videoId = match[1];
+                        }
+                    }
+                }
+
+                // 2. Full transcript HTML
+                let transcriptHtml: string | undefined;
+                const allParagraphs = $detail('.entry-text p');
+                const startIdx = allParagraphs.toArray().findIndex((p) => $detail(p).text().includes('Text zprávy:'));
+                if (startIdx !== -1) {
+                    const endIdx = allParagraphs.toArray().findIndex((p, i) => {
+                        if (i <= startIdx) {
+                            return false;
+                        }
+                        const txt = $detail(p).text();
+                        return txt.includes('Online cvičení') || txt.includes('Pracovní list') || txt.includes('Krátké české zprávy můžete sledovat') || txt.includes('Toto dílo podléhá licenci');
+                    });
+                    const slice = allParagraphs.slice(startIdx + 1, endIdx === -1 ? undefined : endIdx);
+                    transcriptHtml = slice.filter((_, p) => $detail(p).text().trim() !== '').toString();
+                }
+
+                // 3. Online exercise link
+                const exerciseHref = $detail('.entry-text a[href*="wordwall.net"]').attr('href');
+
+                // 4. Worksheet link & enclosure
+                let worksheetHref: string | undefined;
+                let worksheetExt: string | undefined;
+                let enclosureUrl: string | undefined;
+                let enclosureType: string | undefined;
+
+                const rawWsHref = $detail('.entry-text a[href*="uploads"]').attr('href');
+                if (rawWsHref && (rawWsHref.includes('PL_') || rawWsHref.endsWith('.docx') || rawWsHref.endsWith('.pdf'))) {
+                    const wsHref = rawWsHref.startsWith('http') ? rawWsHref : `${baseUrl}${rawWsHref}`;
+                    worksheetHref = wsHref;
+                    enclosureUrl = wsHref;
+                    if (wsHref.endsWith('.pdf')) {
+                        enclosureType = 'application/pdf';
+                        worksheetExt = 'PDF';
+                    } else if (wsHref.endsWith('.docx')) {
+                        enclosureType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+                        worksheetExt = 'DOCX';
+                    } else {
+                        worksheetExt = 'soubor';
+                    }
+                }
+
+                const description = renderDescription({
+                    videoId,
+                    transcriptHtml,
+                    exerciseHref,
+                    worksheetHref,
+                    worksheetExt,
+                });
+
+                const detailDateStr = $detail('.sigle-meta__date').text().trim();
+                const pubDate = detailDateStr ? parseDate(detailDateStr, 'D. M. YYYY') : item.pubDate;
+
+                return {
+                    title: item.title,
+                    link: item.link,
+                    pubDate,
+                    description,
+                    enclosure_url: enclosureUrl,
+                    enclosure_type: enclosureType,
+                };
+            })
+        )
+    );
+
+    return {
+        title: 'Krátké české zprávy - CzechStepByStep',
+        link: targetUrl,
+        description: 'Short Czech news (Krátké české zprávy) from CzechStepByStep including video, full transcript, online exercises, and worksheets.',
+        language: 'cs',
+        item: items,
+    };
+};
+
+export const route: Route = {
+    path: '/kratke-ceske-zpravy',
+    categories: ['study'],
+    example: '/czechstepbystep/kratke-ceske-zpravy',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.czechstepbystep.cz/kategorie/kratke-ceske-zpravy'],
+            target: '/kratke-ceske-zpravy',
+        },
+    ],
+    name: 'Krátké české zprávy',
+    maintainers: ['cmp0xff'],
+    handler,
+    url: 'www.czechstepbystep.cz/kategorie/kratke-ceske-zpravy',
+    description: 'Short Czech news (Krátké české zprávy) from CzechStepByStep including video, full transcript, online exercises, and worksheets.',
+};

--- a/lib/routes/czechstepbystep/namespace.ts
+++ b/lib/routes/czechstepbystep/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'CzechStepByStep',
+    url: 'www.czechstepbystep.cz',
+    lang: 'cs',
+};

--- a/lib/routes/czechstepbystep/templates/description.tsx
+++ b/lib/routes/czechstepbystep/templates/description.tsx
@@ -1,0 +1,47 @@
+import { raw } from 'hono/html';
+import { renderToString } from 'hono/jsx/dom/server';
+
+import { renderYoutube as renderYouTubeDescription } from '@/routes/youtube/utils';
+
+interface DescriptionData {
+    videoId?: string;
+    transcriptHtml?: string;
+    exerciseHref?: string;
+    worksheetHref?: string;
+    worksheetExt?: string;
+}
+
+const CzechStepByStepDescription = ({ videoId, transcriptHtml, exerciseHref, worksheetHref, worksheetExt }: DescriptionData) => (
+    <div>
+        {videoId && raw(renderYouTubeDescription(true, videoId, undefined, undefined))}
+
+        {transcriptHtml && (
+            <>
+                <p>
+                    <strong>Text zprávy:</strong>
+                </p>
+                {raw(transcriptHtml)}
+            </>
+        )}
+
+        {exerciseHref && (
+            <p>
+                <strong>Online cvičení:</strong>{' '}
+                <a href={exerciseHref} target="_blank" rel="noopener noreferrer">
+                    Otevřít online cvičení (Wordwall)
+                </a>
+            </p>
+        )}
+
+        {worksheetHref && (
+            <p>
+                <strong>Pracovní list:</strong>{' '}
+                <a href={worksheetHref} target="_blank" rel="noopener noreferrer">
+                    Stáhnout pracovní list ({worksheetExt || 'soubor'})
+                </a>
+            </p>
+        )}
+    </div>
+);
+
+export const renderDescription = (data: DescriptionData) => renderToString(<CzechStepByStepDescription {...data} />);

--- a/lib/routes/czechstepbystep/templates/description.tsx
+++ b/lib/routes/czechstepbystep/templates/description.tsx
@@ -13,7 +13,7 @@ const CzechStepByStepDescription = ({ videoId, transcriptHtml, exerciseHref, wor
     <div>
         {videoId && (
             <>
-                <iframe id="ytplayer" type="text/html" width="640" height="360" src={`https://www.youtube-nocookie.com/embed/${videoId}`} frameborder="0" allowfullscreen referrerpolicy="strict-origin-when-cross-origin" />
+                <iframe id="ytplayer" type="text/html" width="640" height="360" src={`https://www.youtube-nocookie.com/embed/${videoId}`} frameborder="0" allowfullscreen />
                 <br />
             </>
         )}

--- a/lib/routes/czechstepbystep/templates/description.tsx
+++ b/lib/routes/czechstepbystep/templates/description.tsx
@@ -1,8 +1,6 @@
 import { raw } from 'hono/html';
 import { renderToString } from 'hono/jsx/dom/server';
 
-import { renderYoutube as renderYouTubeDescription } from '@/routes/youtube/utils';
-
 interface DescriptionData {
     videoId?: string;
     transcriptHtml?: string;
@@ -13,7 +11,12 @@ interface DescriptionData {
 
 const CzechStepByStepDescription = ({ videoId, transcriptHtml, exerciseHref, worksheetHref, worksheetExt }: DescriptionData) => (
     <div>
-        {videoId && raw(renderYouTubeDescription(true, videoId, undefined, undefined))}
+        {videoId && (
+            <>
+                <iframe id="ytplayer" type="text/html" width="640" height="360" src={`https://www.youtube-nocookie.com/embed/${videoId}`} frameborder="0" allowfullscreen referrerpolicy="strict-origin-when-cross-origin" />
+                <br />
+            </>
+        )}
 
         {transcriptHtml && (
             <>


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

None

## Example for the Proposed Route(s) / 路由地址示例

```routes
/czechstepbystep/kratke-ceske-zpravy
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign?
- [x] Date and time / 日期和时间
    - [x] Parsed
    - [x] Correct time zone
- [ ] New package added / 添加了新的包
- [ ] Puppeteer

## Note / 说明

Adds an RSS route for **CzechStepByStep: Krátké české zprávy** (https://www.czechstepbystep.cz/kategorie/kratke-ceske-zpravy) — short Czech news for language learners.

Each item includes:
- Embedded YouTube video (inline player)
- Full transcript under "Text zprávy"
- Wordwall online exercise link
- Downloadable worksheet (.docx / .pdf) as both link and enclosure

Replaces #23016, which was closed by automation after a CI typecheck failure; all review feedback has been addressed.

<!--
## AI Agent Context (hidden from human reviewers)

### Background
- This PR replaces #23016, which was auto-closed because commit `53fbecd` imported the non-existent export `renderDescription` from `@/routes/youtube/utils`.
- Branch `feat/czechstepbystep` was rebased onto `upstream/master` and force-pushed; PR head is commit `8fb29e33f`.

### Full plan
1. Refactor the article parser into small helpers (`extractYouTubeId`, `extractTranscript`, `extractExerciseHref`, `extractWorksheet`, `parseArticle`) to fix the CodeFactor "Complex Method" (complexity 16) issue.
2. Video: use a single `.entry-text iframe` selector reading `data-src || src`; drop the blanket `a[href]` fallback; throw a visible error if no YouTube id is found.
3. Worksheet: anchor on the paragraph containing `Pracovní list`, take its `a[href]`, and derive the extension once via `/\.(docx|pdf)(?:[?#]|$)/i` for both display and `enclosure_type`.
4. Transcript: use the `Text zprávy:` paragraph as the start boundary and the `Krátké české zprávy můžete sledovat` paragraph as the single end boundary.
5. Template: inline the YouTube `<iframe>` in `templates/description.tsx`; remove the cross-namespace `@/routes/youtube/utils` dependency.
6. Remove the iframe `referrerpolicy` attribute per the no-referrer-policy route rule (RSSHub middleware injects the policy automatically).

### Decisions / rationale
- `extractYouTubeId` throwing on a missing video is intentional: the route's value is video + transcript, and hard failure makes site changes visible to CI/maintainers instead of silently omitting the video.

### Verification
- `pnpm typecheck`
- `pnpm exec oxlint --type-aware --config=.oxlintrc.ci.json lib/routes/czechstepbystep`
- `pnpm dev` + `curl http://localhost:1200/czechstepbystep/kratke-ceske-zpravy` → 9 items with iframe/transcript/wordwall/worksheet/enclosure

### Commit and push
- Commits:
  - `refactor(route/czechstepbystep): simplify article parsing`
  - `refactor(route/czechstepbystep): drop iframe referrerpolicy`
- Commit trailer on each: `Co-authored-by: deepseek-v4-pro <noreply@deepseek.com>`
- Push: `git push origin feat/czechstepbystep`
-->

