### PR TITLE
feat(route/hackernews): filter stories by minimum comment count

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
             - 'dependabot/**'
         paths:
             - 'lib/**'
+            - 'test/**'
             - 'package.json'
             - 'pnpm-lock.yaml'
             - '.github/workflows/test.yml'

--- a/lib/routes/hackernews/index.ts
+++ b/lib/routes/hackernews/index.ts
@@ -7,7 +7,7 @@ import got from '@/utils/got';
 import { parseDate } from '@/utils/parse-date';
 
 export const route: Route = {
-    path: '/:section?/:type?/:value?',
+    path: '/:section?/:type?/:value?/:minComments?',
     categories: ['programming'],
     view: ViewType.Articles,
     example: '/hackernews/threads/comments_list/dang',
@@ -19,7 +19,12 @@ export const route: Route = {
             description: 'Content format, default to `sources`. `sources` links to original articles, `comments` fetches full comment threads, `comments_list` shows parent story with single comment',
         },
         value: {
-            description: 'For `threads`/`submitted` sections, set user ID. For `over` section, set minimum points threshold (default 100). For other sections, appended as `?id=<value>` (e.g. `value=dang` → `?id=dang`)',
+            description:
+                'For `threads`/`submitted` sections, set user ID. For `over` section, set minimum points threshold (default 100). For other sections, appended as `?id=<value>` (e.g. `value=dang` → `?id=dang`). In story-listing sections (`index`, `best`, `front`, `active`, `newest`, `ask`, `show`, `shownew`, `asknew`, `noobstories`, `pool`, `classic`, `launches`, `news`, `invited`), a purely numeric value acts as minimum comment count instead (same as `minComments`)',
+        },
+        minComments: {
+            description:
+                'Minimum comment count, items below it are filtered out. Works with any story-listing section, e.g. `/hackernews/over/sources/100/10`. For sections where `value` is unused (`index`, `best`, `front`, `active`, `newest`, `ask`, `show`, `shownew`, `asknew`, `noobstories`, `pool`, `classic`, `launches`, `news`, `invited`), the number may be placed in `value` instead, e.g. `/hackernews/index/sources/10`. Ignored on sections without story comment counts (`jobs`, `threads`, `newcomments`, `bestcomments`, `noobcomments`, `highlights`)',
         },
     },
     features: {
@@ -38,13 +43,13 @@ export const route: Route = {
     name: 'Stories',
     maintainers: ['nczitzk', 'xie-dongping'],
     handler,
-    description: `Subscribe to Hacker News content by section, user, or minimum points
+    description: `Subscribe to Hacker News content by section, user, minimum points, or minimum comments
 
 Examples:
 
-| HN100              | User submitted                       | User threads                       | Comments list                            |
-| ------------------ | ------------------------------------ | ---------------------------------- | ---------------------------------------- |
-| \`/hackernews/over\` | \`/hackernews/submitted/sources/dang\` | \`/hackernews/threads/sources/dang\` | \`/hackernews/threads/comments_list/dang\` |`,
+| HN100              | User submitted                       | User threads                       | Comments list                            | Min comments                   |
+| ------------------ | ------------------------------------ | ---------------------------------- | ---------------------------------------- | ------------------------------ |
+| \`/hackernews/over\` | \`/hackernews/submitted/sources/dang\` | \`/hackernews/threads/sources/dang\` | \`/hackernews/threads/comments_list/dang\` | \`/hackernews/index/sources/10\` |`,
 };
 
 type Story = Omit<DataItem, 'comments' | 'upvotes'> & {
@@ -55,58 +60,103 @@ type Story = Omit<DataItem, 'comments' | 'upvotes'> & {
     currentComment: string;
 };
 
-async function handler(ctx) {
-    const section = ctx.req.param('section') ?? 'index';
-    const type = ctx.req.param('type') ?? 'sources';
-    const value = ctx.req.param('value') ?? '';
+const getCommentCount = (item: Story) => {
+    const count = Number.parseInt(String(item.comments));
+    return Number.isNaN(count) ? 0 : count;
+};
 
-    const rootUrl = 'https://news.ycombinator.com';
+const parseComments = (text: string): Story['comments'] => {
+    const normalizedText = text.trim();
+    if (normalizedText === 'discuss') {
+        return normalizedText;
+    }
+
+    const match = normalizedText.match(/^(\d+)\s+comments?$/);
+    return match ? Number.parseInt(match[1]) : '';
+};
+
+const rootUrl = 'https://news.ycombinator.com';
+
+function getListingOptions(section: string, value: string, explicitMinComments?: string) {
+    // Story-listing sections where `value` has no dedicated meaning; a purely numeric value there doubles as the
+    // minimum comment count. Everywhere else numeric values stay HN IDs passed through as `?id=` (e.g. `/item`)
+    const numericThresholdSections = ['index', 'best', 'front', 'active', 'newest', 'ask', 'show', 'shownew', 'asknew', 'noobstories', 'pool', 'classic', 'launches', 'news', 'invited'];
+    // Sections whose rows carry no parseable story comment counts (comment listings or curated link pages),
+    // so the filter cannot apply there
+    const sectionsWithoutCommentCounts = ['jobs', 'threads', 'newcomments', 'bestcomments', 'noobcomments', 'highlights'];
+    const valueIsThreshold = numericThresholdSections.includes(section) && /^\d+$/.test(value);
+    const rawMinComments = explicitMinComments ?? (valueIsThreshold ? value : '');
+    const minComments = /^\d+$/.test(rawMinComments) && !sectionsWithoutCommentCounts.includes(section) ? Number.parseInt(rawMinComments) : 0;
+
     const sectionUrl = section === 'index' ? '' : `/${section}`;
-    let optUrl = value === '' ? '' : '?id=' + value;
+    let optUrl = value !== '' && !valueIsThreshold ? '?id=' + value : '';
 
     if (section === 'over') {
         optUrl = value === '' ? '?points=100' : '?points=' + value;
     }
 
-    const currentUrl = `${rootUrl}${sectionUrl}${optUrl}`;
+    return { currentUrl: `${rootUrl}${sectionUrl}${optUrl}`, minComments };
+}
+
+async function handler(ctx) {
+    const section = ctx.req.param('section') ?? 'index';
+    const type = ctx.req.param('type') ?? 'sources';
+    const cacheType = ['sources', 'comments', 'comments_list'].includes(type) ? type : 'unknown';
+    const value = ctx.req.param('value') ?? '';
+    const { currentUrl, minComments } = getListingOptions(section, value, ctx.req.param('minComments'));
+
     const response = await got(currentUrl);
 
     const $ = load(response.data);
 
-    const list = $('.athing')
-        .slice(0, ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 30)
-        .toArray()
-        .map((thing) => {
-            const $thing = $(thing);
+    const limit = ctx.req.query('limit') ? Number.parseInt(ctx.req.query('limit')) : 30;
 
-            const item: Story = {
-                guid: $thing.attr('id'),
-                title: $thing.find('.titleline').children('a').text(),
-                category: $thing.find('.sitestr').text(),
-                author: $thing.next().find('.hnuser').text(),
-                pubDate: parseDate(($thing.find('.age').attr('title') ?? $thing.next().find('.age').attr('title'))!),
+    const things = $('.athing').toArray();
+    const thingsToParse = minComments > 0 ? things : things.slice(0, limit);
 
-                link: '',
-                origin: $thing.find('.titleline').children('a').attr('href'),
-                onStory: $thing.find('.onstory').text().slice(2),
+    const list = thingsToParse.map((thing) => {
+        const $thing = $(thing);
+        const lastSubtextLink = $thing.next().find('a').last().text();
+        // Preserve the legacy U+00A0 split for GUIDs independently of numeric comment parsing.
+        const guidComments = lastSubtextLink.split('\u{00A0}comment', 1)[0];
+        const guid = $thing.attr('id');
+        if (!guid) {
+            throw new Error('Hacker News item is missing an ID');
+        }
 
-                comments: $thing.next().find('a').last().text().split(' comment', 1)[0],
-                upvotes: $thing.next().find('.score').text().split(' point', 1)[0],
+        const item: Story = {
+            guid,
+            title: $thing.find('.titleline').children('a').text(),
+            category: $thing.find('.sitestr').text(),
+            author: $thing.next().find('.hnuser').text(),
+            pubDate: parseDate(($thing.find('.age').attr('title') ?? $thing.next().find('.age').attr('title'))!),
 
-                currentComment: $thing.find('.comment').text(),
-                description: '',
-            };
+            link: '',
+            origin: $thing.find('.titleline').children('a').attr('href'),
+            onStory: $thing.find('.onstory').text().slice(2),
 
-            item.link = `${rootUrl}/item?id=${item.guid}`;
-            item.guid = type === 'sources' ? item.guid : `${item.guid}${item.comments === 'discuss' ? '' : `-${item.comments}`}`;
-            item.description = `<a href="${item.link}">Comments on Hacker News</a> | <a href="${item.origin}">Source</a>`;
+            // Only a "N comments" link carries the count; other trailing links (e.g. an age like "22 days ago"
+            // on /invited) must not be misparsed as one
+            comments: parseComments(lastSubtextLink),
+            upvotes: $thing.next().find('.score').text().split(' point', 1)[0],
 
-            return item;
-        });
+            currentComment: $thing.find('.comment').text(),
+            description: '',
+        };
+
+        item.link = `${rootUrl}/item?id=${item.guid}`;
+        item.guid = type === 'sources' || guidComments === 'discuss' ? item.guid : `${item.guid}-${guidComments}`;
+        item.description = `<a href="${item.link}">Comments on Hacker News</a> | <a href="${item.origin}">Source</a>`;
+
+        return item;
+    });
+
+    const filteredList = minComments > 0 ? list.filter((item) => getCommentCount(item) >= minComments) : list;
+    const limitedList = minComments > 0 ? filteredList.slice(0, limit) : filteredList;
 
     const items = await Promise.all(
-        list.map((item) =>
-            cache.tryGet(item.guid!, async () => {
+        limitedList.map((item) =>
+            cache.tryGet(`hackernews:${cacheType}:${item.guid}`, async () => {
                 if (item.comments !== 'discuss' && type === 'comments') {
                     const detailResponse = await got({
                         method: 'get',
@@ -142,9 +192,7 @@ async function handler(ctx) {
                     item.description = item.currentComment;
                 }
 
-                if (Number.isNaN(item.comments)) {
-                    item.comments = 0;
-                }
+                item.comments = getCommentCount(item);
 
                 item.link = (type === 'sources' ? item.origin : item.link)!;
 

--- a/test/routes/hackernews.test.ts
+++ b/test/routes/hackernews.test.ts
@@ -1,0 +1,303 @@
+import type { Context } from 'hono';
+import { http, HttpResponse } from 'msw';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { route } from '@/routes/hackernews/index';
+import server from '@/setup.test';
+import type { Data } from '@/types';
+import cache from '@/utils/cache';
+import type * as ParseDateModule from '@/utils/parse-date';
+import { parseDate } from '@/utils/parse-date';
+
+vi.mock('@/utils/parse-date', async (importOriginal) => {
+    const actual = await importOriginal<typeof ParseDateModule>();
+    return { ...actual, parseDate: vi.fn(actual.parseDate) };
+});
+
+const parseDateMock = vi.mocked(parseDate);
+
+const createContext = (params: Record<string, string | undefined>, query: Record<string, string | undefined> = {}) =>
+    ({
+        req: {
+            param: (name: string) => params[name],
+            query: (name: string) => query[name],
+        },
+    }) as unknown as Context;
+
+const runRoute = async (params: Record<string, string | undefined>, query: Record<string, string | undefined> = {}) => (await route.handler(createContext(params, query))) as Data;
+
+const createStoryRow = (id: string, comments: number | string) => `
+    <tr class="athing" id="${id}">
+        <td class="title">
+            <span class="titleline"><a href="https://example.com/${id}">Story ${id}</a><span class="sitestr">example.com</span></span>
+        </td>
+    </tr>
+    <tr>
+        <td class="subtext">
+            <span class="score">10 points</span>
+            <a class="hnuser">author</a>
+            <span class="age" title="2026-08-31T00:00:00 000000"><a>1 hour ago</a></span>
+            <a href="item?id=${id}">${typeof comments === 'number' ? `${comments}&nbsp;comments` : comments}</a>
+        </td>
+    </tr>
+`;
+
+const createStoryListHtml = (stories: Array<[string, number | string]>) => `
+    <html>
+        <head><title>Hacker News</title></head>
+        <body>
+            <table>
+                ${stories.map(([id, comments]) => createStoryRow(id, comments)).join('')}
+            </table>
+        </body>
+    </html>
+`;
+
+const createStoryHtml = (id: string, comments: number | string) => createStoryListHtml([[id, comments]]);
+
+const mockHackerNews = (html: string, onRequest?: (url: URL) => void) => {
+    server.use(
+        http.get(/^https:\/\/news\.ycombinator\.com(?:\/.*)?$/, ({ request }) => {
+            onRequest?.(new URL(request.url));
+            return HttpResponse.text(html);
+        })
+    );
+};
+
+describe('Hacker News GUID compatibility', () => {
+    const outputTypes = ['sources', 'comments', 'comments_list', 'unknown', undefined];
+    // Expected suffixes from the route before minimum-comment filtering was added.
+    const labels = [
+        { html: 'discuss', suffix: '', count: 0 },
+        { html: '', suffix: '-', count: 0 },
+        { html: '22 days ago', suffix: '-22 days ago', count: 0 },
+        { html: '1&nbsp;comment', suffix: '-1', count: 1 },
+        { html: '10&nbsp;comments', suffix: '-10', count: 10 },
+        { html: '10 comments', suffix: '-10 comments', count: 10 },
+        { html: '010&nbsp;comments', suffix: '-010', count: 10 },
+        { html: ' 10&nbsp;comments ', suffix: '- 10', count: 10 },
+    ];
+
+    beforeEach(() => {
+        vi.spyOn(cache, 'tryGet').mockImplementation((_key, getValue) => getValue());
+    });
+
+    afterEach(() => {
+        vi.mocked(cache.tryGet).mockRestore();
+    });
+
+    it.each(outputTypes)('preserves legacy GUIDs for output %s', async (type) => {
+        mockHackerNews(createStoryListHtml(labels.map(({ html }, index) => [`40${index}`, html])));
+
+        const result = await runRoute({ section: 'index', type });
+
+        expect(result.item?.map((item) => item.guid)).toEqual(labels.map(({ suffix }, index) => `40${index}${type === 'sources' || type === undefined ? '' : suffix}`));
+        expect(result.item?.map((item) => item.comments)).toEqual(labels.map(({ count }) => count));
+    });
+
+    it.each(outputTypes)('does not change retained GUIDs when filtering output %s', async (type) => {
+        mockHackerNews(createStoryListHtml(labels.map(({ html }, index) => [`50${index}`, html])));
+
+        const unfiltered = await runRoute({ section: 'index', type });
+        const filtered = await runRoute({ section: 'index', type, value: '10' });
+
+        expect(filtered.item?.map((item) => item.guid)).toEqual(unfiltered.item?.filter((item) => Number(item.comments) >= 10).map((item) => item.guid));
+        expect(filtered.item).toHaveLength(4);
+    });
+
+    it('separates cached output formats even when their legacy GUIDs coincide', async () => {
+        const entries = new Map<string, string>();
+        const cacheMock = vi.spyOn(cache, 'tryGet').mockImplementation(async (key, getValue) => {
+            if (!entries.has(key)) {
+                entries.set(key, JSON.stringify(await getValue()));
+            }
+            return JSON.parse(entries.get(key)!);
+        });
+        mockHackerNews(createStoryHtml('6001', '10&nbsp;comments'));
+        server.use(http.get('https://news.ycombinator.com/item', () => HttpResponse.text('<table><tr class="comtr"><td><span class="commtext">Full comment</span></td></tr></table>')));
+
+        const comments = await runRoute({ type: 'comments' });
+        const commentList = await runRoute({ type: 'comments_list' });
+        const cachedComments = await runRoute({ type: 'comments', value: '10' });
+
+        expect(comments.item?.[0].guid).toBe('6001-10');
+        expect(commentList.item?.[0].guid).toBe('6001-10');
+        expect(comments.item?.[0].description).toContain('Full comment');
+        expect(commentList.item?.[0].description).not.toContain('Full comment');
+        expect(cachedComments.item).toEqual(comments.item);
+        expect(cacheMock.mock.calls.map(([key]) => key)).toEqual(['hackernews:comments:6001-10', 'hackernews:comments_list:6001-10', 'hackernews:comments:6001-10']);
+        expect(entries.size).toBe(2);
+    });
+});
+
+describe('Hacker News listing parameters', () => {
+    it.each([
+        { section: 'over', value: undefined, minComments: undefined, path: '/over?points=100', count: 2 },
+        { section: 'over', value: '100', minComments: '10', path: '/over?points=100', count: 1 },
+        { section: 'submitted', value: 'dang', minComments: '10', path: '/submitted?id=dang', count: 1 },
+        { section: 'threads', value: 'dang', minComments: '10', path: '/threads?id=dang', count: 2 },
+        { section: 'invited', value: '10', minComments: undefined, path: '/invited', count: 1 },
+        { section: 'index', value: '10', minComments: '0', path: '/', count: 2 },
+        { section: 'index', value: '10', minComments: '', path: '/', count: 2 },
+        { section: 'index', value: '10', minComments: 'invalid', path: '/', count: 2 },
+        { section: 'index', value: 'dang', minComments: undefined, path: '/?id=dang', count: 2 },
+        { section: 'item', value: '7001', minComments: '10', path: '/item?id=7001', count: 1 },
+        { section: 'other', value: '42', minComments: undefined, path: '/other?id=42', count: 2 },
+    ])('preserves $section parameters with value=$value and minComments=$minComments', async ({ section, value, minComments, path, count }) => {
+        const requestedUrls: string[] = [];
+        mockHackerNews(
+            createStoryListHtml([
+                ['7001', 1],
+                ['7002', 10],
+            ]),
+            (url) => {
+                requestedUrls.push(url.href);
+            }
+        );
+
+        const result = await runRoute({ section, type: 'sources', value, minComments });
+
+        expect(requestedUrls).toEqual([`https://news.ycombinator.com${path}`]);
+        expect(result.item).toHaveLength(count);
+        expect(result.item?.map((item) => item.guid)).toEqual(count === 1 ? ['7002'] : ['7001', '7002']);
+    });
+});
+
+describe('Hacker News minimum comment filter', () => {
+    beforeEach(() => {
+        parseDateMock.mockClear();
+    });
+
+    it('keeps a fully filtered listing subject to empty-feed checks', async () => {
+        mockHackerNews(createStoryHtml('1001', 5));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('keeps an empty upstream listing reportable', async () => {
+        mockHackerNews('<html><head><title>Hacker News</title></head><body></body></html>');
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('keeps an unparseable comment listing reportable', async () => {
+        mockHackerNews(createStoryHtml('1004', '22 days ago'));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('recognizes discuss links as zero-comment stories', async () => {
+        mockHackerNews(createStoryHtml('1005', 'discuss'));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '1' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('does not fetch comment threads for discuss links', async () => {
+        const requestedUrls: URL[] = [];
+        mockHackerNews(createStoryHtml('1009', 'discuss'), (url) => {
+            requestedUrls.push(url);
+        });
+
+        const result = await runRoute({ section: 'index', type: 'comments', value: '' });
+
+        expect(requestedUrls).toHaveLength(1);
+        expect(result.item).toHaveLength(1);
+        expect(result.item?.[0].comments).toBe(0);
+    });
+
+    it('uses the explicit minimum-comments parameter without treating a numeric value as an ID', async () => {
+        let requestedUrl: URL | undefined;
+        mockHackerNews(createStoryHtml('1006', 5), (url) => {
+            requestedUrl = url;
+        });
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '5', minComments: '10' });
+
+        expect(requestedUrl?.search).toBe('');
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('does not allow an empty feed caused only by limit zero', async () => {
+        mockHackerNews(createStoryHtml('1002', 15));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' }, { limit: '0' });
+
+        expect(result.item).toEqual([]);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('returns matching stories without enabling empty feeds', async () => {
+        mockHackerNews(createStoryHtml('1003', 15));
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '10' });
+
+        expect(result.item).toHaveLength(1);
+        expect(result).not.toHaveProperty('allowEmpty');
+    });
+
+    it('limits rows before parsing when the comment filter is disabled', async () => {
+        const stories = Array.from({ length: 40 }, (_, index) => [`20${index.toString().padStart(2, '0')}`, 10] as [string, number]);
+        mockHackerNews(createStoryListHtml(stories));
+
+        const result = await runRoute({ section: 'item', type: 'sources', value: '2000' }, { limit: '5' });
+
+        expect(result.item).toHaveLength(5);
+        expect(parseDateMock).toHaveBeenCalledTimes(5);
+    });
+
+    it('filters the full listing before applying the limit', async () => {
+        mockHackerNews(
+            createStoryListHtml([
+                ['3001', 1],
+                ['3002', 10],
+            ])
+        );
+
+        const result = await runRoute({ section: 'index', type: 'sources', value: '5' }, { limit: '1' });
+
+        expect(result.item).toHaveLength(1);
+        expect(result.item?.[0].title).toBe('Story 3002');
+        expect(parseDateMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('preserves numeric Hacker News IDs outside story-listing sections', async () => {
+        let requestedUrl: URL | undefined;
+        mockHackerNews(createStoryHtml('1007', 5), (url) => {
+            requestedUrl = url;
+        });
+
+        const result = await runRoute({ section: 'item', type: 'sources', value: '1007' });
+
+        expect(requestedUrl?.pathname).toBe('/item');
+        expect(requestedUrl?.search).toBe('?id=1007');
+        expect(result.item).toHaveLength(1);
+    });
+
+    it('preserves the existing behavior for unknown output types', async () => {
+        mockHackerNews(createStoryHtml('1008', 5));
+
+        const result = await runRoute({ section: 'index', type: 'unknown', value: '' });
+
+        expect(result.item).toHaveLength(1);
+        expect(result.item?.[0].link).toBe('https://news.ycombinator.com/item?id=1008');
+    });
+
+    it('rejects listing rows without a Hacker News item ID', async () => {
+        mockHackerNews(createStoryHtml('', 5));
+
+        await expect(runRoute({ section: 'index', type: 'sources', value: '' })).rejects.toThrow('Hacker News item is missing an ID');
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
         "resolveJsonModule": true,
         "isolatedModules": true
     },
-    "include": ["./lib/**/*"],
+    "include": ["./lib/**/*", "./test/**/*"],
     "exclude": ["node_modules", "*.test.*"]
 }


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Replaces #23216.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/hackernews
/hackernews/index/sources/10
/hackernews/best/sources/10
/hackernews/newest
/hackernews/index/comments/10?limit=1
/hackernews/over/sources/100/10
/hackernews/submitted/sources/dang/1
/hackernews/item/sources/8863
/hackernews/threads/comments_list/dang
/hackernews/jobs
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
  - [ ] Follows [[Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard)](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [[路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Anti-bot or rate limit / 反爬/频率限制
  - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [[Date and time](https://docs.rsshub.app/joinus/advanced/pub-date)](https://docs.rsshub.app/joinus/advanced/pub-date) / [[日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
  - [ ] Parsed / 可以解析
  - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Add minimum-comment filtering before the common limit, preserving existing ID parameters, GUIDs and empty-feed checks. Normalize comment counts independently of GUID construction and separate caches by output format. Move tests outside route sources to fix the Docker build failure in #23216, with type-checking and CI coverage.

Before rebasing, 427 tests (including 24 Hacker News tests), 14 workerd tests, type checking, targeted lint/format checks, Docker build and startup checks passed. Local code review completed without unresolved actionable findings. Git range-diff confirms the patch is unchanged after rebasing; the new HEAD has not been revalidated.

HN may return HTTP 429; this change adds no new anti-bot or rate-limit handling. High thresholds can yield empty feeds. These 10 examples sample distinct parameter and output behaviors to reduce live HN requests; full-comment output uses limit=1.