### PR TITLE
feat(route/nytimes): add Wirecutter

### DIFF
--- a/lib/routes/nytimes/templates/wirecutter.tsx
+++ b/lib/routes/nytimes/templates/wirecutter.tsx
@@ -1,0 +1,156 @@
+import type { FC } from 'hono/jsx';
+import { renderToString } from 'hono/jsx/dom/server';
+
+const imageBase = 'https://cdn.thewirecutter.com/';
+
+// Presentational or promotional nodes that carry no article content
+const dropTypes = new Set(['adslot', 'shortcode-recirc', 'shortcode-scoop_form_callout']);
+
+// hono/jsx only applies void-element rules to literal tags, so a dynamic <Tag> must be self-closed
+// explicitly: <Tag></Tag> would emit `<br></br>`, which HTML parsers turn into two line breaks
+const voidTags = new Set(['br', 'hr', 'img', 'source']);
+
+const allowedTags = new Set([
+    'p',
+    'a',
+    'strong',
+    'b',
+    'em',
+    'i',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'ul',
+    'ol',
+    'li',
+    'br',
+    'hr',
+    'img',
+    'blockquote',
+    'figure',
+    'figcaption',
+    'div',
+    'span',
+    'video',
+    'source',
+    'table',
+    'thead',
+    'tbody',
+    'tr',
+    'th',
+    'td',
+]);
+// Everything else is layout plumbing or tracking metadata
+const allowedAttributes = new Set(['href', 'src', 'alt', 'title', 'width', 'height', 'colspan', 'rowspan']);
+
+// Images are served through a resizing CDN; without the query string the original is returned
+const originalImage = (url: string): string => (url.startsWith('http') ? url : `${imageBase}${url.replace(/^\//, '')}`).split('?', 1)[0];
+
+const Image: FC<{ src?: string; alt?: string; caption?: string }> = ({ src, alt, caption }) =>
+    src ? (
+        <figure>
+            <img src={originalImage(src)} alt={alt || undefined} />
+            {caption ? <figcaption>{caption}</figcaption> : null}
+        </figure>
+    ) : null;
+
+// A Wirecutter pick: the product, why it won, and its photo
+const Callout: FC<{ node: any }> = ({ node }) => (
+    <>
+        {(node.dbData?.callouts ?? []).map((pick) => {
+            const heading = [pick.ribbon || node.dbData?.ribbon, pick.name].filter(Boolean).join(': ');
+            return (
+                <blockquote>
+                    {heading ? <h4>{heading}</h4> : null}
+                    <Image src={pick.images?.full} alt={pick.name} />
+                    {pick.title ? (
+                        <p>
+                            <strong>{pick.title}</strong>
+                        </p>
+                    ) : null}
+                    {pick.description ? <p>{pick.description}</p> : null}
+                </blockquote>
+            );
+        })}
+    </>
+);
+
+const Nodes: FC<{ nodes?: any[] }> = ({ nodes }) => (
+    <>
+        {(nodes ?? []).map((node) => (
+            <Node node={node} />
+        ))}
+    </>
+);
+
+const Node: FC<{ node: any }> = ({ node }) => {
+    if (node.type === 'text') {
+        return <>{node.data ?? ''}</>;
+    }
+    if (node.type === 'comment') {
+        return null;
+    }
+    if (node.type !== 'tag') {
+        throw new Error(`Unsupported node type: ${node.type}`);
+    }
+
+    const name = node.name;
+    if (dropTypes.has(name)) {
+        return null;
+    }
+    switch (name) {
+        case 'shortcode-gallery':
+            return (
+                <>
+                    {(node.dbData ?? []).map((image) => (
+                        <Image src={image.dbData?.source ?? image.imagePaths?.full} alt={image.alt} caption={image.credit} />
+                    ))}
+                </>
+            );
+        case 'shortcode-callout':
+            return <Callout node={node} />;
+        case 'shortcode-caption':
+            return (
+                <figure>
+                    <Nodes nodes={node.children} />
+                    {node.dbData?.credit ? <figcaption>{node.dbData.credit}</figcaption> : null}
+                </figure>
+            );
+        default:
+            break;
+    }
+    if (!allowedTags.has(name)) {
+        throw new Error(`Unsupported tag: ${name}`);
+    }
+
+    const attributes = Object.fromEntries(
+        Object.entries(node.attribs ?? {})
+            .filter(([key]) => allowedAttributes.has(key))
+            .map(([key, value]) => [key, key === 'src' ? originalImage(String(value)) : value])
+    );
+    const Tag = name as unknown as FC;
+
+    return voidTags.has(name) ? (
+        <Tag {...attributes} />
+    ) : (
+        <Tag {...attributes}>
+            <Nodes nodes={node.children} />
+        </Tag>
+    );
+};
+
+const Post: FC<{ post: any }> = ({ post }) => (
+    <>
+        {post.heroImage ? <Image src={post.heroImage.source} alt={post.heroImage.alt} caption={post.heroImage.caption} /> : null}
+        {(post.chapters ?? []).map((chapter) => (
+            <>
+                {chapter.title ? <h2>{chapter.title}</h2> : null}
+                <Nodes nodes={chapter.body} />
+            </>
+        ))}
+    </>
+);
+
+export const renderPost = (post: any): string => renderToString(<Post post={post} />);

