### PR TITLE
feat(route/youtube): live streams with upcoming and past ones

### DIFF
--- a/lib/routes/youtube/api/youtubei.ts
+++ b/lib/routes/youtube/api/youtubei.ts
@@ -1,10 +1,12 @@
+import pMap from 'p-map';
 import { Innertube, YTNodes } from 'youtubei.js';
 
+import { config } from '@/config';
 import type { Data, DataItem } from '@/types';
 import cache from '@/utils/cache';
 import { parseDate, parseRelativeDate } from '@/utils/parse-date';
 
-import { getVideoUrl, renderYoutube } from '../utils';
+import { formatDescription, getVideoUrl, renderYoutube } from '../utils';
 import { getSrtAttachmentBatch } from './subtitles';
 
 let innertubePromise: Promise<Innertube> | undefined;
@@ -62,7 +64,29 @@ const getPubDate = (metadataTexts: Array<string | undefined>) => {
     return scheduledText ? parseDate(scheduledText.slice(SCHEDULED_PREFIX.length), 'M/D/YY, h:mm A') : undefined;
 };
 
-const lockupViewToItem = (video: YTNodes.LockupView, embed: boolean): DataItem => {
+// The lockup of a video only carries its title, so the description takes one player request per video
+const getVideoDescription = async (videoId: string) => {
+    try {
+        // The value is wrapped in an object because an empty string does not survive a cache round trip
+        const { description } = await cache.tryGet<{ description: string }>(
+            `youtube:getVideoDescription:${videoId}`,
+            async () => {
+                const innertube = await getInnertube();
+                const info = await innertube.getBasicInfo(videoId);
+                return { description: info.basic_info.short_description ?? '' };
+            },
+            config.cache.contentExpire,
+            // The expiration is not renewed on a hit, so an edited description still shows up in a steadily polled feed
+            false
+        );
+        return description;
+    } catch {
+        // A stream can be unplayable, e.g. a members-only one, which should not take the whole feed down
+        return '';
+    }
+};
+
+const lockupViewToItem = (video: YTNodes.LockupView, embed: boolean, description = ''): DataItem => {
     const videoId = video.content_id;
     const img = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
     const metadataRows = video.metadata?.metadata?.metadata_rows ?? [];
@@ -70,7 +94,7 @@ const lockupViewToItem = (video: YTNodes.LockupView, embed: boolean): DataItem =
 
     return {
         title: video.metadata?.title?.text || `YouTube Video ${videoId}`,
-        description: renderYoutube(embed, videoId, img, ''),
+        description: renderYoutube(embed, videoId, img, formatDescription(description)),
         link: `https://www.youtube.com/watch?v=${videoId}`,
         author: metadataRows.length > 1 ? metadataRows[0].metadata_parts?.[0]?.text?.text : undefined,
         image: img,
@@ -124,12 +148,14 @@ export const getStreamsByChannelId = async ({
     includeLive,
     includeUpcoming,
     includeCompleted,
+    includeDescription,
 }: {
     channelId: string;
     embed: boolean;
     includeLive: boolean;
     includeUpcoming: boolean;
     includeCompleted: boolean;
+    includeDescription: boolean;
 }): Promise<Data> => {
     const innertube = await getInnertube();
     const channel = await innertube.getChannel(channelId);
@@ -139,6 +165,9 @@ export const getStreamsByChannelId = async ({
         upcoming: includeUpcoming,
         completed: includeCompleted,
     };
+    const videos = streams.videos.filter((video) => video instanceof YTNodes.LockupView).filter((video) => included[getStreamState(video)]);
+    // pMap keeps the results in the order of the input, so a description matches the stream at the same index
+    const descriptions = includeDescription ? await pMap(videos, (video) => getVideoDescription(video.content_id), { concurrency: 5 }) : [];
 
     return {
         title: `${channel.metadata.title || channelId} - Live - YouTube`,
@@ -146,10 +175,7 @@ export const getStreamsByChannelId = async ({
         image: channel.metadata.avatar?.[0].url,
         description: channel.metadata.description,
 
-        item: streams.videos
-            .filter((video) => video instanceof YTNodes.LockupView)
-            .filter((video) => included[getStreamState(video)])
-            .map((video) => lockupViewToItem(video, embed)),
+        item: videos.map((video, index) => lockupViewToItem(video, embed, descriptions[index])),
         allowEmpty: true,
     };
 };

--- a/lib/routes/youtube/api/youtubei.ts
+++ b/lib/routes/youtube/api/youtubei.ts
@@ -2,7 +2,7 @@ import { Innertube, YTNodes } from 'youtubei.js';
 
 import type { Data, DataItem } from '@/types';
 import cache from '@/utils/cache';
-import { parseRelativeDate } from '@/utils/parse-date';
+import { parseDate, parseRelativeDate } from '@/utils/parse-date';
 
 import { getVideoUrl, renderYoutube } from '../utils';
 import { getSrtAttachmentBatch } from './subtitles';
@@ -26,19 +26,47 @@ const getInnertube = () => {
     return innertubePromise;
 };
 
+// A duration is grouped for readability once it reaches a thousand hours, e.g. `20,772:51:34`
+const DURATION_BADGE_REGEX = /^[\d,]+(?::\d+)+$/;
+const UPCOMING_BADGE_TEXT = 'Upcoming';
+const SCHEDULED_PREFIX = 'Scheduled for ';
+
+const getThumbnailBadges = (video: YTNodes.LockupView) => {
+    const thumbnail = video.content_image?.is(YTNodes.ThumbnailView) ? video.content_image : undefined;
+    return thumbnail?.overlays.filter((overlay) => overlay.is(YTNodes.ThumbnailBottomOverlayView)).flatMap((overlay) => overlay.badges ?? []) ?? [];
+};
+
+const getMetadataTexts = (video: YTNodes.LockupView) => (video.metadata?.metadata?.metadata_rows ?? []).flatMap((row) => row.metadata_parts ?? []).map((part) => part.text?.text);
+
+type StreamState = 'live' | 'upcoming' | 'completed';
+
+// An ongoing stream carries a "LIVE" badge and a scheduled one an "Upcoming" badge, so anything else has already ended
+const getStreamState = (video: YTNodes.LockupView): StreamState => {
+    const badges = getThumbnailBadges(video);
+    if (badges.some((badge) => badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE')) {
+        return 'live';
+    }
+    if (badges.some((badge) => badge.text === UPCOMING_BADGE_TEXT) || getMetadataTexts(video).some((text) => text?.startsWith(SCHEDULED_PREFIX))) {
+        return 'upcoming';
+    }
+    return 'completed';
+};
+
+const getPubDate = (metadataTexts: Array<string | undefined>) => {
+    const publishedText = metadataTexts.findLast((text) => text?.endsWith('ago'));
+    if (publishedText) {
+        return parseRelativeDate(publishedText);
+    }
+    // A stream that hasn't started has no publish date, only the time it is scheduled to start at
+    const scheduledText = metadataTexts.find((text) => text?.startsWith(SCHEDULED_PREFIX));
+    return scheduledText ? parseDate(scheduledText.slice(SCHEDULED_PREFIX.length), 'M/D/YY, h:mm A') : undefined;
+};
+
 const lockupViewToItem = (video: YTNodes.LockupView, embed: boolean): DataItem => {
     const videoId = video.content_id;
-    const thumbnail = video.content_image?.is(YTNodes.ThumbnailView) ? video.content_image : undefined;
     const img = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
     const metadataRows = video.metadata?.metadata?.metadata_rows ?? [];
-    const publishedText = metadataRows
-        .flatMap((row) => row.metadata_parts ?? [])
-        .map((part) => part.text?.text)
-        .findLast((text) => text?.endsWith('ago'));
-    const durationText = thumbnail?.overlays
-        ?.filter((overlay) => overlay.is(YTNodes.ThumbnailBottomOverlayView))
-        .flatMap((overlay) => overlay.badges ?? [])
-        .find((badge) => /^\d+(?::\d+)+$/.test(badge.text))?.text;
+    const durationText = getThumbnailBadges(video).find((badge) => DURATION_BADGE_REGEX.test(badge.text))?.text;
 
     return {
         title: video.metadata?.title?.text || `YouTube Video ${videoId}`,
@@ -46,12 +74,12 @@ const lockupViewToItem = (video: YTNodes.LockupView, embed: boolean): DataItem =
         link: `https://www.youtube.com/watch?v=${videoId}`,
         author: metadataRows.length > 1 ? metadataRows[0].metadata_parts?.[0]?.text?.text : undefined,
         image: img,
-        pubDate: publishedText ? parseRelativeDate(publishedText) : undefined,
+        pubDate: getPubDate(getMetadataTexts(video)),
         attachments: [
             {
                 url: getVideoUrl(videoId),
                 mime_type: 'text/html',
-                duration_in_seconds: durationText ? durationText.split(':').reduce((acc, part) => acc * 60 + Number(part), 0) : undefined,
+                duration_in_seconds: durationText ? durationText.split(':').reduce((acc, part) => acc * 60 + Number(part.replaceAll(',', '')), 0) : undefined,
             },
         ],
     };
@@ -87,6 +115,42 @@ export const getDataByChannelId = async ({ channelId, embed, isJsonFeed }: { cha
             item.attachments?.push(...(isJsonFeed ? videoSubtitles[video.content_id] || [] : []));
             return item;
         }),
+    };
+};
+
+export const getStreamsByChannelId = async ({
+    channelId,
+    embed,
+    includeLive,
+    includeUpcoming,
+    includeCompleted,
+}: {
+    channelId: string;
+    embed: boolean;
+    includeLive: boolean;
+    includeUpcoming: boolean;
+    includeCompleted: boolean;
+}): Promise<Data> => {
+    const innertube = await getInnertube();
+    const channel = await innertube.getChannel(channelId);
+    const streams = await channel.getLiveStreams();
+    const included = {
+        live: includeLive,
+        upcoming: includeUpcoming,
+        completed: includeCompleted,
+    };
+
+    return {
+        title: `${channel.metadata.title || channelId} - Live - YouTube`,
+        link: `https://www.youtube.com/channel/${channelId}/streams`,
+        image: channel.metadata.avatar?.[0].url,
+        description: channel.metadata.description,
+
+        item: streams.videos
+            .filter((video) => video instanceof YTNodes.LockupView)
+            .filter((video) => included[getStreamState(video)])
+            .map((video) => lockupViewToItem(video, embed)),
+        allowEmpty: true,
     };
 };
 

--- a/lib/routes/youtube/api/youtubei.ts
+++ b/lib/routes/youtube/api/youtubei.ts
@@ -142,30 +142,11 @@ export const getDataByChannelId = async ({ channelId, embed, isJsonFeed }: { cha
     };
 };
 
-export const getStreamsByChannelId = async ({
-    channelId,
-    embed,
-    includeLive,
-    includeUpcoming,
-    includeCompleted,
-    includeDescription,
-}: {
-    channelId: string;
-    embed: boolean;
-    includeLive: boolean;
-    includeUpcoming: boolean;
-    includeCompleted: boolean;
-    includeDescription: boolean;
-}): Promise<Data> => {
+export const getStreamsByChannelId = async ({ channelId, embed, includeDescription }: { channelId: string; embed: boolean; includeDescription: boolean }): Promise<Data> => {
     const innertube = await getInnertube();
     const channel = await innertube.getChannel(channelId);
     const streams = await channel.getLiveStreams();
-    const included = {
-        live: includeLive,
-        upcoming: includeUpcoming,
-        completed: includeCompleted,
-    };
-    const videos = streams.videos.filter((video) => video instanceof YTNodes.LockupView).filter((video) => included[getStreamState(video)]);
+    const videos = streams.videos.filter((video) => video instanceof YTNodes.LockupView);
     // pMap keeps the results in the order of the input, so a description matches the stream at the same index
     const descriptions = includeDescription ? await pMap(videos, (video) => getVideoDescription(video.content_id), { concurrency: 5 }) : [];
 
@@ -175,8 +156,8 @@ export const getStreamsByChannelId = async ({
         image: channel.metadata.avatar?.[0].url,
         description: channel.metadata.description,
 
-        item: videos.map((video, index) => lockupViewToItem(video, embed, descriptions[index])),
-        allowEmpty: true,
+        // The state is exposed as a category so that a single state can be picked out with the common `filter_category` parameter
+        item: videos.map((video, index) => ({ ...lockupViewToItem(video, embed, descriptions[index]), category: [getStreamState(video)] })),
     };
 };
 

--- a/lib/routes/youtube/streams.ts
+++ b/lib/routes/youtube/streams.ts
@@ -1,5 +1,6 @@
 import type { Route } from '@/types';
 import { ViewType } from '@/types';
+import { fallback, queryToBoolean } from '@/utils/readable-social';
 
 import { getChannelIdByUsername, getStreamsByChannelId } from './api/youtubei';
 import { isYouTubeChannelId } from './utils';
@@ -28,12 +29,13 @@ export const route: Route = {
     handler,
     description: `::: tip Parameter
 
-| Name             | Description                                                                        | Default |
-| ---------------- | ---------------------------------------------------------------------------------- | ------- |
-| embed            | Whether to embed the video, fill in any value to disable embedding                 | embed   |
-| includeLive      | Whether to include ongoing live streams, fill in any falsy value to exclude them   | true    |
-| includeUpcoming  | Whether to include scheduled live streams, fill in any falsy value to exclude them | true    |
-| includeCompleted | Whether to include finished live streams, fill in any falsy value to exclude them  | true    |
+| Name               | Description                                                                                 | Default |
+| ------------------ | ------------------------------------------------------------------------------------------- | ------- |
+| embed              | Whether to embed the video, fill in any value to disable embedding                          | embed   |
+| includeLive        | Whether to include ongoing live streams, fill in any falsy value to exclude them            | true    |
+| includeUpcoming    | Whether to include scheduled live streams, fill in any falsy value to exclude them          | true    |
+| includeCompleted   | Whether to include finished live streams, fill in any falsy value to exclude them           | true    |
+| includeDescription | Whether to include the description of each stream, fill in any truthy value to include them | false   |
 
 :::
 
@@ -41,21 +43,24 @@ export const route: Route = {
 Unlike [Live](#youtube-live), this route reads the channel's Live tab, so it also covers scheduled and finished streams, and it does not require an API key.
 
 For example, \`/youtube/streams/@GawrGura/includeCompleted=false\` only tracks streams that are live or about to start.
+
+The Live tab does not carry the stream descriptions, so \`includeDescription\` costs one extra request per stream and is off by default.
 :::`,
 };
 
 async function handler(ctx) {
     const handle = ctx.req.param('handle');
     const params = new URLSearchParams(ctx.req.param('routeParams'));
-    const isIncluded = (name: string) => [null, '', 'true'].includes(params.get(name));
+    const isEnabled = (name: string, byDefault: boolean): boolean => fallback(undefined, queryToBoolean(params.get(name)), byDefault);
 
     const channelId = isYouTubeChannelId(handle) ? handle : await getChannelIdByUsername(handle);
 
     return await getStreamsByChannelId({
         channelId,
         embed: !params.get('embed'),
-        includeLive: isIncluded('includeLive'),
-        includeUpcoming: isIncluded('includeUpcoming'),
-        includeCompleted: isIncluded('includeCompleted'),
+        includeLive: isEnabled('includeLive', true),
+        includeUpcoming: isEnabled('includeUpcoming', true),
+        includeCompleted: isEnabled('includeCompleted', true),
+        includeDescription: isEnabled('includeDescription', false),
     });
 }

--- a/lib/routes/youtube/streams.ts
+++ b/lib/routes/youtube/streams.ts
@@ -1,0 +1,61 @@
+import type { Route } from '@/types';
+import { ViewType } from '@/types';
+
+import { getChannelIdByUsername, getStreamsByChannelId } from './api/youtubei';
+import { isYouTubeChannelId } from './utils';
+
+export const route: Route = {
+    path: '/streams/:handle/:routeParams?',
+    categories: ['live'],
+    view: ViewType.Videos,
+    example: '/youtube/streams/@GawrGura',
+    parameters: {
+        handle: 'YouTube handle or channel id',
+        routeParams: 'Extra parameters, see the table below',
+    },
+    radar: [
+        {
+            source: ['www.youtube.com/@:handle/streams'],
+            target: '/streams/@:handle',
+        },
+        {
+            source: ['www.youtube.com/channel/:handle/streams'],
+            target: '/streams/:handle',
+        },
+    ],
+    name: 'Live Streams',
+    maintainers: ['ouuan'],
+    handler,
+    description: `::: tip Parameter
+
+| Name             | Description                                                                        | Default |
+| ---------------- | ---------------------------------------------------------------------------------- | ------- |
+| embed            | Whether to embed the video, fill in any value to disable embedding                 | embed   |
+| includeLive      | Whether to include ongoing live streams, fill in any falsy value to exclude them   | true    |
+| includeUpcoming  | Whether to include scheduled live streams, fill in any falsy value to exclude them | true    |
+| includeCompleted | Whether to include finished live streams, fill in any falsy value to exclude them  | true    |
+
+:::
+
+::: tip
+Unlike [Live](#youtube-live), this route reads the channel's Live tab, so it also covers scheduled and finished streams, and it does not require an API key.
+
+For example, \`/youtube/streams/@GawrGura/includeCompleted=false\` only tracks streams that are live or about to start.
+:::`,
+};
+
+async function handler(ctx) {
+    const handle = ctx.req.param('handle');
+    const params = new URLSearchParams(ctx.req.param('routeParams'));
+    const isIncluded = (name: string) => [null, '', 'true'].includes(params.get(name));
+
+    const channelId = isYouTubeChannelId(handle) ? handle : await getChannelIdByUsername(handle);
+
+    return await getStreamsByChannelId({
+        channelId,
+        embed: !params.get('embed'),
+        includeLive: isIncluded('includeLive'),
+        includeUpcoming: isIncluded('includeUpcoming'),
+        includeCompleted: isIncluded('includeCompleted'),
+    });
+}

--- a/lib/routes/youtube/streams.ts
+++ b/lib/routes/youtube/streams.ts
@@ -32,9 +32,6 @@ export const route: Route = {
 | Name               | Description                                                                                 | Default |
 | ------------------ | ------------------------------------------------------------------------------------------- | ------- |
 | embed              | Whether to embed the video, fill in any value to disable embedding                          | embed   |
-| includeLive        | Whether to include ongoing live streams, fill in any falsy value to exclude them            | true    |
-| includeUpcoming    | Whether to include scheduled live streams, fill in any falsy value to exclude them          | true    |
-| includeCompleted   | Whether to include finished live streams, fill in any falsy value to exclude them           | true    |
 | includeDescription | Whether to include the description of each stream, fill in any truthy value to include them | false   |
 
 :::
@@ -42,7 +39,7 @@ export const route: Route = {
 ::: tip
 Unlike [Live](#youtube-live), this route reads the channel's Live tab, so it also covers scheduled and finished streams, and it does not require an API key.
 
-For example, \`/youtube/streams/@GawrGura/includeCompleted=false\` only tracks streams that are live or about to start.
+Every stream is categorized as \`live\`, \`upcoming\` or \`completed\`, so a single state can be picked out with the \`filter_category\` and \`filterout_category\` [common parameters](https://docs.rsshub.app/guide/parameters#filtering). For example, \`/youtube/streams/@GawrGura?filterout_category=completed\` only tracks streams that are live or about to start.
 
 The Live tab does not carry the stream descriptions, so \`includeDescription\` costs one extra request per stream and is off by default.
 :::`,
@@ -58,9 +55,6 @@ async function handler(ctx) {
     return await getStreamsByChannelId({
         channelId,
         embed: !params.get('embed'),
-        includeLive: isEnabled('includeLive', true),
-        includeUpcoming: isEnabled('includeUpcoming', true),
-        includeCompleted: isEnabled('includeCompleted', true),
         includeDescription: isEnabled('includeDescription', false),
     });
 }

--- a/lib/utils/parse-date.test.ts
+++ b/lib/utils/parse-date.test.ts
@@ -83,6 +83,18 @@ describe('parseRelativeDate', () => {
             expect(p('10 分鐘後')).toBe(NOW_TIMESTAMP + 10 * minute);
         });
 
+        it('handles abbreviated units', () => {
+            expect(p('1y ago')).toBe(dayjs(NOW_TIMESTAMP).subtract(1, 'year').valueOf());
+            expect(p('3mo ago')).toBe(dayjs(NOW_TIMESTAMP).subtract(3, 'month').valueOf());
+            expect(p('2w ago')).toBe(NOW_TIMESTAMP - 2 * week);
+            expect(p('5d ago')).toBe(NOW_TIMESTAMP - 5 * day);
+        });
+
+        it('does not read the "m" of a month as a minute', () => {
+            expect(p('11 months ago')).toBe(dayjs(NOW_TIMESTAMP).subtract(11, 'month').valueOf());
+            expect(p('11mo ago')).toBe(dayjs(NOW_TIMESTAMP).subtract(11, 'month').valueOf());
+        });
+
         it('handles mixed units', () => {
             expect(p('1d 1h ago')).toBe(NOW_TIMESTAMP - (day + hour));
         });

--- a/lib/utils/parse-date.test.ts
+++ b/lib/utils/parse-date.test.ts
@@ -7,6 +7,8 @@ import { parseRelativeDate } from './parse-date';
 
 dayjs.extend(weekday);
 
+const p = (...args: Parameters<typeof parseRelativeDate>) => parseRelativeDate(...args).getTime();
+
 describe('parseRelativeDate', () => {
     // === CONSTANTS ===
     const second = 1000;
@@ -29,8 +31,6 @@ describe('parseRelativeDate', () => {
     const PREVIOUS_WEDNESDAY = TODAY_START + 2 * day - week; // Jan 28 (Last week)
     const LAST_SUNDAY = new Date('2026-02-01T00:00:00').getTime(); // Yesterday (Feb 01)
     const LAST_FRIDAY = new Date('2026-01-30T00:00:00').getTime(); // Last Friday (Jan 30)
-
-    const p = (str: string, ...opts: any[]) => parseRelativeDate(str, ...opts).getTime();
 
     beforeEach(() => {
         MockDate.set(NOW_TIMESTAMP);

--- a/lib/utils/parse-date.ts
+++ b/lib/utils/parse-date.ts
@@ -48,12 +48,13 @@ const REGEX_IS_PM = /下午|晚上|晚|pm|p\.m\./i;
 const REGEX_IS_AM = /上午|凌晨|早|晨|am|a\.m\./i;
 
 const UNIT_PATTERNS: UnitPattern[] = [
-    { unit: 'years', regExp: /(\d+)\s*(?:年|y(?:ea)?rs?)/i },
-    { unit: 'months', regExp: /(\d+)\s*(?:[个個]?月|months?)/i },
-    { unit: 'weeks', regExp: /(\d+)\s*(?:周|[个個]?星期|weeks?)/i },
+    { unit: 'years', regExp: /(\d+)\s*(?:年|y(?:(?:ea)?rs?)?)/i },
+    { unit: 'months', regExp: /(\d+)\s*(?:[个個]?月|mo(?:n(?:th)?s?)?)/i },
+    { unit: 'weeks', regExp: /(\d+)\s*(?:周|[个個]?星期|w(?:(?:ee)?ks?)?)/i },
     { unit: 'days', regExp: /(\d+)\s*(?:天|日|d(?:ay)?s?)/i },
     { unit: 'hours', regExp: /(\d+)\s*(?:[个個]?(?:小?时|[時点點])|h(?:(?:ou)?r)?s?)/i },
-    { unit: 'minutes', regExp: /(\d+)\s*(?:分[鐘钟]?|m(?:in(?:ute)?)?s?)/i },
+    // The lookahead keeps the bare `m` from also matching the `mo` of a month
+    { unit: 'minutes', regExp: /(\d+)\s*(?:分[鐘钟]?|m(?:in(?:ute)?)?s?(?![a-z]))/i },
     { unit: 'seconds', regExp: /(\d+)\s*(?:秒[鐘钟]?|s(?:ec(?:ond)?)?s?)/i },
 ];
 


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

N/A

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes

```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/youtube/streams/@lovelive_series
/youtube/streams/@lovelive_series/embed=0?filter_category=completed|live
/youtube/streams/@lovelive_series/includeDescription=1?filterout_category=completed
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

`/youtube/live` searches for ongoing broadcasts through the Data API, so there was no way to follow a channel's schedule or its past streams. This route reads the channel's Live tab through InnerTube instead, which lists all three, and the route params pick which of them end up in the feed. No API key or cookie needed, one request per poll.

The Live tab abbreviates relative dates (`3mo ago`, `2w ago`), which `parseRelativeDate` did not accept, so this PR extends its unit patterns and adds tests.

The lockups on the Live tab carry only a title, so `includeDescription` fetches each description from the player response separately. That costs a request per stream instead of one per poll, hence the option and its default of false.