### PR TITLE
feat: add full-text DR.dk news RSS routes

### DIFF
--- a/lib/routes/dr/fixtures/article.html
+++ b/lib/routes/dr/fixtures/article.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="da">
+    <head>
+        <meta charset="utf-8" />
+        <title>Frygt for naturen er ude af proportioner, mener eksperter</title>
+    </head>
+    <body>
+        <script id="__NEXT_DATA__" type="application/json">
+            {
+                "props": {
+                    "pageProps": {
+                        "viewProps": {
+                            "article": {
+                                "type": "Article",
+                                "urn": "urn:dr:umbraco:article:111ea74f-9a12-4aa2-94d6-46105268ccf2",
+                                "published": true,
+                                "title": "Frygt for naturen er ude af proportioner, mener eksperter",
+                                "summary": "Vi er blevet mere fremmede over for naturen, og vi bliver bange, når der kommer nye dyr, mener professor i biodiversitet.",
+                                "urlPathId": "/nyheder/indland/frygt-naturen-er-ude-af-proportioner-mener-eksperter-det-er-ikke-bare-naturangst-det-er-hysterisk",
+                                "startDate": "2026-08-30T11:07:00+00:00",
+                                "changedDate": null,
+                                "wordCount": 653,
+                                "format": "StandardArticleFormat",
+                                "publications": [
+                                    { "breaking": false, "live": false, "serviceChannel": { "urn": "urn:dr:drupal:site:471efb0d-19ed-4b08-9e94-ed8406bcf664" } },
+                                    { "breaking": false, "live": false, "serviceChannel": { "urn": "urn:dr:drupal:site:2f9c3cf8-b55e-4ee1-bf43-001e79223bdb" } }
+                                ],
+                                "liveBlog": null,
+                                "googlePlayId": null,
+                                "appleAppStoreId": null,
+                                "indexingMetadata": { "title": null, "description": null, "robots": null },
+                                "glossary": [
+                                    { "word": "naturvejleder", "match": "naturvejleder", "description": "En naturvejleder er en person, der ved meget om naturen og fortæller om den til andre." },
+                                    { "word": "naturvejleder", "match": "naturvejledere", "description": "En naturvejleder er en person, der ved meget om naturen og fortæller om den til andre." },
+                                    { "word": "medierne", "match": "medierne", "description": "Medier er for eksempel tv-stationer, radiokanaler og aviser." },
+                                    { "word": "naturvejledere", "match": "naturvejledere", "description": "En naturvejleder er en person, der arbejder med at fortælle og lære andre om naturen." },
+                                    { "word": "Biodiversitet", "match": "biodiversitet", "description": "Biodiversitet handler om, hvor mange arter der er af dyr og planter." }
+                                ],
+                                "teaserImage": {
+                                    "type": "ArticleImage",
+                                    "default": {
+                                        "type": "Image",
+                                        "url": "https://asset.dr.dk/drdk/umbraco-images/tupi5mm0/20260709-172845-l.jpg",
+                                        "managedUrl": "https://asset.dr.dk/drdk/umbraco-images/tupi5mm0/20260709-172845-l.jpg"
+                                    }
+                                },
+                                "head": [
+                                    {
+                                        "type": "ImageComponent",
+                                        "image": {
+                                            "type": "ContextImage",
+                                            "default": {
+                                                "type": "Image",
+                                                "url": "https://asset.dr.dk/drdk/umbraco-images/svlh2t0w/20260704-145611-l.jpg",
+                                                "width": 6000,
+                                                "height": 4000,
+                                                "managedUrl": "https://asset.dr.dk/drdk/umbraco-images/svlh2t0w/20260704-145611-l.jpg",
+                                                "description": "Egeprocessionsspinderen resulterede i lukkede stier, institutioner og demonstrationer, da den slog sig ned i Odense i sommer.",
+                                                "altText": null,
+                                                "ratio": "3:2",
+                                                "copyright": "Ritzau Scanpix",
+                                                "photographer": "Robert Wengler",
+                                                "pressPhotoUrl": null
+                                            },
+                                            "mobile": null
+                                        }
+                                    }
+                                ],
+                                "body": [
+                                    { "type": "ParagraphComponent", "body": [{ "type": "Text", "text": "Ulvedebatten raser, og senest var der torsdag aften ulvemøde i Egtved, hvor dyrets fremfærd i Danmark blev diskuteret." }] },
+                                    { "type": "HeadingComponent", "text": "Professor: Vi er uvante med naturen" },
+                                    {
+                                        "type": "ParagraphComponent",
+                                        "body": [
+                                            { "type": "Text", "text": "Det mener " },
+                                            { "type": "Bold", "body": [{ "type": "Text", "text": "Rasmus Ejrnæs" }] },
+                                            { "type": "Text", "text": ", professor i biodiversitet. Læs mere " },
+                                            { "type": "Link", "url": "https://www.dr.dk/nyheder/indland/eksempel", "body": [{ "type": "Text", "text": "her" }] },
+                                            { "type": "Text", "text": "." }
+                                        ]
+                                    },
+                                    { "type": "QuoteComponent", "body": "Den voldsomme frygt for flåter, fjæsing og planter bliver blæst ud af proportioner.", "citation": "Rune Engelbreht Larsen, idéhistoriker" },
+                                    {
+                                        "type": "EmphasizedListComponent",
+                                        "items": [
+                                            { "title": null, "marker": null, "body": [{ "type": "ParagraphComponent", "body": [{ "type": "Text", "text": "Første punkt på listen" }] }] },
+                                            { "title": null, "marker": null, "body": [{ "type": "ParagraphComponent", "body": [{ "type": "Text", "text": "Andet punkt på listen" }] }] }
+                                        ]
+                                    },
+                                    {
+                                        "type": "ImageComponent",
+                                        "priority": "low",
+                                        "image": {
+                                            "type": "ContextImage",
+                                            "default": { "type": "Image", "url": "https://asset.dr.dk/drdk/umbraco-images/t0ofa3bi/rune.jpg", "description": "Rune Engelbreht Larsen mener, at fakta betyder noget" }
+                                        }
+                                    },
+                                    {
+                                        "type": "MediaComponent",
+                                        "autoplay": true,
+                                        "caption": "Rasmus Ejrnæs, professor i biodiversitet",
+                                        "resource": { "type": "Clip", "imageUri": "https://api.dr.dk/odacache/api/Publication/Image/urn:dr:od3:clippublication:6a8309ca9590f6145c9a361c?imageId=cac84079" }
+                                    },
+                                    {
+                                        "type": "ReadMoreLinkComponent",
+                                        "label": null,
+                                        "title": "Ponyen Bellami blev dræbt og ædt i ulveangreb",
+                                        "url": "https://www.dr.dk/nyheder/indland/ponyen-bellami-blev-draebt-og-aedt-i-ulveangreb"
+                                    },
+                                    { "type": "CodeComponent", "html": "<div id='interactive'></div>" },
+                                    { "type": "OEmbedComponent", "url": "https://automat.drintern.dk/grafik/abc" }
+                                ],
+                                "site": { "type": "Site", "title": "Indland", "url": "/nyheder/indland" },
+                                "contributions": [
+                                    { "agent": { "name": "Annette Jespersen", "email": "atj@dr.dk" }, "prefix": "Af", "role": "Author" },
+                                    { "agent": { "name": "Asta Holst Bach", "email": "asht@dr.dk" }, "prefix": "Af", "role": "Author" }
+                                ],
+                                "yarn": null
+                            },
+                            "emergencyMessages": [],
+                            "searchParams": {},
+                            "subrouteType": "ARTICLE"
+                        },
+                        "pageVars": { "params": { "catchall": ["nyheder", "indland", "frygt-naturen-er-ude-af-proportioner-mener-eksperter-det-er-ikke-bare-naturangst-det-er-hysterisk"] }, "searchParams": {} },
+                        "env": {
+                            "AUTH_HOST": "",
+                            "FRONT_PAGE_EDITION_ID": "5d023c534ff3c845599d0953",
+                            "GRAPHQL_BASE_PATH": "https://www.dr.dk/tjenester/steffi/graphql",
+                            "GRAPHQL_APPLICATION_NAME": "hydra-unknown",
+                            "HYDRA_HOSTNAME": "www.dr.dk",
+                            "HYDRA_ENABLE_FRONTPAGE_FOCUS_SPOTS": true,
+                            "HYDRA_ENABLE_FRONTPAGE_POPULAR_PODCASTS": true,
+                            "LATEST_NEWS_PRIORITY_LIST_URN": "",
+                            "MIDAS_OEMBED_BASE_PATH": "https://www.dr.dk/tjenester/oembed/v2",
+                            "OEMBED_BASE_PATH": "https://www.dr.dk/tjenester/oembed/v2",
+                            "NEWS_OVERVIEW_PRIORITY_LIST_ID": "",
+                            "SEARCH_PAGE_POPULAR_TOPICS_URN": "urn:dr:drupal:priority-list:45480",
+                            "TTS_BASE_PATH": "",
+                            "USER_UPLOAD_API_BASE_PATH": "https://api.dr.dk/user-media-upload/upload",
+                            "ENABLE_HYDRA_LOGIN": true
+                        }
+                    },
+                    "__N_SSP": true
+                },
+                "page": "/[...catchall]",
+                "query": { "catchall": ["nyheder", "indland", "frygt-naturen-er-ude-af-proportioner-mener-eksperter-det-er-ikke-bare-naturangst-det-er-hysterisk"] },
+                "buildId": "orefZQSpfhiw0f_Pt1bKK",
+                "assetPrefix": "//www.dr.dk/hydra/resources",
+                "isFallback": false,
+                "isExperimentalCompile": false,
+                "gssp": true,
+                "scriptLoader": []
+            }
+        </script>
+    </body>
+</html>

