### PR TITLE
feat(route/gatesnotes): add Gates Notes routes

### DIFF
--- a/lib/routes/gatesnotes/books.ts
+++ b/lib/routes/gatesnotes/books.ts
@@ -1,0 +1,82 @@
+import type { Context } from 'hono';
+
+import type { Data, DataItem, Language, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+import { apiUrl, bookElements, getTaxonomy, mapArticle, siteUrl } from './utils';
+
+const mapBook = (item): Promise<DataItem> => {
+    const bookTitle: string | undefined = item.elements.book_title?.value || undefined;
+    const bookAuthor: string | undefined = item.elements.book_author?.value || undefined;
+    const lead = bookTitle ? `<p><em>${bookTitle}${bookAuthor ? ` by ${bookAuthor}` : ''}</em></p>` : '';
+
+    return mapArticle(item, lead);
+};
+
+export const handler = async (ctx: Context): Promise<Data> => {
+    const { category } = ctx.req.param();
+    const limit = Number(ctx.req.query('limit') ?? '30');
+
+    const search = new URLSearchParams({
+        'system.type': 'article',
+        'elements.book_title[neq]': '',
+        order: 'elements.date[desc]',
+        limit: String(limit),
+        elements: bookElements,
+        ...(category && { 'elements.page_taxonomy_set__gn_taxonomy[contains]': category.replaceAll('-', '_') }),
+    });
+
+    const response = await ofetch(`${apiUrl}?${search.toString()}`);
+
+    const codename = category?.replaceAll('-', '_');
+    const entry = codename ? (await getTaxonomy())[codename] : undefined;
+    if (category && (!entry || entry.parent !== 'books')) {
+        throw new Error(`Unknown Gates Notes book category "${category}". Valid categories are listed on ${siteUrl}/books`);
+    }
+
+    return {
+        title: entry ? `Gates Notes - Book Reviews - ${entry.name}` : 'Gates Notes - Book Reviews',
+        description: 'Book reviews by Bill Gates from [Gates Notes](https://www.gatesnotes.com/books).',
+        link: `${siteUrl}/books`,
+        language: 'en' as const satisfies Language,
+        icon: `${siteUrl}/favicon.ico`,
+        logo: `${siteUrl}/favicon.ico`,
+        author: 'Bill Gates',
+        item: await Promise.all(response.items.map((item) => mapBook(item))),
+    };
+};
+
+export const route: Route = {
+    path: '/books/:category?',
+    name: 'Book Reviews',
+    url: 'www.gatesnotes.com',
+    maintainers: ['wongJG'],
+    handler,
+    example: '/gatesnotes/books/science',
+    parameters: {
+        category: {
+            description: 'Book category, can be found in the URL of the corresponding category page on Gates Notes, e.g. `science` or `science-fiction`; leave empty for all book reviews',
+        },
+    },
+    description: 'Subscribe to the book reviews by Bill Gates from [Gates Notes](https://www.gatesnotes.com/books).',
+    categories: ['blog'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.gatesnotes.com/books'],
+            target: '/books',
+        },
+        {
+            source: ['www.gatesnotes.com/books/:category'],
+            target: '/books/:category',
+        },
+    ],
+};

