### PR TITLE
feat(route/hackernews): filter stories by minimum comment count

### DIFF
--- a/lib/routes/hackernews.test.ts
+++ b/lib/routes/hackernews.test.ts
@@ -1,0 +1,203 @@
+import type { Context } from 'hono';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { route } from '@/routes/hackernews/index';
+import server from '@/setup.test';
+import type { Data } from '@/types';
+import type * as ParseDateModule from '@/utils/parse-date';
+import { parseDate } from '@/utils/parse-date';
+
+vi.mock('@/utils/parse-date', async (importOriginal) => {
+    const actual = await importOriginal<typeof ParseDateModule>();
+    return { ...actual, parseDate: vi.fn(actual.parseDate) };
+});
+
+const parseDateMock = vi.mocked(parseDate);
+
+const createContext = (params: Record<string, string | undefined>, query: Record<string, string | undefined> = {}) =>
+    ({
+        req: {
+            param: (name: string) => params[name],
+            query: (name: string) => query[name],
+        },
+    }) as unknown as Context;
+
+const runRoute = async (params: Record<string, string | undefined>, query: Record<string, string | undefined> = {}) => (await route.handler(createContext(params, query))) as Data;
+
+const createStoryRow = (id: string, comments: number | string) => `
+    <tr class="athing" id="${id}">
+        <td class="title">
+            <span class="titleline"><a href="https://example.com/${id}">Story ${id}</a><span class="sitestr">example.com</span></span>
+        </td>
+    </tr>
+    <tr>
+        <td class="subtext">
+            <span class="score">10 points</span>
+            <a class="hnuser">author</a>
+            <span class="age" title="2026-08-31T00:00:00 000000"><a>1 hour ago</a></span>
+            <a href="item?id=${id}">${typeof comments === 'number' ? `${comments}&nbsp;comments` : comments}</a>
+        </td>
+    </tr>
+`;
+
+const createStoryListHtml = (stories: Array<[string, number | string]>) => `
+    <html>
+        <head><title>Hacker News</title></head>
+        <body>
+            <table>
+                ${stories.map(([id, comments]) => createStoryRow(id, comments)).join('')}
+            </table>
+        </body>
+    </html>
+`;
+
+const createStoryHtml = (id: string, comments: number | string) => createStoryListHtml([[id, comments]]);
+
+const mockHackerNews = (html: string, onRequest?: (url: URL) => void) => {
+    server.use(
+        http.get(/^https:\/\/news\.ycombinator\.com(?:\/.*)?$/, ({ request }) => {
+            onRequest?.(new URL(request.url));
+            return HttpResponse.text(html);
+        })
+    );
+};
+
+describe('Hacker News minimum comment filter', () => {
+    beforeEach(() => {
+        parseDateMock.mockClear();
+    });
+
+    it('keeps a fully filtered listing subject to empty-feed checks', async () => {
+        mockHackerNews(createStoryHtml('1001', 5));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('keeps an empty upstream listing reportable', async () => {
+        mockHackerNews('<html><head><title>Hacker News</title></head><body></body></html>');
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('keeps an unparseable comment listing reportable', async () => {
+        mockHackerNews(createStoryHtml('1004', '22 days ago'));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('recognizes discuss links as zero-comment stories', async () => {
+        mockHackerNews(createStoryHtml('1005', 'discuss'));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '1' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('does not fetch comment threads for discuss links', async () => {
+        const requestedUrls: URL[] = [];
+        mockHackerNews(createStoryHtml('1009', 'discuss'), (url) => {
+            requestedUrls.push(url);
+        });
+
+        const result = await runRoute({ section: 'index', type: 'comments', value: '' });
+
+        expect(requestedUrls).toHaveLength(1);
+        expect(result.item).toHaveLength(1);
+        expect(result.item?.[0].comments).toBe(0);
+    });
+
+    it('uses the explicit minimum-comments parameter without treating a numeric value as an ID', async () => {
+        let requestedUrl: URL | undefined;
+        mockHackerNews(createStoryHtml('1006', 5), (url) => {
+            requestedUrl = url;
+        });
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '5', minComments: '10' });
+
+        expect(requestedUrl?.search).toBe('');
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('does not allow an empty feed caused only by limit zero', async () => {
+        mockHackerNews(createStoryHtml('1002', 15));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' }, { limit: '0' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('returns matching stories without enabling empty feeds', async () => {
+        mockHackerNews(createStoryHtml('1003', 15));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' });
+
+        expect(result.item).toHaveLength(1);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('limits rows before parsing when the comment filter is disabled', async () => {
+        const stories = Array.from({ length: 40 }, (_, index) => [`20${index.toString().padStart(2, '0')}`, 10] as [string, number]);
+        mockHackerNews(createStoryListHtml(stories));
+
+        const result = await runRoute({ section: 'item', type: 'sources', value: '2000' }, { limit: '5' });
+
+        expect(result.item).toHaveLength(5);
+        expect(parseDateMock).toHaveBeenCalledTimes(5);
+    });
+
+    it('filters the full listing before applying the limit', async () => {
+        mockHackerNews(
+            createStoryListHtml([
+                ['3001', 1],
+                ['3002', 10],
+            ])
+        );
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '5' }, { limit: '1' });
+
+        expect(result.item).toHaveLength(1);
+        expect(result.item?.[0].title).toBe('Story 3002');
+        expect(parseDateMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('preserves numeric Hacker News IDs outside story-listing sections', async () => {
+        let requestedUrl: URL | undefined;
+        mockHackerNews(createStoryHtml('1007', 5), (url) => {
+            requestedUrl = url;
+        });
+
+        const result = await runRoute({ section: 'item', type: 'sources', value: '1007' });
+
+        expect(requestedUrl?.pathname).toBe('/item');
+        expect(requestedUrl?.search).toBe('?id=1007');
+        expect(result.item).toHaveLength(1);
+    });
+
+    it('preserves the existing behavior for unknown output types', async () => {
+        mockHackerNews(createStoryHtml('1008', 5));
+
+        const result = await runRoute({ section: 'index', type: 'unknown', value: '' });
+
+        expect(result.item).toHaveLength(1);
+        expect(result.item?.[0].link).toBe('https://news.ycombinator.com/item?id=1008');
+    });
+
+    it('rejects listing rows without a Hacker News item ID', async () => {
+        mockHackerNews(createStoryHtml('', 5));
+
+        await expect(runRoute({ section: 'index', type: 'sources', value: '' })).rejects.toThrow('Hacker News item is missing an ID');
+    });
+});

--- a/lib/routes/hackernews/index.ts
+++ b/lib/routes/hackernews/index.ts
@@ -7,7 +7,7 @@ import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
-    path: '/:section?/:type?/:value?',
+    path: '/:section?/:type?/:value?/:minComments?',
     categories: ['programming'],
     view: ViewType.Articles,
     example: '/hackernews/threads/comments_list/dang',
@@ -19,7 +19,12 @@ export const route: Route = {
             description: 'Content format, default to `sources`. `sources` links to original articles, `comments` fetches full comment threads, `comments_list` shows parent story with single comment',
         },
         value: {
-            description: 'For `threads`/`submitted` sections, set user ID. For `over` section, set minimum points threshold (default 100). For other sections, appended as `?id=<value>` (e.g. `value=dang` → `?id=dang`)',
+            description:
+                'For `threads`/`submitted` sections, set user ID. For `over` section, set minimum points threshold (default 100). For other sections, appended as `?id=<value>` (e.g. `value=dang` → `?id=dang`). In story-listing sections (`index`, `best`, `front`, `active`, `newest`, `ask`, `show`, `shownew`, `asknew`, `noobstories`, `pool`, `classic`, `launches`, `news`, `invited`), a purely numeric value acts as minimum comment count instead (same as `minComments`)',
+        },
+        minComments: {
+            description:
+                'Minimum comment count, items below it are filtered out. Works with any story-listing section, e.g. `/hackernews/over/sources/100/10`. For sections where `value` is unused (`index`, `best`, `front`, `active`, `newest`, `ask`, `show`, `shownew`, `asknew`, `noobstories`, `pool`, `classic`, `launches`, `news`, `invited`), the number may be placed in `value` instead, e.g. `/hackernews/index/sources/10`. Ignored on sections without story comment counts (`jobs`, `threads`, `newcomments`, `bestcomments`, `noobcomments`, `highlights`)',
         },
     },
     features: {
@@ -38,13 +43,13 @@ export const route: Route = {
     name: 'Stories',
     maintainers: ['nczitzk', 'xie-dongping'],
     handler,
-    description: `Subscribe to Hacker News content by section, user, or minimum points
+    description: `Subscribe to Hacker News content by section, user, minimum points, or minimum comments
 
 Examples:
 
-| HN100              | User submitted                       | User threads                       | Comments list                            |
-| ------------------ | ------------------------------------ | ---------------------------------- | ---------------------------------------- |
-| \`/hackernews/over\` | \`/hackernews/submitted/sources/dang\` | \`/hackernews/threads/sources/dang\` | \`/hackernews/threads/comments_list/dang\` |`,
+| HN100              | User submitted                       | User threads                       | Comments list                            | Min comments                   |
+| ------------------ | ------------------------------------ | ---------------------------------- | ---------------------------------------- | ------------------------------ |
+| \`/hackernews/over\` | \`/hackernews/submitted/sources/dang\` | \`/hackernews/threads/sources/dang\` | \`/hackernews/threads/comments_list/dang\` | \`/hackernews/index/sources/10\` |`,
 };
 
 type Story = Omit<DataItem, 'comments' | 'upvotes'> & {
@@ -55,14 +60,41 @@ type Story = Omit<DataItem, 'comments' | 'upvotes'> & {
     currentComment: string;
 };
 
+const getCommentCount = (item: Story) => {
+    const count = Number.parseInt(String(item.comments));
+    return Number.isNaN(count) ? 0 : count;
+};
+
+const parseComments = (text: string): Story['comments'] => {
+    const normalizedText = text.trim();
+    if (normalizedText === 'discuss') {
+        return normalizedText;
+    }
+
+    const match = normalizedText.match(/^(\d+)\s+comments?$/);
+    return match ? Number.parseInt(match[1]) : '';
+};
+
 async function handler(ctx) {
     const section = ctx.req.param('section') ?? 'index';
     const type = ctx.req.param('type') ?? 'sources';
+    const cacheType = ['sources', 'comments', 'comments_list'].includes(type) ? type : 'unknown';
     const value = ctx.req.param('value') ?? '';
+
+    // Story-listing sections where `value` has no dedicated meaning; a purely numeric value there doubles as the
+    // minimum comment count. Everywhere else numeric values stay HN IDs passed through as `?id=` (e.g. `/item`)
+    const numericThresholdSections = ['index', 'best', 'front', 'active', 'newest', 'ask', 'show', 'shownew', 'asknew', 'noobstories', 'pool', 'classic', 'launches', 'news', 'invited'];
+    // Sections whose rows carry no parseable story comment counts (comment listings or curated link pages),
+    // so the filter cannot apply there
+    const sectionsWithoutCommentCounts = ['jobs', 'threads', 'newcomments', 'bestcomments', 'noobcomments', 'highlights'];
+    const explicitMinComments = ctx.req.param('minComments');
+    const valueIsThreshold = numericThresholdSections.includes(section) && /^\d+$/.test(value);
+    const rawMinComments = explicitMinComments ?? (valueIsThreshold ? value : '');
+    const minComments = /^\d+$/.test(rawMinComments) && !sectionsWithoutCommentCounts.includes(section) ? Number.parseInt(rawMinComments) : 0;
 
     const rootUrl = 'https://news.ycombinator.com';
     const sectionUrl = section === 'index' ? '' : `/${section}`;
-    let optUrl = value === '' ? '' : '?id=' + value;
+    let optUrl = value !== '' && !valueIsThreshold ? '?id=' + value : '';
 
     if (section === 'over') {
         optUrl = value === '' ? '?points=100' : '?points=' + value;
@@ -73,40 +105,52 @@ async function handler(ctx) {
 
     const $ = load(response.data);
 
-    const list = $('.athing')
-        .slice(0, ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 30)
-        .toArray()
-        .map((thing) => {
-            const $thing = $(thing);
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 30;
 
-            const item: Story = {
-                guid: $thing.attr('id'),
-                title: $thing.find('.titleline').children('a').text(),
-                category: $thing.find('.sitestr').text(),
-                author: $thing.next().find('.hnuser').text(),
-                pubDate: parseDate(($thing.find('.age').attr('title') ?? $thing.next().find('.age').attr('title'))!),
+    const things = $('.athing').toArray();
+    const thingsToParse = minComments > 0 ? things : things.slice(0, limit);
 
-                link: '',
-                origin: $thing.find('.titleline').children('a').attr('href'),
-                onStory: $thing.find('.onstory').text().slice(2),
+    const list = thingsToParse.map((thing) => {
+        const $thing = $(thing);
+        const lastSubtextLink = $thing.next().find('a').last().text();
+        const guid = $thing.attr('id');
+        if (!guid) {
+            throw new Error('Hacker News item is missing an ID');
+        }
 
-                comments: $thing.next().find('a').last().text().split(' comment', 1)[0],
-                upvotes: $thing.next().find('.score').text().split(' point', 1)[0],
+        const item: Story = {
+            guid,
+            title: $thing.find('.titleline').children('a').text(),
+            category: $thing.find('.sitestr').text(),
+            author: $thing.next().find('.hnuser').text(),
+            pubDate: parseDate(($thing.find('.age').attr('title') ?? $thing.next().find('.age').attr('title'))!),
 
-                currentComment: $thing.find('.comment').text(),
-                description: '',
-            };
+            link: '',
+            origin: $thing.find('.titleline').children('a').attr('href'),
+            onStory: $thing.find('.onstory').text().slice(2),
 
-            item.link = `${rootUrl}/item?id=${item.guid}`;
-            item.guid = type === 'sources' ? item.guid : `${item.guid}${item.comments === 'discuss' ? '' : `-${item.comments}`}`;
-            item.description = `<a href="${item.link}">Comments on Hacker News</a> | <a href="${item.origin}">Source</a>`;
+            // Only a "N comments" link carries the count; other trailing links (e.g. an age like "22 days ago"
+            // on /invited) must not be misparsed as one
+            comments: parseComments(lastSubtextLink),
+            upvotes: $thing.next().find('.score').text().split(' point', 1)[0],
 
-            return item;
-        });
+            currentComment: $thing.find('.comment').text(),
+            description: '',
+        };
+
+        item.link = `${rootUrl}/item?id=${item.guid}`;
+        item.guid = type === 'sources' || item.comments === '' || item.comments === 'discuss' ? item.guid : `${item.guid}-${item.comments}`;
+        item.description = `<a href="${item.link}">Comments on Hacker News</a> | <a href="${item.origin}">Source</a>`;
+
+        return item;
+    });
+
+    const filteredList = minComments > 0 ? list.filter((item) => getCommentCount(item) >= minComments) : list;
+    const limitedList = minComments > 0 ? filteredList.slice(0, limit) : filteredList;
 
     const items = await Promise.all(
-        list.map((item) =>
-            cache.tryGet(item.guid!, async () => {
+        limitedList.map((item) =>
+            cache.tryGet(`hackernews:${cacheType}:${item.guid}`, async () => {
                 if (item.comments !== 'discuss' && type === 'comments') {
                     const detailResponse = await got({
                         method: 'get',
@@ -142,9 +186,7 @@ async function handler(ctx) {
                     item.description = item.currentComment;
                 }
 
-                if (Number.isNaN(item.comments)) {
-                    item.comments = 0;
-                }
+                item.comments = getCommentCount(item);
 
                 item.link = (type === 'sources' ? item.origin : item.link)!;
 


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

None.

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/hackernews
/hackernews/index/sources/10
/hackernews/best/sources/10
/hackernews/front/sources/10
/hackernews/active/sources/10
/hackernews/newest/sources/10
/hackernews/ask/sources/10
/hackernews/show/sources/10
/hackernews/shownew/sources/10
/hackernews/asknew/sources/10
/hackernews/noobstories/sources/10
/hackernews/pool/sources/10
/hackernews/classic/sources/10
/hackernews/launches/sources/10
/hackernews/news/sources/10
/hackernews/invited/sources/10
/hackernews/index/comments/10
/hackernews/over/sources/100/10
/hackernews/submitted/sources/dang/10
/hackernews/item/sources/8863
/hackernews/threads/comments_list/dang
/hackernews/threads/sources/dang
/hackernews/over
/hackernews/jobs
/hackernews/newcomments/comments_list
/hackernews/bestcomments/comments_list
/hackernews/noobcomments/comments_list
/hackernews/highlights/comments_list
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add an optional minimum comment count to the existing Hacker News route. For example, `/hackernews/index/sources/10` includes stories with at least 10 comments; `/hackernews/over/sources/100/10` combines the existing points threshold with the new comment threshold.

Numeric values remain IDs where required, including `item` and `submitted`. Sections without story comment counts ignore the filter. Filtering happens before the common `limit` is applied, and excluded stories do not trigger comment-detail requests. Empty results remain subject to the existing empty-feed check.

Parse singular/plural comment labels explicitly, treat `discuss` and age-only links as zero comments, and separate item caches by output format. Comment counts are now numeric in the output. For rows without parseable counts, non-source output GUIDs use the item ID without the previous unparseable suffix; affected subscriptions may see those items again after upgrading.

Validation:

- 13 committed Hacker News tests and 59 parameter middleware tests pass.
- 52 additional local smoke checks pass (not included in this PR), covering old/new behavior, route matching and RSS output, cache isolation, and replay of HTML fetched from index, invited, jobs, threads, and over.
- TypeScript, type-aware lint, formatting, and diff checks pass.

This updates an existing route; no new packages or Puppeteer are needed. HN returned HTTP 429 during a live threads fetch; a retry succeeded.
