### PR TITLE
fix(route): repair Anthropic research feed

### DIFF
--- a/lib/routes/anthropic/research.ts
+++ b/lib/routes/anthropic/research.ts
@@ -28,55 +28,24 @@ async function handler(ctx) {
     const $ = load(response);
     const limit = ctx.req.query('limit') ? Number(ctx.req.query('limit')) : 20;
 
-    // self.__next_f.push
-    const regexp = /self\.__next_f\.push\((.+)\)/;
-    const textList: string[] = [];
-    for (const e of $('script').toArray()) {
-        const $e = $(e);
-        const text = $e.text();
-        const match = regexp.exec(text);
-        if (match) {
-            try {
-                const data = JSON.parse(match[1]);
-                if (Array.isArray(data) && data.length === 2 && data[0] === 1) {
-                    textList.push(data[1]);
-                }
-            } catch {
-                // ignore
-            }
-        }
-    }
-
-    const partRegex = /^([0-9a-z]+):([0-9a-z]+)?(\[.*)$/i;
-    const fd = textList
-        .join('')
-        .split('\n')
-        .map((d) => {
-            const matchPart = partRegex.exec(d);
-            if (matchPart) {
-                return {
-                    id: matchPart[1],
-                    tag: matchPart[2],
-                    data: JSON.parse(matchPart[3]),
-                };
-            }
+    const posts: DataItem[] = $('[class^="PublicationList-module-scss-module__"][class$="__list"] a')
+        .toArray()
+        .map((element) => {
+            const $element = $(element);
+            const title = $element.find('[class*="__title"]').text().trim();
+            const href = $element.attr('href') ?? '';
+            const dateText = $element.find('time').text().trim();
+            const category = $element.find('[class*="__subject"]').text().trim();
+            const postLink = href.startsWith('http') ? href : `https://www.anthropic.com${href}`;
             return {
-                id: '',
-                tag: '',
-                data: d,
+                title,
+                link: postLink,
+                pubDate: dateText ? parseDate(dateText, 'MMM D, YYYY') : undefined,
+                category: category ? [category] : undefined,
             };
-        });
-
-    const sections = fd.flatMap((d) => (Array.isArray(d.data) ? d.data : [])).flatMap((item) => item?.page?.sections ?? []);
-    const publicationSections = sections.filter((section) => section?.title === 'Publications');
-    const posts = publicationSections
-        .flatMap((section) => section?.posts ?? [])
-        .slice(0, limit)
-        .map((post): DataItem => ({
-            title: post.title,
-            link: `https://www.anthropic.com/research/${post.slug.current}`,
-            pubDate: parseDate(post.publishedOn),
-        }));
+        })
+        .filter((post) => post.title && post.link)
+        .slice(0, limit);
 
     const items = await pMap(
         posts,


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

None.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/anthropic/research
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Anthropic changed the nesting of its Next.js RSC payload, causing the research route to return no items. Read the server-rendered publication list using the same selector as the existing news route, and extract dates and subjects while retaining cached article fetching.

The list currently renders 10 articles, so this implementation returns up to those 10 entries without pagination. Dates are available only at day precision in the rendered list; the previous payload included time-of-day information. No source timezone is exposed in the list.

Validation performed locally on September 4, 2026: the default route returned HTTP 200 and 10 items with non-empty content, valid dates, and unique GUIDs. With `limit=3`, the titles and links matched the first three publications on the live website. Pre-commit lint, formatting, and TypeScript checks passed.

Resubmission of #23204 with the required PR template and route example.
