### PR TITLE
feat(route): add DeepSeek API changelog

### DIFF
--- a/lib/routes/deepseek/changelog.ts
+++ b/lib/routes/deepseek/changelog.ts
@@ -1,0 +1,89 @@
+import type { CheerioAPI } from 'cheerio';
+import { load } from 'cheerio';
+import type { Context } from 'hono';
+
+import type { Data, DataItem, Route } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const ROOT_URL = 'https://api-docs.deepseek.com';
+const ARTICLE_CONTENT_SELECTOR = '.theme-doc-markdown > div > div';
+
+const getUpdatesUrl = (language: string | undefined) => `${ROOT_URL}${language === 'en' ? '' : '/zh-cn'}/updates/`;
+
+export const extractChangelogItems = ($: CheerioAPI, updatesUrl: string): DataItem[] =>
+    $(`${ARTICLE_CONTENT_SELECTOR} > h2`)
+        .toArray()
+        .map((heading) => {
+            const $heading = $(heading);
+            const date = $heading.text().match(/\d{4}-\d{2}-\d{2}/)?.[0];
+            const $content = $heading.nextUntil('hr, h2');
+            const $title = $content.filter('h3').first();
+            const anchor = $title.attr('id') ?? $heading.attr('id');
+
+            return {
+                title: $title.text(),
+                link: anchor ? `${updatesUrl}#${anchor}` : updatesUrl,
+                ...(date && { pubDate: parseDate(date) }),
+                description:
+                    $content
+                        .not('h3')
+                        .toArray()
+                        .map((element) => $.html(element))
+                        .join('') || undefined,
+            };
+        })
+        .filter((item) => item.title);
+
+const handler = async (ctx: Context): Promise<Data> => {
+    const language = ctx.req.param('language');
+    const updatesUrl = getUpdatesUrl(language);
+    const response = await ofetch(updatesUrl);
+    const $ = load(response);
+
+    return {
+        title: language === 'en' ? 'DeepSeek Change Log' : 'DeepSeek 更新日志',
+        link: updatesUrl,
+        item: extractChangelogItems($, updatesUrl),
+        language: language === 'en' ? 'en' : 'zh-CN',
+    };
+};
+
+export const route: Route = {
+    path: '/changelog/:language?',
+    categories: ['program-update'],
+    example: '/deepseek/changelog',
+    parameters: {
+        language: 'Language, use `en` for English; defaults to Chinese',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: false,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['api-docs.deepseek.com/updates'],
+            target: '/changelog/en',
+        },
+        {
+            source: ['api-docs.deepseek.com/zh-cn/updates'],
+            target: '/changelog',
+        },
+    ],
+    name: 'Change Log',
+    maintainers: ['ljh12138164'],
+    handler,
+    url: 'api-docs.deepseek.com',
+    description: 'DeepSeek API change log in Chinese and English.',
+    zh: {
+        name: '更新日志',
+        parameters: {
+            language: '语言，可选 `en`，默认为中文',
+        },
+        description: 'DeepSeek API 更新日志，支持中文和英文。',
+    },
+};

--- a/lib/routes/deepseek/namespace.ts
+++ b/lib/routes/deepseek/namespace.ts
@@ -1,8 +1,12 @@
 import type { Namespace } from '@/types';
 
 export const namespace: Namespace = {
-    name: 'Deepseek',
+    name: 'DeepSeek',
     url: 'api-docs.deepseek.com',
-    description: 'Deepseek API 文档。',
+    description: 'DeepSeek API documentation.',
     lang: 'zh-CN',
+    zh: {
+        name: 'DeepSeek',
+        description: 'DeepSeek API 文档。',
+    },
 };

--- a/tests/deepseek-changelog.test.ts
+++ b/tests/deepseek-changelog.test.ts
@@ -1,0 +1,37 @@
+import { load } from 'cheerio';
+import { describe, expect, it } from 'vitest';
+
+import { extractChangelogItems } from '../lib/routes/deepseek/changelog';
+
+describe('DeepSeek changelog route', () => {
+    it.each([
+        ['Date', 'Release', 'English content'],
+        ['时间', '发布', '中文内容'],
+    ])('extracts %s changelog entries', (dateLabel, titleSuffix, content) => {
+        const $ = load(`
+            <div class="theme-doc-markdown"><div><div>
+                <h1>Change Log</h1>
+                <hr>
+                <h2 id="date-2026-09-10">${dateLabel}: 2026-09-10</h2>
+                <h3 id="deepseek-v4-release">DeepSeek V4 ${titleSuffix}</h3>
+                <p>${content}</p>
+                <hr>
+                <h2 id="date-2026-08-21">${dateLabel}: 2026-08-21</h2>
+                <h3 id="deepseek-v3-release">DeepSeek V3 ${titleSuffix}</h3>
+                <p>Older content</p>
+            </div></div></div>
+        `);
+
+        const items = extractChangelogItems($, 'https://api-docs.deepseek.com/updates/');
+
+        expect(items).toHaveLength(2);
+        expect(items[0]).toMatchObject({
+            title: `DeepSeek V4 ${titleSuffix}`,
+            link: 'https://api-docs.deepseek.com/updates/#deepseek-v4-release',
+            description: `<p>${content}</p>`,
+        });
+        expect(items[0].pubDate?.getFullYear()).toBe(2026);
+        expect(items[0].pubDate?.getMonth()).toBe(8);
+        expect(items[0].pubDate?.getDate()).toBe(10);
+    });
+});


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

## Example for the Proposed Route(s) / 路由地址示例

```routes
/deepseek/changelog
/deepseek/changelog/en
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This PR adds an RSS route for the official DeepSeek API changelog.

### Routes

- `/deepseek/changelog` returns the Chinese changelog from `https://api-docs.deepseek.com/zh-cn/updates/`.
- `/deepseek/changelog/en` returns the English changelog from `https://api-docs.deepseek.com/updates/`.

### Implementation

- Parses each dated changelog section as a separate RSS item.
- Extracts the update title, publication date, main content, and source anchor.
- Uses RSSHub's `parseDate` utility for publication dates.
- Provides unique, human-readable links to each changelog section.
- Adds Radar rules for the Chinese and English source pages.
- Adds localized English and Chinese route documentation.
- Does not require authentication, browser automation, or additional packages.

### Validation

- Verified both routes against the live DeepSeek documentation.
- Chinese and English pages each produced 21 RSS items during local testing.
- Added tests covering Chinese and English changelog parsing.
- Verified the following local routes:
    - `http://localhost:1200/deepseek/changelog`
    - `http://localhost:1200/deepseek/changelog/en`
- Passed:
    - Targeted Vitest tests
    - ESLint
    - oxlint
    - Formatting checks
    - TypeScript type checking
    - Pre-commit staged-file validation