### PR TITLE
feat(route/huggingface): add user posts activity

### DIFF
--- a/lib/routes/huggingface/user-posts.ts
+++ b/lib/routes/huggingface/user-posts.ts
@@ -1,3 +1,4 @@
+import * as cheerio from 'cheerio';
 import MarkdownIt from 'markdown-it';
 
 import type { Route } from '@/types';
@@ -37,8 +38,6 @@ interface UserProfileProps {
     posts?: SocialPost[];
     totalPosts?: number;
 }
-
-const decodeHtmlEntities = (input: string): string => input.replaceAll('&quot;', '"').replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>').replaceAll('&#39;', "'");
 
 const getTitle = (raw: string): string => {
     const line = raw
@@ -96,12 +95,13 @@ async function handler(ctx) {
         },
     });
 
-    const matched = /data-target="UserProfile"[^>]*data-props="([^"]*)"/.exec(html);
-    if (!matched) {
+    const $ = cheerio.load(html);
+    const dataProps = $('[data-target="UserProfile"]').attr('data-props');
+    if (!dataProps) {
         throw new Error(`Failed to extract the profile data of "${user}" from the page`);
     }
 
-    const props = JSON.parse(decodeHtmlEntities(matched[1])) as UserProfileProps;
+    const props = JSON.parse(dataProps) as UserProfileProps;
     const posts = props.posts ?? [];
 
     const items = posts.map((post) => {

--- a/lib/routes/huggingface/user-posts.ts
+++ b/lib/routes/huggingface/user-posts.ts
@@ -48,10 +48,7 @@ const getTitle = (raw: string): string => {
         .replace(/^#{1,6}\s*/, '')
         .replaceAll(/[*_`~]/g, '')
         .trim();
-    if (!plain) {
-        return 'Untitled post';
-    }
-    return plain.length > 100 ? `${plain.slice(0, 100)}...` : plain;
+    return plain || 'Untitled post';
 };
 
 export const route: Route = {

--- a/lib/routes/huggingface/user-posts.ts
+++ b/lib/routes/huggingface/user-posts.ts
@@ -1,0 +1,125 @@
+import MarkdownIt from 'markdown-it';
+
+import type { Route } from '@/types';
+import { ViewType } from '@/types';
+import ofetch from '@/utils/ofetch';
+import { parseDate } from '@/utils/parse-date';
+
+const md = MarkdownIt({
+    html: true,
+    linkify: true,
+});
+
+interface PostAuthor {
+    name: string;
+    fullname?: string;
+    avatarUrl?: string;
+}
+
+interface PostContentNode {
+    type: string;
+    value?: string;
+    raw?: string;
+}
+
+interface SocialPost {
+    slug: string;
+    content?: PostContentNode[];
+    rawContent?: string;
+    author?: PostAuthor;
+    publishedAt: string;
+    updatedAt?: string;
+    url: string;
+    numComments?: number;
+}
+
+interface UserProfileProps {
+    posts?: SocialPost[];
+    totalPosts?: number;
+}
+
+const decodeHtmlEntities = (input: string): string => input.replaceAll('&quot;', '"').replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>').replaceAll('&#39;', "'");
+
+const getTitle = (raw: string): string => {
+    const line = raw
+        .split('\n')
+        .map((l) => l.trim())
+        .find((l) => l && !/^[=#>*\-_]+$/.test(l));
+    const plain = (line ?? '')
+        .replace(/^#{1,6}\s*/, '')
+        .replaceAll(/[*_`~]/g, '')
+        .trim();
+    if (!plain) {
+        return 'Untitled post';
+    }
+    return plain.length > 100 ? `${plain.slice(0, 100)}...` : plain;
+};
+
+export const route: Route = {
+    path: '/activity/:user/posts',
+    categories: ['programming'],
+    view: ViewType.SocialMedia,
+    example: '/huggingface/activity/AbstractPhil/posts',
+    parameters: {
+        user: 'Hugging Face username',
+    },
+    features: {
+        requireConfig: false,
+        requirePuppeteer: false,
+        antiCrawler: true,
+        supportBT: false,
+        supportPodcast: false,
+        supportScihub: false,
+    },
+    radar: [
+        {
+            source: ['huggingface.co/:user/activity/posts'],
+            target: '/activity/:user/posts',
+        },
+    ],
+    name: 'User Posts Activity',
+    maintainers: ['qqc20043'],
+    handler,
+    url: 'huggingface.co',
+    zh: {
+        name: '用户帖子动态',
+    },
+};
+
+async function handler(ctx) {
+    const { user } = ctx.req.param();
+    const link = `https://huggingface.co/${user}/activity/posts`;
+
+    const html = await ofetch<string>(link, {
+        headers: {
+            Accept: 'text/html',
+        },
+    });
+
+    const matched = /data-target="UserProfile"[^>]*data-props="([^"]*)"/.exec(html);
+    if (!matched) {
+        throw new Error(`Failed to extract the profile data of "${user}" from the page`);
+    }
+
+    const props = JSON.parse(decodeHtmlEntities(matched[1])) as UserProfileProps;
+    const posts = props.posts ?? [];
+
+    const items = posts.map((post) => {
+        const raw = post.rawContent ?? (post.content ?? []).map((node) => node.value ?? node.raw ?? '').join('');
+
+        return {
+            title: getTitle(raw),
+            link: new URL(post.url, 'https://huggingface.co').href,
+            description: md.render(raw),
+            pubDate: parseDate(post.publishedAt),
+            guid: post.slug,
+            author: post.author?.name ? [{ name: post.author.name, url: `https://huggingface.co/${post.author.name}` }] : undefined,
+        };
+    });
+
+    return {
+        title: `${user} - Posts Activity`,
+        link,
+        item: items,
+    };
+}


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

Close #23059

## Example for the Proposed Route(s) / 路由地址示例

```routes
/huggingface/activity/AbstractPhil/posts
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [x] New Route / 新的路由
    - [x] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [x] Documentation / 文档说明
- [x] Full text / 全文获取
- [x] Use cache / 使用缓存
- [x] Anti-bot or rate limit / 反爬/频率限制
    - [x] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

新增 Hugging Face 用户帖子动态路由，补齐 `huggingface` namespace 下缺失的 posts 类型
（现有 `blog`、`blog-community`、`daily-papers`、`models`、`user-likes` 均无用户帖子）。

实现说明：

1. **数据来源**：Hugging Face 未提供按用户过滤的公开帖子 API
   （`/api/posts?author=` 的 `author` 参数被服务端忽略，始终返回全站最新条目；
   `/api/users/{user}/posts` 返回 404；`/api/social-posts` 需要认证）。
   因此本路由读取 `https://huggingface.co/{user}/activity/posts` 页面，
   该页为 SvelteKit 服务端渲染，帖子数据完整嵌入在
   `data-target="UserProfile"` 节点的 `data-props` 属性中，无需浏览器渲染即可提取。

2. **条目数量**：服务端渲染的首屏数据包含最新的 2 条帖子（`?p=` 等分页参数对该页无效），
   路由直接输出这 2 条。`totalPosts` 字段仅用于参考，未作为分页依据。

3. **全文输出**：`rawContent` 为帖子原始 Markdown，经 `markdown-it` 渲染为 HTML 作为
   `description`，因此订阅端可直接获得全文与内嵌图片。

4. **反爬**：Hugging Face 部署了 AWS WAF，短时间高频请求会返回 429。
   已将 `features.antiCrawler` 置为 `true`，RSSHub 的请求层自带重试与退避。

5. **时间**：`publishedAt` 为 ISO 8601 UTC 时间，统一交由 `parseDate` 处理。

本地验证（示例用户 `AbstractPhil`）：

- `/huggingface/activity/AbstractPhil/posts` → 2 条，标题、链接、`pubDate`、作者均正确
- 链接形如 `https://huggingface.co/posts/AbstractPhil/372092347372730`