--- a/lib/routes/dr/fixtures/feed.xml
+++ b/lib/routes/dr/fixtures/feed.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:media="http://search.yahoo.com/mrss/">
+    <channel>
+        <title>Indland | DR</title>
+        <link>https://www.dr.dk/</link>
+        <description>Nyheder fra sektionen Indland</description>
+        <lastBuildDate>Sun, 30 Aug 2026 12:48:53 GMT</lastBuildDate>
+        <docs>https://www.dr.dk/nyheder/dr-nyheder-som-rss-feed</docs>
+        <generator>rss-feeds</generator>
+        <language>da</language>
+        <atom:link href="https://www.dr.dk/nyheder/service/feeds/indland" rel="self" type="application/rss+xml"/>
+        <item>
+            <title><![CDATA[Hvad har CIA med moderne kunst at gøre?]]></title>
+            <link>https://www.dr.dk/nyheder/indland/reels/hvad-har-cia-med-moderne-kunst-goere</link>
+            <guid isPermaLink="false">urn:dr:umbraco:reel:fa7dfb23-50c6-4c2a-a078-9619505f597f</guid>
+            <pubDate>Sun, 30 Aug 2026 11:32:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Frygt for naturen er ude af proportioner, mener eksperter:  'Det er ikke bare naturangst, det er hysterisk']]></title>
+            <link>https://www.dr.dk/nyheder/indland/frygt-naturen-er-ude-af-proportioner-mener-eksperter-det-er-ikke-bare-naturangst-det-er-hysterisk</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:111ea74f-9a12-4aa2-94d6-46105268ccf2</guid>
+            <pubDate>Sun, 30 Aug 2026 11:07:00 GMT</pubDate>
+            <description><![CDATA[Vi er blevet mere fremmede over for naturen, og vi bliver bange, når der kommer nye dyr, mener professor i biodiversitet.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/tupi5mm0/20260709-172845-l.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Partifælle kalder Søren Gades opførsel 'illoyal']]></title>
+            <link>https://www.dr.dk/nyheder/indland/partifaelle-kalder-soeren-gades-opfoersel-illoyal</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:0229fd2c-c56b-495a-b7bc-0d49be7e90e4</guid>
+            <pubDate>Sun, 30 Aug 2026 10:19:15 GMT</pubDate>
+            <description><![CDATA[To borgmestre er nu gået sammen i et åbent brev, hvor de opfordrer folketingsgruppen til at stemme imod.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/cc0pracw/20250506-120323-2.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[14-årige Matteis kører op mod 200 km/t: Nu er han yngste danmarksmester i Formel 4]]></title>
+            <link>https://www.dr.dk/nyheder/indland/14-aarige-matteis-koerer-op-mod-200-km-t-nu-er-han-yngste-danmarksmester-i-formel-4</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:267b0620-2f6c-4572-a6be-025655fcaae4</guid>
+            <pubDate>Sun, 30 Aug 2026 07:12:00 GMT</pubDate>
+            <description><![CDATA[Drømmen er at blive den allerbedste i verden og køre Formel 1. Og det kræver noget af hele familien.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/wq5dw53e/20260824-205151-2.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Undergrundsbanker tryller narko-milliarder ud af landet]]></title>
+            <link>https://www.dr.dk/nyheder/indland/undergrundsbanker-tryller-narko-milliarder-ud-af-landet</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:361a05e4-c024-45e6-b7e4-ee00ed0749c0</guid>
+            <pubDate>Sun, 30 Aug 2026 06:48:00 GMT</pubDate>
+            <description><![CDATA[Milliarder af kroner fra blandt andet narkohandel er ført ud af landet via såkaldte undergrundsbanker, der ikke efterlader papirspor.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/0u2foazn/14926099_undergrundsbanken_12_insideren_og_narkomillionerne_prog_00922601520-00231617_crop001.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Skal elløbehjul og andre små elkøretøjer være fortid i trafikken? Det mener eksperter]]></title>
+            <link>https://www.dr.dk/nyheder/indland/skal-elloebehjul-og-andre-smaa-elkoeretoejer-vaere-fortid-i-trafikken-det-mener-eksperter</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:2ed3bc69-fd6f-40f2-aea4-55d8cbbf4901</guid>
+            <pubDate>Sun, 30 Aug 2026 05:56:00 GMT</pubDate>
+            <description><![CDATA[I syv år har det været lovligt at køre på de mindre eldrevne køretøjer på cykelstierne gennem forsøgsordninger.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/u3zfgryr/20220101-124634-a.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Mangler du en ny MacBook? Så skal du nok væbne dig med tålmodighed]]></title>
+            <link>https://www.dr.dk/nyheder/indland/mangler-du-en-ny-macbook-saa-skal-du-nok-vaebne-dig-med-taalmodighed</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:7b761d9d-bf2a-4b1e-9fb3-c386aa1206fc</guid>
+            <pubDate>Sun, 30 Aug 2026 05:13:00 GMT</pubDate>
+            <description><![CDATA[Det skaber forsyningsproblemer, at de mange nye datacentre bruger samme komponenter som en MacBook.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/0ejnatgn/20210120-173522-a.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Skrotbrand i Køge ventes først slukket op ad dagen]]></title>
+            <link>https://www.dr.dk/nyheder/indland/ret-voldsom-skrotbrand-i-koege-ventes-foerst-slukket-op-ad-dagen</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:f7f4698b-104e-4e01-b60c-d6c5c08225ca</guid>
+            <pubDate>Sun, 30 Aug 2026 04:49:12 GMT</pubDate>
+            <description><![CDATA[En større brand brød lørdag på havnen. Nu er man nået til efterslukningsarbejdet, som varer flere timer. ]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/pusjuxwv/20260829-212507-l.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Røg fra større brand i Køge har nået Københavns Vestegn]]></title>
+            <link>https://www.dr.dk/nyheder/indland/roeg-fra-stoerre-brand-i-koege-har-naaet-koebenhavns-vestegn</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:054d2429-0d4f-4322-947a-16dfed7fee9b</guid>
+            <pubDate>Sat, 29 Aug 2026 19:30:04 GMT</pubDate>
+            <description><![CDATA[Politiet anbefaler borgere flere steder på Sjælland at lukke døre og vinduer og slukke ventilationsanlæg.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/xuudxejr/20260829-210906-l.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Lægeformand efter nyt Wegovy-studie: Vi kan helt sikkert blive bedre, men...]]></title>
+            <link>https://www.dr.dk/nyheder/indland/laegeformand-efter-nyt-wegovy-studie-vi-kan-helt-sikkert-blive-bedre-men</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:6476ce82-e77f-4412-8e8f-922152bf72e9</guid>
+            <pubDate>Sat, 29 Aug 2026 19:19:00 GMT</pubDate>
+            <description><![CDATA[Ny undersøgelse rejser spørgsmålet om, hvorvidt de praktiserende læger er gode nok til at rådgive deres patienter om brugen af den populære vægttabsmedicin.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/oithfami/20260819-164920-l.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Bonus til nye danskere: Grønlandske sygeplejersker føler sig overset]]></title>
+            <link>https://www.dr.dk/nyheder/penge/bonus-til-nye-danskere-groenlandske-sygeplejersker-foeler-sig-overset</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:fa9cd1f7-4e69-4d94-bde1-b1abdf4d9cfb</guid>
+            <pubDate>Sat, 29 Aug 2026 18:10:00 GMT</pubDate>
+            <description><![CDATA[Ny ordning, der skal lokke danske sygeplejersker og læger til Grønland, møder kritik.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/2d5f5skm/dscf1262kopi.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Annes nytårsforsæt blev pludselig til 100 km i løbeskoene – men hvorfor løber flere danskere så langt?]]></title>
+            <link>https://www.dr.dk/nyheder/indland/ultraloeb-er-populaert-som-aldrig-foer</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:930dceb7-6766-4c05-bb0d-186b7da27087</guid>
+            <pubDate>Sat, 29 Aug 2026 17:02:00 GMT</pubDate>
+            <description><![CDATA[Ifølge landstræneren inden for ultraløb bliver løberne også bedre til at løbe langt.]]></description>
+        </item>
+        <item>
+            <title><![CDATA[Slidte, ubetalte både fylder i danske havne]]></title>
+            <link>https://www.dr.dk/nyheder/indland/reels/slidte-ubetalte-baade-fylder-i-danske-havne</link>
+            <guid isPermaLink="false">urn:dr:umbraco:reel:7d8bf927-d794-4228-897d-65943f76101e</guid>
+            <pubDate>Sat, 29 Aug 2026 15:43:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Kommune siger endnu engang nej til fixerum]]></title>
+            <link>https://www.dr.dk/nyheder/indland/kommune-siger-endnu-engang-nej-til-fixerum</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:d8195751-a016-44e0-aa5d-c49ff715c5d2</guid>
+            <pubDate>Sat, 29 Aug 2026 15:04:00 GMT</pubDate>
+            <description><![CDATA[Stofmisbrugere i Aalborg får ikke et særlig sted, hvor de kan indtage deres stoffer. Behovet er ikke til stede, mener kommunen]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/s35lmuil/stofindtagelsesrum_crop001.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Techgiganter fjerner opslag og truer med at lukke grupper: 'Jeg ved ikke, hvad vi gør forkert']]></title>
+            <link>https://www.dr.dk/nyheder/indland/techgiganter-fjerner-opslag-og-truer-med-lukke-grupper-jeg-ved-ikke-hvad-vi-goer-forkert</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:b2a4691d-9430-48b7-92ab-ce6e43280bc1</guid>
+            <pubDate>Sat, 29 Aug 2026 13:20:00 GMT</pubDate>
+            <description><![CDATA[I dag mødes 200 frivillige i Odense til en konference, hvor de blandt andet skal snakke om de problemer, de oplever med de amerikanske techgiganter, som står bag siderne.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/vord3lam/20260829-083917-6_crop001.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Skole forbyder el-cykler på fællesture]]></title>
+            <link>https://www.dr.dk/nyheder/indland/skole-forbyder-el-cykler-paa-faellesture</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:0f9902c0-294b-47fa-a741-5228b8aa7a4c</guid>
+            <pubDate>Sat, 29 Aug 2026 12:08:00 GMT</pubDate>
+            <description><![CDATA[Når eleverne på Vonsild Skole i Kolding Kommune fremover skal på fælles cykeltur, må el‑cyklerne blive hjemme på skolen. Lokalpolitiker bakker op om idéen.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/mhsj323h/img_5255_crop001.jpeg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[For Benedikte gav det ikke mening at fortsætte med Wegovy]]></title>
+            <link>https://www.dr.dk/nyheder/indland/reels/benedikte-gav-det-ikke-mening-fortsaette-med-wegovy</link>
+            <guid isPermaLink="false">urn:dr:umbraco:reel:e0172702-f8ce-4dcf-b3f7-59b28c2faf60</guid>
+            <pubDate>Sat, 29 Aug 2026 11:01:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Vil du vide, hvordan det var at være vikingekriger? Nu får du chancen]]></title>
+            <link>https://www.dr.dk/nyheder/indland/vil-du-vide-hvordan-det-var-vaere-vikingekriger-nu-faar-du-chancen</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:16453fe0-608a-47b9-835d-689aa8f41dbc</guid>
+            <pubDate>Sat, 29 Aug 2026 10:25:00 GMT</pubDate>
+            <description><![CDATA[Trelleborg ved Slagelse har taget det første spadestik til et ambitiøst projekt, hvor Harald Blåtands mere end 1.000 år gamle vikingeborg bliver genopført.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/zpcdfmbc/trelleborg-visualering-kamp.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Festivalgæster ramt af svindel med deres bookede overnatninger]]></title>
+            <link>https://www.dr.dk/nyheder/indland/festivalgaester-ramt-af-svindel-med-deres-bookede-overnatninger</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:1a685cef-d37d-4ed8-895f-c260c50654f4</guid>
+            <pubDate>Sat, 29 Aug 2026 09:05:21 GMT</pubDate>
+            <description><![CDATA[Flere gæster har været udsat for svindel med udlejningsboliger på årets Tønder Festival. ]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/ygalay0u/20260828-154247-3.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+        <item>
+            <title><![CDATA[Sigtet for drabsforsøg kræves alligevel fængslet]]></title>
+            <link>https://www.dr.dk/nyheder/indland/sigtet-drabsforsoeg-kraeves-alligevel-faengslet</link>
+            <guid isPermaLink="false">urn:dr:umbraco:article:e886481e-d226-4b2d-9eca-8231cb249e20</guid>
+            <pubDate>Sat, 29 Aug 2026 08:45:13 GMT</pubDate>
+            <description><![CDATA[En 24-årig mand fremstilles lørdag i grundlovsforhør efter skudepisode sidste uge i Haderslev.]]></description>
+            <media:content url="https://asset.dr.dk/drdk/umbraco-images/dzjpdekf/20260417-140956-l.jpg?im=AspectCrop=(1200,675),xPosition=.5,yPosition=.5;Resize=(1200,675)&amp;impolicy=medium" medium="image"/>
+        </item>
+    </channel>
+</rss>

--- a/lib/routes/dr/indland.ts
+++ b/lib/routes/dr/indland.ts
@@ -1,0 +1,27 @@
+import type { Route } from '@/types';
+
+import { getNews } from './utils';
+
+export const route: Route = {
+    path: '/indland',
+    categories: ['traditional-media'],
+    example: '/dr/indland',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.dr.dk/nyheder/indland'],
+            target: '/indland',
+        },
+    ],
+    name: 'Indland',
+    maintainers: ['cufezhusy'],
+    handler: () => getNews('indland'),
+    description: 'DRs indlandsnyheder, baseret på den officielle RSS-feed Indland. RSSHub forsøger at hente den fulde artikeltekst fra dr.dk. Hvis den fulde tekst ikke kan hentes, bruges beskrivelsen fra den officielle RSS-feed.',
+};

