### PR TITLE
fix(route/jpxgmn): 跟随发布页 301 直跳解析源站

### DIFF
--- a/lib/routes/jpxgmn/utils.tsx
+++ b/lib/routes/jpxgmn/utils.tsx
@@ -3,14 +3,22 @@ import { renderToString } from 'hono/jsx/dom/server';
 
 import cache from '@/utils/cache';
 import got from '@/utils/got';
+import ofetch from '@/utils/ofetch';
 
 const indexUrl = 'http://mei8.vip/';
 
 const getOriginUrl = async () =>
     await cache.tryGet('jpxgmn:originUrl', async () => {
-        const response = await got(indexUrl);
-        const $ = load(response.data);
+        // 发布页（mei8.vip）已改为 301 直跳源站：发生跨站重定向时最终地址即源站（Fixes #23202）
+        const response = await ofetch.raw(indexUrl);
+        if (new URL(response.url).host !== new URL(indexUrl).host) {
+            return new URL(response.url).origin;
+        }
+        const $ = load(response._data);
         const entries = $('ul > li > span');
+        if (!entries.length) {
+            throw new Error('无法从发布页解析源站地址');
+        }
         return 'http://' + $(entries[Math.floor(Math.random() * entries.length)]).text();
     });
 const getImages = ($articleContent) =>


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #23202

## Example for the Proposed Route(s) / 路由地址示例

```routes
/jpxgmn/weekly
/jpxgmn/tab/top
/jpxgmn/search/candy
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

本次是修复 PR（非新路由），改动只在 `lib/routes/jpxgmn/utils.tsx` 的 `getOriginUrl`（weekly/tab/search 三路由共用）。

### 根因（已用线上实测验证）

`getOriginUrl` 默认发布页 `mei8.vip` 仍是 HTML 列表页，从 `ul > li > span` 随机取一行拼出源站域名。但该页已改为直接 301 跳转，实测：

```
curl -sI http://mei8.vip/
HTTP/1.1 301 Moved Permanently
Location: http://a7.876512.xyz/
```

于是 `entries` 为空，拼出非法的 `'http://'` 并写入 `jpxgmn:originUrl` 缓存 —— 与 #23202 报错 `Failed to parse URL from http://` 完全吻合。旧 issue #18349（CLOSED）是换域名问题，本次是发布页改 301 的新根因。

### 改法

- 改用 `ofetch.raw`（本目录三路由已在用的模式）取发布页：发生跨站重定向时，直接返回最终 URL 的 origin；
- 无重定向时走原有发布页解析；
- 新增空结果保护：解析不到条目时抛错，不再产出非法的 `http://` 污染缓存。

### 本地验证

- 逻辑仿真（node）：301 场景返回 `http://a7.876512.xyz`；旧发布页场景保持原行为；空页面抛错。
- `esbuild` 解析改后 TSX 通过；仓库锁定版 `oxfmt@0.65.0 --check` 通过（LF 下）。
- 未在本地完整跑路由（需拉取目标站内容）；以上证据 + 本 PR 的自动路由测试为准。

### 风险与排除

- 单文件 10+/2-，无路由参数、无输出结构变更；`got` import 保留（`getArticleDesc` 仍在用）。
- sweep：无其他 open PR 改动 jpxgmn（最近相关 #19002 早已合入）。
