### PR TITLE
feat(route/okayafrica): add music latest route

### DIFF
--- a/lib/routes/okayafrica/music.ts
+++ b/lib/routes/okayafrica/music.ts
@@ -1,0 +1,58 @@
+import { load } from 'cheerio';
+
+import type { Data, DataItem, Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+export const route: Route = {
+    path: '/music/latest',
+    categories: ['new-media'],
+    example: '/okayafrica/music/latest',
+    name: 'Music Latest',
+    maintainers: ['ashi-koki'],
+    handler,
+};
+
+async function handler(): Promise<Data> {
+    const rootUrl = 'https://www.okayafrica.com';
+    const listUrl = `${rootUrl}/music/latest`;
+
+    const listResponse = await ofetch(listUrl);
+    const $ = load(listResponse);
+
+    const items = await Promise.all(
+        $('article a[itemprop="url"]')
+            .toArray()
+            .map((el) => {
+                const link = $(el).attr('href')!;
+                const title = $(el).closest('article').find('h2[itemprop="headline"]').text().trim();
+
+                return cache.tryGet(link, async () => {
+                    const pageResponse = await ofetch(link);
+                    const $page = load(pageResponse);
+
+                    $page('.bodytext .google-ad, .bodytext .articlesByTag').remove();
+
+                    const pubDate = $page('.dateGroup.datePublished time').attr('datetime');
+
+                    return {
+                        title: $page('h1.headline').text().trim() || title,
+                        link,
+                        pubDate: pubDate ? parseDate(pubDate) : undefined,
+                        author: $page('.lab-hidden-byline-name').first().text().trim(),
+                        description: $page('.bodytext').html() ?? undefined,
+                        image: $page('meta[property="og:image"]').attr('content'),
+                    };
+                });
+            })
+    );
+
+    return {
+        title: 'OkayAfrica Music',
+        link: listUrl,
+        description: 'Latest music articles from OkayAfrica',
+        language: 'en',
+        item: items as DataItem[],
+    };
+}

--- a/lib/routes/okayafrica/namespace.ts
+++ b/lib/routes/okayafrica/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: 'OkayAfrica',
+    url: 'www.okayafrica.com',
+    lang: 'en',
+};


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/okayafrica/music/latest
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Adds a route for OkayAfrica (okayafrica.com), an African music and culture publication. The site has no native RSS feed, so the route scrapes the `/music/latest` listing and then fetches each article for the full body.

- Listing: `article a[itemprop="url"]` microdata.
- Article: full body from `.bodytext` (ads and related-article widgets removed), author from `.lab-hidden-byline-name`, publish date from `<time datetime>` (normalized with `parseDate`), hero image from `og:image`.
- Per-item results are cached with `cache.tryGet`.