--- a/lib/routes/dr/namespace.ts
+++ b/lib/routes/dr/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'DR (Danmarks Radio)',
+    url: 'dr.dk',
+    lang: 'da',
+};

--- a/lib/routes/dr/nyheder.ts
+++ b/lib/routes/dr/nyheder.ts
@@ -1,0 +1,28 @@
+import type { Route } from '@/types';
+
+import { getNews } from './utils';
+
+export const route: Route = {
+    path: '/nyheder',
+    categories: ['traditional-media'],
+    example: '/dr/nyheder',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.dr.dk/nyheder'],
+            target: '/nyheder',
+        },
+    ],
+    name: 'Seneste nyt (Kort nyt)',
+    maintainers: ['cufezhusy'],
+    handler: () => getNews('senestenyt'),
+    description:
+        'DRs seneste nyheder, baseret på den officielle RSS-feed Kort nyt (<https://www.dr.dk/nyheder/service/feeds/senestenyt>). RSSHub forsøger at hente den fulde artikeltekst fra dr.dk. Hvis den fulde tekst ikke kan hentes, bruges beskrivelsen fra den officielle RSS-feed.',
+};

--- a/lib/routes/dr/penge.ts
+++ b/lib/routes/dr/penge.ts
@@ -1,0 +1,27 @@
+import type { Route } from '@/types';
+
+import { getNews } from './utils';
+
+export const route: Route = {
+    path: '/penge',
+    categories: ['traditional-media'],
+    example: '/dr/penge',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.dr.dk/nyheder/penge'],
+            target: '/penge',
+        },
+    ],
+    name: 'Penge',
+    maintainers: ['cufezhusy'],
+    handler: () => getNews('penge'),
+    description: 'DRs økonominyheder, baseret på den officielle RSS-feed Penge. RSSHub forsøger at hente den fulde artikeltekst fra dr.dk. Hvis den fulde tekst ikke kan hentes, bruges beskrivelsen fra den officielle RSS-feed.',
+};

