### PR TITLE
fix(route): update Shanghai Museum domain name

### DIFF
--- a/lib/routes/shanghaimuseum/namespace.ts
+++ b/lib/routes/shanghaimuseum/namespace.ts
@@ -2,7 +2,7 @@ import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
     name: 'Shanghai Museum',
-    url: 'www.shanghaimuseum.net',
+    url: 'www.shanghaimuseum.cn',
 
     zh: {
         name: '上海博物馆',

--- a/lib/routes/shanghaimuseum/news.ts
+++ b/lib/routes/shanghaimuseum/news.ts
@@ -13,14 +13,14 @@ export const route = {
     maintainers: ['magazian'],
     radar: [
         {
-            source: ['www.shanghaimuseum.net/mu/frontend/pg/infomation/news'],
+            source: ['www.shanghaimuseum.cn/mu/frontend/pg/infomation/news'],
             target: '/information/news',
         },
     ],
     handler: async (ctx) => {
         const type = ctx.req.param('type') || 'all';
 
-        const baseUrl = 'https://www.shanghaimuseum.net';
+        const baseUrl = 'https://www.shanghaimuseum.cn';
         const apiUrl = `${baseUrl}/mu/frontend/pg/infomation/search-info`;
 
         const payload = {

--- a/lib/routes/shanghaimuseum/offline-exhibit.tsx
+++ b/lib/routes/shanghaimuseum/offline-exhibit.tsx
@@ -28,14 +28,14 @@ export const route: Route = {
     maintainers: ['magazian'],
     radar: [
         {
-            source: ['www.shanghaimuseum.net/mu/frontend/pg/display/offline-exhibit'],
+            source: ['www.shanghaimuseum.cn/mu/frontend/pg/display/offline-exhibit'],
             target: '/display/offline-exhibit',
         },
     ],
     handler: async (ctx) => {
         const type = ctx.req.param('type');
 
-        const baseUrl = 'https://www.shanghaimuseum.net';
+        const baseUrl = 'https://www.shanghaimuseum.cn';
         const apiUrl = `${baseUrl}/mu/frontend/pg/display/search-exhibit`;
 
         const fetchExhibits = async (status: string, limit = 20): Promise<ExhibitItem[]> => {
@@ -72,7 +72,7 @@ export const route: Route = {
         const items = rawItems.map((item) => {
             const title = item.name;
             const itemLink = `${baseUrl}/mu/frontend/pg/article/id/${item.code}`;
-            const imgUrl = item.picPath ? `${baseUrl}/${item.picPath}` : '';
+            const imgUrl = item.picPath ? `${baseUrl}/mu/${item.picPath}` : '';
             const location = item.exhibitPlace || '上海博物馆';
             const pubDate = timezone(parseDate(item.issueTime), 8);
 


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/shanghaimuseum/display/offline-exhibit
/shanghaimuseum/display/offline-exhibit/PAST
/shanghaimuseum/display/offline-exhibit/PRESENT
/shanghaimuseum/information/news
/shanghaimuseum/information/news/all
/shanghaimuseum/information/news/news
/shanghaimuseum/information/news/bulletin
/shanghaimuseum/information/news/finance
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明
Notice from Shanghai Museum: Effective September 1, 2026, the Shanghai Museum Official Website will adopt the new domain name: [www.shanghaimuseum.cn](https://www.shanghaimuseum.cn/mu/frontend/pg/en/index). The original URL www.shanghaimuseum.net will be discontinued as of January 1, 2027.