--- a/lib/routes/gatesnotes/index.ts
+++ b/lib/routes/gatesnotes/index.ts
@@ -1,0 +1,56 @@
+import type { Context } from 'hono';
+
+import type { Data, Language, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+import { apiUrl, articleElements, mapArticle, siteUrl } from './utils';
+
+export const handler = async (ctx: Context): Promise<Data> => {
+    const limit = Number(ctx.req.query('limit') ?? '30');
+
+    const response = await ofetch(apiUrl, {
+        query: {
+            'system.type': 'article',
+            order: 'elements.date[desc]',
+            limit,
+            elements: articleElements,
+        },
+    });
+
+    return {
+        title: 'Gates Notes',
+        description: 'Notes and essays by Bill Gates on the issues he is focused on.',
+        link: siteUrl,
+        language: 'en' as const satisfies Language,
+        icon: `${siteUrl}/favicon.ico`,
+        logo: `${siteUrl}/favicon.ico`,
+        author: 'Bill Gates',
+        item: await Promise.all(response.items.map((item) => mapArticle(item))),
+    };
+};
+
+export const route: Route = {
+    path: '/',
+    name: 'Latest Notes',
+    url: 'www.gatesnotes.com',
+    maintainers: ['wongJG'],
+    handler,
+    example: '/gatesnotes',
+    parameters: {},
+    description: 'Subscribe to the latest notes by Bill Gates from [Gates Notes](https://www.gatesnotes.com/).',
+    categories: ['blog'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.gatesnotes.com'],
+        },
+    ],
+};

--- a/lib/routes/gatesnotes/namespace.ts
+++ b/lib/routes/gatesnotes/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Gates Notes',
+    url: 'www.gatesnotes.com',
+    lang: 'en',
+};