--- a/lib/routes/dr/politik.ts
+++ b/lib/routes/dr/politik.ts
@@ -1,0 +1,27 @@
+import type { Route } from '@/types';
+
+import { getNews } from './utils';
+
+export const route: Route = {
+    path: '/politik',
+    categories: ['traditional-media'],
+    example: '/dr/politik',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.dr.dk/nyheder/politik'],
+            target: '/politik',
+        },
+    ],
+    name: 'Politik',
+    maintainers: ['cufezhusy'],
+    handler: () => getNews('politik'),
+    description: 'DRs politiske nyheder, baseret på den officielle RSS-feed Politik. RSSHub forsøger at hente den fulde artikeltekst fra dr.dk. Hvis den fulde tekst ikke kan hentes, bruges beskrivelsen fra den officielle RSS-feed.',
+};

--- a/lib/routes/dr/sport.ts
+++ b/lib/routes/dr/sport.ts
@@ -1,0 +1,27 @@
+import type { Route } from '@/types';
+
+import { getNews } from './utils';
+
+export const route: Route = {
+    path: '/sport',
+    categories: ['sport'],
+    example: '/dr/sport',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.dr.dk/sporten'],
+            target: '/sport',
+        },
+    ],
+    name: 'Sport',
+    maintainers: ['cufezhusy'],
+    handler: () => getNews('sporten'),
+    description: 'DRs sportsnyheder, baseret på den officielle RSS-feed Sport. RSSHub forsøger at hente den fulde artikeltekst fra dr.dk. Hvis den fulde tekst ikke kan hentes, bruges beskrivelsen fra den officielle RSS-feed.',
+};

