### PR TITLE
fix(route/rule34video): use bare domain

### DIFF
--- a/lib/routes/rule34video/latest.ts
+++ b/lib/routes/rule34video/latest.ts
@@ -43,7 +43,6 @@ interface VideoItem {
 }
 
 async function handler() {
-    // Use the bare domain: `www` is behind ddos-guard and blocks datacenter IPs with 502.
     const response = await got({
         method: 'get',
         url: 'https://rule34video.com/latest-updates/',

--- a/lib/routes/rule34video/latest.ts
+++ b/lib/routes/rule34video/latest.ts
@@ -43,9 +43,10 @@ interface VideoItem {
 }
 
 async function handler() {
+    // Use the bare domain: `www` is behind ddos-guard and blocks datacenter IPs with 502.
     const response = await got({
         method: 'get',
-        url: 'https://www.rule34video.com/latest-updates/',
+        url: 'https://rule34video.com/latest-updates/',
     });
 
     const $ = load(response.data);
@@ -82,7 +83,7 @@ async function handler() {
     return {
         allowEmpty: true,
         title: 'Rule34 Video Latest Updates',
-        link: 'https://www.rule34video.com/latest-updates/',
+        link: 'https://rule34video.com/latest-updates/',
         description: 'Latest updates from Rule34 Video',
         item: items.map((item) => buildDataItem(item)),
     };


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/rule34video/latest
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

The `www.rule34video.com` subdomain currently returns 502, while the bare domain `rule34video.com` serves the same `/latest-updates/` page. This switches both the fetch URL and the feed-level `link` to the bare domain.