--- a/lib/routes/nytimes/wirecutter.ts
+++ b/lib/routes/nytimes/wirecutter.ts
@@ -1,0 +1,191 @@
+import { load } from 'cheerio';
+
+import type { DataItem, Route } from '@/types';
+import { ViewType } from '@/types';
+import cache from '@/utils/cache';
+import logger from '@/utils/logger';
+import ofetch from '@/utils/ofetch';
+import parser from '@/utils/rss-parser';
+
+const feedUrl = 'https://www.nytimes.com/wirecutter/feed/';
+const imageBase = 'https://cdn.thewirecutter.com/';
+
+// Presentational or promotional nodes that carry no article content
+const dropTypes = new Set(['adslot', 'shortcode-recirc', 'shortcode-scoop_form_callout']);
+
+const allowedTags = new Set([
+    'p',
+    'a',
+    'strong',
+    'b',
+    'em',
+    'i',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'ul',
+    'ol',
+    'li',
+    'br',
+    'hr',
+    'img',
+    'blockquote',
+    'figure',
+    'figcaption',
+    'div',
+    'span',
+    'video',
+    'source',
+    'table',
+    'thead',
+    'tbody',
+    'tr',
+    'th',
+    'td',
+]);
+const voidTags = new Set(['br', 'hr', 'img', 'source']);
+// Everything else is layout plumbing or tracking metadata
+const allowedAttributes = new Set(['href', 'src', 'alt', 'title', 'width', 'height', 'colspan', 'rowspan']);
+
+const escapeText = (text: string): string => text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+
+const escapeAttribute = (value: string): string => escapeText(value).replaceAll('"', '&quot;');
+
+// Images are served through a resizing CDN; without the query string the original is returned
+const originalImage = (url: string): string => (url.startsWith('http') ? url : `${imageBase}${url.replace(/^\//, '')}`).split('?', 1)[0];
+
+const renderImage = (src: string, alt?: string, caption?: string): string =>
+    src ? `<figure><img src="${escapeAttribute(originalImage(src))}"${alt ? ` alt="${escapeAttribute(alt)}"` : ''}>${caption ? `<figcaption>${escapeText(caption)}</figcaption>` : ''}</figure>` : '';
+
+// A Wirecutter pick: the product, why it won, and its photo
+const renderCallout = (node: any): string =>
+    (node.dbData?.callouts ?? [])
+        .map((pick) => {
+            const heading = [pick.ribbon || node.dbData?.ribbon, pick.name].filter(Boolean).join(': ');
+            return `<blockquote>${heading ? `<h4>${escapeText(heading)}</h4>` : ''}${renderImage(pick.images?.full, pick.name)}${pick.title ? `<p><strong>${escapeText(pick.title)}</strong></p>` : ''}${pick.description ? `<p>${escapeText(pick.description)}</p>` : ''}</blockquote>`;
+        })
+        .join('');
+
+const renderNodes = (nodes: any[] | undefined): string => (nodes ?? []).map((node) => renderNode(node)).join('');
+
+const renderNode = (node: any): string => {
+    if (node.type === 'text') {
+        return escapeText(node.data ?? '');
+    }
+    if (node.type === 'comment') {
+        return '';
+    }
+    if (node.type !== 'tag') {
+        throw new Error(`Unsupported node type: ${node.type}`);
+    }
+
+    const name = node.name;
+    if (dropTypes.has(name)) {
+        return '';
+    }
+    switch (name) {
+        case 'shortcode-gallery':
+            return (node.dbData ?? []).map((image) => renderImage(image.dbData?.source ?? image.imagePaths?.full, image.alt, image.credit)).join('');
+        case 'shortcode-callout':
+            return renderCallout(node);
+        case 'shortcode-caption':
+            return `<figure>${renderNodes(node.children)}${node.dbData?.credit ? `<figcaption>${escapeText(node.dbData.credit)}</figcaption>` : ''}</figure>`;
+        default:
+            break;
+    }
+    if (!allowedTags.has(name)) {
+        throw new Error(`Unsupported tag: ${name}`);
+    }
+
+    const attributes = Object.entries(node.attribs ?? {})
+        .filter(([key]) => allowedAttributes.has(key))
+        .map(([key, value]) => ` ${key}="${escapeAttribute(key === 'src' ? originalImage(String(value)) : String(value))}"`)
+        .join('');
+
+    return voidTags.has(name) ? `<${name}${attributes}>` : `<${name}${attributes}>${renderNodes(node.children)}</${name}>`;
+};
+
+const renderPost = (post: any): string => {
+    const hero = post.heroImage ? renderImage(post.heroImage.source, post.heroImage.alt, post.heroImage.caption) : '';
+    const chapters = (post.chapters ?? []).map((chapter) => `${chapter.title ? `<h2>${escapeText(chapter.title)}</h2>` : ''}${renderNodes(chapter.body)}`).join('');
+    return hero + chapters;
+};
+
+export const route: Route = {
+    path: '/wirecutter',
+    categories: ['traditional-media'],
+    view: ViewType.Articles,
+    example: '/nytimes/wirecutter',
+    parameters: {},
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.nytimes.com/wirecutter', 'www.nytimes.com/wirecutter/reviews/:slug'],
+        },
+    ],
+    name: 'Wirecutter',
+    maintainers: ['IvanWng97'],
+    handler,
+    description: 'The official feed only carries the opening few paragraphs; this route returns the whole review, including the picks and their photos.',
+};
+
+async function handler() {
+    const feedText = await ofetch(feedUrl, {
+        // rss-parser's parseURL relies on Node's https.get, which is unavailable on Cloudflare Workers
+        parseResponse: (text) => text,
+    });
+    const feed = await parser.parseString(feedText);
+
+    const items = await Promise.all(
+        feed.items.map(async (item) => {
+            // the feed appends its own tracking parameters
+            const link = item.link?.split('?', 1)[0];
+            try {
+                return await cache.tryGet(link!, async () => {
+                    const response = await ofetch(link!);
+                    const $ = load(response);
+                    const nextData = JSON.parse($('script#__NEXT_DATA__').text());
+                    const post = nextData.props?.pageProps?.post;
+                    if (!post?.chapters) {
+                        throw new Error('no post chapters in __NEXT_DATA__');
+                    }
+
+                    return {
+                        title: post.title ?? item.title,
+                        link,
+                        description: renderPost(post),
+                        author: (post.authors ?? []).map((a) => a.displayName).join(', ') || item.creator,
+                        pubDate: item.pubDate,
+                        category: [post.primarySection?.name, ...(post.primaryTerms ?? [])].filter(Boolean),
+                    } as DataItem;
+                });
+            } catch (error) {
+                // A single unreadable review should not take down the whole feed; this result is not cached, so it is retried next time
+                logger.warn(`nytimes/wirecutter: falling back to the feed summary for ${link}: ${error}`);
+                return {
+                    title: item.title,
+                    link,
+                    description: item.content,
+                    author: item.creator,
+                    pubDate: item.pubDate,
+                } as DataItem;
+            }
+        })
+    );
+
+    return {
+        title: feed.title ?? 'Wirecutter',
+        link: 'https://www.nytimes.com/wirecutter',
+        description: feed.description,
+        item: items,
+    };
+}

