### PR TITLE
fix(router/twitter): treat empty auth token pool as no-auth to prevent silent guest-mode degradation

### DIFF
--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -55,7 +55,7 @@ const token2Cookie = async (token) => {
 const lockPrefix = 'twitter:lock-token1:';
 
 const getAuth = async (retry: number) => {
-    if (!config.twitter.authToken || retry <= 0) {
+    if (!config.twitter.authToken?.length || retry <= 0) {
         return;
     }
     const index = authTokenIndex++ % config.twitter.authToken.length;


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue
Close #<ISSUE_NUMBER>

## Example for the Proposed Route(s) / 路由地址示例
```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
- [ ] New Route / 新的路由
- [ ] Follows [[Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [[路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [[Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)](https://docs.rsshub.app/joinus/advanced/pub-date) / [[日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [ ] Parsed / 可以解析
- [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

One-line guard fix in `getAuth()` (`lib/routes/twitter/api/web-api/utils.ts`). Fixes the
silent guest-mode failure mode diagnosed in #<ISSUE_NUMBER>.

### Problem

When a 401/403 from X empties the in-memory `config.twitter.authToken` array (via the
existing `splice()`), the guard

```ts
if (!config.twitter.authToken || retry <= 0)
```

fails to catch the empty pool because `[]` is truthy. Execution continues:

```ts
const index = authTokenIndex++ % config.twitter.authToken.length; // x % 0 → NaN
const token = config.twitter.authToken[index];                    // undefined
```

`getAuth` then returns `{ token: undefined }` (truthy), so `twitterGot` never throws
`ConfigNotFoundError` — instead `token2Cookie(undefined)` caches a **guest cookie jar**
under the literal Redis key `twitter:cookie:undefined`, and X responds to guest-mode
requests with HTTP 200 + degraded stale data. Result: twitter routes silently serve
frozen timelines (observed for over a year in production) while feed metadata keeps
updating and no error is ever logged.

### Fix

```diff
-if (!config.twitter.authToken || retry <= 0) {
+if (!config.twitter.authToken?.length || retry <= 0) {
```

An empty pool now returns `undefined`, so `twitterGot` correctly throws
`ConfigNotFoundError` (or serves a proper explicit guest request when `allowNoAuth`
is set — the intended path).

### Operator note

Instances already carrying a poisoned `twitter:cookie:undefined` Redis key must delete
it (and affected timeline caches) manually; upgrading alone won't heal existing caches.

### Related

- Issue: #<ISSUE_NUMBER>
- Follow-up PR with 401/403 handling hardening (temporary lock instead of permanent
  `splice()`) to follow separately, as discussed with @dosu.