--- a/lib/routes/dr/udland.ts
+++ b/lib/routes/dr/udland.ts
@@ -1,0 +1,27 @@
+import type { Route } from '@/types';
+
+import { getNews } from './utils';
+
+export const route: Route = {
+    path: '/udland',
+    categories: ['traditional-media'],
+    example: '/dr/udland',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.dr.dk/nyheder/udland'],
+            target: '/udland',
+        },
+    ],
+    name: 'Udland',
+    maintainers: ['cufezhusy'],
+    handler: () => getNews('udland'),
+    description: 'DRs udlandsnyheder, baseret på den officielle RSS-feed Udland. RSSHub forsøger at hente den fulde artikeltekst fra dr.dk. Hvis den fulde tekst ikke kan hentes, bruges beskrivelsen fra den officielle RSS-feed.',
+};

--- a/lib/routes/dr/utils.test.mts
+++ b/lib/routes/dr/utils.test.mts
@@ -58,7 +58,7 @@ describe('DR article extraction', () => {
         expect(article!.author).toBe('Annette Jespersen, Asta Holst Bach');
         expect(article!.category).toBe('Indland');
         expect(article!.image).toContain('20260709-172845-l.jpg');
-        expect(article!.pubDate).toBe('2026-08-30T11:07:00+00:00');
+        expect(article!.pubDate).toEqual(new Date('2026-08-30T11:07:00+00:00'));
 
         const content = article!.content;
         // paragraphs

--- a/lib/routes/dr/utils.test.mts
+++ b/lib/routes/dr/utils.test.mts
@@ -1,0 +1,224 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { renderToString } from 'hono/jsx/dom/server';
+import { http, HttpResponse } from 'msw';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import server from '@/setup.test';
+import type { Data, DataItem } from '@/types';
+import cache from '@/utils/cache';
+import parser from '@/utils/rss-parser';
+import RSS from '@/views/rss';
+
+import { extractDRArticle, getNews } from './utils';
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+const feedXml = fs.readFileSync(path.join(fixturesDir, 'feed.xml'), 'utf8');
+const articleHtml = fs.readFileSync(path.join(fixturesDir, 'article.html'), 'utf8');
+
+const feedUrl = 'https://www.dr.dk/nyheder/service/feeds/indland';
+
+const stubFeed = async () => {
+    const { default: server } = await import('@/setup.test');
+    server.use(http.get(feedUrl, () => HttpResponse.text(feedXml, { headers: { 'content-type': 'application/xml' } })));
+};
+
+const stubArticle = async () => {
+    const { default: server } = await import('@/setup.test');
+    server.use(http.get('https://www.dr.dk/nyheder/indland/*', () => HttpResponse.text(articleHtml)));
+};
+
+describe('DR RSS parsing', () => {
+    it('parses the official RSS feed', async () => {
+        const { default: server } = await import('@/setup.test');
+        server.use(http.get(feedUrl, () => HttpResponse.text(feedXml, { headers: { 'content-type': 'application/xml' } })));
+
+        const feed = await parser.parseURL(feedUrl);
+
+        expect(feed.title).toBe('Indland | DR');
+        expect(feed.language).toBe('da');
+        expect(feed.items.length).toBeGreaterThan(0);
+
+        const item = feed.items.find((i) => i.link?.includes('frygt-naturen'))!;
+        expect(item.title).toContain('Frygt for naturen');
+        expect(item.link).toBe('https://www.dr.dk/nyheder/indland/frygt-naturen-er-ude-af-proportioner-mener-eksperter-det-er-ikke-bare-naturangst-det-er-hysterisk');
+        expect(item.guid).toBe('urn:dr:umbraco:article:111ea74f-9a12-4aa2-94d6-46105268ccf2');
+        expect(item.pubDate).toBe('Sun, 30 Aug 2026 11:07:00 GMT');
+        expect(item.contentSnippet).toContain('Vi er blevet mere fremmede over for naturen');
+    });
+});
+
+describe('DR article extraction', () => {
+    it('extracts full article content from the page', () => {
+        const article = extractDRArticle(articleHtml);
+
+        expect(article).not.toBeNull();
+        expect(article!.title).toBe('Frygt for naturen er ude af proportioner, mener eksperter');
+        expect(article!.author).toBe('Annette Jespersen, Asta Holst Bach');
+        expect(article!.category).toBe('Indland');
+        expect(article!.image).toContain('20260709-172845-l.jpg');
+        expect(article!.pubDate).toBe('2026-08-30T11:07:00+00:00');
+
+        const content = article!.content;
+        // paragraphs
+        expect(content).toContain('<p>Ulvedebatten raser');
+        // inline bold
+        expect(content).toContain('<strong>Rasmus Ejrnæs</strong>');
+        // inline link
+        expect(content).toContain('<a href="https://www.dr.dk/nyheder/indland/eksempel">her</a>');
+        // heading
+        expect(content).toContain('<h2>Professor: Vi er uvante med naturen</h2>');
+        // quote with citation
+        expect(content).toContain('<blockquote>');
+        expect(content).toContain('Rune Engelbreht Larsen, idéhistoriker');
+        // list
+        expect(content).toContain('<ul>');
+        expect(content).toContain('<li>');
+        // image with figure and caption
+        expect(content).toContain('<figure>');
+        expect(content).toContain('<img src="https://asset.dr.dk/drdk/umbraco-images/t0ofa3bi/rune.jpg"');
+        expect(content).toContain('<figcaption>Rune Engelbreht Larsen mener, at fakta betyder noget</figcaption>');
+        // media poster
+        expect(content).toContain('urn:dr:od3:clippublication:6a8309ca9590f6145c9a361c');
+    });
+
+    it('excludes related articles, interactive graphics and embeds', () => {
+        const article = extractDRArticle(articleHtml)!;
+
+        expect(article.content).not.toContain('Ponyen Bellami');
+        expect(article.content).not.toContain('automat.drintern.dk');
+        expect(article.content).not.toContain('interactive');
+    });
+
+    it('returns null when the page has no article data', () => {
+        expect(extractDRArticle('<html><body><p>nothing here</p></body></html>')).toBeNull();
+    });
+});
+
+describe('DR news route item', () => {
+    afterEach(() => {
+        server.resetHandlers();
+        (cache as any).clients.memoryCache?.clear();
+    });
+
+    it('produces items with title, link, guid and date', async () => {
+        stubFeed();
+        stubArticle();
+
+        const data = await getNews('indland');
+
+        expect(data.title).toBe('Indland | DR');
+        const item = data.item!.find((i) => i.link?.includes('frygt-naturen'))!;
+
+        expect(item.title).toContain('Frygt for naturen');
+        expect(item.link).toBe('https://www.dr.dk/nyheder/indland/frygt-naturen-er-ude-af-proportioner-mener-eksperter-det-er-ikke-bare-naturangst-det-er-hysterisk');
+        expect(item.guid).toBe('urn:dr:umbraco:article:111ea74f-9a12-4aa2-94d6-46105268ccf2');
+        expect(new Date(item.pubDate!).toISOString()).toBe('2026-08-30T11:07:00.000Z');
+        expect(item.author).toBe('Annette Jespersen, Asta Holst Bach');
+        expect(item.category).toBe('Indland');
+    });
+
+    it('embeds the full article text in the description', async () => {
+        stubFeed();
+        stubArticle();
+
+        const data = await getNews('indland');
+        const item = data.item!.find((i) => i.link?.includes('frygt-naturen'))!;
+
+        expect(item.description).toContain('<p>Ulvedebatten raser');
+        expect(item.description).toContain('Professor: Vi er uvante med naturen');
+        // must not be a short snippet
+        expect(item.description!.length).toBeGreaterThan(200);
+    });
+
+    it('falls back to the official RSS description when extraction fails', async () => {
+        stubFeed();
+        const { default: server } = await import('@/setup.test');
+        // no article stub: the real page would not resolve in tests, extraction returns null
+        server.use(http.get('https://www.dr.dk/nyheder/indland/*', () => HttpResponse.text('<html><body></body></html>')));
+
+        const data = await getNews('indland');
+        const item = data.item!.find((i) => i.link?.includes('frygt-naturen'))!;
+
+        expect(item.description).toContain('Vi er blevet mere fremmede over for naturen');
+    });
+});
+
+describe('DR route output XML', () => {
+    it('renders valid RSS/XML with the full article body', () => {
+        const data: Data = {
+            title: 'Indland | DR',
+            link: 'https://www.dr.dk/',
+            description: 'Nyheder fra sektionen Indland',
+            item: [
+                {
+                    title: 'Frygt for naturen er ude af proportioner',
+                    link: 'https://www.dr.dk/nyheder/indland/eksempel',
+                    guid: 'urn:dr:umbraco:article:111ea74f-9a12-4aa2-94d6-46105268ccf2',
+                    pubDate: 'Sun, 30 Aug 2026 11:07:00 GMT',
+                    author: 'Annette Jespersen',
+                    category: 'Indland',
+                    description: '<p>Ulvedebatten raser, og senest var der torsdag aften ulvemøde i Egtved.</p>',
+                },
+            ],
+        };
+
+        const xml = renderToString(RSS({ data }) as any);
+
+        expect(xml).toMatch(/^<rss/);
+        expect(xml).toContain('<title>Frygt for naturen er ude af proportioner</title>');
+        expect(xml).toContain('<link>https://www.dr.dk/nyheder/indland/eksempel</link>');
+        expect(xml).toContain('<guid isPermaLink="false">urn:dr:umbraco:article:111ea74f-9a12-4aa2-94d6-46105268ccf2</guid>');
+        expect(xml).toContain('Sun, 30 Aug 2026 11:07:00 GMT');
+        expect(xml).toContain('<author>Annette Jespersen</author>');
+        expect(xml).toContain('<category>Indland</category>');
+        // the HTML description is entity-escaped but decodable back to full text
+        expect(xml).toContain('&lt;p&gt;Ulvedebatten raser');
+        expect(xml).toContain('</channel>');
+        expect(xml).toContain('</rss>');
+    });
+
+    it('produces parseable XML from the real route output', async () => {
+        const data: Data = {
+            title: 'Indland | DR',
+            link: 'https://www.dr.dk/',
+            description: 'Nyheder fra sektionen Indland',
+            item: [
+                {
+                    title: 'Frygt for naturen er ude af proportioner',
+                    link: 'https://www.dr.dk/nyheder/indland/eksempel',
+                    guid: 'urn:dr:umbraco:article:111ea74f-9a12-4aa2-94d6-46105268ccf2',
+                    pubDate: 'Sun, 30 Aug 2026 11:07:00 GMT',
+                    description: '<p>Ulvedebatten raser.</p>',
+                },
+            ],
+        };
+
+        const xml = renderToString(RSS({ data }) as any);
+        const parsed = await parser.parseString(xml.replaceAll('<rss ', '<rss xmlns="http://www.w3.org/2005/Atom" '));
+
+        expect(parsed.items).toHaveLength(1);
+        expect(parsed.items[0].title).toBe('Frygt for naturen er ude af proportioner');
+        expect(parsed.items[0].guid).toBe('urn:dr:umbraco:article:111ea74f-9a12-4aa2-94d6-46105268ccf2');
+    });
+
+    it('keeps the item shape valid for the whole feed', async () => {
+        stubFeed();
+        stubArticle();
+
+        const data = await getNews('indland');
+        const items = (data.item ?? []) as DataItem[];
+
+        for (const item of items) {
+            expect(item.title).toEqual(expect.any(String));
+            expect(item.link).toEqual(expect.any(String));
+            expect(item.guid).toEqual(expect.any(String));
+            if (item.pubDate) {
+                const pubDate = Date.parse(String(item.pubDate));
+                expect(Number.isNaN(pubDate)).toBe(false);
+            }
+            expect(item.description).toEqual(expect.any(String));
+        }
+    });
+});

--- a/lib/routes/dr/utils.ts
+++ b/lib/routes/dr/utils.ts
@@ -1,0 +1,155 @@
+import { load } from 'cheerio';
+
+import { config } from '@/config';
+import type { Data, DataItem } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import logger from '@/utils/logger';
+import parser from '@/utils/rss-parser';
+
+const rootUrl = 'https://www.dr.dk';
+const feedUrl = (slug: string) => `${rootUrl}/nyheder/service/feeds/${slug}`;
+
+const escapeHtml = (text: string) => text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#39;');
+
+const renderInline = (nodes: any[] = []): string =>
+    nodes
+        .map((node) => {
+            switch (node.type) {
+                case 'Text':
+                    return escapeHtml(node.text ?? '');
+                case 'Italic':
+                    return `<em>${renderInline(node.body)}</em>`;
+                case 'Bold':
+                    return `<strong>${renderInline(node.body)}</strong>`;
+                case 'Link':
+                    return `<a href="${escapeHtml(node.url ?? '')}">${renderInline(node.body)}</a>`;
+                default:
+                    return '';
+            }
+        })
+        .join('');
+
+const renderBody = (components: any[] = []): string =>
+    components
+        .map((component) => {
+            switch (component.type) {
+                case 'ParagraphComponent':
+                    return `<p>${renderInline(component.body)}</p>`;
+                case 'HeadingComponent':
+                    return `<h2>${escapeHtml(component.text ?? '')}</h2>`;
+                case 'QuoteComponent': {
+                    const quote = component.body ? `<p>${escapeHtml(component.body)}</p>` : '';
+                    const citation = component.citation ? `<footer>${escapeHtml(component.citation)}</footer>` : '';
+                    return `<blockquote>${quote}${citation}</blockquote>`;
+                }
+                case 'ImageComponent': {
+                    const image = component.image?.default;
+                    if (!image?.url) {
+                        return '';
+                    }
+                    const alt = image.altText ?? image.description ?? '';
+                    const caption = image.description ? `<figcaption>${escapeHtml(image.description)}</figcaption>` : '';
+                    return `<figure><img src="${escapeHtml(image.url)}" alt="${escapeHtml(alt)}">${caption}</figure>`;
+                }
+                case 'MediaComponent': {
+                    const poster = component.resource?.imageUri ?? component.resource?.image?.managedUrl;
+                    if (!poster) {
+                        return '';
+                    }
+                    const caption = component.caption ? `<figcaption>${escapeHtml(component.caption)}</figcaption>` : '';
+                    return `<figure><img src="${escapeHtml(poster)}" alt="${escapeHtml(component.caption ?? '')}">${caption}</figure>`;
+                }
+                case 'EmphasizedListComponent':
+                    return `<ul>${(component.items ?? []).map((item) => `<li>${renderBody(item.body)}</li>`).join('')}</ul>`;
+                // ReadMoreLinkComponent (related articles), CodeComponent (interactive graphics)
+                // and OEmbedComponent (embedded player) are excluded from the article body.
+                default:
+                    return '';
+            }
+        })
+        .filter(Boolean)
+        .join('\n');
+
+export const extractDRArticle = (html: string) => {
+    const $ = load(html);
+    const nextData = JSON.parse($('script#__NEXT_DATA__').text() || '{}');
+    const viewProps = nextData.props?.pageProps?.viewProps;
+    const resource = viewProps?.resource ?? viewProps?.article;
+    if (!resource) {
+        return null;
+    }
+    const content = renderBody(resource.body);
+    if (!content) {
+        return null;
+    }
+    const author = (resource.contributions ?? [])
+        .map((contribution) => contribution?.agent?.name)
+        .filter(Boolean)
+        .join(', ');
+    const image = resource.teaserImage?.default?.url ?? resource.teaserImage?.default?.managedUrl;
+    return {
+        title: resource.title,
+        content,
+        author: author || undefined,
+        category: resource.site?.title,
+        image: image ?? undefined,
+        pubDate: resource.startDate ?? resource.published,
+    };
+};
+
+const fetchDRArticle = (link: string) =>
+    cache.tryGet(`dr:article:${link}`, async () => {
+        try {
+            const { data: html } = await got(link, {
+                headers: {
+                    'User-Agent': config.trueUA,
+                },
+            });
+            return extractDRArticle(html);
+        } catch (error) {
+            logger.error(`Failed to fetch DR article ${link}: ${error}`);
+            return null;
+        }
+    });
+
+export const getNews = async (slug: string): Promise<Data> => {
+    const feed = await parser.parseURL(feedUrl(slug));
+
+    const items = await Promise.all(
+        feed.items.map(async (item) => {
+            const base = {
+                title: item.title,
+                link: item.link,
+                guid: item.guid ?? item.link,
+                pubDate: item.pubDate,
+            };
+
+            const article = await fetchDRArticle(item.link!);
+
+            if (article?.content) {
+                return {
+                    ...base,
+                    description: article.content,
+                    author: article.author,
+                    category: article.category ?? item.category,
+                    image: article.image,
+                } as DataItem;
+            }
+
+            // Fall back to the official RSS description when the full article cannot be extracted.
+            return {
+                ...base,
+                description: item.contentSnippet ?? item.content,
+            } as DataItem;
+        })
+    );
+
+    return {
+        title: feed.title ?? '',
+        link: feed.link ?? rootUrl,
+        description: feed.description,
+        item: items,
+        language: feed.language,
+    };
+};

--- a/lib/routes/dr/utils.ts
+++ b/lib/routes/dr/utils.ts
@@ -5,6 +5,7 @@ import type { Data, DataItem } from '@/types';
 import cache from '@/utils/cache';
 import got from '@/utils/got';
 import logger from '@/utils/logger';
+import { parseDate } from '@/utils/parse-date';
 import parser from '@/utils/rss-parser';
 
 const rootUrl = 'https://www.dr.dk';
@@ -94,7 +95,7 @@ export const extractDRArticle = (html: string) => {
         author: author || undefined,
         category: resource.site?.title,
         image: image ?? undefined,
-        pubDate: resource.startDate ?? resource.published,
+        pubDate: (resource.startDate ?? resource.published) ? parseDate(resource.startDate ?? resource.published) : undefined,
     };
 };
 
@@ -122,7 +123,7 @@ export const getNews = async (slug: string): Promise<Data> => {
                 title: item.title,
                 link: item.link,
                 guid: item.guid ?? item.link,
-                pubDate: item.pubDate,
+                pubDate: item.pubDate ? parseDate(item.pubDate) : undefined,
             };
 
             const article = await fetchDRArticle(item.link!);

--- a/lib/routes/dr/viden.ts
+++ b/lib/routes/dr/viden.ts
@@ -1,0 +1,27 @@
+import type { Route } from '@/types';
+
+import { getNews } from './utils';
+
+export const route: Route = {
+    path: '/viden',
+    categories: ['traditional-media'],
+    example: '/dr/viden',
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['www.dr.dk/nyheder/viden'],
+            target: '/viden',
+        },
+    ],
+    name: 'Viden',
+    maintainers: ['cufezhusy'],
+    handler: () => getNews('viden'),
+    description: 'DRs videnskabsnyheder, baseret på den officielle RSS-feed Viden. RSSHub forsøger at hente den fulde artikeltekst fra dr.dk. Hvis den fulde tekst ikke kan hentes, bruges beskrivelsen fra den officielle RSS-feed.',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

