### PR TITLE
fix(route/jpxgmn): 跟随发布页 301 直跳解析源站

### DIFF
--- a/lib/routes/jpxgmn/utils.tsx
+++ b/lib/routes/jpxgmn/utils.tsx
@@ -3,14 +3,22 @@ import { renderToString } from 'hono/jsx/dom/server';
 
 import cache from '@/utils/cache';
 import got from '@/utils/got';
+import ofetch from '@/utils/ofetch';
 
 const indexUrl = 'http://mei8.vip/';
 
 const getOriginUrl = async () =>
     await cache.tryGet('jpxgmn:originUrl', async () => {
-        const response = await got(indexUrl);
-        const $ = load(response.data);
+        // 发布页（mei8.vip）已改为 301 直跳源站：发生跨站重定向时最终地址即源站（Fixes #23202）
+        const response = await ofetch.raw(indexUrl);
+        if (new URL(response.url).host !== new URL(indexUrl).host) {
+            return new URL(response.url).origin;
+        }
+        const $ = load(response._data);
         const entries = $('ul > li > span');
+        if (!entries.length) {
+            throw new Error('无法从发布页解析源站地址');
+        }
         return 'http://' + $(entries[Math.floor(Math.random() * entries.length)]).text();
     });
 const getImages = ($articleContent) =>


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #23202

## Example for the Proposed Route(s) / 路由地址示例

```routes
/jpxgmn/weekly
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

本次是修复 PR（非新路由），改动只在 `lib/routes/jpxgmn/utils.tsx` 的 `getOriginUrl`（weekly/tab/search 三路由共用）。

> 路由示例只保留 `/jpxgmn/weekly`：上一轮三条全列导致机器人抓取 tab 全站分页超时。tab/search 与 weekly 共用同一个 `getOriginUrl`，weekly 已能覆盖本次改动的代码路径（机器日志里 weekly 实测 200 见下）。

### 根因（已用线上实测验证）

`getOriginUrl` 默认发布页 `mei8.vip` 仍是 HTML 列表页，从 `ul > li > span` 随机取一行拼出源站域名。但该页已改为直接 301 跳转，实测：

```
curl -sI http://mei8.vip/
HTTP/1.1 301 Moved Permanently
Location: http://a7.876512.xyz/
```

于是 `entries` 为空，拼出非法的 `'http://'` 并写入 `jpxgmn:originUrl` 缓存 —— 与 #23202 报错 `Failed to parse URL from http://` 完全吻合。旧 issue #18349（CLOSED）是换域名问题，本次是发布页改 301 的新根因。

### 改法

- 改用 `ofetch.raw`（本目录三路由已在用的模式）取发布页：发生跨站重定向时，直接返回最终 URL 的 origin；
- 无重定向时走原有发布页解析；
- 新增空结果保护：解析不到条目时抛错，不再产出非法的 `http://` 污染缓存。

### 本地验证

- 逻辑仿真（node）：301 场景返回 `http://a7.876512.xyz`；旧发布页场景保持原行为；空页面抛错。
- `esbuild` 解析改后 TSX 通过；仓库锁定版 `oxfmt@0.65.0 --check` 通过（LF 下）。
- 标准测试（本地真实链路，tsx 直接执行本文件 `getOriginUrl`，内存缓存，真实网络）：4 项全过——
  - 返回合法 origin `http://a7.876512.xyz`（旧 Bug 会产出非法 `http://`）；
  - 与独立链路（原生 fetch 跟随跳转）解析的最终 origin 完全一致；
  - 二次调用缓存一致；
  - 该 origin 站点 GET / 返回 200。
- 上一轮机器人实测：`/jpxgmn/weekly` 返回 200（35s），`tab/top` 已能解析出真实站并开始抓取文章页，失败仅因示例列太多导致抓取超时，与本次改动无关，故本轮示例只保留 weekly。

### 风险与排除

- 单文件 10+/2-，无路由参数、无输出结构变更；`got` import 保留（`getArticleDesc` 仍在用）。
- sweep：无其他 open PR 改动 jpxgmn（最近相关 #19002 早已合入）。