--- a/lib/routes/gatesnotes/utils.tsx
+++ b/lib/routes/gatesnotes/utils.tsx
@@ -1,0 +1,181 @@
+import { raw } from 'hono/html';
+import { renderToString } from 'hono/jsx/dom/server';
+
+import type { DataItem } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+export const siteUrl = 'https://www.gatesnotes.com';
+export const apiUrl = 'https://deliver.kontent.ai/12514eb8-7b51-008e-41a9-512542cf683b/items';
+
+const taxonomyUrl = apiUrl.replace(/items$/, 'taxonomies/master_taxonomy');
+
+export const articleElements = ['article_title', 'article_subtitle', 'date', 'byline', 'page_meta_set__keywords', 'page_image_set__thumbnail'].join(',');
+
+export const bookElements = ['article_title', 'article_subtitle', 'date', 'byline', 'book_title', 'book_author', 'page_meta_set__keywords', 'page_image_set__thumbnail'].join(',');
+
+type ModularContent = Record<string, any>;
+
+const flattenTerms = (terms, parent, map) => {
+    for (const term of terms) {
+        map[term.codename] = { name: term.name, parent };
+        flattenTerms(term.terms, term.codename, map);
+    }
+};
+
+const inlineItemRegex = /<object type="application\/kenticocloud"[^>]*data-codename="([^"]+)"[^>]*><\/object>/;
+
+const asString = (value: unknown): string => (typeof value === 'string' ? value : '');
+const asArray = (value: unknown): string[] => (Array.isArray(value) ? (value as string[]) : []);
+const asAsset = (value: unknown): { url?: string; type?: string } | undefined => (Array.isArray(value) ? value[0] : undefined);
+
+function Asset({ value }: { value: unknown }) {
+    const asset = asAsset(value);
+    if (!asset?.url) {
+        return null;
+    }
+    return asset.type?.startsWith('video/') ? <video controls src={asset.url} /> : <img src={asset.url} />;
+}
+
+function LinkedItem({ modular, codename }: { modular: ModularContent; codename: string }) {
+    const item = modular[codename];
+    if (!item) {
+        return null;
+    }
+    const { elements } = item;
+    switch (item.system.type) {
+        case 'body_copy_block':
+            return <RichText modular={modular} value={elements.body_copy_block_rt?.value} />;
+        case 'body_copy_constrained':
+            return <RichText modular={modular} value={elements.body_copy_and_inline_elements?.value} />;
+        case 'content_combo':
+            return (
+                <>
+                    {asArray(elements.content_items?.value).map((codename) => (
+                        <LinkedItem key={codename} modular={modular} codename={codename} />
+                    ))}
+                </>
+            );
+        case 'content_lockup_list_slide_or_photo_essay':
+            return (
+                <>
+                    {asArray(elements.item_image_set?.value).map((codename) => (
+                        <LinkedItem key={codename} modular={modular} codename={codename} />
+                    ))}
+                    <RichText modular={modular} value={elements.caption?.value} />
+                </>
+            );
+        case 'image_set': {
+            const desktop = asAsset(elements.desktop_image?.value);
+            return <Asset value={desktop?.url ? elements.desktop_image : elements.mobile_image} />;
+        }
+        case 'inline_video_item': {
+            const youtubeId = asString(elements.youtube_id?.value);
+            const url = asString(elements.dbvideolink?.value).replace('www.dropbox.com', 'dl.dropboxusercontent.com');
+            const poster = asAsset(elements.poster_image?.value)?.url;
+            const description = asString(elements.description?.value);
+            return (
+                <>
+                    {youtubeId ? <iframe src={`https://www.youtube.com/embed/${youtubeId}`} allowfullscreen /> : url ? <video controls poster={poster} src={url} /> : null}
+                    {description ? <p>{description}</p> : null}
+                </>
+            );
+        }
+        case 'note': {
+            const eyebrow = asString(elements.eyebrow?.value);
+            const note = asString(elements.title?.value);
+            return (
+                <blockquote>
+                    {eyebrow ? (
+                        <p>
+                            <strong>{eyebrow}</strong>
+                        </p>
+                    ) : null}
+                    {note ? <p>{note}</p> : null}
+                </blockquote>
+            );
+        }
+        case 'quote': {
+            const cta = asString(elements.quote_cta?.value);
+            const link = asString(elements.quote_link_ext?.value);
+            return (
+                <>
+                    <blockquote>
+                        <RichText modular={modular} value={elements.quote_copy?.value} />
+                    </blockquote>
+                    {cta && link ? (
+                        <p>
+                            <a href={link}>{cta}</a>
+                        </p>
+                    ) : null}
+                </>
+            );
+        }
+        case 'download': {
+            const file = asAsset(elements.download?.value);
+            if (!file?.url) {
+                return null;
+            }
+            return (
+                <>
+                    <Asset value={elements.image?.value} />
+                    <RichText modular={modular} value={elements.title?.value} />
+                    <p>
+                        <a href={file.url}>{asString(elements.cta_button_copy?.value) || 'Download'}</a>
+                    </p>
+                    <RichText modular={modular} value={elements.subtitle?.value} />
+                </>
+            );
+        }
+        default:
+            return null;
+    }
+}
+
+function RichText({ modular, value }: { modular: ModularContent; value: unknown }) {
+    const parts = asString(value).split(inlineItemRegex);
+    return <>{parts.map((part, index) => (index % 2 ? <LinkedItem key={part} modular={modular} codename={part} /> : raw(part)))}</>;
+}
+
+export const getArticleBody = (codename: string): Promise<string> =>
+    cache.tryGet(`gatesnotes:body:${codename}`, async () => {
+        const response = await ofetch<{ item: { elements: Record<string, any> }; modular_content?: ModularContent }>(`${apiUrl}/${codename}`);
+        return renderToString(<RichText modular={response.modular_content ?? {}} value={response.item.elements.body_content?.value} />);
+    });
+
+export const getTaxonomy = () =>
+    cache.tryGet('gatesnotes:taxonomy', async () => {
+        const taxonomy = await ofetch(taxonomyUrl);
+        const map = {};
+        flattenTerms(taxonomy.terms, '', map);
+        return map;
+    });
+
+export const mapArticle = async (item, lead = ''): Promise<DataItem> => {
+    const { elements, system } = item;
+
+    const title: string = elements.article_title?.value || '';
+    const subtitle: string | undefined = elements.article_subtitle?.value || undefined;
+    const image: string | undefined = elements.page_image_set__thumbnail?.value?.[0]?.url;
+    const keywords: string = elements.page_meta_set__keywords?.value || '';
+    const categories: string[] = keywords
+        .split(',')
+        .map((keyword) => keyword.trim())
+        .filter(Boolean);
+    const date: string | undefined = elements.date?.value || undefined;
+    const byline: string | undefined = elements.byline?.value || undefined;
+
+    const body = await getArticleBody(system.codename);
+    const description = (image ? `<img src="${image}">` : '') + lead + (subtitle || '') + body;
+
+    return {
+        title,
+        link: new URL(system.name, siteUrl).href,
+        ...(date && { pubDate: parseDate(date) }),
+        ...(description && { description }),
+        ...(byline && { author: byline }),
+        ...(categories.length && { category: categories }),
+        ...(image && { image }),
+    };
+};

