### PR TITLE
feat(route): add iMuseum city exhibitions route

### DIFF
--- a/lib/routes/icity/imuseum.ts
+++ b/lib/routes/icity/imuseum.ts
@@ -1,5 +1,4 @@
 import { load } from 'cheerio';
-import { renderToString } from 'hono/jsx/dom/server';
 
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
@@ -43,12 +42,13 @@ export const route: Route = {
         const response = await ofetch(currentUrl);
         const $ = load(response);
 
-        // The city switcher is the only section with a dropdown, the `all` page additionally has a "world" section above it.
-        const cityName = $('a[data-toggle="dropdown"] h3').first().text().trim();
-        const typeName = $('ul.nav-pills li.active a').text().trim();
+        // The city switcher is the only element with a dropdown, the `all` page has an extra "world" section above it.
+        const cityName = $('a[data-toggle="dropdown"] h3').text();
+        // Scoped to `ul.nav-pills` because the top navbar has another `li.active`.
+        const typeName = $('ul.nav-pills li.active a').text();
 
-        // The `all` page also contains a featured list (`ul.imsm-entries.thumb`) with a different
-        // markup, whose items are shared across every city, so only the main list is used here.
+        // The `all` page also has a featured list (`ul.imsm-entries.thumb`) with a different markup,
+        // whose items are shared across every city, so only the main list is used.
         const list = $('ul.imsm-entries.list > li')
             .toArray()
             .map((item) => {
@@ -56,7 +56,7 @@ export const route: Route = {
                 const $info = $item.find('a.info');
 
                 return {
-                    title: $info.find('div.title').text().trim(),
+                    title: $info.find('div.title').text(),
                     link: new URL($info.attr('href')!, rootUrl).href,
                 };
             });
@@ -69,19 +69,17 @@ export const route: Route = {
                     const $entry = $detail('div.imsm-entry');
 
                     const cover = $entry.find('img.fit-width').attr('src');
-                    const infoTable = $entry.find('table.info-fields').html();
-                    const content = $entry.find('div.content').html();
+
+                    const $description = $detail('<div>');
+                    if (cover) {
+                        $description.append($detail('<img>').attr('src', cover));
+                    }
+                    $description.append($entry.find('table.info-fields'), $entry.find('div.content'));
 
                     return {
                         title: item.title,
                         link: item.link,
-                        description: renderToString(
-                            <div>
-                                {cover && <img src={cover} />}
-                                {infoTable && <div dangerouslySetInnerHTML={{ __html: infoTable }} />}
-                                {content && <div dangerouslySetInnerHTML={{ __html: content }} />}
-                            </div>
-                        ),
+                        description: $description.html(),
                         image: cover,
                     };
                 })

--- a/lib/routes/icity/imuseum.tsx
+++ b/lib/routes/icity/imuseum.tsx
@@ -1,0 +1,98 @@
+import { load } from 'cheerio';
+import { renderToString } from 'hono/jsx/dom/server';
+
+import type { Route } from '@/types';
+import cache from '@/utils/cache';
+import ofetch from '@/utils/ofetch';
+
+const rootUrl = 'https://art.icity.ly';
+
+export const route: Route = {
+    path: '/imuseum/:city/:type?',
+    categories: ['travel'],
+    example: '/icity/imuseum/guangzhou/latest',
+    parameters: {
+        city: '城市，取自站点 URL 中的城市路径，如 guangzhou、shanghai、beijing',
+        type: {
+            description: '展览列表类型',
+            default: 'latest',
+            options: [
+                { value: 'all', label: '全部' },
+                { value: 'latest', label: '最新' },
+                { value: 'hot', label: '热门' },
+                { value: 'end_soon', label: '即将结束' },
+                { value: 'coming', label: '即将开始' },
+                { value: 'outdated', label: '已结束' },
+            ],
+        },
+    },
+    name: 'iMuseum 城市展览',
+    maintainers: ['chouj'],
+    radar: [
+        {
+            source: ['art.icity.ly/:city'],
+            target: '/imuseum/:city',
+        },
+    ],
+    description: 'iMuseum（每日环球展览）各城市正在进行与即将开始的展览。城市与类型均取自站点 URL 路径，例如 `guangzhou/latest`。',
+    handler: async (ctx) => {
+        const { city } = ctx.req.param();
+        const type = ctx.req.param('type') ?? 'latest';
+        const currentUrl = `${rootUrl}/${city}/${type}`;
+
+        const response = await ofetch(currentUrl);
+        const $ = load(response);
+
+        // The city switcher is the only section with a dropdown, the `all` page additionally has a "world" section above it.
+        const cityName = $('a[data-toggle="dropdown"] h3').first().text().trim();
+        const typeName = $('ul.nav-pills li.active a').text().trim();
+
+        // The `all` page also contains a featured list (`ul.imsm-entries.thumb`) with a different
+        // markup, whose items are shared across every city, so only the main list is used here.
+        const list = $('ul.imsm-entries.list > li')
+            .toArray()
+            .map((item) => {
+                const $item = $(item);
+                const $info = $item.find('a.info');
+
+                return {
+                    title: $info.find('div.title').text().trim(),
+                    link: new URL($info.attr('href')!, rootUrl).href,
+                };
+            });
+
+        const items = await Promise.all(
+            list.map((item) =>
+                cache.tryGet(item.link, async () => {
+                    const detailResponse = await ofetch(item.link);
+                    const $detail = load(detailResponse);
+                    const $entry = $detail('div.imsm-entry');
+
+                    const cover = $entry.find('img.fit-width').attr('src');
+                    const infoTable = $entry.find('table.info-fields').html();
+                    const content = $entry.find('div.content').html();
+
+                    return {
+                        title: item.title,
+                        link: item.link,
+                        description: renderToString(
+                            <div>
+                                {cover && <img src={cover} />}
+                                {infoTable && <div dangerouslySetInnerHTML={{ __html: infoTable }} />}
+                                {content && <div dangerouslySetInnerHTML={{ __html: content }} />}
+                            </div>
+                        ),
+                        image: cover,
+                    };
+                })
+            )
+        );
+
+        return {
+            title: `${cityName}${typeName}展览 - iMuseum`,
+            link: currentUrl,
+            language: 'zh-CN',
+            item: items,
+        };
+    },
+};


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes

```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/icity/imuseum/beijing/latest
/icity/imuseum/shanghai/all
/icity/imuseum/guangzhou/latest
/icity/imuseum/shenzhen/hot
/icity/imuseum/hongkong/coming
/icity/imuseum/macao/outdated
/icity/imuseum/singapore/end_soon
/icity/imuseum/tokyo/latest
/icity/imuseum/london/hot
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This route adds the feed for iMuseum（每日环球展览）, the exhibition section of iCity at https://art.icity.ly/, which lists ongoing and upcoming art exhibitions and museum shows by city. It supports a city parameter (the city slug used in the site URL, e.g. guangzhou, shanghai, beijing) and a type parameter (all, latest, hot, end_soon, coming, outdated, default latest) corresponding to the tabs on the city page.

The list page is server-rendered, so no Puppeteer and no new package is required. Only the first page is fetched, as an RSS feed should be.

For each entry the route extracts the exhibition title and the link to its detail page (/events/<id>), then fetches the detail page with cache.tryGet to build the description from the exhibition poster, the info table (展期 / 展馆 / 地址 / 展厅 / 费用) and the introduction. The site does not expose any publication or update time for an exhibition, so no pubDate is set, following the [No Date](https://docs.rsshub.app/joinus/advanced/pub-date#no-date) rule. The exhibition period (e.g. 2026年8月22日 - 2027年8月22日), museum, address, hall and fee are rendered in the item description from the detail page's info table.

中文说明：本路由对应 iCity 旗下「iMuseum 每日环球展览」（https://art.icity.ly/）的城市展览列表，支持 city（城市，取自站点 URL 路径）与 type（all / latest / hot / end_soon / coming / outdated，默认 latest）两个参数。列表页为服务端渲染，无需 Puppeteer、未引入新依赖，且只抓取第一页。源站未公开任何发布/更新时间，因此按 No Date 规范不设置 pubDate；展览展期、展馆、地址、展厅、费用等信息由详情页信息表渲染进 description。