--- a/lib/routes/nytimes/wirecutter.ts
+++ b/lib/routes/nytimes/wirecutter.ts
@@ -5,113 +5,12 @@ import { ViewType } from '@/types';
 import cache from '@/utils/cache';
 import logger from '@/utils/logger';
 import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
 import parser from '@/utils/rss-parser';
 
+import { renderPost } from './templates/wirecutter';
+
 const feedUrl = 'https://www.nytimes.com/wirecutter/feed/';
-const imageBase = 'https://cdn.thewirecutter.com/';
-
-// Presentational or promotional nodes that carry no article content
-const dropTypes = new Set(['adslot', 'shortcode-recirc', 'shortcode-scoop_form_callout']);
-
-const allowedTags = new Set([
-    'p',
-    'a',
-    'strong',
-    'b',
-    'em',
-    'i',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'ul',
-    'ol',
-    'li',
-    'br',
-    'hr',
-    'img',
-    'blockquote',
-    'figure',
-    'figcaption',
-    'div',
-    'span',
-    'video',
-    'source',
-    'table',
-    'thead',
-    'tbody',
-    'tr',
-    'th',
-    'td',
-]);
-const voidTags = new Set(['br', 'hr', 'img', 'source']);
-// Everything else is layout plumbing or tracking metadata
-const allowedAttributes = new Set(['href', 'src', 'alt', 'title', 'width', 'height', 'colspan', 'rowspan']);
-
-const escapeText = (text: string): string => text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-
-const escapeAttribute = (value: string): string => escapeText(value).replaceAll('"', '&quot;');
-
-// Images are served through a resizing CDN; without the query string the original is returned
-const originalImage = (url: string): string => (url.startsWith('http') ? url : `${imageBase}${url.replace(/^\//, '')}`).split('?', 1)[0];
-
-const renderImage = (src: string, alt?: string, caption?: string): string =>
-    src ? `<figure><img src="${escapeAttribute(originalImage(src))}"${alt ? ` alt="${escapeAttribute(alt)}"` : ''}>${caption ? `<figcaption>${escapeText(caption)}</figcaption>` : ''}</figure>` : '';
-
-// A Wirecutter pick: the product, why it won, and its photo
-const renderCallout = (node: any): string =>
-    (node.dbData?.callouts ?? [])
-        .map((pick) => {
-            const heading = [pick.ribbon || node.dbData?.ribbon, pick.name].filter(Boolean).join(': ');
-            return `<blockquote>${heading ? `<h4>${escapeText(heading)}</h4>` : ''}${renderImage(pick.images?.full, pick.name)}${pick.title ? `<p><strong>${escapeText(pick.title)}</strong></p>` : ''}${pick.description ? `<p>${escapeText(pick.description)}</p>` : ''}</blockquote>`;
-        })
-        .join('');
-
-const renderNodes = (nodes: any[] | undefined): string => (nodes ?? []).map((node) => renderNode(node)).join('');
-
-const renderNode = (node: any): string => {
-    if (node.type === 'text') {
-        return escapeText(node.data ?? '');
-    }
-    if (node.type === 'comment') {
-        return '';
-    }
-    if (node.type !== 'tag') {
-        throw new Error(`Unsupported node type: ${node.type}`);
-    }
-
-    const name = node.name;
-    if (dropTypes.has(name)) {
-        return '';
-    }
-    switch (name) {
-        case 'shortcode-gallery':
-            return (node.dbData ?? []).map((image) => renderImage(image.dbData?.source ?? image.imagePaths?.full, image.alt, image.credit)).join('');
-        case 'shortcode-callout':
-            return renderCallout(node);
-        case 'shortcode-caption':
-            return `<figure>${renderNodes(node.children)}${node.dbData?.credit ? `<figcaption>${escapeText(node.dbData.credit)}</figcaption>` : ''}</figure>`;
-        default:
-            break;
-    }
-    if (!allowedTags.has(name)) {
-        throw new Error(`Unsupported tag: ${name}`);
-    }
-
-    const attributes = Object.entries(node.attribs ?? {})
-        .filter(([key]) => allowedAttributes.has(key))
-        .map(([key, value]) => ` ${key}="${escapeAttribute(key === 'src' ? originalImage(String(value)) : String(value))}"`)
-        .join('');
-
-    return voidTags.has(name) ? `<${name}${attributes}>` : `<${name}${attributes}>${renderNodes(node.children)}</${name}>`;
-};
-
-const renderPost = (post: any): string => {
-    const hero = post.heroImage ? renderImage(post.heroImage.source, post.heroImage.alt, post.heroImage.caption) : '';
-    const chapters = (post.chapters ?? []).map((chapter) => `${chapter.title ? `<h2>${escapeText(chapter.title)}</h2>` : ''}${renderNodes(chapter.body)}`).join('');
-    return hero + chapters;
-};
 
 export const route: Route = {
     path: '/wirecutter',
@@ -164,7 +63,7 @@ async function handler() {
                         link,
                         description: renderPost(post),
                         author: (post.authors ?? []).map((a) => a.displayName).join(', ') || item.creator,
-                        pubDate: item.pubDate,
+                        pubDate: item.pubDate ? parseDate(item.pubDate) : undefined,
                         category: [post.primarySection?.name, ...(post.primaryTerms ?? [])].filter(Boolean),
                     } as DataItem;
                 });
