### PR TITLE
fix(router/twitter): lock tokens temporarily on 401/403 instead of permanent removal

### DIFF
--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -55,7 +55,7 @@ const token2Cookie = async (token) => {
 const lockPrefix = 'twitter:lock-token1:';
 
 const getAuth = async (retry: number) => {
-    if (!config.twitter.authToken || retry <= 0) {
+    if (!config.twitter.authToken?.length || retry <= 0) {
         return;
     }
     const index = authTokenIndex++ % config.twitter.authToken.length;

--- a/lib/routes/twitter/api/web-api/utils.ts
+++ b/lib/routes/twitter/api/web-api/utils.ts
@@ -85,6 +85,13 @@ export const twitterGot = async (
 ) => {
     const auth = await getAuth(30);
 
+    // Defensive check: a truthy auth object with an undefined token must never reach
+    // token2Cookie(), otherwise a guest cookie jar gets cached under the literal key
+    // `twitter:cookie:undefined`.
+    if (auth && !auth.token) {
+        throw new ConfigNotFoundError('Twitter auth pool returned an invalid (undefined) token');
+    }
+
     if (!auth && !options?.allowNoAuth) {
         throw new ConfigNotFoundError('No valid Twitter token found');
     }
@@ -196,35 +203,13 @@ export const twitterGot = async (
             logger.debug(`twitter debug: twitter rate limit exceeded for token ${auth.token} with status ${response.status}`);
             await cache.set(`${lockPrefix}${auth.token}`, '1', 2000);
         } else if (response.status === 403 || response.status === 401) {
-            // const newCookie = await login({
-            //     username: auth.username,
-            //     password: auth.password,
-            //     authenticationSecret: auth.authenticationSecret,
-            // });
-            // if (newCookie) {
-            //     logger.debug(`twitter debug: reset twitter cookie for token ${auth.token}, ${newCookie}`);
-            //     await cache.set(`twitter:cookie:${auth.token}`, newCookie, config.cache.contentExpire);
-            //     await cache.set(`${lockPrefix}${auth.token}`, '', 1);
-            // } else {
-            const tokenIndex = config.twitter.authToken?.indexOf(auth.token);
-            if (tokenIndex !== undefined && tokenIndex !== -1) {
-                config.twitter.authToken?.splice(tokenIndex, 1);
-            }
-            // if (auth.username) {
-            //     const usernameIndex = config.twitter.username?.indexOf(auth.username);
-            //     if (usernameIndex !== undefined && usernameIndex !== -1) {
-            //         config.twitter.username?.splice(usernameIndex, 1);
-            //     }
-            // }
-            // if (auth.password) {
-            //     const passwordIndex = config.twitter.password?.indexOf(auth.password);
-            //     if (passwordIndex !== undefined && passwordIndex !== -1) {
-            //         config.twitter.password?.splice(passwordIndex, 1);
-            //     }
-            // }
-            logger.debug(`twitter debug: delete twitter cookie for token ${auth.token} with status ${response.status}, remaining tokens: ${config.twitter.authToken?.length}`);
+            // Lock the token temporarily instead of removing it permanently from the
+            // in-memory pool: a transient 401/403 from X should not disable the token
+            // until process restart. Once every token is locked, getAuth exhausts its
+            // retries and returns undefined, so twitterGot throws ConfigNotFoundError
+            // and the failure finally surfaces to the operator.
+            logger.debug(`twitter debug: lock twitter cookie for token ${auth.token} with status ${response.status}, remaining tokens: ${config.twitter.authToken?.length}`);
             await cache.set(`${lockPrefix}${auth.token}`, '1', 3600);
-            // }
         } else {
             logger.debug(`twitter debug: unlock twitter cookie with success for token ${auth.token}`);
             await cache.set(`${lockPrefix}${auth.token}`, '', 1);


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue
Close #<ISSUE_NUMBER>

## Example for the Proposed Route(s) / 路由地址示例
```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表
- [ ] New Route / 新的路由
- [ ] Follows [[Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [[路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
- [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [[Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)](https://docs.rsshub.app/joinus/advanced/pub-date) / [[日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
- [ ] Parsed / 可以解析
- [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Behavior hardening for the 401/403 path in `twitterGot()`
(`lib/routes/twitter/api/web-api/utils.ts`), building on #<PR1_NUMBER>.

### Problem

On 401/403 the current code does

```ts
config.twitter.authToken?.splice(tokenIndex, 1);
```

which removes the token from the in-memory array **irreversibly** (until process
restart) — even for a transient error. With a single-token deployment, one transient
401/403 permanently disables authenticated access. This is also the first half of the
silent guest-degradation chain fixed in #<PR1_NUMBER>.

### Changes

1. **`splice()` → existing time-based lock (3600s)** on 401/403, consistent with the
   429/rate-limit path. Transient auth errors lock the token temporarily instead of
   deleting it permanently.
2. **Defensive check in `twitterGot`**: `auth && !auth.token` now throws
   `ConfigNotFoundError`, guaranteeing a guest cookie jar can never be cached under
   the literal key `twitter:cookie:undefined`, even if `getAuth` changes in the future.
3. Removed the dead commented-out re-login fallback code in this block (the
   username/password fields it references are already commented out in `getAuth`).

### Design notes (per discussion with @dosu in #<ISSUE_NUMBER>)

- **Failure still surfaces**: once every token is locked, `getAuth(30)` exhausts its
  retries (~30s worst case) and returns `undefined`, so `twitterGot` throws
  `ConfigNotFoundError` instead of looping forever — the failure is no longer silent.
- **Recovery**: a locked token is retried after the 3600s lock expires. If maintainers
  prefer a different duration now that the lock is the sole recovery mechanism (vs a
  backstop before permanent removal), happy to adjust — e.g. escalate the TTL on
  repeated 401/403 for the same token.
- Multi-token pools keep rotating through unlocked tokens while one is locked.

### Related

- Issue: #<ISSUE_NUMBER>
- Depends on #<PR1_NUMBER>
```

---

## 给 @dosu 的 issue 回复（确认拆分方案）

```markdown
Thanks @dosu — agreed on splitting, that's cleaner for review and bisecting. Plan:

**PR 1** (minimal, obviously correct): the `!config.twitter.authToken?.length` guard
alone.

**PR 2** (behavior change): `splice()` → temporary lock on 401/403 + the
`auth && !auth.token` defensive check.

On your design question: keeping the 3600s lock for now, and I believe the
"eventually surface the failure" requirement is already satisfied without extra code —
once all tokens are locked, `getAuth(30)` exhausts its retries (each retry sleeps
500–1000ms and moves to the next index) and returns `undefined`, so `twitterGot`
throws `ConfigNotFoundError` after ~30s worst case rather than looping forever. The
failure stops being silent either way.

The remaining judgment call is the lock TTL: with `splice()` gone, 3600s becomes the
sole recovery mechanism, so a permanently revoked token would retry hourly forever
(though each retry only costs one failed request, and the failure is now logged and
surfaced). If maintainers prefer, I can escalate the TTL on repeated 401/403 for the
same token instead of a fixed 3600s — will leave that open for review.

Opening the PRs now.