### PR TITLE
feat(route): add 98zhibo football highlights route

### DIFF
--- a/lib/routes/98zhibo/namespace.ts
+++ b/lib/routes/98zhibo/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '98直播吧',
+    url: 'www.98zhibo.com',
+    lang: 'zh-CN',
+};

--- a/lib/routes/98zhibo/zuqiujijin.ts
+++ b/lib/routes/98zhibo/zuqiujijin.ts
@@ -46,7 +46,7 @@ async function handler(): Promise<Data> {
         .map((item) => {
             const $item = $(item);
             const $link = $item.find('a');
-            const title = $link.text().trim();
+            const title = $link.text();
 
             return {
                 title,

--- a/lib/routes/98zhibo/zuqiujijin.ts
+++ b/lib/routes/98zhibo/zuqiujijin.ts
@@ -1,0 +1,108 @@
+import { load } from 'cheerio';
+import iconv from 'iconv-lite';
+
+import type { Data, Route } from '@/types';
+import cache from '@/utils/cache';
+import got from '@/utils/got';
+import { parseDate } from '@/utils/parse-date';
+import timezone from '@/utils/timezone';
+
+const baseUrl = 'https://www.98zhibo.com';
+
+const headers = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+};
+
+export const route: Route = {
+    path: '/zuqiujijin',
+    categories: ['sport'],
+    example: '/98zhibo/zuqiujijin',
+    name: '足球集锦',
+    maintainers: ['chouj'],
+    radar: [
+        {
+            source: ['www.98zhibo.com/zuqiujijin/'],
+            target: '/zuqiujijin',
+        },
+    ],
+    handler,
+};
+
+// Titles start with the publish date, e.g. 2026年9月9日 欧冠-贝蒂斯客场3-2逆转十人里尔 ...
+const parsePubDateFromTitle = (title: string) => {
+    const match = title.match(/^(\d{4})年(\d{1,2})月(\d{1,2})日/);
+    return match ? timezone(parseDate(`${match[1]}-${match[2]}-${match[3]}`), 8) : undefined;
+};
+
+async function handler(): Promise<Data> {
+    const currentUrl = `${baseUrl}/zuqiujijin/`;
+
+    const response = await got({
+        method: 'get',
+        url: currentUrl,
+        responseType: 'buffer',
+        headers,
+    });
+
+    const $ = load(iconv.decode(response.data, 'gbk'));
+
+    const list = $('.list_body_bd li')
+        .toArray()
+        .map((item) => {
+            const $item = $(item);
+            const $link = $item.find('a');
+            const title = $link.text().trim();
+
+            return {
+                title,
+                link: new URL($link.attr('href')!, baseUrl).href,
+                pubDate: parsePubDateFromTitle(title),
+            };
+        });
+
+    const items = await Promise.all(
+        list.map((item) =>
+            cache.tryGet(item.link, async () => {
+                const detailResponse = await got({
+                    method: 'get',
+                    url: item.link,
+                    responseType: 'buffer',
+                    headers,
+                });
+                const $detail = load(iconv.decode(detailResponse.data, 'gbk'));
+
+                const $body = $detail('.Content-body');
+                // The hidden block holds the raw match data, the kickoff time is in UTC+8, e.g. 比赛时间：2026-09-09 03:00:00
+                const matchTime = $body
+                    .find('div[style*="display:none"]')
+                    .text()
+                    .match(/比赛时间：(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/)?.[1];
+
+                // Drop inline scripts, HTML comments and the hidden raw data block, keep only the visible content
+                $body.find('script, div[style*="display:none"]').remove();
+                $body
+                    .contents()
+                    .filter((_, node) => node.type === 'comment')
+                    .remove();
+
+                const $description = $detail('<div>');
+                if (matchTime) {
+                    $description.append($detail('<p>').text(`比赛时间：${matchTime}`));
+                }
+                $description.append($body.html() ?? '');
+
+                return {
+                    ...item,
+                    description: $description.html(),
+                };
+            })
+        )
+    );
+
+    return {
+        title: '足球集锦 - 98直播吧',
+        link: currentUrl,
+        language: 'zh-CN',
+        item: items,
+    };
+}

--- a/lib/routes/98zhibo/zuqiujijin.ts
+++ b/lib/routes/98zhibo/zuqiujijin.ts
@@ -9,10 +9,6 @@ import timezone from '@/utils/timezone';
 
 const baseUrl = 'https://www.98zhibo.com';
 
-const headers = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
-};
-
 export const route: Route = {
     path: '/zuqiujijin',
     categories: ['sport'],
@@ -41,7 +37,6 @@ async function handler(): Promise<Data> {
         method: 'get',
         url: currentUrl,
         responseType: 'buffer',
-        headers,
     });
 
     const $ = load(iconv.decode(response.data, 'gbk'));
@@ -67,7 +62,6 @@ async function handler(): Promise<Data> {
                     method: 'get',
                     url: item.link,
                     responseType: 'buffer',
-                    headers,
                 });
                 const $detail = load(iconv.decode(detailResponse.data, 'gbk'));
 


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

```routes
/98zhibo/zuqiujijin
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This route adds the feed for 足球集锦 (football highlights), the highlight section of 98直播吧 at `https://www.98zhibo.com/zuqiujijin/`, which collects match highlights replay links.

The list page is served as static HTML in GBK, so the response body is decoded with `iconv-lite` before being parsed by cheerio. No Puppeteer and no new package is required — `iconv-lite` is already a dependency used by many existing routes. Only the first page is fetched, as an RSS feed should be.

For each entry the route extracts the title and the link to its detail page, then fetches the detail page with `cache.tryGet` to build the description from the visible content of `.Content-body`, stripping inline scripts, HTML comments and the hidden raw data block. The kickoff time found in that hidden block (e.g. `比赛时间：2026-09-09 03:00:00`, UTC+8) is prepended to the description.

The publication date is parsed from the date prefix of the title (e.g. `2026年9月9日`) and normalised with `timezone(..., 8)`. Note it is the publish date, not the kickoff time — the latter is only rendered in the description.

中文说明：本路由对应 98直播吧的「足球集锦」栏目，汇总比赛集锦链接。列表页为 GBK 编码的静态 HTML，需用 `iconv-lite` 解码后再交给 cheerio 解析；无需 Puppeteer，也未引入新依赖（`iconv-lite` 已是现有依赖），且只抓取第一页。每条提取标题与详情页链接，再通过 `cache.tryGet` 抓取详情页，取 `.Content-body` 的可见正文（移除内联脚本、HTML 注释与隐藏原始数据块），并将隐藏块中的开球时间（东八区）前置显示。`pubDate` 取自标题开头的发布日期并用 `timezone(..., 8)` 校正，注意它是发布日期而非比赛时间，后者仅展示在正文中。