@@ -176,7 +75,7 @@ async function handler() {
                     link,
                     description: item.content,
                     author: item.creator,
-                    pubDate: item.pubDate,
+                    pubDate: item.pubDate ? parseDate(item.pubDate) : undefined,
                 } as DataItem;
             }
         })


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

```routes
/nytimes/wirecutter
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

**Why.** Wirecutter has an official feed at `nytimes.com/wirecutter/feed/`, but it only carries the opening few paragraphs. For *The Best Plain Yogurt* that is ~4KB of `content:encoded` against a ~29KB review — the feed stops before any of the actual picks. Wirecutter reviews are also structured as chapters with product callouts, which is exactly the part that gets cut.

**How.** The feed supplies the item list; each review is then rendered from `props.pageProps.post` in the page's `__NEXT_DATA__`:

- chapter titles become headings, and each chapter's `body` node tree is rendered through a tag/attribute allowlist (layout classes and `data-gtm-*` tracking attributes are dropped)
- `shortcode-gallery` becomes figures with the photo credit as the caption, `shortcode-caption` becomes a `figure`/`figcaption`, and `shortcode-callout` — the picks — renders as the ribbon, product name, photo, verdict and description
- `adslot`, `shortcode-recirc` and `shortcode-scoop_form_callout` are dropped as ads, in-house promos and a form
- images drop the resizing query string so the original is served

**Failure handling.** An unknown node type throws rather than being silently skipped, so that review falls back to the feed summary instead of emitting a body with a hole in it. That fallback happens outside `cache.tryGet`, so it is not cached and is retried on the next run; one unreadable review never takes down the feed. Verified by breaking the `__NEXT_DATA__` selector: all 10 items degrade to the summary and the route still returns 200.

The node inventory was taken across 8 reviews (1,300+ nodes) to make sure the allowlist and the dropped types cover what Wirecutter actually publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)