### PR TITLE
fix(core): parse Tuesday and Thursday as weekdays

### DIFF
--- a/lib/utils/parse-date.test.ts
+++ b/lib/utils/parse-date.test.ts
@@ -118,6 +118,23 @@ describe('parseRelativeDate', () => {
             expect(p('周三')).toBe(PREVIOUS_WEDNESDAY);
         });
 
+        it.each([
+            ['Tuesday', '2026-01-27T00:00:00'],
+            ['Tue', '2026-01-27T00:00:00'],
+            ['Thursday', '2026-01-29T00:00:00'],
+            ['Thu', '2026-01-29T00:00:00'],
+            ['Tuesday 3pm', '2026-01-27T15:00:00'],
+            ['Thu 10:00', '2026-01-29T10:00:00'],
+        ])('parses %s as a past weekday instead of tomorrow', (input, expected) => {
+            expect(p(input)).toBe(new Date(expected).getTime());
+        });
+
+        it.each(['Tomorrow', 't'])('preserves %s as tomorrow with optional time', (input) => {
+            expect(p(input)).toBe(TOMORROW_START);
+            expect(p(`${input}3pm`)).toBe(TOMORROW_START + 15 * hour);
+            expect(p(`${input} 10:00`)).toBe(TOMORROW_START + 10 * hour);
+        });
+
         it('handles "Sunday" (Past: Sun is Yesterday -> Feb 01)', () => {
             // Sunday (Feb 01) is strictly before Monday (Feb 02).
             expect(p('Sunday')).toBe(LAST_SUNDAY);

--- a/lib/utils/parse-date.ts
+++ b/lib/utils/parse-date.ts
@@ -114,7 +114,7 @@ const KEYWORDS: KeywordDefinition[] = [
         calc: () => dayjs().subtract(2, 'days').startOf('day'),
     },
     {
-        regExp: /^(?:明[天日早晨晚]|t(?:omorrow)?)/i,
+        regExp: /^(?:明[天日早晨晚]|t(?:omorrow|(?![a-z])))/i,
         calc: () => dayjs().add(1, 'days').startOf('day'),
     },
     {


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
NOROUTE
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows Script Standard / 跟随路由规范
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] Date and time / 日期和时间
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] Puppeteer

## Note / 说明

Tuesday and Thursday, including Tue and Thu, are currently parsed as tomorrow: the earlier tomorrow pattern consumes their leading `t`. With the clock fixed to Monday, February 2, both return February 3 instead of January 27 and January 29.

Restrict the bare `t` shorthand when another English letter follows. Full `tomorrow` and shorthand inputs such as `t3pm` retain their behavior. Add regression cases for weekday names, abbreviations, attached times, and tomorrow shorthand.

Validation: six regression cases fail on the base and pass with the fix. The date/timezone suites pass all 27 tests on macOS (Node 24.19) and Linux (Node 24.20, UTC and Asia/Taipei). Type checking, focused lint and formatting checks pass on both systems. Tests use a fixed clock and make no source-site requests.