--- a/lib/routes/gatesnotes/work.ts
+++ b/lib/routes/gatesnotes/work.ts
@@ -1,0 +1,70 @@
+import type { Context } from 'hono';
+
+import type { Data, Language, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+
+import { apiUrl, articleElements, getTaxonomy, mapArticle, siteUrl } from './utils';
+
+export const handler = async (ctx: Context): Promise<Data> => {
+    const { topic } = ctx.req.param();
+    const limit = Number(ctx.req.query('limit') ?? '30');
+
+    const entry = (await getTaxonomy())[topic.replaceAll('-', '_')];
+    if (!entry || (entry.parent !== 'work' && entry.parent !== 'meet_bill')) {
+        throw new Error(`Unknown Gates Notes topic "${topic}". Valid topics are listed on ${siteUrl}/work and ${siteUrl}/meet-bill`);
+    }
+
+    const response = await ofetch(apiUrl, {
+        query: {
+            'system.type': 'article',
+            'elements.page_taxonomy_set__gn_taxonomy[contains]': topic.replaceAll('-', '_'),
+            order: 'elements.date[desc]',
+            limit,
+            elements: articleElements,
+        },
+    });
+
+    const section = entry.parent === 'meet_bill' ? 'meet-bill' : 'work';
+
+    return {
+        title: `Gates Notes - ${entry.name}`,
+        description: 'Notes and essays by Bill Gates from [Gates Notes](https://www.gatesnotes.com/).',
+        link: `${siteUrl}/${section}/${topic}`,
+        language: 'en' as const satisfies Language,
+        icon: `${siteUrl}/favicon.ico`,
+        logo: `${siteUrl}/favicon.ico`,
+        author: 'Bill Gates',
+        item: await Promise.all(response.items.map((item) => mapArticle(item))),
+    };
+};
+
+export const route: Route = {
+    path: '/work/:topic',
+    name: 'Topic',
+    url: 'www.gatesnotes.com',
+    maintainers: ['wongJG'],
+    handler,
+    example: '/gatesnotes/work/make-ai-work-for-everyone',
+    parameters: {
+        topic: {
+            description: 'Topic, can be found in the URL of the corresponding topic page on Gates Notes, e.g. `make-ai-work-for-everyone`',
+        },
+    },
+    description: 'Subscribe to notes and essays of a specific topic from [Gates Notes](https://www.gatesnotes.com/work).',
+    categories: ['blog'],
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportRadar: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.gatesnotes.com/work/:topic', 'www.gatesnotes.com/meet-bill/:topic'],
+            target: '/work/:topic',
+        },
+    ],
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close None

## Example for the Proposed Route(s) / 路由地址示例

```routes
/gatesnotes
/gatesnotes/books
/gatesnotes/books/science
/gatesnotes/work/make-ai-work-for-everyone
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds three routes for [Gates Notes](https://www.gatesnotes.com/), Bill Gates' blog:

- `/gatesnotes` — latest notes
- `/gatesnotes/books/:category?` — book reviews, optionally filtered by book categories
- `/gatesnotes/work/:topic` — notes and essays of a specific topic

gatesnotes.com is built on Kontent.ai, and the routes use the same API endpoint the site itself calls.