### PR TITLE
feat(twitch): add Twitch routes for videos, clips, and live stream

### DIFF
--- a/clips.ts
+++ b/clips.ts
@@ -1,0 +1,67 @@
+import { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+import { getTwitchHeaders, getUserId } from './utils';
+
+export const route: Route = {
+    path: '/clips/:channel',
+    categories: ['live'],
+    example: '/twitch/clips/xqc',
+    parameters: {
+        channel: 'Twitch channel login name (e.g. `xqc`)',
+    },
+    features: {
+        requireConfig: [
+            { name: 'TWITCH_CLIENT_ID', description: 'Twitch app Client ID' },
+            { name: 'TWITCH_CLIENT_SECRET', description: 'Twitch app Client Secret' },
+        ],
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['twitch.tv/:channel/clips'],
+            target: '/clips/:channel',
+        },
+    ],
+    name: 'Channel Clips',
+    maintainers: [],
+    handler: async (ctx) => {
+        const { channel } = ctx.req.param();
+
+        const headers = await getTwitchHeaders();
+        const user = await getUserId(channel);
+
+        const params = new URLSearchParams({
+            broadcaster_id: user.id,
+            first: '20',
+        });
+
+        const data = await ofetch(`https://api.twitch.tv/helix/clips?${params}`, { headers });
+
+        const items = (data.data ?? []).map((clip: any) => ({
+            title: clip.title,
+            link: clip.url,
+            description: `
+                <a href="${clip.url}">
+                    <img src="${clip.thumbnail_url}" alt="${clip.title}" />
+                </a>
+                <p>Clipped by: ${clip.creator_name}</p>
+                <p>Views: ${clip.view_count.toLocaleString()} | Duration: ${clip.duration}s</p>
+            `,
+            pubDate: parseDate(clip.created_at),
+            author: clip.creator_name,
+            category: ['clip'],
+        }));
+
+        return {
+            title: `${user.display_name} — Twitch Clips`,
+            link: `https://www.twitch.tv/${channel}/clips`,
+            image: user.profile_image_url,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/twitch/clips.ts
+++ b/lib/routes/twitch/clips.ts
@@ -1,0 +1,67 @@
+import { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+import { getTwitchHeaders, getUserId } from './utils';
+
+export const route: Route = {
+    path: '/clips/:channel',
+    categories: ['live'],
+    example: '/twitch/clips/xqc',
+    parameters: {
+        channel: 'Twitch channel login name (e.g. `xqc`)',
+    },
+    features: {
+        requireConfig: [
+            { name: 'TWITCH_CLIENT_ID', description: 'Twitch app Client ID' },
+            { name: 'TWITCH_CLIENT_SECRET', description: 'Twitch app Client Secret' },
+        ],
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['twitch.tv/:channel/clips'],
+            target: '/clips/:channel',
+        },
+    ],
+    name: 'Channel Clips',
+    maintainers: [],
+    handler: async (ctx) => {
+        const { channel } = ctx.req.param();
+
+        const headers = await getTwitchHeaders();
+        const user = await getUserId(channel);
+
+        const params = new URLSearchParams({
+            broadcaster_id: user.id,
+            first: '20',
+        });
+
+        const data = await ofetch(`https://api.twitch.tv/helix/clips?${params}`, { headers });
+
+        const items = (data.data ?? []).map((clip: any) => ({
+            title: clip.title,
+            link: clip.url,
+            description: `
+                <a href="${clip.url}">
+                    <img src="${clip.thumbnail_url}" alt="${clip.title}" />
+                </a>
+                <p>Clipped by: ${clip.creator_name}</p>
+                <p>Views: ${clip.view_count.toLocaleString()} | Duration: ${clip.duration}s</p>
+            `,
+            pubDate: parseDate(clip.created_at),
+            author: clip.creator_name,
+            category: ['clip'],
+        }));
+
+        return {
+            title: `${user.display_name} — Twitch Clips`,
+            link: `https://www.twitch.tv/${channel}/clips`,
+            image: user.profile_image_url,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/twitch/stream.ts
+++ b/lib/routes/twitch/stream.ts
@@ -1,0 +1,80 @@
+import { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+import { getTwitchHeaders, getUserId } from './utils';
+
+export const route: Route = {
+    path: '/stream/:channel',
+    categories: ['live'],
+    example: '/twitch/stream/pokimane',
+    parameters: {
+        channel: 'Twitch channel login name (e.g. `pokimane`)',
+    },
+    features: {
+        requireConfig: [
+            { name: 'TWITCH_CLIENT_ID', description: 'Twitch app Client ID' },
+            { name: 'TWITCH_CLIENT_SECRET', description: 'Twitch app Client Secret' },
+        ],
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['twitch.tv/:channel'],
+            target: '/stream/:channel',
+        },
+    ],
+    name: 'Live Stream Status',
+    maintainers: [],
+    handler: async (ctx) => {
+        const { channel } = ctx.req.param();
+
+        const headers = await getTwitchHeaders();
+        const user = await getUserId(channel);
+
+        const data = await ofetch(
+            `https://api.twitch.tv/helix/streams?user_login=${encodeURIComponent(channel)}`,
+            { headers }
+        );
+
+        const stream = data.data?.[0];
+        const isLive = !!stream;
+
+        const items = isLive
+            ? [
+                  {
+                      title: `🔴 LIVE: ${stream.title}`,
+                      link: `https://www.twitch.tv/${channel}`,
+                      description: `
+                        <a href="https://www.twitch.tv/${channel}">
+                            <img src="${stream.thumbnail_url.replace('{width}', '640').replace('{height}', '360')}" alt="${stream.title}" />
+                        </a>
+                        <p>Game: ${stream.game_name}</p>
+                        <p>Viewers: ${stream.viewer_count.toLocaleString()}</p>
+                    `,
+                      pubDate: parseDate(stream.started_at),
+                      author: user.display_name,
+                      category: [stream.game_name, 'live'],
+                  },
+              ]
+            : [
+                  {
+                      title: `${user.display_name} is offline`,
+                      link: `https://www.twitch.tv/${channel}`,
+                      description: `<p>${user.display_name} is not currently streaming.</p>`,
+                      pubDate: new Date(),
+                      author: user.display_name,
+                  },
+              ];
+
+        return {
+            title: `${user.display_name} — Twitch Stream`,
+            link: `https://www.twitch.tv/${channel}`,
+            image: user.profile_image_url,
+            item: items,
+        };
+    },
+};

--- a/lib/routes/twitch/utils.ts
+++ b/lib/routes/twitch/utils.ts
@@ -1,0 +1,67 @@
+import ofetch from '@/utils/ofetch';
+import { config } from '@/config';
+
+let cachedToken: string | null = null;
+let tokenExpiry = 0;
+
+/**
+ * Fetch an App Access Token from Twitch using client credentials flow.
+ * Token is cached and refreshed automatically when expired.
+ */
+export async function getAccessToken(): Promise<string> {
+    const now = Date.now();
+
+    if (cachedToken && now < tokenExpiry) {
+        return cachedToken;
+    }
+
+    const clientId = config.twitch?.clientId;
+    const clientSecret = config.twitch?.clientSecret;
+
+    if (!clientId || !clientSecret) {
+        throw new Error('Twitch Client ID and Client Secret are required. Set TWITCH_CLIENT_ID and TWITCH_CLIENT_SECRET environment variables.');
+    }
+
+    const data = await ofetch('https://id.twitch.tv/oauth2/token', {
+        method: 'POST',
+        body: new URLSearchParams({
+            client_id: clientId,
+            client_secret: clientSecret,
+            grant_type: 'client_credentials',
+        }),
+    });
+
+    cachedToken = data.access_token;
+    // Expire 60 seconds before actual expiry for safety
+    tokenExpiry = now + (data.expires_in - 60) * 1000;
+
+    return cachedToken!;
+}
+
+/**
+ * Return headers required for all Twitch Helix API calls.
+ */
+export async function getTwitchHeaders(): Promise<Record<string, string>> {
+    const clientId = config.twitch?.clientId;
+    const token = await getAccessToken();
+
+    return {
+        'Client-ID': clientId!,
+        Authorization: `Bearer ${token}`,
+    };
+}
+
+/**
+ * Resolve a Twitch login name to a numeric user ID.
+ */
+export async function getUserId(login: string): Promise<{ id: string; display_name: string; profile_image_url: string }> {
+    const headers = await getTwitchHeaders();
+
+    const data = await ofetch(`https://api.twitch.tv/helix/users?login=${encodeURIComponent(login)}`, { headers });
+
+    if (!data.data || data.data.length === 0) {
+        throw new Error(`Twitch user not found: ${login}`);
+    }
+
+    return data.data[0];
+}

--- a/lib/routes/twitch/videos.ts
+++ b/lib/routes/twitch/videos.ts
@@ -1,0 +1,75 @@
+import { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+import { getTwitchHeaders, getUserId } from './utils';
+
+export const route: Route = {
+    path: '/videos/:channel/:type?',
+    categories: ['live'],
+    example: '/twitch/videos/shroud',
+    parameters: {
+        channel: 'Twitch channel login name (e.g. `shroud`)',
+        type: 'Video type: `archive` (past broadcasts), `highlight`, or `upload`. Default: `archive`',
+    },
+    features: {
+        requireConfig: [
+            { name: 'TWITCH_CLIENT_ID', description: 'Twitch app Client ID' },
+            { name: 'TWITCH_CLIENT_SECRET', description: 'Twitch app Client Secret' },
+        ],
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['twitch.tv/:channel/videos'],
+            target: '/videos/:channel',
+        },
+    ],
+    name: 'Channel Videos',
+    maintainers: [],
+    handler: async (ctx) => {
+        const { channel, type = 'archive' } = ctx.req.param();
+        const validTypes = ['archive', 'highlight', 'upload', 'all'];
+        const videoType = validTypes.includes(type) ? type : 'archive';
+
+        const headers = await getTwitchHeaders();
+        const user = await getUserId(channel);
+
+        const params = new URLSearchParams({
+            user_id: user.id,
+            first: '20',
+            sort: 'time',
+        });
+
+        if (videoType !== 'all') {
+            params.set('type', videoType);
+        }
+
+        const data = await ofetch(`https://api.twitch.tv/helix/videos?${params}`, { headers });
+
+        const items = (data.data ?? []).map((video: any) => ({
+            title: video.title,
+            link: `https://www.twitch.tv/videos/${video.id}`,
+            description: `
+                <a href="https://www.twitch.tv/videos/${video.id}">
+                    <img src="${video.thumbnail_url.replace('%{width}', '640').replace('%{height}', '360')}" alt="${video.title}" />
+                </a>
+                <p>${video.description || ''}</p>
+                <p>Duration: ${video.duration} | Views: ${video.view_count.toLocaleString()}</p>
+            `,
+            pubDate: parseDate(video.created_at),
+            author: user.display_name,
+            category: [video.type],
+        }));
+
+        return {
+            title: `${user.display_name} — Twitch ${videoType === 'archive' ? 'Past Broadcasts' : videoType === 'highlight' ? 'Highlights' : 'Videos'}`,
+            link: `https://www.twitch.tv/${channel}/videos`,
+            image: user.profile_image_url,
+            item: items,
+        };
+    },
+};

--- a/namespace.ts
+++ b/namespace.ts
@@ -1,0 +1,13 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Twitch',
+    url: 'twitch.tv',
+    description: `
+:::tip
+Twitch routes require a Client ID and Client Secret.
+Register your app at [Twitch Developer Console](https://dev.twitch.tv/console/apps) and set:
+- \`TWITCH_CLIENT_ID\`
+- \`TWITCH_CLIENT_SECRET\`
+:::`,
+};

--- a/stream.ts
+++ b/stream.ts
@@ -1,0 +1,80 @@
+import { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+import { getTwitchHeaders, getUserId } from './utils';
+
+export const route: Route = {
+    path: '/stream/:channel',
+    categories: ['live'],
+    example: '/twitch/stream/pokimane',
+    parameters: {
+        channel: 'Twitch channel login name (e.g. `pokimane`)',
+    },
+    features: {
+        requireConfig: [
+            { name: 'TWITCH_CLIENT_ID', description: 'Twitch app Client ID' },
+            { name: 'TWITCH_CLIENT_SECRET', description: 'Twitch app Client Secret' },
+        ],
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['twitch.tv/:channel'],
+            target: '/stream/:channel',
+        },
+    ],
+    name: 'Live Stream Status',
+    maintainers: [],
+    handler: async (ctx) => {
+        const { channel } = ctx.req.param();
+
+        const headers = await getTwitchHeaders();
+        const user = await getUserId(channel);
+
+        const data = await ofetch(
+            `https://api.twitch.tv/helix/streams?user_login=${encodeURIComponent(channel)}`,
+            { headers }
+        );
+
+        const stream = data.data?.[0];
+        const isLive = !!stream;
+
+        const items = isLive
+            ? [
+                  {
+                      title: `🔴 LIVE: ${stream.title}`,
+                      link: `https://www.twitch.tv/${channel}`,
+                      description: `
+                        <a href="https://www.twitch.tv/${channel}">
+                            <img src="${stream.thumbnail_url.replace('{width}', '640').replace('{height}', '360')}" alt="${stream.title}" />
+                        </a>
+                        <p>Game: ${stream.game_name}</p>
+                        <p>Viewers: ${stream.viewer_count.toLocaleString()}</p>
+                    `,
+                      pubDate: parseDate(stream.started_at),
+                      author: user.display_name,
+                      category: [stream.game_name, 'live'],
+                  },
+              ]
+            : [
+                  {
+                      title: `${user.display_name} is offline`,
+                      link: `https://www.twitch.tv/${channel}`,
+                      description: `<p>${user.display_name} is not currently streaming.</p>`,
+                      pubDate: new Date(),
+                      author: user.display_name,
+                  },
+              ];
+
+        return {
+            title: `${user.display_name} — Twitch Stream`,
+            link: `https://www.twitch.tv/${channel}`,
+            image: user.profile_image_url,
+            item: items,
+        };
+    },
+};

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,67 @@
+import ofetch from '@/utils/ofetch';
+import { config } from '@/config';
+
+let cachedToken: string | null = null;
+let tokenExpiry = 0;
+
+/**
+ * Fetch an App Access Token from Twitch using client credentials flow.
+ * Token is cached and refreshed automatically when expired.
+ */
+export async function getAccessToken(): Promise<string> {
+    const now = Date.now();
+
+    if (cachedToken && now < tokenExpiry) {
+        return cachedToken;
+    }
+
+    const clientId = config.twitch?.clientId;
+    const clientSecret = config.twitch?.clientSecret;
+
+    if (!clientId || !clientSecret) {
+        throw new Error('Twitch Client ID and Client Secret are required. Set TWITCH_CLIENT_ID and TWITCH_CLIENT_SECRET environment variables.');
+    }
+
+    const data = await ofetch('https://id.twitch.tv/oauth2/token', {
+        method: 'POST',
+        body: new URLSearchParams({
+            client_id: clientId,
+            client_secret: clientSecret,
+            grant_type: 'client_credentials',
+        }),
+    });
+
+    cachedToken = data.access_token;
+    // Expire 60 seconds before actual expiry for safety
+    tokenExpiry = now + (data.expires_in - 60) * 1000;
+
+    return cachedToken!;
+}
+
+/**
+ * Return headers required for all Twitch Helix API calls.
+ */
+export async function getTwitchHeaders(): Promise<Record<string, string>> {
+    const clientId = config.twitch?.clientId;
+    const token = await getAccessToken();
+
+    return {
+        'Client-ID': clientId!,
+        Authorization: `Bearer ${token}`,
+    };
+}
+
+/**
+ * Resolve a Twitch login name to a numeric user ID.
+ */
+export async function getUserId(login: string): Promise<{ id: string; display_name: string; profile_image_url: string }> {
+    const headers = await getTwitchHeaders();
+
+    const data = await ofetch(`https://api.twitch.tv/helix/users?login=${encodeURIComponent(login)}`, { headers });
+
+    if (!data.data || data.data.length === 0) {
+        throw new Error(`Twitch user not found: ${login}`);
+    }
+
+    return data.data[0];
+}

--- a/videos.ts
+++ b/videos.ts
@@ -1,0 +1,75 @@
+import { Route } from '@/types';
+import { parseDate } from '@/utils/parse-date';
+import ofetch from '@/utils/ofetch';
+import { getTwitchHeaders, getUserId } from './utils';
+
+export const route: Route = {
+    path: '/videos/:channel/:type?',
+    categories: ['live'],
+    example: '/twitch/videos/shroud',
+    parameters: {
+        channel: 'Twitch channel login name (e.g. `shroud`)',
+        type: 'Video type: `archive` (past broadcasts), `highlight`, or `upload`. Default: `archive`',
+    },
+    features: {
+        requireConfig: [
+            { name: 'TWITCH_CLIENT_ID', description: 'Twitch app Client ID' },
+            { name: 'TWITCH_CLIENT_SECRET', description: 'Twitch app Client Secret' },
+        ],
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['twitch.tv/:channel/videos'],
+            target: '/videos/:channel',
+        },
+    ],
+    name: 'Channel Videos',
+    maintainers: [],
+    handler: async (ctx) => {
+        const { channel, type = 'archive' } = ctx.req.param();
+        const validTypes = ['archive', 'highlight', 'upload', 'all'];
+        const videoType = validTypes.includes(type) ? type : 'archive';
+
+        const headers = await getTwitchHeaders();
+        const user = await getUserId(channel);
+
+        const params = new URLSearchParams({
+            user_id: user.id,
+            first: '20',
+            sort: 'time',
+        });
+
+        if (videoType !== 'all') {
+            params.set('type', videoType);
+        }
+
+        const data = await ofetch(`https://api.twitch.tv/helix/videos?${params}`, { headers });
+
+        const items = (data.data ?? []).map((video: any) => ({
+            title: video.title,
+            link: `https://www.twitch.tv/videos/${video.id}`,
+            description: `
+                <a href="https://www.twitch.tv/videos/${video.id}">
+                    <img src="${video.thumbnail_url.replace('%{width}', '640').replace('%{height}', '360')}" alt="${video.title}" />
+                </a>
+                <p>${video.description || ''}</p>
+                <p>Duration: ${video.duration} | Views: ${video.view_count.toLocaleString()}</p>
+            `,
+            pubDate: parseDate(video.created_at),
+            author: user.display_name,
+            category: [video.type],
+        }));
+
+        return {
+            title: `${user.display_name} — Twitch ${videoType === 'archive' ? 'Past Broadcasts' : videoType === 'highlight' ? 'Highlights' : 'Videos'}`,
+            link: `https://www.twitch.tv/${channel}/videos`,
+            image: user.profile_image_url,
+            item: items,
+        };
+    },
+};


### PR DESCRIPTION

   Adds Twitch support with three routes:
   - /twitch/videos/:channel — Past broadcasts, highlights and uploads
   - /twitch/clips/:channel — Channel clips
   - /twitch/stream/:channel — Live stream status
   
   Uses Twitch Helix API with client credentials auth.