### PR TITLE
feat(route/mikiki): add mikiki latest articles route

### DIFF
--- a/lib/routes/mikiki/index.ts
+++ b/lib/routes/mikiki/index.ts
@@ -3,6 +3,7 @@ import { load } from 'cheerio';
 import type { Data, DataItem, Route } from '@/types';
 import cache from '@/utils/cache';
 import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
 import parser from '@/utils/rss-parser';
 
 export const route: Route = {
@@ -31,7 +32,7 @@ async function handler(): Promise<Data> {
                 return {
                     title: item.title,
                     link: item.link,
-                    pubDate: item.isoDate,
+                    pubDate: item.isoDate ? parseDate(item.isoDate) : undefined,
                     author: $('.article-header-author-name').first().text(),
                     description: $('.article-body').html(),
                 };

--- a/lib/routes/mikiki/index.ts
+++ b/lib/routes/mikiki/index.ts
@@ -1,0 +1,49 @@
+import { load } from 'cheerio';
+
+import type { Data, DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import parser from '@/utils/rss-parser';
+
+export const route: Route = {
+    path: '/',
+    categories: ['new-media'],
+    example: '/mikiki',
+    name: '最新記事',
+    maintainers: ['ashi-koki'],
+    handler,
+};
+
+async function handler(): Promise<Data> {
+    const rootUrl = 'https://mikiki.tokyo.jp';
+
+    const feedResponse = await ofetch(`${rootUrl}/list/feed/rss`, { responseType: 'text' });
+    const feed = await parser.parseString(feedResponse);
+
+    const items = await Promise.all(
+        feed.items.map((item) =>
+            cache.tryGet(item.link!, async () => {
+                const response = await ofetch(item.link!);
+                const $ = load(response);
+
+                $('.article-index, .ranking-in-article').remove();
+
+                return {
+                    title: item.title,
+                    link: item.link,
+                    pubDate: item.isoDate,
+                    author: $('.article-header-author-name').first().text(),
+                    description: $('.article-body').html(),
+                };
+            })
+        )
+    );
+
+    return {
+        title: feed.title!,
+        link: rootUrl,
+        description: feed.description,
+        language: 'ja',
+        item: items as DataItem[],
+    };
+}

--- a/lib/routes/mikiki/namespace.ts
+++ b/lib/routes/mikiki/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'Mikiki',
+    url: 'mikiki.tokyo.jp',
+    lang: 'ja',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/mikiki
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds a route for MIKIKI (ミュージック・マガジン増刊, mikiki.tokyo.jp), a Japanese music magazine.

- Native RSS feed (`/list/feed/rss`) is fetched via `ofetch` (retry-capable), then each item's article page is fetched to extract the full article body, author and hero image.
- Article content is scraped with `cheerio` from `.article-body`, removing the table-of-contents (`.article-index`) and in-article ranking widgets (`.ranking-in-article`).
- Author is read from `.article-header-author-name`; publish date is taken directly from the feed's `dc:date` (JST).
- Per-item results are cached with `cache.tryGet`.
