### PR TITLE
fix(route/xiaohongshu): restore authenticated user note full text

### DIFF
--- a/lib/routes/xiaohongshu/util.ts
+++ b/lib/routes/xiaohongshu/util.ts
@@ -300,16 +300,29 @@ async function getUserWithCookie(url: string) {
     const cookie = config.xiaohongshu.cookie;
     const res = await fetchWithProxy(url, cookie);
     const $ = load(res);
-    const paths = $('#userPostedFeeds > section > div > a.cover.ld.mask').map((i, item) => item.attributes[3].value);
     const script = extractInitialState($);
     const state = JSON.parse(script);
-    let index = 0;
-    for (const item of state.user.notes.flat()) {
-        const path = paths[index];
-        if (path && path.includes('?')) {
-            item.id += path?.slice(path.indexOf('?'));
+
+    const tokenizedPaths = new Map<string, string>();
+
+    $('a[href*="xsec_token"]').each((_, item) => {
+        const href = $(item).attr('href');
+        if (!href) {
+            return;
         }
-        index += 1;
+
+        const match = href.match(/\/([0-9a-f]{24})(?:\?|$)/i);
+        if (match && href.includes('?')) {
+            tokenizedPaths.set(match[1], href);
+        }
+    });
+
+    for (const item of state.user.notes.flat()) {
+        const path = tokenizedPaths.get(item.id);
+
+        if (path) {
+            item.id += path.slice(path.indexOf('?'));
+        }
     }
     return state.user;
 }
@@ -317,8 +330,11 @@ async function getUserWithCookie(url: string) {
 // Add helper function to extract initial state
 function extractInitialState($: CheerioAPI) {
     let script = $('script:contains("window.__INITIAL_STATE__=")').text();
+
     script = script.slice(script.indexOf('window.__INITIAL_STATE__=') + 'window.__INITIAL_STATE__='.length);
-    script = script.replaceAll('undefined', 'null');
+
+    script = script.replaceAll('undefined', 'null').replaceAll(/new Map\(\s*\[\s*\]\s*\)/g, 'null');
+
     return script;
 }
 

--- a/lib/routes/xiaohongshu/util.ts
+++ b/lib/routes/xiaohongshu/util.ts
@@ -305,7 +305,7 @@ async function getUserWithCookie(url: string) {
 
     const tokenizedPaths = new Map<string, string>();
 
-    $('a[href*="xsec_token"]').each((_, item) => {
+    $('#userPostedFeeds a[href*="xsec_token"]').each((_, item) => {
         const href = $(item).attr('href');
         if (!href) {
             return;


### PR DESCRIPTION
<!--
If you have any difficulties in filling out this form, please refer to https://docs.rsshub.app/joinus/new-rss/submit-route
如果你在填写此表单时遇到任何困难，请参考 https://docs.rsshub.app/zh/joinus/new-rss/submit-route
-->

## Involved Issue / 该 PR 相关 Issue

Close #

## Example for the Proposed Route(s) / 路由地址示例

<!--
Please include route starts with /, with all required and optional parameters.
Fail to comply will result in your pull request being closed automatically.
请在 `routes` 区域填写以 / 开头的完整路由地址，否则你的 PR 将会被无条件关闭。
如果路由包含在文档中列出可以完全穷举的参数（例如分类），请依次全部列出。

```routes
/some/route
/some/other/route
/dont/use/this/or/modify/it
/use/the/fenced/code/block/below
```

If your changes are not related to route, please fill in `routes` section with `NOROUTE`. Fail to comply will result in your PR being closed.
如果你的 PR 与路由无关, 请在 `routes` 区域 填写 `NOROUTE`，而不是直接删除 `routes` 区域。否则你的 PR 将会被无条件关闭。
-->

```routes
/xiaohongshu/user/6597ccba000000001f038330/notes
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [ ] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [ ] Parsed / 可以解析
    - [ ] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

Fix authenticated Xiaohongshu user-note full-text fetching.

- Xiaohongshu profile markup no longer matches the old `a.cover.ld.mask` selector. 
  Token-bearing note links are now matched to notes by note ID instead of relying on DOM order and attribute order.
- Current note detail pages may contain `new Map([])` inside `window.__INITIAL_STATE__`, which causes the existing `JSON.parse()` to fail. 
  Empty Map expressions are now normalized before parsing.

With `XIAOHONGSHU_COOKIE` configured, the route now returns full note descriptions again.

修复小红书用户笔记在已配置 Cookie 时无法获取全文的问题。

- 小红书用户主页的页面结构已不再匹配旧的 `a.cover.ld.mask` 选择器。
  现在会根据笔记 ID 匹配带有 `xsec_token` 的笔记链接，不再依赖 DOM 顺序和属性顺序。
- 当前笔记详情页的 `window.__INITIAL_STATE__` 中可能包含 `new Map([])`，导致现有的 `JSON.parse()` 解析失败。
  现在会在解析前将空 Map 表达式规范化处理。

配置 `XIAOHONGSHU_COOKIE` 后，该路由现在可以重新返回完整的笔记正文。