### PR TITLE
fix(route/zhihu): fill missing daily publication dates

### DIFF
--- a/lib/routes/zhihu/daily.ts
+++ b/lib/routes/zhihu/daily.ts
@@ -3,7 +3,7 @@ import cache from '@/utils/cache';
 import logger from '@/utils/logger';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
-import { parseDateInTimezone } from '@/utils/parse-date-in-timezone';
+import timezone from '@/utils/timezone';
 
 export const route: Route = {
     path: '/daily',
@@ -31,7 +31,6 @@ export const route: Route = {
 
 async function handler() {
     const latest = await ofetch('https://daily.zhihu.com/api/4/stories/latest');
-    const latestDate = `${latest.date.slice(0, 4)}-${latest.date.slice(4, 6)}-${latest.date.slice(6, 8)}`;
 
     const items = (
         await Promise.all(
@@ -49,7 +48,7 @@ async function handler() {
                         description: storyJson.body,
                         link: storyJson.url,
                         image: storyJson.image,
-                        pubDate: storyJson.publish_time ? parseDate(storyJson.publish_time, 'X') : parseDateInTimezone(latestDate, 8),
+                        pubDate: storyJson.publish_time ? parseDate(storyJson.publish_time, 'X') : timezone(parseDate(latest.date, 'YYYYMMDD'), 8),
                     };
                 } catch (error) {
                     logger.debug(`Failed to fetch story detail: ${storyUrl} - ${error instanceof Error ? error.message : String(error)}`);

--- a/lib/routes/zhihu/daily.ts
+++ b/lib/routes/zhihu/daily.ts
@@ -1,10 +1,9 @@
-import { load } from 'cheerio';
-
 import type { Route } from '@/types';
 import cache from '@/utils/cache';
 import logger from '@/utils/logger';
 import ofetch from '@/utils/ofetch';
 import { parseDate } from '@/utils/parse-date';
+import { parseDateInTimezone } from '@/utils/parse-date-in-timezone';
 
 export const route: Route = {
     path: '/daily',
@@ -14,7 +13,7 @@ export const route: Route = {
     features: {
         requireConfig: false,
         requirePuppeteer: false,
-        antiCrawler: true,
+        antiCrawler: false,
         supportBT: false,
         supportPodcast: false,
         supportScihub: false,
@@ -31,37 +30,32 @@ export const route: Route = {
 };
 
 async function handler() {
-    const response = await ofetch('https://daily.zhihu.com/');
-
-    const $ = load(response);
+    const latest = await ofetch('https://daily.zhihu.com/api/4/stories/latest');
+    const latestDate = `${latest.date.slice(0, 4)}-${latest.date.slice(4, 6)}-${latest.date.slice(6, 8)}`;
 
     const items = (
         await Promise.all(
-            $('.box')
-                .toArray()
-                .map(async (item) => {
-                    const $item = $(item);
-                    const linkElem = $item.find('.link-button');
-                    const storyUrl = 'https://daily.zhihu.com/api/4' + linkElem.attr('href');
+            latest.stories.map(async (story) => {
+                const storyUrl = `https://daily.zhihu.com/api/4/story/${story.id}`;
 
-                    try {
-                        const storyJson = await cache.tryGet(storyUrl, async () => {
-                            const response = await ofetch(storyUrl);
-                            return response;
-                        });
+                try {
+                    const storyJson = await cache.tryGet(storyUrl, async () => {
+                        const response = await ofetch(storyUrl);
+                        return response;
+                    });
 
-                        return {
-                            title: storyJson.title,
-                            description: storyJson.body,
-                            link: storyJson.url,
-                            image: storyJson.image,
-                            pubDate: storyJson.publish_time ? parseDate(storyJson.publish_time, 'X') : undefined,
-                        };
-                    } catch (error) {
-                        logger.debug(`Failed to fetch story detail: ${storyUrl} - ${error instanceof Error ? error.message : String(error)}`);
-                        return null;
-                    }
-                })
+                    return {
+                        title: storyJson.title,
+                        description: storyJson.body,
+                        link: storyJson.url,
+                        image: storyJson.image,
+                        pubDate: storyJson.publish_time ? parseDate(storyJson.publish_time, 'X') : parseDateInTimezone(latestDate, 8),
+                    };
+                } catch (error) {
+                    logger.debug(`Failed to fetch story detail: ${storyUrl} - ${error instanceof Error ? error.message : String(error)}`);
+                    return null;
+                }
+            })
         )
     ).filter((item) => item !== null);
 


### PR DESCRIPTION
## Involved Issue / 该 PR 相关 Issue

N/A — no associated issue.

## Example for the Proposed Route(s) / 路由地址示例

```routes
/zhihu/daily
```

## New RSS Route Checklist / 新 RSS 路由检查表

- [ ] New Route / 新的路由
    - [ ] Follows [Script Standard](https://docs.rsshub.app/joinus/advanced/script-standard) / 跟随 [路由规范](https://docs.rsshub.app/zh/joinus/advanced/script-standard)
- [ ] Anti-bot or rate limit / 反爬/频率限制
    - [ ] If yes, do your code reflect this sign? / 如果有, 是否有对应的措施?
- [x] [Date and time](https://docs.rsshub.app/joinus/advanced/pub-date) / [日期和时间](https://docs.rsshub.app/zh/joinus/advanced/pub-date)
    - [x] Parsed / 可以解析
    - [x] Correct time zone / 时区正确
- [ ] New package added / 添加了新的包
- [ ] `Puppeteer`

## Note / 说明

This PR fixes missing publication dates in `/zhihu/daily`. It uses the public v4 `stories/latest` API for the daily story list, continues to fetch and cache each story detail, and falls back to the list-level date in UTC+8 when `publish_time` is unavailable.

Side effect: the route now returns only the latest 4 stories for the current day instead of the multi-day set shown on the website homepage.

Checks completed: formatting, Oxlint, ESLint, and TypeScript typecheck.