None

## Example for the Proposed Route(s) / 路由地址示例

```routes
/dr/nyheder
/dr/indland
/dr/udland
/dr/politik
/dr/penge
/dr/viden
/dr/sport
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds full-text RSS routes for DR (Danmarks Radio), Denmark's national broadcasting corporation.

### What

- `/dr/nyheder` — Seneste nyt (Kort nyt)
- `/dr/indland` — Indland
- `/dr/udland` — Udland
- `/dr/politik` — Politik
- `/dr/penge` — Penge
- `/dr/viden` — Viden
- `/dr/sport` — Sport

### How it works

1. Each route uses DR's official RSS feed as the source.
2. For each item, the route fetches the article page and extracts the structured article body from the `#__NEXT_DATA__` JSON embedded in the page (`props.pageProps.viewProps.resource` / `props.pageProps.viewProps.article`).
3. The structured component tree is rendered into full article HTML and placed in the RSS `description`.
4. When full-text extraction fails for a single article, the route falls back to the official RSS description — a single failure never breaks the whole feed.
5. Article content is cached with the standard RSSHub cache mechanism.

### Testing

- 10 DR-specific tests (RSS parsing, article extraction, HTML escaping, fallback behavior, and valid RSS 2.0 output) using mocked fixtures.
- `pnpm build:routes` passed
- `pnpm lint` passed
- `npx tsc --noEmit` passed

No global RSSHub behavior is modified; the change is scoped entirely to `lib/routes/dr/`.