### PR TITLE
feat(route): add author feeds for The Atlantic

### DIFF
--- a/lib/routes/theatlantic/author.ts
+++ b/lib/routes/theatlantic/author.ts
@@ -1,0 +1,57 @@
+import type { Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import rssParser from '@/utils/rss-parser';
+
+import { getArticleDetails } from './utils';
+
+export const route: Route = {
+    path: '/author/:slug',
+    categories: ['traditional-media'],
+    example: '/theatlantic/author/ian-bogost',
+    parameters: { slug: 'Author slug, which can be found in the author page URL' },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.theatlantic.com/author/:slug'],
+            target: '/author/:slug',
+        },
+    ],
+    name: 'Author',
+    maintainers: ['DzmingLi'],
+    handler,
+    description: 'Articles written by a specific author.',
+};
+
+async function handler(ctx) {
+    const host = 'https://www.theatlantic.com';
+    const slug = ctx.req.param('slug');
+    const link = `${host}/author/${slug}/`;
+    const feed = await rssParser.parseString(await ofetch(`${host}/feed/author/${slug}/`));
+    const author = feed.title?.replace(' | The Atlantic', '') ?? slug;
+    const list = feed.items
+        .filter((item) => item.link)
+        .map((item) => {
+            const articleUrl = new URL(item.link!);
+            articleUrl.search = '';
+
+            return {
+                link: articleUrl.href,
+                pubDate: item.pubDate,
+            };
+        });
+    const items = await getArticleDetails(list);
+
+    return {
+        title: feed.title ?? `The Atlantic - ${author}`,
+        link,
+        description: `The Atlantic articles by ${author}`,
+        item: items,
+    };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/theatlantic/author/ian-bogost
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds an author route for The Atlantic. It uses The Atlantic's official per-author Atom feed as the article list source and reuses the existing `getArticleDetails()` helper for article content.

Full-content behavior was verified against the Ian Bogost feed: all 25 entries in the official author feed contain article content, and all 25 entries produced by the RSSHub route contain the article body generated by `getArticleDetails()` rather than only the summary.

Validation performed:

- Route build
- TypeScript typecheck
- Route-specific formatting and lint checks
- End-to-end request to `/theatlantic/author/ian-bogost` (HTTP 200, 25 complete items)
